### PR TITLE
a naive autoscaler

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=8192
+disable: C0111, C0103, C0121, R0913, W0702, R0915, R0914, W0614, C1801, C0302, R0903

--- a/app/jobs/autoscaling.py
+++ b/app/jobs/autoscaling.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+import json
+import os
+import sys
+import subprocess
+import time
+import hashlib
+import random
+from functools import wraps
+
+
+# As opposed to "development", where different containers belong to different developers.
+MULTICONTAINER_ENVIRONMENTS = ["production", "alpha"]
+
+# If you are running into problems with this autoscaler, just delete this tag from
+# any affected autoscaling group, and it will be left alone.  The value is a list
+# of environments permitted to trigger scaling, usually just "production".
+SCALING_PERMISSION_TAG = "IDSeqEnvsThatCanScale"
+
+
+SCALING_METRIC_TAG_PREFIX = "IDSeqScalingData_"
+SCALING_METRIC_TAG_FORMAT = SCALING_METRIC_TAG_PREFIX + "{environment}"
+
+
+# A value recorded this many minutes earlier will be ignored
+EXPIRATION_PERIOD_MINUTES = 60
+
+
+DEBUG = False
+
+
+def retry(operation, randgen=random.Random().random):
+    # Note the use of a separate random generator for retries so transient
+    # errors won't perturb other random streams used in the application.
+    @wraps(operation)
+    def wrapped_operation(*args, **kwargs):
+        remaining_attempts = 3
+        delay = 1.0
+        while remaining_attempts > 1:
+            try:
+                return operation(*args, **kwargs)
+            except:
+                time.sleep(delay * (1.0 + randgen()))
+                delay *= 3.0
+                remaining_attempts -= 1
+        # The last attempt is outside try/catch so caller can handle exception
+        return operation(*args, **kwargs)
+    return wrapped_operation
+
+
+@retry
+def aws_command(command_str):
+    return subprocess.check_output(command_str.split())
+
+
+def find_asg(asg_list, name_prefix):
+    matching = []
+    for asg in asg_list:
+        if asg['AutoScalingGroupName'].startswith(name_prefix):
+            matching.append(asg)
+    assert len(matching) == 1
+    return matching[0]
+
+
+def at_most(upper_limit):
+    return lambda n: min(n, upper_limit)
+
+
+def at_least(lower_limit):
+    return lambda n: max(n, lower_limit)
+
+
+def exactly(value):
+    return lambda _n: value
+
+
+def get_tag(asg, tag_key):
+    for tag in asg['Tags']:
+        if tag['Key'] == tag_key:
+            return tag['Value']
+    return None
+
+
+def get_tags_by_prefix(asg, tag_key_prefix):
+    results = {}
+    for tag in asg['Tags']:
+        if tag['Key'].startswith(tag_key_prefix):
+            assert tag['Key'] not in results
+            results[tag['Key']] = tag['Value']
+    return results
+
+
+def set_tag(asg, key, value):
+    cmd = "aws autoscaling create-or-update-tags --tags ResourceId={asg_name},ResourceType=auto-scaling-group,Key={key},Value={value},PropagateAtLaunch=false"
+    cmd = cmd.format(asg_name=asg['AutoScalingGroupName'], key=key, value=value)
+    if DEBUG:
+        print cmd
+    aws_command(cmd)
+
+
+def set_metric_value(asg, value, my_environment):
+    tag_key = SCALING_METRIC_TAG_FORMAT.format(environment=my_environment)
+    # parsed in update_metric_values
+    tag_value = "{unixtime:d}::{value:d}".format(unixtime=int(time.time()), value=int(value))
+    set_tag(asg, tag_key, tag_value)
+    return (tag_key, tag_value)
+
+
+def delete_expired_metric_tags(asg, garbage_tag_keys):
+    # Gargbage collect expired development (non-cloud) environment tags so as to stay below the aws 50 tags limit.
+    garbage_tags = []
+    tag_pattern = "ResourceId={asg_name},ResourceType=auto-scaling-group,Key={key}"
+    for gtk in garbage_tag_keys:
+        if gtk.split("_", 1) not in MULTICONTAINER_ENVIRONMENTS:
+            garbage_tags.append(tag_pattern.format(asg_name=asg['AutoScalingGroupName'], key=gtk))
+    if garbage_tags:
+        cmd = "aws autoscaling delete-tags --tags " + " ".join(garbage_tags)
+        if DEBUG:
+            print cmd
+        aws_command(cmd)
+
+
+def permission_to_scale(asg, my_environment):
+    allowed_envs = get_tag(asg, SCALING_PERMISSION_TAG)
+    if allowed_envs == None:
+        # Let's hope this never overwrites anything important.
+        # set_tag(asg, SCALING_PERMISSION_TAG, "joe_test_123")
+        return False
+    return my_environment in set(s.strip() for s in allowed_envs.split(","))
+
+
+def update_metric_values(asg, value, my_environment):
+    mvals = get_tags_by_prefix(asg, SCALING_METRIC_TAG_PREFIX)
+    my_key, my_val = set_metric_value(asg, value, my_environment)
+    mvals[my_key] = my_val
+    if DEBUG:
+        print json.dumps(mvals, indent=2)
+    results = {}
+    expired_keys = []
+    for k, v in mvals.items():
+        parts = v.split("::")
+        unixtime = int(parts[0])
+        if time.time() - unixtime < EXPIRATION_PERIOD_MINUTES * 60:
+            results[k] = int(parts[1])
+        else:
+            expired_keys.append(k)
+            if DEBUG:
+                print "Expired value {} for key {}".format(v, k)
+    delete_expired_metric_tags(asg, expired_keys)
+    return results
+
+
+def count_healthy_instances(asg):
+    # This will become more useful when we start scaling down
+    num_healthy = 0
+    for inst in asg["Instances"]:
+        if inst["HealthStatus"] == "Healthy" and inst["LifecycleState"] != "Terminating":
+            num_healthy += 1
+    return num_healthy
+
+
+def set_desired_capacity(asg, compute_desired_instances, my_environment):
+    can_scale = permission_to_scale(asg, my_environment)
+    asg_name = asg['AutoScalingGroupName']
+    num_healthy = count_healthy_instances(asg)
+    previous_desired = int(asg.get("DesiredCapacity", asg.get("MinSize", 0)))
+    # Manually input DesiredCapacity will never be reduced so long as there are pending jobs.
+    num_desired = compute_desired_instances(previous_desired)
+    if num_desired == previous_desired:
+        action = "should remain"
+    else:
+        action = "should change to"
+    cmd = "aws autoscaling set-desired-capacity --auto-scaling-group-name {asg_name} --desired-capacity {num_desired}"
+    cmd = cmd.format(asg_name=asg_name, num_desired=num_desired)
+    msg = "Autoscaling group {asg_name} has {num_healthy} healthy instance(s). Desired capacity {action} {num_desired}."
+    if not can_scale:
+        msg += " However, scaling by agents of {} is not permitted.".format(my_environment)
+    print msg.format(asg_name=asg_name, num_healthy=num_healthy, action=action, num_desired=num_desired)
+    if can_scale:
+        if DEBUG:
+            print cmd
+        aws_command(cmd)
+
+
+def autoscaling_update(my_num_jobs, my_environment="development"):
+    if my_environment not in MULTICONTAINER_ENVIRONMENTS:
+        # Distinguish different developers' environments based on hostname
+        hostname = (
+            os.environ.get("HOSTNAME") or
+            os.environ.get("HOST") or
+            subprocess.check_output(["hostname"]).strip()
+        )
+        # sha hexdigest is used to sanitize the hostname so it's safe for tags
+        my_environment += "_" + hashlib.sha224(hostname).hexdigest()[:10]
+    asg_json = aws_command("aws autoscaling describe-auto-scaling-groups")
+    asg_list = json.loads(asg_json).get('AutoScalingGroups', [])
+    gsnap_asg = find_asg(asg_list, "gsnapl-asg-production")
+    rapsearch2_asg = find_asg(asg_list, "rapsearch2-asg-production")
+    mvals = update_metric_values(gsnap_asg, my_num_jobs, my_environment)
+    num_jobs = sum(mvals.values())
+    print json.dumps(mvals, indent=2)
+    print "ASG tags indicate {num_jobs} running job(s) across {num_env} environments above.".format(num_jobs=num_jobs, num_env=len(mvals))
+    if DEBUG:
+        print json.dumps(gsnap_asg, indent=2)
+        print json.dumps(rapsearch2_asg, indent=2)
+    # This is a very basic heuristic.
+    if num_jobs == 0:
+        set_desired_capacity(gsnap_asg, exactly(0), my_environment)
+        set_desired_capacity(rapsearch2_asg, exactly(0), my_environment)
+    elif 1 <= num_jobs <= 5:
+        set_desired_capacity(gsnap_asg, at_least(1), my_environment)
+        set_desired_capacity(rapsearch2_asg, at_least(2), my_environment)
+    else:
+        set_desired_capacity(gsnap_asg, at_least(3), my_environment)
+        set_desired_capacity(rapsearch2_asg, at_least(7), my_environment)
+
+
+if __name__ == "__main__":
+    assert len(sys.argv) > 2
+    assert sys.argv[1] in ("update", "debug")
+    assert sys.argv[2].isdigit()
+    if sys.argv[1] == "debug":
+        DEBUG = True
+    autoscaling_update(int(sys.argv[2]), *sys.argv[3:])

--- a/app/jobs/check_pipeline_runs.rb
+++ b/app/jobs/check_pipeline_runs.rb
@@ -11,5 +11,9 @@ class CheckPipelineRuns
       @logger.info("  Checking pipeline run #{pr.id} for sample #{pr.sample_id}")
       pr.update_job_status
     end
+    @logger.info("Autoscaling update.")
+    c_stdout, c_stderr, c_status = Open3.capture3("app/jobs/autoscaling.py update #{PipelineRun.in_progress.count} #{Rails.env}")
+    @logger.info(c_stdout)
+    @logger.error(c_stderr) unless c_status.success? && c_stderr.blank?
   end
 end


### PR DESCRIPTION
This seems to work, thanks @yunfangjuan for the suggestion to use ASG tags and @cdebourcy for thoughtful discussions.

here are the various aspects:

  --- scaling policy is simple;  if there are no jobs anywhere, scale down to zero;  otherwise make sure at least 1 server is running

  --- number of jobs is computed by adding up ASG tags updated by the resque workers of the various deployed environments to reflect how many jobs in flight each of those environment has;    tags that are stale are ignored, and stale tags from development environments are eventually deleted (to stay under the amazon 50 tags limit)

  --- only the production environment should be permitted to make scaling changes; tag IDSeqEnvsThatCanScale lists environments that are permitted to trigger scaling for the group;   eventually that should be just "production", but others can be added for testing

  --- cloud environments are identified as in RAILS;  non-cloud environments (i.e. "development") whose multiple instances appear the same to RAILS are distinguished here using their container hash, so the various laptop environments will look like "development_abcd1234" and "development_efefef78".

Here is example execution.

(aeon) app/jobs/autoscaling.py update 1 boris_test

{
  "IDSeqScalingData_boris_test_3caf5d975d": 1, 
  "IDSeqScalingData_testenv_3caf5d975d": 0
}
ASG tags indicate 1 running job(s) across 2 environments above.
Autoscaling group gsnapl-asg-production-20180113014244765900000002 has 1 healthy instance(s). Desired capacity would be 1.
Autoscaling group rapsearch2-asg-production-20171202000233875700000002 has 2 healthy instance(s). Desired capacity would be 2.

(aeon) app/jobs/autoscaling.py update 1 boristest

{
  "IDSeqScalingData_boris_test_3caf5d975d": 1, 
  "IDSeqScalingData_testenv_3caf5d975d": 0, 
  "IDSeqScalingData_boristest_3caf5d975d": 1
}
ASG tags indicate 2 running job(s) across 3 environments above.
Autoscaling group gsnapl-asg-production-20180113014244765900000002 has 1 healthy instance(s). Desired capacity would be 1. However, scaling by agents of boristest_3caf5d975d is not permitted.
Autoscaling group rapsearch2-asg-production-20171202000233875700000002 has 2 healthy instance(s). Desired capacity would be 2. However, scaling by agents of boristest_3caf5d975d is not permitted.
