### PR TITLE
Airbrake if pipeline run fails

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -77,7 +77,7 @@ class PipelineRun < ApplicationRecord
       if prs.failed?
         self.finalized = 1
         self.job_status = "#{prs.step_number}.#{prs.name}-#{STATUS_FAILED}"
-        Airbrake.notify("Sample #{sample.id} failed #{prs.step_number}.#{prs.name}")
+        Airbrake.notify("Sample #{sample.id} failed #{prs.name}")
         return nil
       elsif prs.succeeded?
         next

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -77,6 +77,7 @@ class PipelineRun < ApplicationRecord
       if prs.failed?
         self.finalized = 1
         self.job_status = "#{prs.step_number}.#{prs.name}-#{STATUS_FAILED}"
+        Airbrake.notify("Sample #{sample.id} failed #{prs.step_number}.#{prs.name}")
         return nil
       elsif prs.succeeded?
         next


### PR DESCRIPTION
# Description
Airbrake notifications for every sample that fails. As we are rolling out the app to more people, we should probably tightly supervise any failures and solve them immediately