### PR TITLE
tweak gsnap options for i3.16xlarge according to perf experimenrts

### DIFF
--- a/aws_batch/non_host_alignment.py
+++ b/aws_batch/non_host_alignment.py
@@ -40,7 +40,7 @@ FILE_TYPE = 'fastq.gz'
 ENVIRONMENT = 'production'
 
 # compute capacity
-GSNAPL_MAX_CONCURRENT = 20 # number of gsnapl jobs allowed to run concurrently on 1 machine
+GSNAPL_MAX_CONCURRENT = 5 # number of gsnapl jobs allowed to run concurrently on 1 machine
 RAPSEARCH2_MAX_CONCURRENT = 3
 GSNAPL_CHUNK_SIZE = 30000 # number of fasta records in a chunk
 RAPSEARCH_CHUNK_SIZE = 10000
@@ -537,8 +537,8 @@ def run_gsnapl_chunk(part_suffix, remote_home_dir, remote_index_dir, remote_work
             commands += "aws s3 cp %s/%s %s/ ; " % \
                      (SAMPLE_S3_OUTPUT_CHUNKS_PATH, input_fa, remote_work_dir)
         commands += " ".join([remote_home_dir+'/bin/gsnapl',
-                              '-A', 'm8', '--batch=2',
-                              '--gmap-mode=none', '--npaths=1',
+                              '-A', 'm8', '--batch=0', '--use-shared-memory=0',
+                              '--gmap-mode=none', '--npaths=1', '--ordered',
                               '-t', '32',
                               '--maxsearch=5', '--max-mismatches=20',
                               '-D', remote_index_dir, '-d', 'nt_k16']
@@ -775,7 +775,7 @@ def run_stage2(lazy_run = True):
         generate_merged_fasta(cleaned_files, _merged_fasta)
         execute_command("aws s3 cp %s %s/" % (_merged_fasta, SAMPLE_S3_OUTPUT_PATH))
 
-    # Make sure there are no tabs in sequence names, since tabs are used as a delimiter in m8 files    
+    # Make sure there are no tabs in sequence names, since tabs are used as a delimiter in m8 files
     files_to_collapse_basenames = _gsnapl_input_files + [EXTRACT_UNMAPPED_FROM_SAM_OUT3]
     collapsed_files = ["%s/nospace.%s" % (RESULT_DIR, f) for f in files_to_collapse_basenames]
     for file_basename in files_to_collapse_basenames:

--- a/aws_batch/pipeline.py
+++ b/aws_batch/pipeline.py
@@ -38,7 +38,7 @@ BOWTIE2="bowtie2"
 
 LZW_FRACTION_CUTOFF = 0.45
 
-GSNAPL_MAX_CONCURRENT = 20
+GSNAPL_MAX_CONCURRENT = 5
 RAPSEARCH2_MAX_CONCURRENT = 5
 
 STAR_GENOME = 's3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz'
@@ -1194,7 +1194,7 @@ def run_gsnapl_remotely(sample, input_files,
         commands += "aws s3 cp %s/%s %s/ ; " % \
                  (sample_s3_output_path, input_fa, remote_work_dir)
     commands += " ".join([remote_home_dir+'/bin/gsnapl',
-                          '-A', 'm8', '--batch=2',
+                          '-A', 'm8', '--batch=0', '--use-shared-memory=0',
                           '--gmap-mode=none', '--npaths=1', '--ordered',
                           '-t', '32',
                           '--maxsearch=5', '--max-mismatches=20',


### PR DESCRIPTION
pasting from experiment report published in slack proj-biohub
on Nov 21, 2017:

bdimitrov [7:16 PM]
My recommendation is to split paired-end reads jobs into chunks of 31,000 reads.
A chunk running alone on a 64 vCPU machine should take 5 minutes.
About 90% of max throughput is achieved running 4 chunks concurrently
with -t 32 each, in batch mode 0.   Command:

nohup time /mnt/nvme_raid8/gmap-gsnap/src/gsnapl.avx2 -A m8 --batch=0 --use-shared-memory=0 --gmap-mode=none --npaths=1 --ordered -t 32 --maxsearch=5  -D /mnt/nvme_raid8/chunked/nt_k16 -d nt_k16 r1.fasta.3 r2.fasta.3 &> chunk_3.m8 &

I've tried a variety of other scenarios, but this is overall the best.
Each chunk slows down from 5min to 8m 20s, but overall throughput
is nearly doubled.

The number of concurrent chunks can be increased quite a bit (I tried 3,4,5,6,7,8)
and nothing bad happens;  this is very convenient when scaling up/down based on load.
Throughput peaks at 5 whereas latency is best at 2.   For bigger jobs, even the
overall job latency is more determined by throughput, so my recommendation is 4,
skewed toward higher throughput .   If we found that the majority of jobs were tiny,
we could set it to 3.   Note each chunk gets 32 threads so it can use the entire
CPU if no other chunks are runnig.

  