### PR TITLE
switch to using private ip addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Sometimes you may be prompted to run a migration or configuration command like `
 
 ## DB backup/restore within and across environments
 
+Note that this requires the proper ssh config to access the deployed versions of the site. That info is deployment specific, so check with a teammate.
+
 1. Backup your local `development` DB into a local file:
 `docker-compose exec web mysqldump -h db -u root idseq_development | gzip -c > idseq_development.sql.gz`
 1. Backup cloud `alpha` DB into a local file:

--- a/bin/clam
+++ b/bin/clam
@@ -20,7 +20,7 @@
 ENV=$1
 shift
 
-MACHINE=`bin/get_public_ip $ENV`
+MACHINE=`bin/get_private_ip $ENV`
 
 CONTAINER=`ssh ec2-user@$MACHINE "docker ps | grep ecs-idseq-web | head -1" | awk '{print $NF}'`
 

--- a/bin/get_private_ip
+++ b/bin/get_private_ip
@@ -7,10 +7,8 @@ require 'aws-sdk-ec2'
 require 'pp'
 
 env = ARGV.shift
-command = ARGV.shift || "rails console"
 if !env
-  puts 'Usage: ./bin/shell ENV [COMMAND]'
-  puts '  COMMAND: default is "rails console"'
+  puts 'Usage: ./bin/get_private_ip ENV'
   abort
 end
 
@@ -29,14 +27,6 @@ instances = ecs_client.describe_container_instances(cluster: env,
 
 resp = ec2_client.describe_instances(instance_ids: [instances.container_instances[0].ec2_instance_id])
 
-public_ip = resp.reservations.first.instances.first.public_ip_address
+private_ip = resp.reservations.first.instances.first.private_ip_address
 
-puts public_ip
-
-#exec %(ssh -t ec2-user@#{public_ip} "echo docker exec -it \\`docker ps | grep chanzuckerberg/idseq-web | head -1 | awk '{print \\$NF}'\\` #{command} ")
-
-#idseq_web_container = `ssh ec2-user@#{public_ip} "docker ps | grep chanzuckerberg/idseq-web | head -1 | awk '{print \\$NF}'"`.strip
-
-#puts "ssh ec2-user@#{public_ip} 'docker exec #{idseq_web_container} /bin/bash -c '"
-
-#exec %(ssh ec2-user@#{public_ip} 'docker exec #{idseq_web_container} /bin/bash -c "echo \$HOSTNAME mysqldump -h \$RDS_ADDRESS -u \$DB_USERNAME --password=\$DB_PASSWORD idseq_dev"')
+puts private_ip

--- a/bin/shell
+++ b/bin/shell
@@ -29,6 +29,6 @@ instances = ecs_client.describe_container_instances(cluster: env,
 
 resp = ec2_client.describe_instances(instance_ids: [instances.container_instances[0].ec2_instance_id])
 
-public_ip = resp.reservations.first.instances.first.public_ip_address
+private_ip = resp.reservations.first.instances.first.private_ip_address
 
-exec %(ssh -t ec2-user@#{public_ip} "docker exec -it \\`docker ps | grep ecs-idseq-web | head -1 | awk '{print \\$NF}'\\` #{command} ")
+exec %(ssh -t ec2-user@#{private_ip} "docker exec -it \\`docker ps | grep ecs-idseq-web | head -1 | awk '{print \\$NF}'\\` #{command} ")


### PR DESCRIPTION
# Description

This switches the commands in ./bin to use private IPs rather than public.

This changes is because you will soon need to use a bastion and access the ECS cluster by private IP addresses.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)
- [X] infra/security improvment

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. use bin/shell or bin/clam

## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?

none

Specific components 

