### PR TITLE
handle data absence

### DIFF
--- a/app/controllers/pipeline_outputs_controller.rb
+++ b/app/controllers/pipeline_outputs_controller.rb
@@ -32,6 +32,7 @@ class PipelineOutputsController < ApplicationController
       nt_array = get_taxid_fasta(@pipeline_output, params[:taxid], params[:tax_level].to_i, 'NT').split(">")
       nr_array = get_taxid_fasta(@pipeline_output, params[:taxid], params[:tax_level].to_i, 'NR').split(">")
       @taxid_fasta = ">" + ((nt_array | nr_array) - ['']).join(">")
+      @taxid_fasta = "Coming soon" if @taxid_fasta == ">" # Temporary fix
     else
       @taxid_fasta = get_taxid_fasta(@pipeline_output, params[:taxid], params[:tax_level].to_i, params[:hit_type])
     end

--- a/app/helpers/pipeline_outputs_helper.rb
+++ b/app/helpers/pipeline_outputs_helper.rb
@@ -17,7 +17,11 @@ module PipelineOutputsHelper
     uri_parts = s3_path.split("/", 4)
     bucket = uri_parts[2]
     key = uri_parts[3]
-    resp = Client.get_object(bucket: bucket, key: key)
-    resp.body.read
+    begin
+      resp = Client.get_object(bucket: bucket, key: key)
+      return resp.body.read
+    rescue
+      return 'Coming soon' # Temporary fix
+    end
   end
 end


### PR DESCRIPTION
Tested on my local dev. Temporary message to handle data absence for samples that have not been re-processed with the new pipeline. Eventually we'll change this to check for presence of data files in S3 and, if not, pass a flag to the front-end that prevents download links from appearing.