### PR TITLE
Closes #780. Update upload pages to use CLI modal on click

### DIFF
--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -28,6 +28,7 @@ class BulkUploadImport extends React.Component {
     });
     this.userDetails = props.loggedin_user;
     this.toggleCheckBox = this.toggleCheckBox.bind(this);
+    this.openCliModal = this.openCliModal.bind(this);
     this.state = {
       submitting: false,
       allProjects: props.projects || [],
@@ -506,6 +507,11 @@ class BulkUploadImport extends React.Component {
       </div>
     )
   }
+
+  openCliModal() {
+    $('#cli_modal').modal('open');
+  }
+
   renderBulkUploadImportForm() {
     return (
       <div id='samplesUploader' className='row'>
@@ -522,8 +528,8 @@ class BulkUploadImport extends React.Component {
             <div>
               <p className='upload-question'>
                 Only want to upload one sample? <a href='/samples/new'>Click here.</a>
-                <br/>
-                Rather use our CLI? <a href='https://github.com/chanzuckerberg/idseq-web/blob/master/README.md#submit-a-sample' target='_blank'>Read documentation here.</a>
+                <br></br>Rather use our command-line interface?
+                { <a onClick={ this.openCliModal } href="#!"> Instructions here.</a> }
               </p>
             </div>
             { this.state.success ?

--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -50,6 +50,7 @@ class SampleUpload extends React.Component {
     this.firstInput = this.selected.inputFiles.length && this.selected.inputFiles[0] ? (this.selected.inputFiles[0].source === null ? '' : this.selected.inputFiles[0].source) : '';
     this.secondInput = this.selected.inputFiles.length && this.selected.inputFiles[1] ? (this.selected.inputFiles[1].source === null ? '' : this.selected.inputFiles[1].source) : '';
     this.toggleCheckBox = this.toggleCheckBox.bind(this);
+    this.openCliModal = this.openCliModal.bind(this);
     this.state = {
       submitting: false,
       allProjects: this.projects || [],
@@ -583,6 +584,10 @@ class SampleUpload extends React.Component {
     )
   }
 
+  openCliModal() {
+    $('#cli_modal').modal('open');
+  }
+
   renderSampleForm() {
     return (
       <div id='samplesUploader' className='row'>
@@ -599,7 +604,8 @@ class SampleUpload extends React.Component {
             <div>
               <p className='upload-question'>
                 Want to upload multiple samples at once? <a href='/samples/bulk_new'>Click here.</a>
-                <br/>
+                <br></br>Rather use our command-line interface?
+                { <a onClick={ this.openCliModal } href="#!"> Instructions here.</a> }
               </p>
             </div>
             { this.state.success ?


### PR DESCRIPTION
- Closes #780 . Update upload pages to use CLI modal on click

"(a) When you go to https://idseq.net/samples/bulk_new, there's a line saying "Rather use our CLI? Read documentation here". The text should be replaced by "Rather use our command-line interface? Instructions here" and when you click on "Instructions here", it should open the same modal as when you click on "New sample (command line)" in the top right dropdown.

(b) When you go to https://idseq.net/samples/new, it should have the same line and link: "Rather use our command-line interface? Instructions here""

![mar-13-2018 14-56-51](https://user-images.githubusercontent.com/5652739/37372199-30c52dac-26cf-11e8-9060-c6196743fe60.gif)
