### PR TITLE
new hit calling and poll single output file

### DIFF
--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -572,7 +572,11 @@ module ReportHelper
         # TODO: Can we keep the accession numbers to show in these cases?
         level_str = tax_info['tax_level'] == TaxonCount::TAX_LEVEL_SPECIES ? 'species' : 'genus'
         tax_info['name'] = "All taxa without #{level_str} classification"
-        if tax_id == TaxonLineage::BLACKLIST_GENUS_ID
+        if tax_id < TaxonLineage::INVALID_CALL_BASE_ID && tax_info['tax_level'] == TaxonCount::TAX_LEVEL_SPECIES
+          parent_taxid = tax_info['genus_taxid']
+          parent_name = taxon_counts_2d[parent_taxid]['name']
+          tax_info['name'] = "Non-#{level_str}-specific #{parent_name} reads"
+        elsif tax_id == TaxonLineage::BLACKLIST_GENUS_ID
           tax_info['name'] = "All artificial constructs"
         elsif !(TaxonLineage::MISSING_LINEAGE_ID.values.include? tax_id) && tax_id != TaxonLineage::MISSING_SPECIES_ID_ALT
           tax_info['name'] += " #{tax_id}"

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -66,11 +66,8 @@ class PipelineRunStage < ApplicationRecord
   end
 
   def output_ready?
-    s3_output_list = send(output_func)
-    s3_output_list.each do |out_f|
-      return false unless file_generated_since_run(out_f)
-    end
-    true
+    s3_output_file = send(output_func)
+    file_generated_since_run(s3_output_file)
   end
 
   def run_job
@@ -256,10 +253,20 @@ class PipelineRunStage < ApplicationRecord
     pr.save
   end
 
+  def output_json_name
+    pipeline_run.multihit? ? PipelineRun::MULTIHIT_OUTPUT_JSON_NAME : PipelineRun::OUTPUT_JSON_NAME
+  end
+
+  def invalid_genus_call?(tcnt)
+    tcnt['genus_taxid'].to_i < TaxonLineage::INVALID_CALL_BASE_ID
+  rescue
+    false
+  end
+
   def db_load_alignment
     pr = pipeline_run
 
-    output_json_s3_path = "#{pipeline_run.alignment_output_s3_path}/#{PipelineRun::OUTPUT_JSON_NAME}"
+    output_json_s3_path = "#{pipeline_run.alignment_output_s3_path}/#{output_json_name}"
     stats_json_s3_path = "#{pipeline_run.alignment_output_s3_path}/#{PipelineRun::STATS_JSON_NAME}"
 
     # Get the file
@@ -282,10 +289,12 @@ class PipelineRunStage < ApplicationRecord
     version_s3_path = "#{pipeline_run.alignment_output_s3_path}/#{PipelineRun::VERSION_JSON_NAME}"
     pr.version = `aws s3 cp #{version_s3_path} -`
 
-    # only keep species level counts
+    # only keep counts at certain taxonomic levels
     taxon_counts_attributes_filtered = []
+    acceptable_tax_levels = [TaxonCount::TAX_LEVEL_SPECIES]
+    acceptable_tax_levels << TaxonCount::TAX_LEVEL_GENUS if pr.multihit?
     pipeline_output_dict['taxon_counts_attributes'].each do |tcnt|
-      if tcnt['tax_level'].to_i == TaxonCount::TAX_LEVEL_SPECIES
+      if acceptable_tax_levels.include?(tcnt['tax_level'].to_i) && !invalid_genus_call?(tcnt)
         taxon_counts_attributes_filtered << tcnt
       end
     end
@@ -296,7 +305,7 @@ class PipelineRunStage < ApplicationRecord
     pr.updated_at = Time.now.utc
     pr.save
     # aggregate the data at genus level
-    pr.generate_aggregate_counts('genus')
+    pr.generate_aggregate_counts('genus') unless pr.multihit?
     # merge more accurate name information from lineages table
     pr.update_names
     # denormalize genus_taxid and superkingdom_taxid into taxon_counts
@@ -324,19 +333,14 @@ class PipelineRunStage < ApplicationRecord
   def host_filtering_outputs
     pr = pipeline_run
     pr.pipeline_version = pr.fetch_pipeline_version
-
-    stats_json_s3_path = "#{pipeline_run.host_filter_output_s3_path}/#{PipelineRun::STATS_JSON_NAME}"
-    unmapped_fasta_s3_path = "#{pipeline_run.host_filter_output_s3_path}/unmapped.bowtie2.lzw.cdhitdup.priceseqfilter.unmapped.star.merged.fasta"
-    [stats_json_s3_path, unmapped_fasta_s3_path]
+    "#{pipeline_run.host_filter_output_s3_path}/#{PipelineRun::STATS_JSON_NAME}"
   end
 
   def alignment_outputs
-    stats_json_s3_path = "#{pipeline_run.alignment_output_s3_path}/#{PipelineRun::STATS_JSON_NAME}"
-    output_json_s3_path = "#{pipeline_run.alignment_output_s3_path}/#{PipelineRun::OUTPUT_JSON_NAME}"
-    [stats_json_s3_path, output_json_s3_path]
+    "#{pipeline_run.alignment_output_s3_path}/#{PipelineRun::STATS_JSON_NAME}"
   end
 
   def postprocess_outputs
-    ["#{pipeline_run.postprocess_output_s3_path}/#{PipelineRun::TAXID_BYTERANGE_JSON_NAME}"]
+    "#{pipeline_run.postprocess_output_s3_path}/#{PipelineRun::TAXID_BYTERANGE_JSON_NAME}"
   end
 end

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -1,5 +1,6 @@
 # The TaxonLineage model gives the taxids forming the taxonomic lineage of any given species-level taxid.
 class TaxonLineage < ApplicationRecord
+  INVALID_CALL_BASE_ID = -100_000_000 # don't run into -2e9 limit (not common, mostly a concern for fp32 or int32)
   MISSING_SPECIES_ID = -100
   MISSING_SPECIES_ID_ALT = -1
   MISSING_GENUS_ID = -200


### PR DESCRIPTION
Handle the new data type with pipeline version >= 1.5 that identifies hits
which map to multiple species within a genus and group under a
line item "non species-specific hits to genus".

Poll a single output file emitted at the end of a successful batch job,
as opposed to requiring the presence of a number of files.  This leads
to a more robust pipeline in future, and to a more tolerant webapp
in present (able to support pipeline versions before and after 1.5).

Based on the work of Charles De Bourcy, with minor fixes by BD.