### PR TITLE
File size tags (#1106)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,8 +49,8 @@ gem 'will_paginate'
 # Use AWS-SDK to make AWS requests with byte range
 gem 'aws-sdk'
 # Redirect
-gem 'rack-host-redirect'
 gem 'activesupport'
+gem 'rack-host-redirect'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'will_paginate'
 gem 'aws-sdk'
 # Redirect
 gem 'rack-host-redirect'
+gem 'activesupport'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -862,6 +862,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_query_trace
+  activesupport
   airbrake (~> 7.0)
   airbrake-ruby
   aws-sdk

--- a/app/assets/src/components/ResultsFolder.jsx
+++ b/app/assets/src/components/ResultsFolder.jsx
@@ -41,7 +41,7 @@ class ResultsFolder extends React.Component {
             </thead>
             <tbody>
             { this.fileList.map((file, i) => {
-              return <tr onClick={this.download.bind(this, file.url)} key={i}><td><i className="fa fa-file" />{file['display_name']}</td></tr>
+              return <tr onClick={this.download.bind(this, file.url)} key={i}><td><i className="fa fa-file" />{file['display_name']}<span className="size-tag"> -- {file['size']}</span></td></tr>
             })}
             </tbody>
           </table> : 'No files to show' }

--- a/app/assets/src/styles/_resultsfolder.scss
+++ b/app/assets/src/styles/_resultsfolder.scss
@@ -32,4 +32,7 @@
   i.fa-file {
     margin-right: 15px;
   }
+  .size-tag {
+    color: #D3D3D3;
+  }
 }  

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -132,14 +132,14 @@ class Sample < ApplicationRecord
     file_list = S3_CLIENT.list_objects(bucket: SAMPLES_BUCKET_NAME,
                                        prefix: "#{prefix}/",
                                        delimiter: "/")
-    file_list.contents.map { |f|
+    file_list.contents.map do |f|
       {
         key: f.key,
         display_name: end_path(f.key, display_prefix),
         url: Sample.get_signed_url(f.key),
         size: ActiveSupport::NumberHelper.number_to_human_size(f.size)
       }
-    }
+    end
   end
 
   def results_folder_files

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -132,7 +132,14 @@ class Sample < ApplicationRecord
     file_list = S3_CLIENT.list_objects(bucket: SAMPLES_BUCKET_NAME,
                                        prefix: "#{prefix}/",
                                        delimiter: "/")
-    file_list.contents.map { |f| { key: f.key, display_name: end_path(f.key, display_prefix), url: Sample.get_signed_url(f.key) } }
+    file_list.contents.map { |f|
+      {
+        key: f.key,
+        display_name: end_path(f.key, display_prefix),
+        url: Sample.get_signed_url(f.key),
+        size: ActiveSupport::NumberHelper.number_to_human_size(f.size)
+      }
+    }
   end
 
   def results_folder_files


### PR DESCRIPTION
- Issue #1106 
- Add file size tags to /results_folder and /fastqs_folder
- Was going to put it more to the right but it was quite hard to read with short file names

![screen shot 2018-04-06 at 11 05 21 am](https://user-images.githubusercontent.com/5652739/38436801-730a0ff2-398a-11e8-9b3b-c5a418e3f18d.png)
