### PR TITLE
fix /projects index view

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -9,7 +9,7 @@
       <th>User(s)</th>
       <th>Number of samples</th>
       <th>Date created</th>
-      <th colspan="3"></th>
+      <th colspan="1"></th>
     </tr>
   </thead>
 
@@ -25,8 +25,6 @@
         <td><%= project.samples.count %></td>
         <td><%= project.created_at %></td>
         <td><%= button_to 'Show', project %></td>
-        <td><%= button_to 'Edit', edit_project_path(project) %></td>
-        <td><%= button_to 'Destroy', project, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -24,7 +24,7 @@
         </td>
         <td><%= project.samples.count %></td>
         <td><%= project.created_at %></td>
-        <td><%= button_to 'Show', project %></td>
+        <td><%= button_to 'Show', project_path(project), method: :get %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   resources :projects do
     get :visuals, on: :member
   end
+  get 'projects/:id', to: 'projects#show'
   resources :host_genomes
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]
   mount Resque::Server.new, at: '/resque'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,6 @@ Rails.application.routes.draw do
   resources :projects do
     get :visuals, on: :member
   end
-  get 'projects/:id', to: 'projects#show'
   resources :host_genomes
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]
   mount Resque::Server.new, at: '/resque'


### PR DESCRIPTION
# Description

Fixes bug where clicking on the "show/edit/destroy" buttons in alpha.idseq.net/projects leads to an error. "edit/destroy" buttons are removed for safety, "show" button is implemented correctly so we can inspect projects.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Test and Reproduce
1. go to localhost:3000/projects
2. click on a show button

## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?
- [x] none of the user-facing pages -- only project index view

# Checklist:
- [x] I have done relevant tests that prove my fix is effective or that my feature works

