### PR TITLE
make filter-sidebar sticky

### DIFF
--- a/app/assets/javascripts/components/ReportFilter.jsx
+++ b/app/assets/javascripts/components/ReportFilter.jsx
@@ -19,6 +19,21 @@ class ReportFilter extends React.Component {
     this.clearGenusSearch = this.clearGenusSearch.bind(this);
   }
 
+  componentDidMount() {
+    // a polyfill for firefox, but disbaled for now
+    // $(window).resize(() => {
+    //   this.resizeFilterHeight();
+    // });
+  }
+
+  resizeFilterHeight() {
+    const height = window.innerHeight;
+    const subHeader = $('.sub-header-component').height();
+    const headerHeight = $('.site-header').height();
+    const newHeight = height;
+    // $('.reports-sidebar').css('min-height', newHeight);
+  }
+
   static genusSearchValueFor(selected_genus) {
     genus_search_value = selected_genus == 'None' ? '' : selected_genus;
     return {genus_search_value};

--- a/app/assets/stylesheets/reports.scss
+++ b/app/assets/stylesheets/reports.scss
@@ -16,6 +16,15 @@ input[type=number] {
 
 .reports-sidebar {
   background: $sidebar-background;
+  position: sticky;
+  z-index: 1;
+  position: -webkit-sticky;
+  position: -moz-sticky;
+  position: -o-sticky;
+  position: -ms-sticky;
+  top: 0;
+  min-height: -webkit-fill-available !important;
+  border-right: 1px solid rgb(212, 212, 212);
 }
 
 .sidebar-title {


### PR DESCRIPTION
# Description
This PR makes the report filter sidebar sticky so it remains fixed when you scroll the page

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?
- [x] Report Page

Specific components 

* ReportFilter

# Testing Script:

###Report Page
* Data loads succesfully 
* Collapse and Uncollapse button works
* Clicking on the taxonomy name gives you total reads for that taxon
* Category filter works
* Genus Search works
* Filters work as expected
* Disabling Filters works
* Filtering by column works 

# Checklist:

- [x] I have run through the testing script to make sure current functionality is unchanged
- [x] I have done relevant tests that prove my fix is effective or that my feature works
- [x] I have spent time testing out edge cases for my feature
- [x] I have updated the test script or pull request template if necessary
- [x] New and existing unit tests pass locally with my changes

