### PR TITLE
remove host_genomes job_queue column

### DIFF
--- a/app/controllers/host_genomes_controller.rb
+++ b/app/controllers/host_genomes_controller.rb
@@ -71,7 +71,7 @@ class HostGenomesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def host_genome_params
-    params.require(:host_genome).permit(:name, :sample_memory, :job_queue, :s3_star_index_path,
+    params.require(:host_genome).permit(:name, :sample_memory, :s3_star_index_path,
                                         :s3_bowtie2_index_path, :default_background_id)
   end
 end

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -33,7 +33,11 @@ class PipelineRunStage < ApplicationRecord
       queue = Sample::DEFAULT_QUEUE_HIMEM
     end
     if pipeline_run.sample.job_queue.present?
-      queue = pipeline_run.sample.job_queue
+      if Sample::DEPRECATED_QUEUES.include? pipeline_run.sample.job_queue
+        Rails.logger.info "Overriding deprecated queue #{pipeline_run.sample.job_queue} with #{queue}"
+      else
+        queue = pipeline_run.sample.job_queue
+      end
     end
     command += " --storage /mnt=#{Sample::DEFAULT_STORAGE_IN_GB} --ecr-image idseq --memory #{memory} --queue #{queue} --vcpus #{vcpus} --job-role idseq-pipeline "
     command

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -28,6 +28,9 @@ class Sample < ApplicationRecord
   DEFAULT_QUEUE_HIMEM = 'idseq_himem'.freeze
   DEFAULT_VCPUS_HIMEM = 8
 
+  # These zombies keep coming back, so we now expressly fail submissions to them.
+  DEPRECATED_QUEUES = %w[idseq_alpha_stg1 aegea_batch_ondemand idseq_production_high_pri_stg1].freeze
+
   METADATA_FIELDS = [:sample_host, # this has been repurposed to be patient ID (nothing to do with host genome)
                      :sample_location, :sample_date, :sample_tissue,
                      :sample_template, # this refers to nucleotide type (RNA or DNA)
@@ -237,7 +240,6 @@ class Sample < ApplicationRecord
       self.s3_star_index_path = host_genome.s3_star_index_path
       self.s3_bowtie2_index_path = host_genome.s3_bowtie2_index_path
       self.sample_memory ||= host_genome.sample_memory
-      self.job_queue = host_genome.job_queue if job_queue.blank?
     end
     s3_preload_result_path ||= ''
     s3_preload_result_path.strip!

--- a/app/views/host_genomes/_form.html.erb
+++ b/app/views/host_genomes/_form.html.erb
@@ -19,10 +19,6 @@
     <%= form.text_field :sample_memory, id: :host_genome_sample_memory, placeholder: 'Required' %>
   </div>
   <div class="field">
-    <%= form.label 'Job queue' %><br>
-    <%= form.text_field :job_queue, id: :host_genome_job_queue, placeholder: 'Required' %>
-  </div>
-  <div class="field">
     <%= form.label 'S3 STAR index path' %><br>
     <%= form.text_field :s3_star_index_path, id: :host_genome_s3_star_index_path, placeholder: 'Required' %>
   </div>

--- a/app/views/host_genomes/_host_genomes.html.erb
+++ b/app/views/host_genomes/_host_genomes.html.erb
@@ -25,7 +25,6 @@
           <td><%= host_genome.name %></td>
           <td><%= host_genome.id %></td>
           <td><%= host_genome.sample_memory %></td>
-          <td><%= host_genome.job_queue %></td>
           <td><%= host_genome.s3_star_index_path %> </td>
           <td> <%= host_genome.s3_bowtie2_index_path %> </td>
           <td><%= link_to host_genome.default_background.name, host_genome.default_background if host_genome.default_background %></td>

--- a/db/migrate/20180213225338_remove_job_queue_from_host_genomes.rb
+++ b/db/migrate/20180213225338_remove_job_queue_from_host_genomes.rb
@@ -1,0 +1,5 @@
+class RemoveJobQueueFromHostGenomes < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :host_genomes, :job_queue, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180212210554) do
+ActiveRecord::Schema.define(version: 20180213225338) do
 
   create_table "archived_backgrounds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "archive_of"
@@ -62,7 +62,6 @@ ActiveRecord::Schema.define(version: 20180212210554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sample_memory"
-    t.string "job_queue"
     t.integer "skip_deutero_filter"
   end
 


### PR DESCRIPTION
the only remaining purpose of this column was to default all submissions
on alpha into the trashcan aegea_test queue, but that's no longer
the desired behavior, and keeping it around has the downside of
bogus zombies queues becoming resurrected from local development envs
