### PR TITLE
Slack deploy notifications

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -149,12 +149,20 @@ def notify_slack(env, image, stage)
       puts `curl -X POST --data-urlencode 'payload={"icon_emoji": ":ghost:", "text": "starting to deploy #{image} to #{env}"}' #{slack_hook}`
     elsif stage=="end"
       puts `curl -X POST --data-urlencode 'payload={"icon_emoji": ":sharkdance:", "text": "finished deploying #{image} to #{env}"}' #{slack_hook}`
+    elsif stage=="failure"
+      puts `curl -X POST --data-urlencode 'payload={"icon_emoji": ":sob:", "text": "deploy of #{image} to #{env} failed"}' #{slack_hook}`
     end
+  else
+    puts "Not notifying Slack of this deploy because environment variable SLACK_HOOK is not set. Please add an appropriate webhook to ~/.bash_profile."
   end
 end 
 
 notify_slack(env, image, "start")
-deploy(client, env, RAILS_SERVICE, REPO, image, true)
-deploy(client, env, RESQUE_WORKER_SERVICE, REPO, image, false)
-deploy(client, env, RESQUE_SCHEDULER_SERVICE, REPO, image, false)
-notify_slack(env, image, "end")
+begin
+  deploy(client, env, RAILS_SERVICE, REPO, image, true)
+  deploy(client, env, RESQUE_WORKER_SERVICE, REPO, image, false)
+  deploy(client, env, RESQUE_SCHEDULER_SERVICE, REPO, image, false)
+  notify_slack(env, image, "end")
+rescue
+  notify_slack(env, image, "failure")
+end

--- a/bin/deploy
+++ b/bin/deploy
@@ -142,6 +142,18 @@ def deploy(client, cluster, service, repo, image, run_migrations = false)
   puts "#{service} deployment probably complete, but this tool is pretty rudimentary so check for yourself"
 end
 
+def notify_slack(env, image, stage)
+  slack_hook = ENV["SLACK_HOOK"]
+  puts slack_hook
+  if stage=="start"
+    puts `curl -X POST --data-urlencode 'payload={"text": "starting to deploy #{image} to #{env}"}' #{slack_hook}`
+  elsif stage=="end"
+    puts `curl -X POST --data-urlencode 'payload={"text": "finished deploying #{image} to #{env}"}' #{slack_hook}`
+  end
+end 
+
+notify_slack(env, image, "start")
 deploy(client, env, RAILS_SERVICE, REPO, image, true)
 deploy(client, env, RESQUE_WORKER_SERVICE, REPO, image, false)
 deploy(client, env, RESQUE_SCHEDULER_SERVICE, REPO, image, false)
+notify_slack(env, image, "end")

--- a/bin/deploy
+++ b/bin/deploy
@@ -144,11 +144,12 @@ end
 
 def notify_slack(env, image, stage)
   slack_hook = ENV["SLACK_HOOK"]
-  puts slack_hook
-  if stage=="start"
-    puts `curl -X POST --data-urlencode 'payload={"text": "starting to deploy #{image} to #{env}"}' #{slack_hook}`
-  elsif stage=="end"
-    puts `curl -X POST --data-urlencode 'payload={"text": "finished deploying #{image} to #{env}"}' #{slack_hook}`
+  if slack_hook
+    if stage=="start"
+      puts `curl -X POST --data-urlencode 'payload={"icon_emoji": ":ghost:", "text": "starting to deploy #{image} to #{env}"}' #{slack_hook}`
+    elsif stage=="end"
+      puts `curl -X POST --data-urlencode 'payload={"icon_emoji": ":sharkdance:", "text": "finished deploying #{image} to #{env}"}' #{slack_hook}`
+    end
   end
 end 
 


### PR DESCRIPTION
This will notify your Slack channel of deploys if you have the environment variable SLACK_HOOK set to an appropriate incoming webhook.