### PR TITLE
Fixes all the wonky checkbox animations

### DIFF
--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -1111,25 +1111,31 @@ input[type="button"] {
   }
 }
 
+[type=checkbox].filled-in {
+    height: 20px !important;
+    width: 20px !important;
+}
+
 [type=checkbox].filled-in:not(:checked)+label:after {
-    height: 16px !important;
-    width: 16px !important;
+    top: 4px;
     background-color: transparent;
     border: 2px solid #5a5a5a;
-    top: 4px;
     z-index: 0;
 }
 
 [type=checkbox].filled-in:checked+label:after {
-    top: 0;
-    width: 16px !important;
-    height: 16px !important;
+    top: 4px;
     border: 10px solid #188fd8;
     background-color: #188fd8;
     &.check-all {
       padding: 10px 21px 8px 16px;
     }
 }
+
+[type=checkbox].filled-in:checked+label:before {
+    top: 4px;
+}
+
 .dropdown-content li>a, .dropdown-content li>span {
   font-size: 14px;
 }


### PR DESCRIPTION
- Closes #752 . Sets the checkboxes to 20px and aligns them with "top 4px" since that was what it was before.
- I actually tried getting all the checkboxes to 12px or 16px but I couldn't get the actual checkmark to shrink that small.
- Now all the checkboxes are nice and the same size/position so the check animation doesn't do the weird repositioning jerks.

![screen shot 2018-03-12 at 4 44 44 pm](https://user-images.githubusercontent.com/5652739/37315201-b1d02650-2615-11e8-95f2-c32c0b9acddf.png)
