### PR TITLE
speed up pipeline state transitions

### DIFF
--- a/app/jobs/check_pipeline_runs.rb
+++ b/app/jobs/check_pipeline_runs.rb
@@ -1,19 +1,67 @@
 # Jos to check the status of pipeline runs
 require 'logger'
 require 'resque/plugins/lock'
+
 class CheckPipelineRuns
   extend Resque::Plugins::Lock
   @queue = :q03_pipeline_run
   @logger = Logger.new(STDOUT)
-  def self.perform
-    @logger.info("Checking the active pipeline runs")
+
+  # A fresh CheckPipelineRuns should run every 5 minutes.
+  # This should match resque_schedule.yml.
+  @cron_period = 5 * 60
+  @cron_drift = 5 # up to 5 seconds, prevents piling up of queued events
+
+  # Don't poll faster than this, in seconds.
+  @min_refresh_interval = 20
+
+  def self.update_jobs(silent)
     PipelineRun.in_progress.each do |pr|
-      @logger.info("  Checking pipeline run #{pr.id} for sample #{pr.sample_id}")
+      @logger.info("  Checking pipeline run #{pr.id} for sample #{pr.sample_id}") unless silent
       pr.update_job_status
     end
-    @logger.info("Autoscaling update.")
-    c_stdout, c_stderr, c_status = Open3.capture3("app/jobs/autoscaling.py update #{PipelineRun.in_progress.count} #{Rails.env}")
+  end
+
+  def self.autoscaling_update(last_count)
+    new_count = PipelineRun.in_progress.count
+    return last_count if new_count == last_count
+    if last_count.nil?
+      @logger.info("Autoscaling update to #{new_count}.")
+    else
+      @logger.info("Autoscaling update from #{last_count} to #{new_count}.")
+    end
+    c_stdout, c_stderr, c_status = Open3.capture3("app/jobs/autoscaling.py update #{new_count} #{Rails.env}")
     @logger.info(c_stdout)
     @logger.error(c_stderr) unless c_status.success? && c_stderr.blank?
+    new_count
+  end
+
+  def self.perform
+    # Loop for up to cron_period - cron_drift seconds.
+    @logger.info("Checking the active pipeline runs every #{@min_refresh_interval} seconds over the next #{@cron_period / 60} minutes.")
+    t_now = Time.now.to_f # unixtime
+    t_end = t_now + @cron_period - @cron_drift
+    autoscaling_state = nil
+    max_work_duration = 0
+    iteration_count = 0
+    loop do
+      iteration_count += 1
+      t_iteration_start = t_now
+      update_jobs(iteration_count != 1)
+      autoscaling_state = autoscaling_update(autoscaling_state)
+      t_now = Time.now.to_f
+      max_work_duration = [t_now - t_iteration_start, max_work_duration].max
+      t_iteration_end = [t_now, t_iteration_start + @min_refresh_interval].max
+      if t_iteration_end + max_work_duration > t_end
+        # we won't have time to complete another iteration before t_end
+        @logger.info("Exiting loop after #{iteration_count} iterations.")
+        break
+      end
+      if t_now < t_iteration_end
+        # @logger.info("Sleeping for #{t_iteration_end - t_now} seconds.")
+        sleep t_iteration_end - t_now
+        t_now = Time.now.to_f
+      end
+    end
   end
 end

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -12,6 +12,9 @@ class PipelineRunStage < ApplicationRecord
   STATUS_LOADED = 'LOADED'.freeze
   STATUS_ERROR = 'ERROR'.freeze
 
+  # Max number of times we resubmit a job when it gets killed by EC2.
+  MAX_RETRIES = 5
+
   before_save :check_job_status
 
   def install_pipeline
@@ -46,6 +49,7 @@ class PipelineRunStage < ApplicationRecord
   def check_job_status
     return if completed? || !started? || !id
     if output_ready?
+      Airbrake.notify("LoadResultForRunStage #{id} may be repeated.") unless job_status != STATUS_CHECKED
       self.job_status = STATUS_CHECKED
       Resque.enqueue(LoadResultForRunStage, id)
       terminate_job
@@ -113,8 +117,19 @@ class PipelineRunStage < ApplicationRecord
     self.failed_jobs = existing_failed_jobs + new_failed_job
   end
 
+  def count_failed_tries
+    return 0 if failed_jobs.blank?
+    1 + failed_jobs.count(",")
+  end
+
+  def due_for_aegea_check?
+    rand < 0.2
+  end
+
   def update_job_status
     return if completed?
+    return unless due_for_aegea_check? || output_ready?
+    skip_save = false
     stdout, stderr, status = Open3.capture3("aegea", "batch", "describe", job_id.to_s)
     if status.exitstatus.zero?
       self.job_description = stdout
@@ -124,16 +139,21 @@ class PipelineRunStage < ApplicationRecord
         self.job_log_id = job_hash['container']['logStreamName']
       end
       if instance_terminated?(job_hash)
+        # note failed attempt and retry
         add_failed_job
-        run_job # retry if necessary
-        return
+        if count_failed_tries <= MAX_RETRIES
+          run_job # this saves
+          skip_save = true
+        else
+          Airbrake.notify("Job #{job_id} for pipeline run #{id} was killed #{MAX_RETRIES} times.")
+        end
       end
     else
       Airbrake.notify("Error for update job status for pipeline run #{id} with error #{stderr}")
       self.job_status = STATUS_ERROR
       self.job_status = STATUS_FAILED if stderr =~ /IndexError/ # job no longer exists
     end
-    save
+    save unless skip_save
   end
 
   def file_generated_since_run(s3_path)


### PR DESCRIPTION
Detect completed jobs much faster by checking S3 every 20 seconds.   Detect failed jobs by checking with aegea batch every 100 seconds, just slightly more frequent than before.   If the checks become slower, then they will run less frequently.   Metrics for scaling are updated within 20 seconds of when they change, and the autoscaling groups respond immediately if the request is from prod, or with up to 5 minute delay if responding to a change in one fo the other environments.