### PR TITLE
Expand report page widths for usability

### DIFF
--- a/app/assets/src/styles/_header.scss
+++ b/app/assets/src/styles/_header.scss
@@ -162,7 +162,12 @@ a {
   min-height: 120px;
   padding-top: 20px;
   box-shadow: 1px 2px 5px 2px #eaeaea;
+}
 
+.sub-header-component {
+  .container {
+    width: 90%;
+  }
 }
 
 /* SubHeader styles */

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -261,6 +261,10 @@ margin-bottom: 0px;
   background: #ffffff !important;
 }
 
+.reports-screen.container {
+  width: 90%;
+}
+
 .reports-table-title .result-count {
   font-size: 12px;
   color: #535353;


### PR DESCRIPTION
Closes #958 . Just expands the report page size on small screens. Still looks fine on large screens.

![mar-16-2018 12-57-16](https://user-images.githubusercontent.com/5652739/37542027-f63a58f4-2919-11e8-9ba2-fb03d19fdc59.gif)
