### PR TITLE
Add extra space after the name

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -497,7 +497,7 @@ class PipelineSampleReads extends React.Component {
               <div className="sub-title col s9">
                 <a
                 href={`/?project_id=${this.projectInfo.id}`}>
-                  {this.projectInfo.name}
+                  {this.projectInfo.name + ' '}
                 </a>
                 > { sample_dropdown }
               </div>


### PR DESCRIPTION
Closes #880. Adds an extra space after the project name in the display so it's not right next to the ">"... unless it'd be better to add nbsp ?