### PR TITLE
change column type of archived background data from json to text

### DIFF
--- a/app/controllers/backgrounds_controller.rb
+++ b/app/controllers/backgrounds_controller.rb
@@ -41,7 +41,7 @@ class BackgroundsController < ApplicationController
   # PATCH/PUT /backgrounds/1
   # PATCH/PUT /backgrounds/1.json
   def update
-    current_data = @background.as_json(include: [{ pipeline_outputs: { only: [:id, :pipeline_run_id] } },
+    current_data = @background.to_json(include: [{ pipeline_outputs: { only: [:id, :pipeline_run_id] } },
                                                  { samples: { only: :id } }])
     current_data_full_string = @background.to_json(include: [{ pipeline_outputs: { only: [:id, :pipeline_run_id] } },
                                                              { samples: { only: :id } },

--- a/db/migrate/20180110233619_change_column_type_archived_background_data.rb
+++ b/db/migrate/20180110233619_change_column_type_archived_background_data.rb
@@ -1,0 +1,5 @@
+class ChangeColumnTypeArchivedBackgroundData < ActiveRecord::Migration[5.1]
+  def change
+    change_column :archived_backgrounds, :data, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180108234340) do
+ActiveRecord::Schema.define(version: 20180110233619) do
 
   create_table "archived_backgrounds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "archive_of"
-    t.json "data"
+    t.text "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "s3_backup_path"


### PR DESCRIPTION
json is new in MySQL 5.7.8 and thus not yet supported on Aurora
