### PR TITLE
add total run time to pipeline_run_info

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -141,7 +141,7 @@ module SamplesHelper
           run_stages.each do |rs|
             pipeline_run_entry[rs[:name]] = rs.job_status
           end
-          pipeline_run_entry[:total_runtime] = run_stages.map{ |rs| rs.updated_at - rs.created_at }.sum
+          pipeline_run_entry[:total_runtime] = run_stages.map { |rs| rs.updated_at - rs.created_at }.sum
         else
           pipeline_run_status = recent_pipeline_run.job_status
           pipeline_run_entry[:job_status_description] =

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -141,6 +141,7 @@ module SamplesHelper
           run_stages.each do |rs|
             pipeline_run_entry[rs[:name]] = rs.job_status
           end
+          pipeline_run_entry[:total_runtime] = run_stages.map{ |rs| rs.updated_at - rs.created_at }.sum
         else
           pipeline_run_status = recent_pipeline_run.job_status
           pipeline_run_entry[:job_status_description] =


### PR DESCRIPTION
@sadelokiki is this what you need?
@eggerdesigns I haven't seen the new page design, so not sure if this has already been thought of, but I think it would be good if the page specified whether the run time is for initial processing or lazy rerun (the latter will be much faster obviously)