### PR TITLE
Charles/report details cleanup

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -149,14 +149,16 @@ class SamplesController < ApplicationController
     @background_models = Background.all
     @can_edit = current_power.updatable_sample?(@sample)
 
-    default_background_id = @sample.host_genome && @sample.host_genome.default_background ? @sample.host_genome.default_background.id : nil
     if @pipeline_run && (@pipeline_run.remaining_reads.to_i > 0 || @pipeline_run.finalized?) && !@pipeline_run.failed?
-      background_id = params[:background_id] || default_background_id
+      background_id = params[:background_id] || @sample.default_background_id
+      # Here background_id is only used to decide whether a report can be shown.
+      # No report/background-specific data is actually being shown.
+      # Background selection is used in report_info action, which fetches the actual report data.
       if background_id
         @report_present = 1
         @report_ts = @pipeline_run.updated_at.to_i
         @all_categories = all_categories
-        @report_details = report_details(@pipeline_run, Background.find(background_id))
+        @report_details = report_details(@pipeline_run)
         @report_page_params = clean_params(params, @all_categories)
       end
     end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -207,10 +207,8 @@ class SamplesController < ApplicationController
     ## Duct tape for changing background id dynamically
     ## TODO(yf): clean the following up.
     ####################################################
-    background_id = nil
-    default_background_id = @sample.host_genome && @sample.host_genome.default_background ? @sample.host_genome.default_background.id : nil
     if @pipeline_run && (@pipeline_run.remaining_reads.to_i > 0 || @pipeline_run.finalized?) && !@pipeline_run.failed?
-      background_id = params[:background_id] || default_background_id
+      background_id = params[:background_id] || @sample.default_background_id
       pipeline_run_id = @pipeline_run.id
     end
 

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -176,10 +176,11 @@ module ReportHelper
     data
   end
 
-  def report_details(pipeline_run, _background)
-    # Gives some auxiliary information on pipeline_run.
-    # Not actually anything to do with report-specific data and does not use background argument.
+  def report_details(pipeline_run, _background = nil)
+    # Provides some auxiliary information on pipeline_run.
+    # Not actually anything to do with report-specific data and does not use _background argument.
     {
+      pipeline_info: pipeline_run,
       subsampled_reads: pipeline_run.subsampled_reads,
       sample_info: pipeline_run.sample,
       taxon_fasta_flag: pipeline_run.finalized?

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -176,13 +176,12 @@ module ReportHelper
     data
   end
 
-  def report_details(pipeline_run, background)
+  def report_details(pipeline_run, _background)
+    # Gives some auxiliary information on pipeline_run.
+    # Not actually anything to do with report-specific data and does not use background argument.
     {
-      pipeline_info: pipeline_run,
       subsampled_reads: pipeline_run.subsampled_reads,
       sample_info: pipeline_run.sample,
-      project_info: pipeline_run.sample.project,
-      background_model: background,
       taxon_fasta_flag: pipeline_run.finalized?
     }
   end
@@ -823,8 +822,7 @@ module ReportHelper
   def report_csv_from_params(sample, params)
     params[:is_csv] = 1
     params[:sort_by] = "highest_nt_aggregatescore"
-    default_background_id = sample.host_genome && sample.host_genome.default_background ? sample.host_genome.default_background.id : nil
-    background_id = params[:background_id] || default_background_id
+    background_id = params[:background_id] || sample.default_background_id
     pipeline_run = sample.pipeline_runs.first
     pipeline_run_id = pipeline_run ? pipeline_run.id : nil
     return "" if pipeline_run_id.nil? || pipeline_run.total_reads.nil?

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -231,7 +231,7 @@ class Sample < ApplicationRecord
   end
 
   def default_background_id
-    host_genome && host_genome.default_background ? sample.host_genome.default_background.id : nil
+    host_genome && host_genome.default_background ? host_genome.default_background.id : nil
   end
 
   def as_json(_options = {})

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -230,6 +230,10 @@ class Sample < ApplicationRecord
     host_genome.name if host_genome
   end
 
+  def default_background_id
+    host_genome && host_genome.default_background ? sample.host_genome.default_background.id : nil
+  end
+
   def as_json(_options = {})
     super(methods: [:sample_input_folder_url, :sample_output_folder_url, :sample_annotated_fasta_url, :input_files,
                     :sample_unidentified_fasta_url, :host_genome_name])


### PR DESCRIPTION
# Description
Cleanup after ajaxification of report page. Reduce confusion by removing unused code and adding comments.
Make explicit that default background ID is same for report page and report csv download.