### PR TITLE
Charles/re org pipeline run

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -25,7 +25,7 @@ class PipelineRun < ApplicationRecord
   after_create :kickoff_job
 
   def archive_s3_path
-    's3://#{SAMPLES_BUCKET_NAME}/pipeline_runs/#{id}'
+    "s3://#{SAMPLES_BUCKET_NAME}/pipeline_runs/#{id}"
   end
 
   def self.in_progress

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -24,6 +24,10 @@ class PipelineRun < ApplicationRecord
   before_save :check_job_status
   after_create :kickoff_job
 
+  def archive_s3_path
+    's3://#{SAMPLES_BUCKET_NAME}/pipeline_runs/#{id}'
+  end
+
   def self.in_progress
     where("job_status != '#{STATUS_FAILED}' OR job_status IS NULL")
       .where(finalized: 0)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -25,7 +25,7 @@ class PipelineRun < ApplicationRecord
   after_create :kickoff_job
 
   def archive_s3_path
-    "s3://#{SAMPLES_BUCKET_NAME}/pipeline_runs/#{id}"
+    "s3://#{SAMPLES_BUCKET_NAME}/pipeline_runs/#{id}_sample#{sample.id}"
   end
 
   def self.in_progress

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -223,8 +223,8 @@ class Sample < ApplicationRecord
       _stdout, _stderr, status = Open3.capture3(command)
       # Delete pipeline_run
       if !File.zero?(file.path) && status.exitstatus.zero?
-        pr.pipeline_run_stages.destroy_all
-        pr.destroy
+        PipelineRunStage.where(pipeline_run_id: pr.id).delete_all
+        PipelineRun.delete(pr.id)
       end
       file.unlink
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -230,7 +230,7 @@ class Sample < ApplicationRecord
       # Delete any taxon_counts / taxon_byteranges associated with the pipeline run
       po = pr.pipeline_output
       next unless po
-      if !File.zero?(file.path) && status.exitstatus.zero?
+      if !File.zero?(file.path) && status.exitstatus && status.exitstatus.zero?
         TaxonCount.where(pipeline_output_id: po.id).delete_all
         TaxonByterange.where(pipeline_output_id: po.id).delete_all
       end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -218,7 +218,8 @@ class Sample < ApplicationRecord
       file.write(pr.to_json(include: :pipeline_run_stages))
       file.close
       # Copy file to S3
-      command = "aws s3 cp #{file.path} #{pr.archive_s3_path}/"
+      pr_s3_file_name = "pipeline_run_#{pr.id}.json"
+      command = "aws s3 cp #{file.path} #{pr.archive_s3_path}/#{pr_s3_file_name}"
       _stdout, _stderr, status = Open3.capture3(command)
       # Delete pipeline_run
       if !File.zero?(file.path) && status.exitstatus.zero?

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'json'
+require 'tempfile'
 
 class Sample < ApplicationRecord
   STATUS_CREATED  = 'created'.freeze
@@ -209,6 +210,25 @@ class Sample < ApplicationRecord
     kickoff_pipeline
   end
 
+  def archive_old_pipeline_runs
+    old_pipeline_runs = pipeline_runs.order('id desc').offset(1)
+    old_pipeline_runs.each do |pr|
+      # Write pipeline_run data to file
+      file = Tempfile.new
+      file.write(pr.to_json(include: :pipeline_run_stages))
+      file.close
+      # Copy file to S3
+      command = "aws s3 cp #{file.path} #{pr.archive_s3_path}/"
+      _stdout, _stderr, status = Open3.capture3(command)
+      # Delete pipeline_run
+      if !File.zero?(file.path) && status.exitstatus.zero?
+        pr.pipeline_run_stages.destroy_all
+        pr.destroy
+      end
+      file.unlink
+    end
+  end
+
   def kickoff_pipeline
     # only kickoff pipeline when no active pipeline_run running
     return unless pipeline_runs.in_progress.empty?
@@ -216,5 +236,7 @@ class Sample < ApplicationRecord
     pr = PipelineRun.new
     pr.sample = self
     pr.save
+
+    archive_old_pipeline_runs
   end
 end

--- a/lib/tasks/archive_all_old_pipeline_runs.rake
+++ b/lib/tasks/archive_all_old_pipeline_runs.rake
@@ -1,5 +1,3 @@
 task archive_all_old_pipeline_runs: :environment do
-  Sample.all.each do |sample|
-    sample.archive_old_pipeline_runs
-  end
+  Sample.all.each(&:archive_old_pipeline_runs)
 end

--- a/lib/tasks/archive_all_old_pipeline_runs.rake
+++ b/lib/tasks/archive_all_old_pipeline_runs.rake
@@ -1,0 +1,5 @@
+task archive_all_old_pipeline_runs: :environment do
+  Sample.all.each do |sample|
+    sample.archive_old_pipeline_runs
+  end
+end


### PR DESCRIPTION
# Description
When a new pipeline_run is kicked off, the info on older pipeline_runs for the sample should get archived in a file in S3. 
There is a rake task for one-time use to archive all existing pipeline_runs, except the most recent one for each sample.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Call the function archive_old_pipeline_runs on a sample with multiple pipeline_runs. All but the most recent one should get archived in "s3://czbiohub-idseq-samples-development/pipeline_runs/#{id}" and deleted from the mysql database.

2. Rerun a sample and verify that a new pipeline_run gets created and older ones get archived as above.

3. Run the rake task to see if archiving works in bulk for all samples.

## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?
- samples/all page
- sample upload