### PR TITLE
add health check gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'bcrypt', '~> 3.1.7'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 gem 'devise', '4.3.0'
+gem "health_check"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Logger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,6 +513,8 @@ GEM
       railties (>= 3.2, < 5.2)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    health_check (2.6.0)
+      rails (>= 4.0)
     i18n (0.8.6)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -719,6 +721,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise (= 4.3.0)
   font-awesome-rails
+  health_check
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)


### PR DESCRIPTION
Currently the load balancer uses '/' to check health. This appears to be a pretty slow and expensive page to build.

This gem gives us a simple endpoint specifically for checking the health of the running server.