### PR TITLE
Remove border from the check all button

### DIFF
--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -721,7 +721,6 @@ $break-large: 1070px;
     .check-all {
       display: inline-block;
       float: left;
-      border: 1px solid #ddd;
       padding: 9px 17px;
       margin: 0 10px 0px 0px;
       label {


### PR DESCRIPTION
- From Jenn. Just removes the border from the check all button.

![screen shot 2018-03-13 at 3 06 01 pm](https://user-images.githubusercontent.com/5652739/37372540-452ce9f0-26d0-11e8-9c26-fe6f5d01d069.png)
