### PR TITLE
Add some bottom padding to the Project section headers

### DIFF
--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -867,13 +867,14 @@ input[type="button"] {
         .title {
           color: #f1f1f1;
           letter-spacing: 1.5px;
-          padding: 21px 21px 0 21px;
+          padding: 21px 21px 10px 21px;
           font-size: 14px;
         }
       }
       .projects {
         .title {
           color: #f1f1f1;
+          margin-bottom: 10px !important;
         }
       }
       .projects-wrapper {


### PR DESCRIPTION
- Pointed out by Jenn. Add some bottom padding to the Project section headers in the sidebar so there's more space.

Before:
![screen shot 2018-03-13 at 2 19 19 pm](https://user-images.githubusercontent.com/5652739/37370472-98884182-26c9-11e8-91d7-71d339024608.png)

After:
![screen shot 2018-03-13 at 2 18 51 pm](https://user-images.githubusercontent.com/5652739/37370490-a01f98c8-26c9-11e8-84aa-840c188fc79e.png)
