### PR TITLE
Remove scrollbars from Filter menu

### DIFF
--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -711,8 +711,7 @@ $break-large: 1070px;
         z-index: 100;
         border-radius: 3px;
         box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-        height: 300px;
-        overflow: scroll;
+        height: auto !important;
         .col.s6 {
           .options-wrapper {
             label {


### PR DESCRIPTION
- Fixes the Filter menu on the All Samples page b/c the scrollbars were a bit of an eyesore.
- Adding more items is fine b/c height is set to auto.
- Overflow: scroll was what was causing scrollbars to show even though they weren't active.

![screen shot 2018-03-23 at 10 10 13 am](https://user-images.githubusercontent.com/5652739/37843527-68003ffe-2e82-11e8-8168-7fffd14918e6.png)
