### PR TITLE
cosmetic improvements to report genera expand/collapse

### DIFF
--- a/app/assets/javascripts/components/PipelineSampleReport.jsx
+++ b/app/assets/javascripts/components/PipelineSampleReport.jsx
@@ -86,10 +86,10 @@ class PipelineSampleReport extends React.Component {
       // emphasize genus, soften category and species count
       category_name = tax_info.tax_id == -200 ? '' : tax_info.category_name;
       // Most groups are initially expanded, so they get a toggle with fa-minus initial state.
-      plus_or_minus = <i className={`fa fa-minus ${tax_info.tax_id}`} onClick={this.expandOrCollapseGenus}></i>;
+      plus_or_minus = <i className={`fa fa-angle-down ${tax_info.tax_id}`} onClick={this.expandOrCollapseGenus}></i>;
       if (tax_info.tax_id <= 0) {
         // Except for group "All taxa without genus classification", which is initially collapsed.
-        plus_or_minus = <i className={`fa fa-plus ${tax_info.tax_id}`} onClick={this.expandOrCollapseGenus}></i>;
+        plus_or_minus = <i className={`fa fa-angle-right ${tax_info.tax_id}`} onClick={this.expandOrCollapseGenus}></i>;
       }
       // Except in Genus view, nothing is expandable.
       if (this.props.report_page_params.view_level == 'genus') {
@@ -156,17 +156,18 @@ class PipelineSampleReport extends React.Component {
   }
 
   expandOrCollapseGenus(e) {
-    // className as set in render_name() is like 'fa fa-plus ${taxId}'
+    // className as set in render_name() is like 'fa fa-angle-right ${taxId}'
     const className = e.target.attributes.class.nodeValue;
     const attr = className.split(' ');
     const taxId = attr[2];
     $(`.report-row-species.${taxId}`).toggleClass('hidden');
     // HACK.  Flipping plus/minus should be done with React, not DOM change.
-    if (attr[1] == 'fa-plus') {
-      e.target.attributes.class.nodeValue = `fa fa-minus ${taxId}`;
+    if (attr[1] == 'fa-angle-right') {
+      e.target.attributes.class.nodeValue = `fa fa-angle-down ${taxId}`;
     } else {
-      e.target.attributes.class.nodeValue = `fa fa-plus ${taxId}`;
+      e.target.attributes.class.nodeValue = `fa fa-angle-right ${taxId}`;
     }
+    e.nativeEvent.stopImmediatePropagation();
   }
 
   render() {

--- a/app/assets/stylesheets/reports.scss
+++ b/app/assets/stylesheets/reports.scss
@@ -183,16 +183,25 @@
   cursor: pointer;
 }
 
-.report-table .genus-name {
+.report-table .count-info {
   color: #A0A0A0;
+}
+
+.report-table .genus-name {
   display: inline-block;
   margin-right: 5px;
 
   .fa {
-    margin-right: 10px;
+    margin-left: 5px;
+    font-size: 20px;
+    width: 20px;
     &:hover {
       color: #444242;
     }
+    -webkit-user-select: none;  /* Chrome all / Safari all */
+    -moz-user-select: none;     /* Firefox all */
+    -ms-user-select: none;      /* IE 10+ */
+    user-select: none;          /* Likely future */
   }
 }
 .report-table .species-name {


### PR DESCRIPTION
arrows instead of plus/minus

prevent accidental genus name highlighting when you expand/collapse

revert earlier accidental change in genus name coloring