### PR TITLE
add lineage/name table

### DIFF
--- a/app/models/taxon_lineage_name.rb
+++ b/app/models/taxon_lineage_name.rb
@@ -1,0 +1,2 @@
+class TaxonLineageName < ApplicationRecord
+end

--- a/db/migrate/20171010010939_create_taxon_lineage_names.rb
+++ b/db/migrate/20171010010939_create_taxon_lineage_names.rb
@@ -1,0 +1,16 @@
+class CreateTaxonLineageNames < ActiveRecord::Migration[5.1]
+  def change
+    create_table :taxon_lineage_names do |t|
+      t.integer :taxid
+      t.string :superkingdom_name
+      t.string :phylum_name
+      t.string :class_name
+      t.string :order_name
+      t.string :family_name
+      t.string :genus_name
+      t.string :species_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171010011300_add_index_lineage_names.rb
+++ b/db/migrate/20171010011300_add_index_lineage_names.rb
@@ -1,0 +1,5 @@
+class AddIndexLineageNames < ActiveRecord::Migration[5.1]
+  def change
+    add_index :taxon_lineage_names, :taxid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171009164151) do
+ActiveRecord::Schema.define(version: 20171010011300) do
 
   create_table "backgrounds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
@@ -158,6 +158,20 @@ ActiveRecord::Schema.define(version: 20171009164151) do
     t.index ["pipeline_output_id", "tax_id", "count_type"], name: "new_index_taxon_counts", unique: true
     t.index ["pipeline_output_id", "tax_level", "count_type", "tax_id"], name: "index_taxon_counts", unique: true
     t.index ["pipeline_output_id"], name: "index_taxon_counts_on_pipeline_output_id"
+  end
+
+  create_table "taxon_lineage_names", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer "taxid"
+    t.string "superkingdom_name"
+    t.string "phylum_name"
+    t.string "class_name"
+    t.string "order_name"
+    t.string "family_name"
+    t.string "genus_name"
+    t.string "species_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["taxid"], name: "index_taxon_lineage_names_on_taxid", unique: true
   end
 
   create_table "taxon_lineages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/lib/tasks/lineagenames.rake
+++ b/lib/tasks/lineagenames.rake
@@ -1,0 +1,35 @@
+require 'open3'
+require 'csv'
+require 'English'
+task load_lineage_name_db: :environment do
+  local_taxonomy_path = "/app/tmp/taxonomy"
+  host = if Rails.env == 'development'
+           'db'
+         else
+           '$RDS_ADDRESS'
+         end
+  date = `date +"%Y-%m-%d"`.strip
+  lineages_file = 'lineages.csv'
+  preload = true
+  preload_s3_path = 's3://czbiohub-infectious-disease/taxonomy'
+
+  ` mkdir -p #{local_taxonomy_path};
+    cd #{local_taxonomy_path};
+    # get necessary software
+    git clone https://github.com/chanzuckerberg/ncbitax2lin.git;
+    # generate CSV files with lineage and name information
+    cd ncbitax2lin;
+    if #{preload}; then
+      aws s3 cp #{preload_s3_path}/#{lineages_file}.gz .
+    else
+      make
+    fi
+    # import to database
+    gunzip *.csv.gz;
+    tail -n+2 #{lineages_file} | awk -F "," '{print x+=1,","$0",#{date},#{date}"}' | sed 's= ,=,=' > taxon_lineage_names;
+    mysqlimport --delete --local --user=$DB_USERNAME --host=#{host} --password=$DB_PASSWORD --fields-terminated-by=',' idseq_#{Rails.env} taxon_lineage_names;
+    cd /app;
+    rm -rf #{local_taxonomy_path};
+  `
+  raise "lineage database import failed" unless $CHILD_STATUS.success?
+end

--- a/spec/models/taxon_lineage_name_spec.rb
+++ b/spec/models/taxon_lineage_name_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TaxonLineageName, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
We haven't fully decided whether it is best to have:
(1) a lineage table (expressed as taxids) plus a taxid-to-name conversion table, or
(2) a table that gives the lineage for every taxid in terms of the names of the parents.
@cyrielo, it sounds like you would find (2) useful as it allows you to look up the info you need for report displays directly and easily -- so that's what this pull request does