### PR TITLE
Revert "Avoid failure in populate_fraction_subsampled.rake"

### DIFF
--- a/lib/tasks/populate_fraction_subsampled.rake
+++ b/lib/tasks/populate_fraction_subsampled.rake
@@ -2,7 +2,6 @@ task populate_fraction_subsampled: :environment do
   pipeline_runs = PipelineRun.where("id in (select max(id) from pipeline_runs where job_status = 'CHECKED' and sample_id in (select id from samples) group by sample_id)")
   pipeline_runs = pipeline_runs.order(id: :desc)
   pipeline_runs.each do |pr|
-    next unless pr.remaining_reads
     pr.update(fraction_subsampled: pr.subsample_fraction)
   end
 end


### PR DESCRIPTION
See if it fixes the build.
Boris, you'll have to reapply "redis locks are no longer necessary"