### PR TITLE
Change title on All Samples page to say All Samples

### DIFF
--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1134,7 +1134,7 @@ class Samples extends React.Component {
         }
         <div className={ project_id === 'all' ? "col s7 wrapper" : "col s5 wrapper" }>
           <div className={(!this.state.project) ? "proj-title heading all-proj" : "heading proj-title"}>
-          { (!this.state.project) ? <div className="">All Projects</div>
+          { (!this.state.project) ? <div className="">All Samples</div>
               : <div>
                   <span className="">{ this.state.project.name }</span>
                 </div>


### PR DESCRIPTION
Jenn pointed this out but the 'All Samples' page used to say 'All Projects' at the top. Although it really means like 'All Samples from All Projects'.

![screen shot 2018-03-13 at 1 57 13 pm](https://user-images.githubusercontent.com/5652739/37369486-76c148f8-26c6-11e8-8722-4678dd5ebb60.png)
