### PR TITLE
Move out onClick listener so whole project row is clickable

### DIFF
--- a/app/assets/src/components/ProjectSelection.jsx
+++ b/app/assets/src/components/ProjectSelection.jsx
@@ -50,6 +50,7 @@ import Samples from './Samples';
   }
 
   toggleFavorite(e) {
+    e.stopPropagation();
     let favStatus = e.target.getAttribute('data-fav');
     let projectId = e.target.getAttribute('data-id');
     favStatus == 'true' ?  _satellite.track('unfavorite') : _satellite.track('favorite');

--- a/app/assets/src/components/ProjectSelection.jsx
+++ b/app/assets/src/components/ProjectSelection.jsx
@@ -295,9 +295,9 @@ import Samples from './Samples';
         <div className="row">
           <div className='col no-padding s12'>
             <div className="projects-wrapper">
-              <div className="all-samples project-item">
-                <span className='project-label'
-                  onClick={this.handleProjectClick}>
+              <div className="all-samples project-item"
+                   onClick={this.handleProjectClick} >
+                <span className='project-label'>
                   All Samples
                 </span>
               </div>

--- a/app/assets/src/components/ProjectSelection.jsx
+++ b/app/assets/src/components/ProjectSelection.jsx
@@ -211,9 +211,11 @@ import Samples from './Samples';
               .slice(0,4)
               .map((project, i) => {
                 return (
-                  <div className="project-item fav-item" data-id={project.id} key={i}>
+                  <div className="project-item fav-item"
+                       onClick={this.handleProjectClick} data-type='favorite'
+                       data-id={project.id} key={i}>
                     <span className='project-label'
-                      onClick={this.handleProjectClick} data-type='favorite'
+                      data-type='favorite'
                       data-id={project.id}>
                       {project.name}
                     </span>
@@ -225,9 +227,11 @@ import Samples from './Samples';
           .sort(sortLogic)
           .map((project, i) => {
             return (
-              <div className="project-item fav-item" data-id={project.id} key={i}>
+              <div className="project-item fav-item"
+                   onClick={this.handleProjectClick} data-type='favorite'
+                   data-id={project.id} key={i}>
                 <span className='project-label'
-                  onClick={this.handleProjectClick} data-type='favorite'
+                  data-type='favorite'
                   data-id={project.id}>
                   {project.name}
                 </span>
@@ -258,9 +262,11 @@ import Samples from './Samples';
                .slice(0,7)
                .map((project, i) => {
                 return (
-                    <div className="all project-item" data-id={project.id}  key={i}>
+                    <div className="all project-item"
+                         onClick={this.handleProjectClick}
+                         data-id={project.id}  key={i}>
                       <span className='project-label'
-                        onClick={this.handleProjectClick} data-id={project.id}>
+                        data-id={project.id}>
                         {project.name}
                       </span>
                       {this.addFavIconClass(project)}
@@ -269,9 +275,11 @@ import Samples from './Samples';
             }) :
             this.state.formattedProjectList.sort(sortLogic).map((project, i) => {
             return (
-              <div className="all project-item" data-id={project.id} key={i}>
+              <div className="all project-item"
+                   onClick={this.handleProjectClick}
+                   data-id={project.id} key={i}>
                 <span className='project-label'
-                  onClick={this.handleProjectClick} data-id={project.id}>
+                  data-id={project.id}>
                   {project.name}
                 </span>
                 {this.addFavIconClass(project)}


### PR DESCRIPTION
Closes #771 . Moves out the onClick listener so the whole project row incl. the text title is clickable.

![screen shot 2018-03-12 at 3 45 17 pm](https://user-images.githubusercontent.com/5652739/37313464-97bb9942-260c-11e8-8c31-d3cf67f6f107.png)
