### PR TITLE
fix subtle sort/filter bug and unrelated navigation state bug

### DIFF
--- a/app/assets/javascripts/components/PipelineSampleReport.jsx
+++ b/app/assets/javascripts/components/PipelineSampleReport.jsx
@@ -59,7 +59,8 @@ class PipelineSampleReport extends React.Component {
   }
 
   isGenusSearch() {
-    return this.props.report_page_params.selected_genus != 'None';
+    params = this.props.report_page_params;
+    return params.selected_genus != 'None' && params.disable_filters != 1;
   }
 
   render_name(tax_info, report_details) {
@@ -232,7 +233,7 @@ class PipelineSampleReport extends React.Component {
                       <span className={`table-arrow ${right_arrow_initial_visibility}`}>
                         <i className={`fa fa-angle-right`} onClick={this.expandTable}></i>
                       </span>
-                      <span className={`table-arrow hidden hidden`}>
+                      <span className={`table-arrow hidden`}>
                         <i className={`fa fa-angle-down`} onClick={this.collapseTable}></i>
                       </span>
                       Taxonomy


### PR DESCRIPTION
This pull request fixes two independent subtle bugs.

First, a bug with sorting and filtering by aggregate score.   This manifested itself by ranking the "All Taxa Without Genera" group very high in the sort order by aggregate score, due to a species contained within that group that has a very high aggregate score.   When that species is filtered out by the default filters, expanding the group reveals only species with very low aggregate scores, which looks to the user like a bug in the tool.   The fix is to define the genus aggregate score as the MAX species aggregate score ONLY OVER SPECIES THAT SURVIVE FILTERS.

Second, a bug that manifests when you do a genus search, and then choose 'disable filters'.   That led to a fully expanded table without any expand/collapse arrows.   The fix is obvious, lead to the fully collapsed table as expected.