### PR TITLE
honeycomb logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'puma', '~> 3.7'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem "libhoney"
 gem 'rails', '~> 5.1.2'
 gem 'rake'
 gem 'react-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,6 +512,10 @@ GEM
     et-orbi (1.0.5)
       tzinfo
     execjs (2.7.0)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.9.18)
     font-awesome-rails (4.7.0.2)
       railties (>= 3.2, < 5.2)
@@ -528,6 +532,10 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    libhoney (1.2.0)
+      faraday (~> 0.12)
+      faraday_middleware (~> 0.12)
+      net-http-persistent (~> 3.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -551,8 +559,11 @@ GEM
       railties (>= 3.1)
     mono_logger (1.1.0)
     multi_json (1.12.2)
+    multipart-post (2.0.0)
     mustermann (1.0.1)
     mysql2 (0.4.9)
+    net-http-persistent (3.0.0)
+      connection_pool (~> 2.2)
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
@@ -736,6 +747,7 @@ DEPENDENCIES
   health_check
   jbuilder (~> 2.5)
   jquery-rails
+  libhoney
   listen (>= 3.0.5, < 3.2)
   logger
   materialize-sass

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,0 +1,26 @@
+# See https://honeycomb.io/docs/guides/rails/
+require 'libhoney'
+
+if ENV["IDSEQ_HONEYCOMB_WRITE_KEY"] && ENV["IDSEQ_HONEYCOMB_DATA_SET"]
+
+  HONEYCOMB = Libhoney::Client.new(writekey: ENV["IDSEQ_HONEYCOMB_WRITE_KEY"],
+                                   dataset: ENV["IDSEQ_HONEYCOMB_DATA_SET"])
+
+  # See http://guides.rubyonrails.org/active_support_instrumentation.html
+  ActiveSupport::Notifications.subscribe(/process_action.action_controller/) do |*args|
+    event = ActiveSupport::Notifications::Event.new(*args)
+
+    # These are the keys we're interested in! Skipping noisy keys (:headers, :params) for now.
+    data = event.payload.slice(:controller, :action, :method, :path, :format,
+                               :status, :db_runtime, :view_runtime)
+
+    # Massage data to return "all" as the :format if not set
+    data[:format] = "all" if !data[:format] || data[:format] == "format:*/*"
+
+    # Pull top-level attributes off of the ActiveSupport Event.
+    data[:duration_ms] = event.duration
+
+    HONEYCOMB.send_now(data)
+  end
+
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,10 @@ services:
       - redis
     environment:
       - SAMPLES_BUCKET_NAME=czbiohub-idseq-samples-development
+      - IDSEQ_AIRBRAKE_PROJECT_ID
+      - IDSEQ_AIRBRAKE_PROJECT_KEY
+      - IDSEQ_HONEYCOMB_DATA_SET
+      - IDSEQ_HONEYCOMB_WRITE_KEY
   resque:
     build: .
     volumes:


### PR DESCRIPTION
Honeycomb is a super basic analytics DB that lets you filter and group timestamped log events and chart sum/avg/percentile of any event field over time.

The rails code here emits stats that are already being gathered by rails.  For example, db_runtime, the total latency of DB queries in the request.  We can extend this event listener pattern as needed to emit more information.   The idea is to keep all logging here.

To use this, you need to set IDSEQ_HONEYCOMB_WRITE_KEY to a special value and IDSEQ_HONEYCOMB_DATA_SET to idseq_web.   Ryan can invite you to our team account on honeycomb so you can issue queries against the events.   Events show up pretty instantaneously.

TODO:  Add event fields for environment, host,  logged in user id, more per-request stats.