### PR TITLE
Showing s3 data in app

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -4,7 +4,7 @@ class SamplesController < ApplicationController
   include PipelineOutputsHelper
 
   before_action :authenticate_user!, only: [:new, :index, :update, :destroy, :edit, :show, :reupload_source, :kickoff_pipeline, :bulk_new, :bulk_import, :bulk_upload]
-  before_action :set_sample, only: [:show, :edit, :update, :destroy, :reupload_source, :kickoff_pipeline, :pipeline_runs, :save_metadata, :report_info, :search_list, :report_csv, :show_taxid_fasta, :nonhost_fasta, :unidentified_fasta]
+  before_action :set_sample, only: [:show, :edit, :update, :destroy, :reupload_source, :kickoff_pipeline, :pipeline_runs, :save_metadata, :report_info, :search_list, :report_csv, :show_taxid_fasta, :nonhost_fasta, :unidentified_fasta, :results_folder, :fastqs_folder]
   acts_as_token_authentication_handler_for User, only: [:create, :bulk_upload], fallback: :devise
   protect_from_forgery unless: -> { request.format.json? }
   PAGE_SIZE = 30
@@ -214,6 +214,18 @@ class SamplesController < ApplicationController
   def unidentified_fasta
     @unidentified_fasta = get_s3_file(@sample.unidentified_fasta_s3_path)
     send_data @unidentified_fasta, filename: @sample.name + '_unidentified.fasta'
+  end
+
+  def results_folder
+    @file_list = @sample.get_results_folder_files
+    @file_path = "#{@sample.sample_path}/results/"
+    render template: "samples/folder"
+  end
+
+  def fastqs_folder
+    @file_list = @sample.get_fastqs_folder_files
+    @file_path = "#{@sample.sample_path}/fastqs/"
+    render template: "samples/folder"
   end
 
   # GET /samples/new

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -217,13 +217,13 @@ class SamplesController < ApplicationController
   end
 
   def results_folder
-    @file_list = @sample.get_results_folder_files
+    @file_list = @sample.results_folder_files
     @file_path = "#{@sample.sample_path}/results/"
     render template: "samples/folder"
   end
 
   def fastqs_folder
-    @file_list = @sample.get_fastqs_folder_files
+    @file_list = @sample.fastqs_folder_files
     @file_path = "#{@sample.sample_path}/fastqs/"
     render template: "samples/folder"
   end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -78,6 +78,33 @@ class Sample < ApplicationRecord
     end
   end
 
+  def self.get_signed_url(s3key)
+    begin
+      if s3key && !s3key.empty?
+        return S3_PRESIGNER.presigned_url(:get_object,
+          bucket: SAMPLES_BUCKET_NAME, key: s3key,
+          expires_in: SAMPLE_DOWNLOAD_EXPIRATION).to_s
+      end
+    rescue Exception => e
+      puts "AWS error: #{e.inspect}"
+    end
+    return nil
+  end
+
+  def get_results_folder_files
+    file_list = S3_CLIENT.list_objects(bucket: SAMPLES_BUCKET_NAME,
+                                       prefix: "#{sample_path}/results/",
+                                       delimiter: "/")
+    file_list.contents.map { |f| {key: f.key, url: Sample.get_signed_url(f.key) } }
+  end
+
+  def get_fastqs_folder_files
+    file_list = S3_CLIENT.list_objects(bucket: SAMPLES_BUCKET_NAME,
+                                       prefix: "#{sample_path}/fastqs/",
+                                       delimiter: "/")
+    file_list.contents.map { |f| {key: f.key, url: Sample.get_signed_url(f.key) } }
+  end
+
   def initiate_input_file_upload
     return unless input_files.first.source_type == InputFile::SOURCE_TYPE_S3
     Resque.enqueue(InitiateS3Cp, id)
@@ -163,6 +190,7 @@ class Sample < ApplicationRecord
     super(methods: [:sample_input_folder_url, :sample_output_folder_url, :sample_annotated_fasta_url, :input_files,
                     :sample_unidentified_fasta_url, :host_genome_name])
   end
+
 
   def postprocess_batch_command
     postprocess_script_name = File.basename(IdSeqPipeline::S3_POSTPROCESS_SCRIPT_LOC)

--- a/app/views/samples/folder.html.erb
+++ b/app/views/samples/folder.html.erb
@@ -1,0 +1,17 @@
+<h3><%= @file_path %> > </h3>
+<div>
+<% if @file_list.count == 0 %>
+No files under this directory
+<% else %>
+<ul>
+  <% @file_list.each do |file| %>
+    <li>
+      <a class="custom-button" style= "margin: 0" href=<%= file[:url] %> >
+        <i class="fa fa-cloud-download"></i>
+        <%= file[:key].split("/")[-1] %>
+      </a>
+    </li>
+  <% end %>
+</ul>
+<% end %>
+</div>

--- a/config/initializers/s3_presigner.rb
+++ b/config/initializers/s3_presigner.rb
@@ -1,2 +1,4 @@
-S3_PRESIGNER = Aws::S3::Presigner.new # auth from the env
+S3_CLIENT = Aws::S3::Client.new
+S3_PRESIGNER = Aws::S3::Presigner.new(client: S3_CLIENT) # auth from the env
 SAMPLES_BUCKET_NAME = ENV['SAMPLES_BUCKET_NAME']
+SAMPLE_DOWNLOAD_EXPIRATION = 3600 # seconds

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
     get :bulk_import, on: :collection
     get :nonhost_fasta, on: :member
     get :unidentified_fasta, on: :member
+    get :results_folder, on: :member
+    get :fastqs_folder, on: :member
     post :bulk_upload, on: :collection
     post :save_metadata, on: :member
   end


### PR DESCRIPTION
# Description

Download data directly from the idseq app instead of having to log into the AWS account to download the files. (This is part of the idseq permissions/access controls) so people can't go to the S3 bucket directly to access data. 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Two new urls for each sample 
1. http://localhost:3000/samples/<sample_id>/results_folder 
2. http://localhost:3000/samples/<sample_id>/fastqs_folder  

Once this is done, the links to the source and results folders on sample details page should be changed to above

## Impacted Areas in Application
List general components of the application that this PR will affect:

Nothing for now. But once it's approved and merged, next step is to clean up the UI and change the urls on the sample details page

Which pages?

- [ ] Login Screen
- [ ] Single Upload Page
- [ ] Batch Upload Page
- [ ] All Projects Page
- [ X] Sample Details Page
- [ ] Report Page

Specific components 

* 

# Testing Script:

###Login Page
* Successfully login to the application and get taken to the project page

###Single Upload
* Using an AWS path that doesn't exist throws an error
* Succesfully uploaded files from a folder (use test host)
* Uploading a duplicate file throws an error
* Pipeline gets initiated successfully 

###Batch Upload
* Using an AWS path that doesn't exist throws an error
* Succesfully uploaded files from a folder (use test host)
* Navigate to batch upload settings page after upload 
* Host selection from previous page still selected 
* Uploading a duplicate file throws a warning
* Pipeline gets initiated successfully 

###All Project Page
* Switch between projects 
* Search for a sample
* Navigate through different pages of samples
* Select Upload new sample button
* Select sample to see generated report

###Sample Details Page
* Information is consistent from Project Page
* Notes are editable and save successfully 
* Can navigate to report page 

###Report Page
* Data loads succesfully 
* Collapse and Uncollapse button works
* Clicking on the taxonomy name gives you total reads for that taxon
* Category filter works
* Genus Search works
* Filters work as expected
* Disabling Filters works
* Filtering by column works 

# Checklist:

- [ ] I have run through the testing script to make sure current functionality is unchanged
- [ ] I have done relevant tests that prove my fix is effective or that my feature works
- [ ] I have spent time testing out edge cases for my feature
- [ ] I have updated the test script or pull request template if necessary
- [ ] New and existing unit tests pass locally with my changes

