### PR TITLE
(Minor) Change filter to live update

### DIFF
--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1083,10 +1083,7 @@ class Samples extends React.Component {
         });
       }
 
-      if (
-        !this.state.displayDropdown &&
-        (this.state.hostFilterChange || this.state.tissueFilterChange)
-      ) {
+      if (this.state.hostFilterChange || this.state.tissueFilterChange) {
         this.setUrlLocation("none");
         this.fetchResults();
         this.state.hostFilterChange = false;


### PR DESCRIPTION
- Makes main filter on the All Samples page live update like the other dropdowns. For consistency and because it caused user confusion.