### PR TITLE
increase gsnapl max-mismatches

### DIFF
--- a/aws_batch/non_host_alignment.py
+++ b/aws_batch/non_host_alignment.py
@@ -530,7 +530,7 @@ def run_gsnapl_chunk(part_suffix, remote_home_dir, remote_index_dir, remote_work
                               '-A', 'm8', '--batch=2',
                               '--gmap-mode=none', '--npaths=1', '--ordered',
                               '-t', '32',
-                              '--maxsearch=5', '--max-mismatches=20',
+                              '--maxsearch=5', '--max-mismatches=40',
                               '-D', remote_index_dir, '-d', 'nt_k16']
                               + [remote_work_dir+'/'+input_fa for input_fa in input_files]
                               + ['> '+remote_outfile, ';'])


### PR DESCRIPTION
2017 version of GSNAP calculates mismatches over entire read rather than aligned portion as for 2105 version. This results in lower sensitivity for the same value of --max-mismatches. A value of 40 instead of 20 gives most of the desired hits without causing catastrophic loss of specificity.

Merge only once we're ready to receive results with a different sensitivity standard compared to previous ones.
  