### PR TITLE
Make style tweaks to report page top filters

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -508,7 +508,7 @@ class PipelineSampleReads extends React.Component {
                   <li>
                     <a href={this.getDownloadLink()}>
                       <Button icon labelPosition="left" className="icon link download-btn">
-                        <Icon name="cloud download alternate" />
+                        <Icon name="cloud download" />
                         Download
                       </Button>
                     </a>

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1063,7 +1063,7 @@ class PipelineSampleReport extends React.Component {
                           <span className='filter-label-count'>{this.validThresholdCount(this.state.activeThresholds)} </span>
                           <i className="fa fa-angle-down right down-box" />
                         </div>
-                        <div className="advanced-filters-modal">
+                        <div className="advanced-filters-modal round-me">
                           <div className="filter-inputs">
                             {
                               this.state.activeThresholds.map((activeThreshold, index) => {
@@ -1073,7 +1073,7 @@ class PipelineSampleReport extends React.Component {
                                       <select
                                         value={activeThreshold.label}
                                         onChange={(e) => this.setThresholdProperty(index, 'label', e.target.value) }
-                                        className="browser-default">
+                                        className="browser-default inner-menus">
                                         {
                                           this.allThresholds.map((thresholdObject) => {
                                             return (
@@ -1091,7 +1091,7 @@ class PipelineSampleReport extends React.Component {
                                       <select
                                         value={activeThreshold.operator}
                                         onChange={(e) => this.setThresholdProperty(index, 'operator', e.target.value)}
-                                        className="browser-default">
+                                        className="browser-default inner-menus">
                                         <option value=">=">
                                           >=
                                         </option>
@@ -1102,7 +1102,7 @@ class PipelineSampleReport extends React.Component {
                                     </div>
                                     <div className="col s3">
                                       <input
-                                        className="browser-default metric-thresholds"
+                                        className="browser-default metric-thresholds inner-menus"
                                         onChange={(e) => this.setThresholdProperty(index, 'value', e.target.value)}
                                         onKeyDown={(e) => this.handleThresholdEnter(e, index)}
                                         name="group2"
@@ -1119,12 +1119,12 @@ class PipelineSampleReport extends React.Component {
                               })
                             }
                           </div>
-                          <div className="add-threshold-filter" onClick={ () => this.appendThresholdFilter() }>
+                          <div className="add-threshold-filter inner-menus" onClick={ () => this.appendThresholdFilter() }>
                             <i className="fa fa-plus-circle" /> Add threshold
                           </div>
                           <br/>
                           <div className="" >
-                            <button className="btn" onClick={ () => this.saveThresholdFilters()}>
+                            <button className="inner-menus save-btn" onClick={ () => this.saveThresholdFilters()}>
                               Save
                             </button>
                           </div>

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -4,6 +4,7 @@ import Cookies from 'js-cookie';
 import $ from 'jquery';
 import Tipsy from 'react-tipsy';
 import ReactAutocomplete from 'react-autocomplete';
+import { Dropdown } from 'semantic-ui-react'
 import Samples from './Samples';
 import ReportFilter from './ReportFilter';
 import numberWithCommas from '../helpers/strings';
@@ -980,60 +981,52 @@ class PipelineSampleReport extends React.Component {
                         <i className='fa fa-search'></i>
                       </li>
 
-                      <li className='name-type-dropdown top-filter-dropdown'
-                        data-activates='name-type-dropdown'>
-                        <span className='filter-label'>
+                      <Dropdown
+                        text={
+                          this.state.name_type ? this.state.name_type : 'Select name type'
+                        }
+                        className="filter-btn"
+                      >
+                        <Dropdown.Menu>
+                          <Dropdown.Item
+                            text="Scientific Name"
+                            onClick={() => this.handleNameTypeChange('Scientific name')}
+                          />
+                          <Dropdown.Item
+                            text="Common Name"
+                            onClick={() => this.handleNameTypeChange('Common name')}
+                          />
+                        </Dropdown.Menu>
+                      </Dropdown>
+
+                      <Dropdown
+                        text={
+                          this.state.backgroundName ? this.state.backgroundName : 'Background model'
+                        }
+                        className={"filter-btn"}
+                      >
+                        <Dropdown.Menu>
                           {
-                            this.state.name_type ? this.state.name_type : 'Select name type'
-                          }
-                        </span>
-                        <i className='fa fa-angle-down right'></i>
-                        <div id='name-type-dropdown' className='dropdown-content'>
-                          <ul>
-                          <li
-                              onClick={() => this.handleNameTypeChange('')}
-                              ref= "name_type">
-                              Select name type
-                            </li>
-                            <li
-                              onClick={() => this.handleNameTypeChange('Scientific name')}
-                              ref= "name_type">
-                              Scientific Name
-                            </li>
-                            <li
-                              onClick={() => this.handleNameTypeChange('Common name')}
-                              ref= "name_type">
-                              Common Name
-                            </li>
-                          </ul>
-                        </div>
-                      </li>
-                      <li className='background-model-dropdown top-filter-dropdown'
-                        data-activates='background-model-dropdown'>
-                        <span className='filter-label'>
-                          {
-                            this.state.backgroundName ? this.state.backgroundName : 'Background model'
-                          }
-                        </span>
-                        <i className='fa fa-angle-down right'></i>
-                        <div id='background-model-dropdown' className='dropdown-content'>
-                          <ul>
-                            {
-                              this.all_backgrounds.length ?
-                              this.all_backgrounds.map((background, i) => {
+                            this.all_backgrounds.length ?
+                              this.all_backgrounds.slice(0, -1).map((background, i) => {
                                 return (
-                                  <li
-                                  onClick={() => this.handleBackgroundModelChange(background.name, background.id)}
-                                  ref= "background" key={i}>
-                                    {background.name}
-                                  </li>);
-                                })
-                                : <li>No background models to display</li>
-                            }
-                          </ul>
-                        </div>
-                      </li>
-                      <li className='categories-dropdown top-filter' >
+                                  <Dropdown.Item
+                                    text={background.name}
+                                    ref="background"
+                                    key={i}
+                                    onClick={() => this.handleBackgroundModelChange(background.name, background.id)}
+                                  />
+                                );
+                              })
+                            :
+                              <Dropdown.Item
+                                text="No background models to display"
+                              />
+                          }
+                        </Dropdown.Menu>
+                      </Dropdown>
+
+                      <li className='categories-dropdown top-filter ui dropdown filter-btn' >
                         <div className="categories-filters-activate">
                           <span className='filter-label'>Categories</span>
                           <span className='filter-label-count'>{(this.all_categories.length-this.state.excluded_categories.length)} </span>
@@ -1061,10 +1054,11 @@ class PipelineSampleReport extends React.Component {
                           </div>
                         </div>
                       </li>
-                      <li className="top-filter ">
+
+                      <li className="advanced-filter-top top-filter ui dropdown filter-btn">
                         <div className="advanced-filters-activate" onClick= {(e) => {this.saveThresholdFilters(false);} } >
                           <span className="filter-label">
-                            Advanced Filtering
+                            Advanced Filters
                           </span>
                           <span className='filter-label-count'>{this.validThresholdCount(this.state.activeThresholds)} </span>
                           <i className="fa fa-angle-down right" />

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1030,7 +1030,7 @@ class PipelineSampleReport extends React.Component {
                         <div className="categories-filters-activate">
                           <span className='filter-label'>Categories</span>
                           <span className='filter-label-count'>{(this.all_categories.length-this.state.excluded_categories.length)} </span>
-                          <i className='fa fa-angle-down right'></i>
+                          <i className='fa fa-angle-down right down-box'></i>
                         </div>
                         <div className='categories-filters-modal'>
                           <div className="categories">
@@ -1061,7 +1061,7 @@ class PipelineSampleReport extends React.Component {
                             Advanced Filters
                           </span>
                           <span className='filter-label-count'>{this.validThresholdCount(this.state.activeThresholds)} </span>
-                          <i className="fa fa-angle-down right" />
+                          <i className="fa fa-angle-down right down-box" />
                         </div>
                         <div className="advanced-filters-modal">
                           <div className="filter-inputs">

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -938,7 +938,7 @@ class Samples extends React.Component {
 
     let table_download_dropdown = (
       <div className="col s2 download-wrapper">
-        <Dropdown button className="icon link download-btn" labeled icon="cloud download alternate" text="Download">
+        <Dropdown button className="icon link download-btn" labeled icon="cloud download" text="Download">
           <Dropdown.Menu>
             <Dropdown.Item href={`/projects/${project_id}/csv`}>Download Table</Dropdown.Item>
             { project_id === 'all' ? null : <Dropdown.Item onClick={this.startReportGeneration} className="download-reports">Download Reports</Dropdown.Item> }

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -475,6 +475,7 @@ margin-bottom: 0px;
 }
 .genus-autocomplete-container {
   padding: 0 !important;
+  height: 30px !important;
   &:hover {
     background: inherit !important;
   }
@@ -500,14 +501,10 @@ margin-bottom: 0px;
     [role='combobox'] {
       padding-left: 8px;
       width: inherit;
-      height: inherit;
+      height: 20px !important;
       outline: none;
       &::placeholder, &::-webkit-input-placeholder, &:-moz-placeholder, &::placeholder {
         color: #BAC7CF
-      }
-      &:focus {
-        box-shadow: 0 0 5px #00a9f4 !important;
-        border: 1px solid #00a9f4 !important;
       }
     }
   }
@@ -561,7 +558,7 @@ margin-bottom: 0px;
 
         color: #ffffff;
         .filter-tag-name {
-          font-family: OpenSans;
+          font-family: Open Sans, Helvetica, Arial, sans-serif;
           font-size: 12px;
           font-weight: 600;
           font-style: normal;
@@ -580,6 +577,16 @@ margin-bottom: 0px;
           object-fit: contain;
         }
       }
+    }
+    .filter-btn {
+      margin: 10px;
+      height: 30px !important;
+    }
+    .categories-dropdown {
+      top: 3px !important;
+    }
+    .advanced-filter-top {
+      top: 3px !important;
     }
     .report-top-filters {
       .filter-lists {
@@ -606,6 +613,7 @@ margin-bottom: 0px;
               width: 80%;
               position: relative;
               top: 4px;
+              font-size: 8pt;
             }
             .filter-label-count {
                 width: 24px;
@@ -636,9 +644,10 @@ margin-bottom: 0px;
               padding: 7px;
               padding-right: 35px;
               position: relative;
-              top: -5px;
+              top: -2px;
               margin: 0;
-              height: 31px;
+              height: 14px !important;
+              border-radius: 75px;
             }
             i {
               color: #878787;
@@ -748,7 +757,30 @@ margin-bottom: 0px;
   }
 }
 
-.advanced-filters-modal, .categories-filters-modal {
+.advanced-filters-modal {
+  width: 500px !important;
+  height: 170px !important;
+  display: none;
+  position: absolute;
+  background: #fff;
+  box-shadow: 1px 3px 3px 2px #c8c8c8;
+  margin-left: -16px;
+  margin-top: 8px;
+  padding: 10px;
+  cursor: auto;
+  .metric-thresholds {
+    width: 100%;
+  }
+  .add-threshold-filter {
+    background: #f7f7f7;
+    padding: 5px;
+    width: 175px;
+    text-align: center;
+    cursor: pointer;
+  }
+}
+
+.categories-filters-modal {
   display: none;
   position: absolute;
   background: #fff;

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -582,12 +582,6 @@ margin-bottom: 0px;
       margin: 10px;
       height: 30px !important;
     }
-    .categories-dropdown {
-      top: 3px !important;
-    }
-    .advanced-filter-top {
-      top: 3px !important;
-    }
     .report-top-filters {
       .filter-lists {
         margin-left: 15px;
@@ -644,7 +638,7 @@ margin-bottom: 0px;
               padding: 7px;
               padding-right: 35px;
               position: relative;
-              top: -2px;
+              top: -5px;
               margin: 0;
               height: 14px !important;
               border-radius: 75px;

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -581,6 +581,7 @@ margin-bottom: 0px;
     .filter-btn {
       margin: 10px;
       height: 30px !important;
+      margin-left: auto !important;
     }
     .report-top-filters {
       .filter-lists {
@@ -606,23 +607,26 @@ margin-bottom: 0px;
               overflow: hidden;
               width: 80%;
               position: relative;
-              top: 4px;
               font-size: 8pt;
             }
             .filter-label-count {
-                width: 24px;
-                height: 24px;
-                border-radius: 14px;
-                background-color: #f8f8f8;
-                font-family: OpenSans;
-                font-size: 12px;
-                font-weight: 600;
-                font-style: normal;
-                font-stretch: normal;
-                line-height: normal;
-                letter-spacing: 1.4px;
-                text-align: left;
-                color: #3867fa;
+              width: 24px;
+              height: 24px;
+              border-radius: 14px;
+              background-color: #f8f8f8;
+              font-family: OpenSans;
+              font-size: 12px;
+              font-weight: 600;
+              font-style: normal;
+              font-stretch: normal;
+              line-height: normal;
+              letter-spacing: 1.4px;
+              text-align: left;
+              color: #3867fa;
+              vertical-align: top;
+            }
+            .down-box {
+              position: initial !important;
             }
             &.download-report-button {
               padding: 8px;
@@ -753,7 +757,6 @@ margin-bottom: 0px;
 
 .advanced-filters-modal {
   width: 500px !important;
-  height: 170px !important;
   display: none;
   position: absolute;
   background: #fff;

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -760,11 +760,12 @@ margin-bottom: 0px;
   display: none;
   position: absolute;
   background: #fff;
-  box-shadow: 1px 3px 3px 2px #c8c8c8;
+  box-shadow: 1px 2px 2px 2px #c8c8c8;
   margin-left: -16px;
   margin-top: 8px;
   padding: 10px;
   cursor: auto;
+  border-radius: 10px;
   .metric-thresholds {
     width: 100%;
   }
@@ -774,6 +775,21 @@ margin-bottom: 0px;
     width: 175px;
     text-align: center;
     cursor: pointer;
+  }
+  .round-me {
+    border-radius: 10px;
+  }
+  .inner-menus {
+    font-family: Open Sans, Helvetica, Arial, sans-serif;
+    border-radius: 20px;
+    font-size: 10pt;
+    height: 30px;
+  }
+  .save-btn {
+    background: #3867fa;
+    color: white;
+    padding-left: 20px;
+    padding-right: 20px;
   }
 }
 


### PR DESCRIPTION
- So I managed to swap out the "name type" and "background model" dropdowns for Semantic UI dropdowns since that was straightforward.
- The search box, category box, and advanced filters box had a lot of custom JS/HTML so I didn't want to change all of that right now for the sake of time, so I just standardized CSS tweaks for those.
- So all of the JS hooks and actions should be the same / functionally the same as before basically.
- Might not fix all the visual bugs people mentioned but good enough to get out now.

PART ONE:
![part 1](https://user-images.githubusercontent.com/5652739/37428667-3dd51316-278a-11e8-984d-3ecdc3610d96.gif)

PART TWO:
![part 2](https://user-images.githubusercontent.com/5652739/37428681-497ddfb8-278a-11e8-824e-adb0a8464abb.gif)