### PR TITLE
redis locks are no longer necessary

### DIFF
--- a/app/jobs/load_results_for_run_stage.rb
+++ b/app/jobs/load_results_for_run_stage.rb
@@ -1,15 +1,8 @@
 # Jos to initiate database download
 require 'logger'
-require 'resque/plugins/lock'
 class LoadResultForRunStage
-  extend Resque::Plugins::Lock
   @queue = :q03_pipeline_run
   @logger = Logger.new(STDOUT)
-  @git_version = ENV['GIT_VERSION'] || ""
-
-  def self.lock(pipeline_run_stage_id)
-    "LoadResultsFromS3-#{pipeline_run_stage_id}-#{@git_version}"
-  end
 
   def self.perform(pipeline_run_stage_id)
     @logger.info("load pipeline run stage #{pipeline_run_stage_id} into database")


### PR DESCRIPTION
removing these locks because they frequently fail to release,
and they are actually not necessary

proof:

    LoadResultForStage is enqueued in just one code location,
    that location is unreachable if the job status is already "CHECKED",
    and the job status is changed to CHECKED just before the enqueue,
    ensuring the enqueue can happen just once
