### PR TITLE
prohibit deploying latest

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -12,6 +12,12 @@ if !env || !image
   puts 'Usage: ./bin/deploy ENV IMAGE_TAG'
   abort
 end
+
+if image == 'latest'
+  puts "you should not deploy latest (it doesn't mean what you think it does)"
+  abort
+end
+
 puts "deploying #{image} to #{env}"
 
 RAILS_SERVICE = "idseq-web-#{env}".freeze


### PR DESCRIPTION
I noticed someone trying to deploy latest the other day. We should prohibit that because 'latest' means "the most recently build docker image", which could be any branch or PR.

If you deploy it who knows what you'll get.