### PR TITLE
Script to run BASH commands on the WEB container for DEV/ALPHA

### DIFF
--- a/bin/clam
+++ b/bin/clam
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+#  In order for this script to work, you will need PEM credentials for SSH.
+#
+#  Usage:
+#
+#      bin/clam dev bash
+#
+#      bin/clam dev 'echo $HOSTNAME'
+#
+#      bin/clam dev 'mysqldump -h $RDS_ADDRESS -u $DB_USERNAME --password=$DB_PASSWORD idseq_dev | gzip -c' > id_dev.sql.gz
+#
+#  Above, the specified commands run in the web container on environment "dev",
+#  so that the $HOSTNAME, $RDS_ADDRESS, etc variables are expanded in that
+#  environment
+#
+#  Race conditions during (re)deploy may cause this script to fail or timeout.
+#
+
+ENV=$1
+shift
+
+MACHINE=`bin/get_public_ip $ENV`
+
+CONTAINER=`ssh ec2-user@$MACHINE "docker ps | grep chanzuckerberg/idseq-web | head -1" | awk '{print $NF}'`
+
+ssh ec2-user@$MACHINE 'docker exec '$CONTAINER' /bin/bash -c '"'$*'"

--- a/bin/get_public_ip
+++ b/bin/get_public_ip
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'bundler/setup'
+require 'aws-sdk-ecs'
+require 'aws-sdk-ec2'
+require 'pp'
+
+env = ARGV.shift
+command = ARGV.shift || "rails console"
+if !env
+  puts 'Usage: ./bin/shell ENV [COMMAND]'
+  puts '  COMMAND: default is "rails console"'
+  abort
+end
+
+ecs_client = Aws::ECS::Client.new(region: 'us-west-2')
+ec2_client = Aws::EC2::Client.new(region: 'us-west-2')
+service = "idseq-web-#{env}"
+
+resp = ecs_client.describe_services(cluster: env, services: [service])
+service = resp.services.first
+
+task = ecs_client.list_tasks(cluster: env, service_name: "idseq-web-#{env}").task_arns.first
+
+tasks = ecs_client.describe_tasks(cluster: env, tasks: [task])
+instances = ecs_client.describe_container_instances(cluster: env,
+                                                    container_instances: [tasks.tasks[0].container_instance_arn])
+
+resp = ec2_client.describe_instances(instance_ids: [instances.container_instances[0].ec2_instance_id])
+
+public_ip = resp.reservations.first.instances.first.public_ip_address
+
+puts public_ip
+
+#exec %(ssh -t ec2-user@#{public_ip} "echo docker exec -it \\`docker ps | grep chanzuckerberg/idseq-web | head -1 | awk '{print \\$NF}'\\` #{command} ")
+
+#idseq_web_container = `ssh ec2-user@#{public_ip} "docker ps | grep chanzuckerberg/idseq-web | head -1 | awk '{print \\$NF}'"`.strip
+
+#puts "ssh ec2-user@#{public_ip} 'docker exec #{idseq_web_container} /bin/bash -c '"
+
+#exec %(ssh ec2-user@#{public_ip} 'docker exec #{idseq_web_container} /bin/bash -c "echo \$HOSTNAME mysqldump -h \$RDS_ADDRESS -u \$DB_USERNAME --password=\$DB_PASSWORD idseq_dev"')


### PR DESCRIPTION
To obtain a SQL dump from environment 'dev', run it like so:

    bin/clam dev 'mysqldump -h $RDS_ADDRESS -u $DB_USERNAME --password=$DB_PASSWORD idseq_dev | gzip -c' | gzip -dc > id_dev.sql

Note how the environment variables are expanded on the remote container,
and how the sql dump is compressed on the remote machine, streamed in
compressed format, and uncompressed on the receiving machine.

This differs from the bin/shell script in that it does not run the command
in a tty but does run it in the correct container environment to enable
the expansion of environment variables and shell pipes.

Make sure to use single-quotes as in the above example.