### PR TITLE
re-decorate create button for adding project visibility

### DIFF
--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -69,6 +69,7 @@ class BulkUploadImport extends React.Component {
 
   toggleNewProjectInput(e) {
     $('.new-project-input').slideToggle();
+    $('.new-project-input  .input-icon').slideToggle();
     $('.new-project-button').toggleClass('active');
     this.setState({
       disableProjectSelect: !this.state.disableProjectSelect
@@ -580,6 +581,13 @@ class BulkUploadImport extends React.Component {
                     </div>
                     <div className='col no-padding s12 new-project-input hidden'>
                       <input type='text' ref='new_project' onFocus={ this.clearError } className='browser-default' placeholder='Input new project name' />
+                      <Tipsy content='Create project'
+                        placement='right'>
+                        <i className="fa fa-check-circle input-icon hidden"
+                          onClick={(e) => { if (this.refs.new_project.value.trim().length) {this.handleProjectSubmit()};
+                            $('.new-project-button').click();}}>
+                        </i>
+                      </Tipsy>
                       {
                         (this.state.errors.new_project) ?
                           <div className='field-error'>
@@ -587,18 +595,10 @@ class BulkUploadImport extends React.Component {
                           </div> : null
                       }
                     </div>
-                    <div className='col no-padding s8 new-project-input hidden'>
+                    <div className='col no-padding 12 new-project-input public_access hidden'>
                       <input ref="public_checked" type="checkbox" name="switch" id="public_checked" className="col s8 filled-in" onChange={ this.toggleCheckBox }
                              value={ this.state.public_checked } />
                       <label htmlFor="public_checked" className="checkbox">Make project public</label>
-                    </div>
-                    <div className='col no-padding s4 new-project-input hidden'>
-                      <button type='button'
-                              onClick={(e) => { if (this.refs.new_project.value.trim().length) {this.handleProjectSubmit()};
-                                                $('.new-project-button').click(); }}
-                              className='no-padding new-button skyblue-button'>
-                        <span>Create</span>
-                      </button>
                     </div>
                   </div>
                 </div>

--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -438,6 +438,7 @@ class SampleUpload extends React.Component {
 
   toggleNewProjectInput(e) {
     $('.new-project-input').slideToggle();
+    $('.new-project-input  .input-icon').slideToggle();
     $('.new-project-button').toggleClass('active');
     this.setState({
       disableProjectSelect: !this.state.disableProjectSelect
@@ -637,7 +638,14 @@ class SampleUpload extends React.Component {
                       </Tipsy>
                     </div>
                     <div className='col no-padding s12 new-project-input hidden'>
-                      <input type='text' ref='new_project' onFocus={ this.clearError } className='browser-default' placeholder='Input new project name' />
+                      <input type='text' ref='new_project' onFocus={ this.clearError } className='browser-default new_project_input' placeholder='Input new project name' />
+                      <Tipsy content='Create project'
+                        placement='right'>
+                        <i className="fa fa-check-circle input-icon hidden"
+                          onClick={(e) => { if (this.refs.new_project.value.trim().length) {this.handleProjectSubmit()};
+                            $('.new-project-button').click();}}>
+                        </i>
+                      </Tipsy>
                       {
                         (this.state.errors.new_project) ?
                           <div className='field-error'>
@@ -645,18 +653,10 @@ class SampleUpload extends React.Component {
                           </div> : null
                       }
                     </div>
-                    <div className='col no-padding s8 new-project-input hidden'>
+                    <div className='col no-padding s12 new-project-input public_access hidden'>
                       <input ref="public_checked" type="checkbox" name="switch" id="public_checked" className="col s8 filled-in" onChange={ this.toggleCheckBox }
                              value={ this.state.public_checked } />
                       <label htmlFor="public_checked" className="checkbox">Make project public</label>
-                    </div>
-                    <div className='col no-padding s4 new-project-input hidden'>
-                      <button type='button'
-                              onClick={(e) => { if (this.refs.new_project.value.trim().length) {this.handleProjectSubmit()};
-                                                $('.new-project-button').click(); }}
-                              className='no-padding new-button skyblue-button'>
-                        <span>Create</span>
-                      </button>
                     </div>
                   </div>
                 </div>

--- a/app/assets/src/styles/samplesUpload.scss
+++ b/app/assets/src/styles/samplesUpload.scss
@@ -61,6 +61,9 @@
                 padding: 10px;
                 border: 1px solid #CAD0DA;
                 background: #fff;
+                &.new_project_input {
+                  padding-right: 45px;
+                }
               }
               .checkbox {
                 font-size: 12px;
@@ -70,6 +73,23 @@
               [disabled] {
                 background: #EEF1F2;
                 border: #CAD0DA;
+              }
+              .input-icon {
+                position: absolute;
+                margin-left: -43px;
+                margin-top: 1px;
+                font-size: 30px;
+                background: #eef1f2;
+                padding: 5px;
+                width: 42px;
+                text-align: center;
+                &:hover {
+                  background: #c3dde5;
+                  color: #4c9db1;
+                }
+              }
+              .public_access {
+                margin-top: 5px;
               }
             }
 


### PR DESCRIPTION
# Description
This PR restyles the button for adding a new project when uploading a sample

## Type of change
- [x] New feature (non-breaking change which adds functionality)



## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?

- [x] Single Upload Page
- [x] Bulk Upload Page

Specific components 

* SampleUpload

# Testing Script:

###Login Page
* Successfully login to the application and get taken to the project page

### Single Upload
* Using an AWS path that doesn't exist throws an error
* Successfully uploaded files from a folder (use test host)
* Uploading a duplicate file throws an error
* Pipeline gets initiated successfully 

### Batch Upload
* Using an AWS path that doesn't exist throws an error
* Successfully uploaded files from a folder (use test host)
* Navigate to batch upload settings page after upload 
* Host selection from the previous page still selected 
* Uploading a duplicate file throws a warning
* Pipeline gets initiated successfully 

# Checklist:

- [x] I have run the testing script to make sure current functionality is unchanged
- [x] I have done relevant tests that prove my fix is effective or that my feature works
- [x] I have spent time testing out edge cases for my feature
- [x] I have updated the test script or pull request template if necessary
- [x] New and existing unit tests pass locally with my changes

