### PR TITLE
load more samples and load more aggressively

### DIFF
--- a/app/assets/javascripts/components/samples.jsx
+++ b/app/assets/javascripts/components/samples.jsx
@@ -49,7 +49,7 @@ class Samples extends React.Component {
     if (e.target.value !== '') {
       this.setState({ searchParams: e.target.value });
     } else {
-      this.setState({ 
+      this.setState({
         searchParams: '',
         pageEnd: false,
         pagesLoaded: 0
@@ -98,7 +98,7 @@ class Samples extends React.Component {
     var hDisplay = h > 0 ? h + (h == 1 ? " hour, " : " hours, ") : "";
     var mDisplay = m > 0 ? m + (m == 1 ? " minute, " : " minutes, ") : "";
     var sDisplay = s > 0 ? s + (s == 1 ? " second" : " seconds") : "";
-    return hDisplay + mDisplay + sDisplay; 
+    return hDisplay + mDisplay + sDisplay;
 }
 
   renderPipelineOutput(samples) {
@@ -129,7 +129,7 @@ class Samples extends React.Component {
               <p className="sample-name">{dbSample.name}</p>
               <p className="uploader">
                 <span>Uploaded {moment(dbSample.created_at).startOf('second').fromNow()}</span>
-                { !uploader || uploader === '' ? '' : <span> | by {uploader}</span>} 
+                { !uploader || uploader === '' ? '' : <span> | by {uploader}</span>}
               </p>
             </div>
             <div className="reads col s1">
@@ -140,7 +140,7 @@ class Samples extends React.Component {
             <div className="reads col s2">
               <p>
               { (!derivedOutput.summary_stats || !derivedOutput.summary_stats.remaining_reads) ? BLANK_TEXT : numberWithCommas(derivedOutput.summary_stats.remaining_reads) }
-              { (!derivedOutput.summary_stats || !derivedOutput.summary_stats.percent_remaining) ? '' : <span className="percent"> {`(${derivedOutput.summary_stats.percent_remaining.toFixed(2)}%)`} </span> } 
+              { (!derivedOutput.summary_stats || !derivedOutput.summary_stats.percent_remaining) ? '' : <span className="percent"> {`(${derivedOutput.summary_stats.percent_remaining.toFixed(2)}%)`} </span> }
               </p>
             </div>
             <div className="reads col s1">
@@ -164,7 +164,7 @@ class Samples extends React.Component {
   scrollDown() {
     var that = this;
     $(window).scroll(function() {
-      if ($(window).scrollTop() > $(document).height() - $(window).height() - 60) {
+     if ($(window).scrollTop() > $(document).height() - $(window).height() - 6000) {
         { !that.state.isRequesting && !that.state.pageEnd ? that.loadMore() : null }
         return false;
       }
@@ -199,12 +199,12 @@ class Samples extends React.Component {
   //fetch all Projects
   fetchProjects() {
     axios.get(`/projects.json`).then((res) => {
-      this.setState({ 
+      this.setState({
         allProjects: res.data,
         loading: false,
       })
     }).catch((err) => {
-      this.setState({ 
+      this.setState({
         allProjects: [],
         loading: false,
       })
@@ -330,12 +330,12 @@ class Samples extends React.Component {
     if (e.target.value !== '' && e.key === 'Enter') {
       this.setState({
         loading: true,
-        pagesLoaded: 0, 
-        pageEnd: false, 
-        searchParams: e.target.value 
+        pagesLoaded: 0,
+        pageEnd: false,
+        searchParams: e.target.value
       }, () => {
         this.setUrlLocation();
-        this.fetchResults(); 
+        this.fetchResults();
       });
     }
   }
@@ -343,8 +343,8 @@ class Samples extends React.Component {
   //Select or switch Project
   switchProject(e) {
     let id = e.target.getAttribute('data-id');
-    this.setState({ 
-      selectedProjectId: id, 
+    this.setState({
+      selectedProjectId: id,
       pageEnd: false
     }, () => {
       this.setUrlLocation();
@@ -364,7 +364,7 @@ class Samples extends React.Component {
     } else {
       projId = parseInt(projId);
       axios.get(`projects/${projId}.json`).then((res) => {
-        this.setState({ 
+        this.setState({
           pagesLoaded: 0,
           project: res.data
         })
@@ -485,12 +485,12 @@ class Samples extends React.Component {
     this.setState({
       loading: true,
       pagesLoaded: 0,
-      pageEnd: false, 
-      filterParams: status 
+      pageEnd: false,
+      filterParams: status
     }, () => {
       this.setUrlLocation();
       this.displayCheckMarks(this.state.filterParams);
-      this.fetchResults(); 
+      this.fetchResults();
     });
   }
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -6,6 +6,7 @@ class SamplesController < ApplicationController
   before_action :set_sample, only: [:show, :edit, :update, :destroy, :reupload_source, :kickoff_pipeline, :pipeline_runs, :save_metadata]
   acts_as_token_authentication_handler_for User, only: [:create, :bulk_upload], fallback: :devise
   protect_from_forgery unless: -> { request.format.json? }
+  PAGE_SIZE = 30
 
   # GET /samples
   # GET /samples.json
@@ -25,7 +26,7 @@ class SamplesController < ApplicationController
     results = results.search(name_search_query) if name_search_query.present?
     results = filter_samples(results, filter_query) if filter_query.present?
 
-    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || 15)
+    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || PAGE_SIZE)
     @samples_count = results.size
     @all_samples = format_samples(@samples)
 


### PR DESCRIPTION
# Description

* Load 30 samples at a time instead of 15
* Load when a user scrolls just a little bit. 
## Type of change

- [X ] New feature (non-breaking change which adds functionality)


# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1.  go to the home page and try to scroll down

## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?

- [ ] Login Screen
- [ ] Single Upload Page
- [ ] Batch Upload Page
- [ X] All Projects Page
- [ ] Sample Details Page
- [ ] Report Page

Specific components 


# Testing Script:

###Login Page
* Successfully login to the application and get taken to the project page

###Single Upload
* Using an AWS path that doesn't exist throws an error
* Succesfully uploaded files from a folder (use test host)
* Uploading a duplicate file throws an error
* Pipeline gets initiated successfully 

###Batch Upload
* Using an AWS path that doesn't exist throws an error
* Succesfully uploaded files from a folder (use test host)
* Navigate to batch upload settings page after upload 
* Host selection from previous page still selected 
* Uploading a duplicate file throws a warning
* Pipeline gets initiated successfully 

###All Project Page
* Switch between projects 
* Search for a sample
* Navigate through different pages of samples
* Select Upload new sample button
* Select sample to see generated report

###Sample Details Page
* Information is consistent from Project Page
* Notes are editable and save successfully 
* Can navigate to report page 

###Report Page
* Data loads succesfully 
* Collapse and Uncollapse button works
* Clicking on the taxonomy name gives you total reads for that taxon
* Category filter works
* Genus Search works
* Filters work as expected
* Disabling Filters works
* Filtering by column works 

# Checklist:

- [X ] I have run through the testing script to make sure current functionality is unchanged
- [X ] I have done relevant tests that prove my fix is effective or that my feature works
- [X ] I have spent time testing out edge cases for my feature
- [X ] I have updated the test script or pull request template if necessary
- [X ] New and existing unit tests pass locally with my changes

