### PR TITLE
Update sample name in real-time

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -40,7 +40,8 @@ class PipelineSampleReads extends React.Component {
     this.canSeeAlignViz = props.can_see_align_viz;
     this.state = {
       rerunStatus: "failed",
-      rerunStatusMessage: "Sample run failed"
+      rerunStatusMessage: "Sample run failed",
+      sample_name: props.sampleInfo.name
     };
     this.TYPE_PROMPT = this.can_edit ? "Type here..." : "-";
     this.NUCLEOTIDE_TYPES = ["-", "DNA", "RNA"];
@@ -340,6 +341,10 @@ class PipelineSampleReads extends React.Component {
                 .css("display", "inline-block")
                 .delay(1000)
                 .slideUp(200);
+              if (field === "name") {
+                // update the name displayed in the header in real-time
+                this.setState({ sample_name: newText });
+              }
             } else if (response.data.status === "failed") {
               $(".note-save-failed")
                 .html(
@@ -580,7 +585,7 @@ class PipelineSampleReads extends React.Component {
           className="dropdown-button sample-select-dropdown"
           data-activates="sample-list"
         >
-          <span className="sample-name-label">{this.sampleInfo.name}</span>
+          <span className="sample-name-label">{this.state.sample_name}</span>
           <i className="fa fa-chevron-down right" />
 
           <ul
@@ -588,20 +593,22 @@ class PipelineSampleReads extends React.Component {
             className="dropdown-content sample-dropdown-content"
           >
             {Object.keys(this.sample_map).map((sample_id, i) => {
-              return (
-                <li key={i}>
-                  <a href={`/samples/${sample_id}`}>
-                    {this.sample_map[sample_id]}
-                  </a>
-                </li>
-              );
+              if (parseInt(sample_id) !== parseInt(this.sampleId)) {
+                return (
+                  <li key={i}>
+                    <a href={`/samples/${sample_id}`}>
+                      {this.sample_map[sample_id]}
+                    </a>
+                  </li>
+                );
+              }
             })}
           </ul>
         </div>
       );
     } else {
       sample_dropdown = (
-        <span className="sample-name-label">{this.sampleInfo.name}</span>
+        <span className="sample-name-label">{this.state.sample_name}</span>
       );
     }
 


### PR DESCRIPTION
When user edits the name in the Details tab and saves, the name in the header should update immediately. Also, I removed the current sample from the options in the sample dropdown.