### PR TITLE
disable heatmap button and restyle sample upload button

### DIFF
--- a/app/assets/javascripts/components/samples.jsx
+++ b/app/assets/javascripts/components/samples.jsx
@@ -224,24 +224,11 @@ class Samples extends React.Component {
         <div className="sub-header-home">
           <div className="sub-header-items">
             <div className="content">
-              <div className="sub-header-buttons right">
-                <ul>
-                  <li>
-                    <a href='/samples/new'>
-                      <i className="fa fa-flask" aria-hidden="true"></i>
-                      <span>Upload Sample</span> 
-                    </a>
-                  </li>
-                  {(this.project) ?
-                  <li>
-                    <a href={`/projects/${this.project.id}/visuals`}>
-                      <i className="fa fa-bar-chart" aria-hidden="true"></i>
-                      <span>Project Heatmap</span>
-                    </a>
-                  </li>
-                  : undefined
-                }
-                </ul>
+              <div  className="upload">
+                <a href='/samples/new'>
+                  <i className="fa fa-flask" aria-hidden="true"/>
+                  <span>Upload Sample</span>
+                </a>
               </div>
 
               <div className="sub-title">

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -65,17 +65,25 @@ i.fa {
       }
     }
   }
-  .sub-header-buttons {
-    ul {
-      li {
-        display: inline-block;
-        margin-right: 15px;
-        color: #4ba4c1;
-        letter-spacing: 0.5px;
-        &:hover {
-          color: #336d80;
-        }
-      }
+  .upload {
+    float: right;
+    margin-top: 18px;
+    padding: 9px 20px;
+    border-radius: 30px;
+    border: 1px solid #4ba4c1;
+    color: #4ba4c1;
+    letter-spacing: 0.5px;
+    font-size: 12px;
+    cursor: pointer;
+    &:hover {
+      border-color: #337388;
+      color: #337388;
+    }
+    span {
+      padding-right: 13px;
+    }
+    .fa-flask {
+      padding: 0 7px;
     }
   }
 


### PR DESCRIPTION
# Description
This PR disables the heatmap button for now

## Type of change
- [x] update ui

## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?
- [x] Home Page

Specific components 
- [x] samples 
# Testing Script:
Clicking on the upload samples button still takes you to the sample page
# Checklist:

- [x] I have run through the testing script to make sure current functionality is unchanged
- [x] I have done relevant tests that prove my fix is effective or that my feature works
- [x] I have spent time testing out edge cases for my feature
- [x] I have updated the test script or pull request template if necessary
- [x] New and existing unit tests pass locally with my changes

