### PR TITLE
show phage when phage is selected but viruses is not

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -265,10 +265,16 @@ class PipelineSampleReport extends React.Component {
         selected_taxons = selected_taxons.concat(matched_taxons);
       }
     } else if (excludedCategories.length > 0) {
+      let displayed_subcat_indicator_columns = this.displayedSubcats(excludeSubcats).map((subcat) => {
+        return `is_${subcat.toLowerCase()}`
+      })
       for (var i = 0; i < thresholded_taxons.length; i++) {
         let taxon = thresholded_taxons[i];
         if (excludedCategories.indexOf(taxon.category_name) < 0) {
           // not in the excluded categories
+          selected_taxons.push(taxon);
+        } else if (displayed_subcat_indicator_columns.some((column) => { return taxon[column] == 1; })) {
+          // even if category is excluded, include checked subcategories
           selected_taxons.push(taxon);
         } else if (
           taxon.category_name == "Uncategorized" &&


### PR DESCRIPTION
First, you need to run
```
pipeline_runs = PipelineRun.where("id in (select max(id) from pipeline_runs where job_status = 'CHECKED' and sample_id in (select id from samples) group by sample_id)")
pipeline_runs.map(&:update_genera)
pipeline_runs.map(&:update_is_phage)
```
Until you do that, everything is classified as "not a phage" by default.