### PR TITLE
denormalize genus_taxid into taxon_counts

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -102,6 +102,8 @@ class PipelineRun < ApplicationRecord
     po.generate_aggregate_counts('genus')
     # merge more accurate name information from lineages table
     po.update_names
+    # denormalize genus_taxid and superkingdom_taxid into taxon_counts
+    po.update_genera
 
     self.pipeline_output_id = po.id
     save

--- a/db/migrate/20171103202818_add_lineage_ids_to_taxon_count.rb
+++ b/db/migrate/20171103202818_add_lineage_ids_to_taxon_count.rb
@@ -1,0 +1,6 @@
+class AddLineageIdsToTaxonCount < ActiveRecord::Migration[5.1]
+  def change
+    add_column :taxon_counts, :genus_taxid, :integer
+    add_column :taxon_counts, :superkingdom_taxid, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171103180345) do
+ActiveRecord::Schema.define(version: 20171103202818) do
 
   create_table "backgrounds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
@@ -186,6 +186,8 @@ ActiveRecord::Schema.define(version: 20171103180345) do
     t.float "percent_identity", limit: 24
     t.float "alignment_length", limit: 24
     t.float "e_value", limit: 24
+    t.integer "genus_taxid"
+    t.integer "superkingdom_taxid"
     t.index ["pipeline_output_id", "tax_id", "count_type"], name: "new_index_taxon_counts", unique: true
     t.index ["pipeline_output_id", "tax_level", "count_type", "tax_id"], name: "index_taxon_counts", unique: true
     t.index ["pipeline_output_id"], name: "index_taxon_counts_on_pipeline_output_id"

--- a/lib/tasks/genus_aggregation.rake
+++ b/lib/tasks/genus_aggregation.rake
@@ -8,6 +8,7 @@ task genus_aggregation: :environment do
       )
       po.generate_aggregate_counts('genus')
       po.update_names
+      po.update_genera
     end
   end
 end


### PR DESCRIPTION
this speeds up the report query almost 2x

note:  need to run 'rake genus_aggregation' manually after deploying