### PR TITLE
reduce mem and vCPUs to fit in c3 instances because aegea setup fails on newer instance types like c5

### DIFF
--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -16,6 +16,7 @@ class PipelineRunStage < ApplicationRecord
   MAX_RETRIES = 5
 
   def install_pipeline
+    "pip install --upgrade git+git://github.com/chanzuckerberg/s3mi.git; " \
     "cd /mnt; " \
     "git clone https://github.com/chanzuckerberg/idseq-pipeline.git; " \
     "cd idseq-pipeline; " \

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -21,13 +21,13 @@ class Sample < ApplicationRecord
   # TODO: Make all these params configurable without code change
   DEFAULT_STORAGE_IN_GB = 500
   DEFAULT_MEMORY_IN_MB = 30_000
-  HOST_FILTERING_MEMORY_IN_MB = 71_000
+  HOST_FILTERING_MEMORY_IN_MB = 60_000
 
   DEFAULT_QUEUE = 'idseq'.freeze
   DEFAULT_VCPUS = 4
 
   DEFAULT_QUEUE_HIMEM = 'idseq_himem'.freeze
-  DEFAULT_VCPUS_HIMEM = 36
+  DEFAULT_VCPUS_HIMEM = 32
 
   # These zombies keep coming back, so we now expressly fail submissions to them.
   DEPRECATED_QUEUES = %w[idseq_alpha_stg1 aegea_batch_ondemand idseq_production_high_pri_stg1].freeze


### PR DESCRIPTION
An aegea batch job running on a c5 instance will fail on this `aws confgure` command
```
iid=$(http http://169.254.169.254/latest/dynamic/instance-identity/document)
aws configure set default.region $(echo "$iid" | jq -r .region)
```
The error is as follows:
```
aws: error: the following arguments are required: value
```
The workaround in this change is to lower our requirements to 32 vCPU and 60GB RAM so that we can run on older c3 instances that don't present us with this problem.