### PR TITLE
Closes #654: escape single quote

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,7 @@ module ApplicationHelper
     # using json_escape to prevent XSS vulnerability
     str = json_escape(hash.to_json) unless hash.class == 'String'
     str = str.gsub!("\\", "\\\\\\") if str.include? "\\"
+    str = str.gsub("'", "\\\\'")
     str
   end
 end


### PR DESCRIPTION
No idea why this should still be necessary, suggestions on deeper fix welcome.
Without this fix, creating a project named `Charles's project` will break the "all samples" page, for example.