### PR TITLE
Add metadata fields to Details page and style tweaks to Details page

### DIFF
--- a/app/assets/src/components/ERCCScatterPlot.jsx
+++ b/app/assets/src/components/ERCCScatterPlot.jsx
@@ -16,7 +16,7 @@ class ERCCScatterPlot extends React.Component {
     }
 
     if (!data.length) {
-      return null;
+      return "No data";
     }
 
     return (

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -845,7 +845,7 @@ class PipelineSampleReads extends React.Component {
                             "sample_batch"
                           )}
                           {this.render_metadata_textfield(
-                            "Organism",
+                            "Known organisms",
                             "sample_organism"
                           )}
                           {this.render_metadata_textfield(
@@ -863,7 +863,7 @@ class PipelineSampleReads extends React.Component {
                           this.can_edit
                         )}
                         {this.render_metadata_textfield_wide(
-                          "Confirmed hits",
+                          "Confirmed hits in report",
                           this.state,
                           "confirmed_names",
                           "None",
@@ -877,7 +877,7 @@ class PipelineSampleReads extends React.Component {
                           this.can_edit
                         )}
                         {this.render_metadata_textfield_wide(
-                          "Diagnoses",
+                          "Clinical diagnosis",
                           this.sampleInfo,
                           "sample_diagnosis",
                           this.TYPE_PROMPT,

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -181,6 +181,26 @@ class PipelineSampleReads extends React.Component {
     );
   }
 
+  render_metadata_numfield(label, field) {
+    let display_value = this.sampleInfo[field] || this.TYPE_PROMPT;
+    return (
+      <div className="row detail-row">
+        <div className="col s6 no-padding">{label}</div>
+        <div className="col s6 no-padding">
+          <div className="details-value sample-notes">
+            <pre
+              suppressContentEditableWarning
+              contentEditable={this.can_edit}
+              id={field}
+            >
+              {display_value}
+            </pre>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   gotoReport() {
     $("ul.tabs").tabs("select_tab", "reports");
     PipelineSampleReads.setTab("pipeline_display", "reports");
@@ -796,6 +816,34 @@ class PipelineSampleReads extends React.Component {
                             "Unique ID",
                             "sample_host"
                           )}
+                          {this.render_metadata_textfield(
+                            "Library prep",
+                            "sample_library"
+                          )}
+                          {this.render_metadata_textfield(
+                            "Sequencer",
+                            "sample_sequencer"
+                          )}
+                          {this.render_metadata_textfield(
+                            "Sample collection date",
+                            "sample_date"
+                          )}
+                          {this.render_metadata_numfield(
+                            "RNA/DNA input (ng)",
+                            "sample_input_ng"
+                          )}
+                          {this.render_metadata_numfield(
+                            "Batch",
+                            "sample_batch"
+                          )}
+                          {this.render_metadata_textfield(
+                            "Organism",
+                            "sample_organism"
+                          )}
+                          {this.render_metadata_textfield(
+                            "Detection method",
+                            "sample_detection"
+                          )}
                         </div>
                       </div>
                       <div className="row">
@@ -819,6 +867,10 @@ class PipelineSampleReads extends React.Component {
                           "sample_notes",
                           this.TYPE_PROMPT,
                           this.can_edit
+                        )}
+                        {this.render_metadata_textfield_wide(
+                          "Diagnosis",
+                          "sample_diagnosis"
                         )}
                       </div>
                     </div>

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -52,7 +52,7 @@ class PipelineSampleReads extends React.Component {
         : [],
       sample_name: props.sampleInfo.name
     };
-    this.TYPE_PROMPT = this.can_edit ? "Type here..." : "-";
+    this.TYPE_PROMPT = "-";
     this.NUCLEOTIDE_TYPES = ["-", "DNA", "RNA"];
     this.DROPDOWN_OPTIONS = {
       sample_tissue: PipelineSampleReads.fetchTissueTypes(),

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -363,7 +363,7 @@ class PipelineSampleReads extends React.Component {
               .slideUp(200);
           }
         })
-        .catch(error => {
+        .catch(() => {
           $(".note-save-failed")
             .html(`<i class='fa fa-frown-o'></i> Something went wrong!`)
             .css("display", "inline-block")
@@ -418,9 +418,11 @@ class PipelineSampleReads extends React.Component {
                 .css("display", "inline-block")
                 .delay(1000)
                 .slideUp(200);
+              // Reset back to the old text
+              e.target.innerText = currentText;
             }
           })
-          .catch(error => {
+          .catch(() => {
             $(".note-save-failed")
               .html(`<i class='fa fa-frown-o'></i> Something went wrong!`)
               .css("display", "inline-block")

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -174,7 +174,7 @@ class PipelineSampleReads extends React.Component {
           >
             <pre
               suppressContentEditableWarning
-              contentEditable="true"
+              contentEditable={this.can_edit}
               id={field}
             >
               {display_value}
@@ -198,7 +198,7 @@ class PipelineSampleReads extends React.Component {
           >
             <pre
               suppressContentEditableWarning
-              contentEditable="true"
+              contentEditable={this.can_edit}
               id={field}
             >
               {display_value}

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -144,7 +144,7 @@ class PipelineSampleReads extends React.Component {
     return (
       <div className="details-container col s12">
         <div className="details-title note">{label}</div>
-        <div className="sample-notes note edit-wide">
+        <div className={"sample-notes note " + (editable ? "edit-wide" : "")}>
           <pre
             className="details-value"
             suppressContentEditableWarning
@@ -167,23 +167,19 @@ class PipelineSampleReads extends React.Component {
       <div className="row detail-row">
         <div className="col s6 label">{label}</div>
         <div className="col s6">
-          {this.can_edit ? (
-            <div className="details-value sample-notes edit">
-              <pre
-                suppressContentEditableWarning
-                contentEditable="true"
-                id={field}
-              >
-                {display_value}
-              </pre>
-            </div>
-          ) : (
-            <div className="details-value sample-notes">
-              <pre suppressContentEditableWarning id={field}>
-                {display_value}
-              </pre>
-            </div>
-          )}
+          <div
+            className={
+              "details-value sample-notes " + (this.can_edit ? "edit" : "")
+            }
+          >
+            <pre
+              suppressContentEditableWarning
+              contentEditable="true"
+              id={field}
+            >
+              {display_value}
+            </pre>
+          </div>
         </div>
       </div>
     );
@@ -195,23 +191,19 @@ class PipelineSampleReads extends React.Component {
       <div className="row detail-row">
         <div className="col s6 label">{label}</div>
         <div className="col s6">
-          {this.can_edit ? (
-            <div className="details-value sample-notes edit">
-              <pre
-                suppressContentEditableWarning
-                contentEditable="true"
-                id={field}
-              >
-                {display_value}
-              </pre>
-            </div>
-          ) : (
-            <div className="details-value sample-notes">
-              <pre suppressContentEditableWarning id={field}>
-                {display_value}
-              </pre>
-            </div>
-          )}
+          <div
+            className={
+              "details-value sample-notes " + (this.can_edit ? "edit" : "")
+            }
+          >
+            <pre
+              suppressContentEditableWarning
+              contentEditable="true"
+              id={field}
+            >
+              {display_value}
+            </pre>
+          </div>
         </div>
       </div>
     );
@@ -885,8 +877,11 @@ class PipelineSampleReads extends React.Component {
                           this.can_edit
                         )}
                         {this.render_metadata_textfield_wide(
-                          "Diagnosis",
-                          "sample_diagnosis"
+                          "Diagnoses",
+                          this.sampleInfo,
+                          "sample_diagnosis",
+                          this.TYPE_PROMPT,
+                          this.can_edit
                         )}
                       </div>
                     </div>

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -104,15 +104,15 @@ class PipelineSampleReads extends React.Component {
     let dropdown_options = this.DROPDOWN_OPTIONS[field];
     let display_value = this.sampleInfo[field] ? this.sampleInfo[field] : "-";
     return (
-      <div className="row detail-row no-padding">
-        <div className="col s5 label">{label}</div>
-        <div className="col s7 no-padding">
+      <div className="row detail-row">
+        <div className="col s6 label">{label}</div>
+        <div className="col s6">
           <div className="sample-notes">
             <div
               className="details-value custom-select-dropdown select-dropdown"
               data-activates={field}
             >
-              <div className="hack">{display_value}</div>
+              <div className="details-text">{display_value}</div>
               <i className="fa fa-chevron-down right" />
             </div>
             {this.can_edit ? (
@@ -142,9 +142,9 @@ class PipelineSampleReads extends React.Component {
     let value =
       hash[field] instanceof Array ? hash[field].join("; ") : hash[field];
     return (
-      <div className="col s12">
+      <div className="details-container col s12">
         <div className="details-title note">{label}</div>
-        <div className="sample-notes note">
+        <div className="sample-notes note edit-wide">
           <pre
             className="details-value"
             suppressContentEditableWarning
@@ -165,17 +165,25 @@ class PipelineSampleReads extends React.Component {
         : this.TYPE_PROMPT;
     return (
       <div className="row detail-row">
-        <div className="col s6 no-padding">{label}</div>
-        <div className="col s6 no-padding">
-          <div className="details-value sample-notes">
-            <pre
-              suppressContentEditableWarning
-              contentEditable={this.can_edit}
-              id={field}
-            >
-              {display_value}
-            </pre>
-          </div>
+        <div className="col s6 label">{label}</div>
+        <div className="col s6">
+          {this.can_edit ? (
+            <div className="details-value sample-notes edit">
+              <pre
+                suppressContentEditableWarning
+                contentEditable="true"
+                id={field}
+              >
+                {display_value}
+              </pre>
+            </div>
+          ) : (
+            <div className="details-value sample-notes">
+              <pre suppressContentEditableWarning id={field}>
+                {display_value}
+              </pre>
+            </div>
+          )}
         </div>
       </div>
     );
@@ -185,17 +193,25 @@ class PipelineSampleReads extends React.Component {
     let display_value = this.sampleInfo[field] || this.TYPE_PROMPT;
     return (
       <div className="row detail-row">
-        <div className="col s6 no-padding">{label}</div>
-        <div className="col s6 no-padding">
-          <div className="details-value sample-notes">
-            <pre
-              suppressContentEditableWarning
-              contentEditable={this.can_edit}
-              id={field}
-            >
-              {display_value}
-            </pre>
-          </div>
+        <div className="col s6 label">{label}</div>
+        <div className="col s6">
+          {this.can_edit ? (
+            <div className="details-value sample-notes edit">
+              <pre
+                suppressContentEditableWarning
+                contentEditable="true"
+                id={field}
+              >
+                {display_value}
+              </pre>
+            </div>
+          ) : (
+            <div className="details-value sample-notes">
+              <pre suppressContentEditableWarning id={field}>
+                {display_value}
+              </pre>
+            </div>
+          )}
         </div>
       </div>
     );
@@ -327,7 +343,7 @@ class PipelineSampleReads extends React.Component {
       .trim();
     if (prevValue !== value) {
       parent.prev().html(
-        `<div class='hack'>
+        `<div class='details-text'>
         ${value}
        </div>
        <i class="fa fa-chevron-down right"/>`
@@ -516,14 +532,14 @@ class PipelineSampleReads extends React.Component {
           <div className="row">
             <div className="col s6">
               <div className="row detail-row">
-                <div className="col s6 no-padding">Total reads</div>
-                <div className="details-value col s6 no-padding">
+                <div className="col s6 label">Total reads</div>
+                <div className="details-value col s6 plain">
                   {numberWithCommas(this.pipelineRun.total_reads)}
                 </div>
               </div>
               <div className="row detail-row">
-                <div className="col s6 no-padding">ERCC reads</div>
-                <div className={`details-value col s6 no-padding`}>
+                <div className="col s6 label">ERCC reads</div>
+                <div className="details-value col s6 plain">
                   {!this.pipelineRun.total_ercc_reads
                     ? 0
                     : numberWithCommas(this.pipelineRun.total_ercc_reads)}
@@ -537,9 +553,9 @@ class PipelineSampleReads extends React.Component {
                 </div>
               </div>
               <div className="row detail-row">
-                <div className="col s6 no-padding">Non-host reads</div>
+                <div className="col s6 label">Non-host reads</div>
                 <div
-                  className={`details-value col s6 no-padding ${
+                  className={`details-value col s6 plain ${
                     !this.summary_stats.remaining_reads ? BLANK_TEXT : ""
                   }`}
                 >
@@ -552,9 +568,9 @@ class PipelineSampleReads extends React.Component {
                 </div>
               </div>
               <div className="row detail-row">
-                <div className="col s6 no-padding">Unmapped reads</div>
+                <div className="col s6 label">Unmapped reads</div>
                 <div
-                  className={`details-value col s6 no-padding ${
+                  className={`details-value col s6 plain ${
                     !this.summary_stats.unmapped_reads ? BLANK_TEXT : ""
                   }`}
                 >
@@ -566,9 +582,9 @@ class PipelineSampleReads extends React.Component {
             </div>
             <div className="col s6">
               <div className="row detail-row">
-                <div className="col s6 no-padding">Passed quality control</div>
+                <div className="col s6 label">Passed quality control</div>
                 <div
-                  className={`details-value col s6 no-padding ${
+                  className={`details-value col s6 plain ${
                     !this.summary_stats.qc_percent ? BLANK_TEXT : ""
                   }`}
                 >
@@ -578,9 +594,9 @@ class PipelineSampleReads extends React.Component {
                 </div>
               </div>
               <div className="row detail-row">
-                <div className="col s6 no-padding">Compression ratio</div>
+                <div className="col s6 label">Compression ratio</div>
                 <div
-                  className={`details-value col s6 no-padding ${
+                  className={`details-value col s6 plain ${
                     !this.summary_stats.compression_ratio ? BLANK_TEXT : ""
                   }`}
                 >
@@ -590,9 +606,9 @@ class PipelineSampleReads extends React.Component {
                 </div>
               </div>
               <div className="row detail-row">
-                <div className="col s6 no-padding">Date processed</div>
+                <div className="col s6 label">Date processed</div>
                 <div
-                  className={`details-value col s6 no-padding ${
+                  className={`details-value col s6 plain ${
                     !this.summary_stats.last_processed_at ? BLANK_TEXT : ""
                   }`}
                 >
@@ -779,9 +795,9 @@ class PipelineSampleReads extends React.Component {
                       <div className="row">
                         <div className="col s6">
                           <div className="row detail-row">
-                            <div className="col s6 no-padding">Host</div>
+                            <div className="col s6 label">Host</div>
                             <div
-                              className={`details-value col s6 no-padding
+                              className={`details-value col s6 plain
                             ${!this.host_genome ? BLANK_TEXT : ""}`}
                             >
                               {!this.host_genome
@@ -791,8 +807,8 @@ class PipelineSampleReads extends React.Component {
                           </div>
 
                           <div className="row detail-row">
-                            <div className="col s6 no-padding">Upload date</div>
-                            <div className="details-value col s6 no-padding">
+                            <div className="col s6 label">Upload date</div>
+                            <div className="details-value col s6 plain">
                               {moment(this.sampleInfo.created_at)
                                 .startOf("second")
                                 .fromNow()}
@@ -802,8 +818,6 @@ class PipelineSampleReads extends React.Component {
                             "Location",
                             "sample_location"
                           )}
-                        </div>
-                        <div className="col s6">
                           {this.render_metadata_dropdown(
                             "Tissue type",
                             "sample_tissue"
@@ -817,16 +831,18 @@ class PipelineSampleReads extends React.Component {
                             "sample_host"
                           )}
                           {this.render_metadata_textfield(
+                            "Sample collection date",
+                            "sample_date"
+                          )}
+                        </div>
+                        <div className="col s6">
+                          {this.render_metadata_textfield(
                             "Library prep",
                             "sample_library"
                           )}
                           {this.render_metadata_textfield(
                             "Sequencer",
                             "sample_sequencer"
-                          )}
-                          {this.render_metadata_textfield(
-                            "Sample collection date",
-                            "sample_date"
                           )}
                           {this.render_metadata_numfield(
                             "RNA/DNA input (ng)",

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -839,8 +839,8 @@ class PipelineSampleReads extends React.Component {
                             "sample_sequencer"
                           )}
                           {this.render_metadata_numfield(
-                            "RNA/DNA input (ng)",
-                            "sample_input_ng"
+                            "RNA/DNA input (pg)",
+                            "sample_input_pg"
                           )}
                           {this.render_metadata_numfield(
                             "Batch",

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -552,7 +552,7 @@ class Samples extends React.Component {
   }
 
   renderPipelineOutput(samples) {
-    let BLANK_TEXT = <span className="blank">NA</span>;
+    let BLANK_TEXT = <span className="blank">—</span>;
     return samples.map((sample, i) => {
       let dbSample = sample.db_sample;
       let derivedOutput = sample.derived_sample_output;

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -132,7 +132,7 @@ class Samples extends React.Component {
         "sample_library",
         "sample_sequencer",
         "sample_date",
-        "sample_input_ng",
+        "sample_input_pg",
         "sample_batch",
         "sample_diagnosis",
         "sample_organism",
@@ -196,8 +196,8 @@ class Samples extends React.Component {
         display_name: "Collection date",
         type: "metadata"
       },
-      sample_input_ng: {
-        display_name: "RNA/DNA input (ng)",
+      sample_input_pg: {
+        display_name: "RNA/DNA input (pg)",
         type: "metadata"
       },
       sample_batch: {
@@ -1600,7 +1600,7 @@ function PipelineOutputDataValues({
     "sample_library",
     "sample_sequencer",
     "sample_date",
-    "sample_input_ng",
+    "sample_input_pg",
     "sample_batch",
     "sample_diagnosis",
     "sample_organism",

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -205,11 +205,11 @@ class Samples extends React.Component {
         type: "metadata"
       },
       sample_diagnosis: {
-        display_name: "Diagnosis",
+        display_name: "Clinical diagnosis",
         type: "metadata"
       },
       sample_organism: {
-        display_name: "Organism",
+        display_name: "Known organisms",
         type: "metadata"
       },
       sample_detection: {

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -15,7 +15,7 @@ import {
   Form
 } from "semantic-ui-react";
 import Nanobar from "nanobar";
-import colors from "../styles/themes"
+import colors from "../styles/themes";
 import SortHelper from "./SortHelper";
 import numberWithCommas from "../helpers/strings";
 import ProjectSelection from "./ProjectSelection";
@@ -128,7 +128,8 @@ class Samples extends React.Component {
         "pipeline_status",
         "notes",
         "nucleotide_type",
-        "tissue_type"
+        "tissue_type",
+        "sample_library"
       ]
     };
 
@@ -174,6 +175,10 @@ class Samples extends React.Component {
       },
       notes: {
         display_name: "Notes",
+        type: "metadata"
+      },
+      sample_library: {
+        display_name: "Library prep",
         type: "metadata"
       }
     };
@@ -1552,7 +1557,15 @@ function PipelineOutputDataValues({
         ? derivedOutput.host_genome_name
         : BLANK_TEXT,
     notes:
-      dbSample && dbSample.sample_notes ? dbSample.sample_notes : BLANK_TEXT
+      dbSample && dbSample.sample_notes ? dbSample.sample_notes : BLANK_TEXT,
+    sample_library:
+      dbSample && dbSample.sample_library
+        ? dbSample.sample_library
+        : BLANK_TEXT,
+    sample_sequencer:
+      dbSample && dbSample.sample_sequencer
+        ? dbSample.sample_sequencer
+        : BLANK_TEXT
   };
 }
 

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -129,7 +129,14 @@ class Samples extends React.Component {
         "notes",
         "nucleotide_type",
         "tissue_type",
-        "sample_library"
+        "sample_library",
+        "sample_sequencer",
+        "sample_date",
+        "sample_input_ng",
+        "sample_batch",
+        "sample_diagnosis",
+        "sample_organism",
+        "sample_detection"
       ]
     };
 
@@ -179,6 +186,34 @@ class Samples extends React.Component {
       },
       sample_library: {
         display_name: "Library prep",
+        type: "metadata"
+      },
+      sample_sequencer: {
+        display_name: "Sequencer",
+        type: "metadata"
+      },
+      sample_date: {
+        display_name: "Collection date",
+        type: "metadata"
+      },
+      sample_input_ng: {
+        display_name: "RNA/DNA input (ng)",
+        type: "metadata"
+      },
+      sample_batch: {
+        display_name: "Batch",
+        type: "metadata"
+      },
+      sample_diagnosis: {
+        display_name: "Diagnosis",
+        type: "metadata"
+      },
+      sample_organism: {
+        display_name: "Organism",
+        type: "metadata"
+      },
+      sample_detection: {
+        display_name: "Detection method",
         type: "metadata"
       }
     };
@@ -1517,7 +1552,7 @@ function PipelineOutputDataValues({
   stats,
   dbSample
 }) {
-  return {
+  let res = {
     total_reads: !derivedOutput.pipeline_run
       ? BLANK_TEXT
       : numberWithCommas(derivedOutput.pipeline_run.total_reads),
@@ -1557,16 +1592,33 @@ function PipelineOutputDataValues({
         ? derivedOutput.host_genome_name
         : BLANK_TEXT,
     notes:
-      dbSample && dbSample.sample_notes ? dbSample.sample_notes : BLANK_TEXT,
-    sample_library:
-      dbSample && dbSample.sample_library
-        ? dbSample.sample_library
-        : BLANK_TEXT,
-    sample_sequencer:
-      dbSample && dbSample.sample_sequencer
-        ? dbSample.sample_sequencer
-        : BLANK_TEXT
+      dbSample && dbSample.sample_notes ? dbSample.sample_notes : BLANK_TEXT
   };
+
+  // Add more fields or blank_text values
+  let fields = [
+    "sample_library",
+    "sample_sequencer",
+    "sample_date",
+    "sample_input_ng",
+    "sample_batch",
+    "sample_diagnosis",
+    "sample_organism",
+    "sample_detection"
+  ];
+  fields.forEach(function(field) {
+    AddValOrBlank(res, dbSample, field);
+  });
+  return res;
+}
+
+function AddValOrBlank(all, sample, key) {
+  let BLANK_TEXT = <span className="blank">NA</span>;
+  if (sample && sample[key]) {
+    all[key] = sample[key];
+  } else {
+    all[key] = BLANK_TEXT;
+  }
 }
 
 function PipelineOutputCards({

--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -13,6 +13,12 @@
 }
 $break-large: 1070px;
 
+.column_name {
+  .fa-check.right {
+    margin-top: 5px;
+  }
+}
+
 .tabs {
   display: block !important;
   .tab {

--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -43,7 +43,7 @@ $break-large: 1070px;
     color: #313e49;
     font-size: $font-size-h5;
     font-weight: $headings-font-weight;
-    margin: 25px 0;
+    margin: 20px 0;
   }
 }
 
@@ -91,18 +91,47 @@ $break-large: 1070px;
   }
 }
 
+.col.s12.details-container {
+  padding-top: 15px;
+}
+
+.edit {
+  background: #f6faff;
+  &:hover {
+    background: #ebeff4;
+  }
+}
+
+.edit-wide {
+  background: #f6faff;
+  border: 1px solid #d0d4d9;
+  margin-top: 10px;
+  &:hover {
+    background: #ebeff4;
+  }
+}
+
+.details-title {
+  margin-top: 10px;
+}
+
 .detail-row {
   margin: 0 !important;
   border-bottom: 1px solid #cad0da;
-  padding: 10px 0;
   .label {
     padding: 10px 0 !important;
   }
   .details-value {
+    &.plain {
+      padding-left: 20px;
+    }
     width: 100%;
     font-weight: 600;
     margin-top: 2px;
-    .hack {
+    height: 37px;
+    padding-top: 10px;
+    padding-left: 10px;
+    .details-text {
       width: 80%;
       display: inline;
     }
@@ -126,11 +155,10 @@ $break-large: 1070px;
   }
   .custom-select-dropdown {
     padding: 8px;
+    background: #f6faff;
     &:hover,
     &.active {
-      border: 1px solid #3867fa;
-      background: #b7e0f5;
-      color: #3867fa;
+      background: #ebeff4;
       i {
         display: inline-block;
       }

--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -105,6 +105,7 @@ $break-large: 1070px;
 .edit-wide {
   background: #f6faff;
   border: 1px solid #d0d4d9;
+  border-radius: 5px;
   margin-top: 10px;
   &:hover {
     background: #ebeff4;
@@ -176,12 +177,8 @@ $break-large: 1070px;
   pre {
     font-weight: 600;
     margin-left: 5px;
-    border: 1px solid transparent;
     padding: 15px 5px;
     cursor: text;
-    &:hover {
-      border-color: #cad0da;
-    }
   }
 }
 .data-divider {

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -545,6 +545,7 @@ class SamplesController < ApplicationController
                                    :sample_memory, :sample_location, :sample_date, :sample_tissue,
                                    :sample_template, :sample_library, :sample_sequencer,
                                    :sample_notes, :job_queue, :search, :subsample, :pipeline_branch,
+                                   :sample_input_ng, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection,
                                    input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts])
   end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -545,7 +545,7 @@ class SamplesController < ApplicationController
                                    :sample_memory, :sample_location, :sample_date, :sample_tissue,
                                    :sample_template, :sample_library, :sample_sequencer,
                                    :sample_notes, :job_queue, :search, :subsample, :pipeline_branch,
-                                   :sample_input_ng, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection,
+                                   :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection,
                                    input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts])
   end
 

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -37,7 +37,7 @@ module SamplesHelper
                         sample_library: db_sample ? db_sample[:sample_library] : '',
                         sample_sequencer: db_sample ? db_sample[:sample_sequencer] : '',
                         sample_date: db_sample ? db_sample[:sample_date] : '',
-                        sample_input_ng: db_sample ? db_sample[:sample_input_ng] : '',
+                        sample_input_pg: db_sample ? db_sample[:sample_input_pg] : '',
                         sample_batch: db_sample ? db_sample[:sample_batch] : '',
                         sample_diagnosis: db_sample ? db_sample[:sample_diagnosis] : '',
                         sample_organism: db_sample ? db_sample[:sample_organism] : '',

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -33,7 +33,10 @@ module SamplesHelper
                         nonhost_alignment_status: run_info ? run_info['GSNAPL/RAPSEARCH alignment'] : '',
                         postprocessing_status: run_info ? run_info['Post Processing'] : '',
                         uploader: sample_info[:uploader] ? sample_info[:uploader][:name] : '',
-                        runtime_seconds: run_info ? run_info[:total_runtime] : '' }
+                        runtime_seconds: run_info ? run_info[:total_runtime] : '',
+                        sample_library: db_sample ? db_sample[:sample_library] : '',
+                        sample_sequencer: db_sample ? db_sample[:sample_sequencer] : '',
+        }
         stage_statuses = data_values.values_at(:host_filtering_status, :nonhost_alignment_status, :postprocessing_status)
         if stage_statuses.any? { |status| status == "FAILED" }
           data_values[:overall_job_status] = "FAILED"

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -41,8 +41,7 @@ module SamplesHelper
                         sample_batch: db_sample ? db_sample[:sample_batch] : '',
                         sample_diagnosis: db_sample ? db_sample[:sample_diagnosis] : '',
                         sample_organism: db_sample ? db_sample[:sample_organism] : '',
-                        sample_detection: db_sample ? db_sample[:sample_detection] : '',
-        }
+                        sample_detection: db_sample ? db_sample[:sample_detection] : '' }
         stage_statuses = data_values.values_at(:host_filtering_status, :nonhost_alignment_status, :postprocessing_status)
         if stage_statuses.any? { |status| status == "FAILED" }
           data_values[:overall_job_status] = "FAILED"

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -36,6 +36,12 @@ module SamplesHelper
                         runtime_seconds: run_info ? run_info[:total_runtime] : '',
                         sample_library: db_sample ? db_sample[:sample_library] : '',
                         sample_sequencer: db_sample ? db_sample[:sample_sequencer] : '',
+                        sample_date: db_sample ? db_sample[:sample_date] : '',
+                        sample_input_ng: db_sample ? db_sample[:sample_input_ng] : '',
+                        sample_batch: db_sample ? db_sample[:sample_batch] : '',
+                        sample_diagnosis: db_sample ? db_sample[:sample_diagnosis] : '',
+                        sample_organism: db_sample ? db_sample[:sample_organism] : '',
+                        sample_detection: db_sample ? db_sample[:sample_detection] : '',
         }
         stage_statuses = data_values.values_at(:host_filtering_status, :nonhost_alignment_status, :postprocessing_status)
         if stage_statuses.any? { |status| status == "FAILED" }

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -39,7 +39,7 @@ class Sample < ApplicationRecord
   METADATA_FIELDS = [:sample_host, # this has been repurposed to be 'Unique ID' (e.g. in human case, patient ID -- nothing to do with host genome)
                      :sample_location, :sample_date, :sample_tissue,
                      :sample_template, # this refers to nucleotide type (RNA or DNA)
-                     :sample_library, :sample_sequencer, :sample_notes, :sample_input_ng, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection].freeze
+                     :sample_library, :sample_sequencer, :sample_notes, :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection].freeze
 
   attr_accessor :bulk_mode
 
@@ -58,7 +58,7 @@ class Sample < ApplicationRecord
   after_save :set_presigned_url_for_local_upload
 
   # Error on trying to save string values to float
-  validates :sample_input_ng, :sample_batch, numericality: true, allow_nil: true
+  validates :sample_input_pg, :sample_batch, numericality: true, allow_nil: true
 
   # getter
   attr_reader :bulk_mode

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -58,7 +58,7 @@ class Sample < ApplicationRecord
   after_save :set_presigned_url_for_local_upload
 
   # Error on trying to save string values to float
-  validates :sample_input_ng, :sample_batch, :numericality => true, :allow_nil => true
+  validates :sample_input_ng, :sample_batch, numericality: true, allow_nil: true
 
   # getter
   attr_reader :bulk_mode

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -39,7 +39,7 @@ class Sample < ApplicationRecord
   METADATA_FIELDS = [:sample_host, # this has been repurposed to be 'Unique ID' (e.g. in human case, patient ID -- nothing to do with host genome)
                      :sample_location, :sample_date, :sample_tissue,
                      :sample_template, # this refers to nucleotide type (RNA or DNA)
-                     :sample_library, :sample_sequencer, :sample_notes].freeze
+                     :sample_library, :sample_sequencer, :sample_notes, :sample_input_ng, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection].freeze
 
   attr_accessor :bulk_mode
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -58,7 +58,7 @@ class Sample < ApplicationRecord
   after_save :set_presigned_url_for_local_upload
 
   # Error on trying to save string values to float
-  validates_numericality_of :sample_input_ng, :sample_batch
+  validates :sample_input_ng, :sample_batch, :numericality => true, :allow_nil => true
 
   # getter
   attr_reader :bulk_mode

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -57,6 +57,9 @@ class Sample < ApplicationRecord
   before_save :check_host_genome, :concatenate_input_parts, :check_status
   after_save :set_presigned_url_for_local_upload
 
+  # Error on trying to save string values to float
+  validates_numericality_of :sample_input_ng, :sample_batch
+
   # getter
   attr_reader :bulk_mode
 

--- a/db/migrate/20180419230428_add_more_metadata.rb
+++ b/db/migrate/20180419230428_add_more_metadata.rb
@@ -1,0 +1,9 @@
+class AddMoreMetadata < ActiveRecord::Migration[5.1]
+  def change
+    add_column :samples, :sample_input_ng, :float
+    add_column :samples, :sample_batch, :integer
+    add_column :samples, :sample_diagnosis, :text
+    add_column :samples, :sample_organism, :string
+    add_column :samples, :sample_detection, :string
+  end
+end

--- a/db/migrate/20180423230428_add_more_metadata.rb
+++ b/db/migrate/20180423230428_add_more_metadata.rb
@@ -1,6 +1,6 @@
 class AddMoreMetadata < ActiveRecord::Migration[5.1]
   def change
-    add_column :samples, :sample_input_ng, :float
+    add_column :samples, :sample_input_pg, :float
     add_column :samples, :sample_batch, :integer
     add_column :samples, :sample_diagnosis, :text
     add_column :samples, :sample_organism, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180418215805) do
-
+ActiveRecord::Schema.define(version: 20180419230428) do
   create_table "archived_backgrounds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "archive_of"
     t.text "data"
@@ -208,6 +207,11 @@ ActiveRecord::Schema.define(version: 20180418215805) do
     t.bigint "user_id"
     t.integer "subsample"
     t.string "pipeline_branch"
+    t.float "sample_input_ng", limit: 24
+    t.integer "sample_batch"
+    t.text "sample_diagnosis"
+    t.string "sample_organism"
+    t.string "sample_detection"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
     t.index ["user_id"], name: "index_samples_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180419230428) do
+ActiveRecord::Schema.define(version: 20180423230428) do
 
   create_table "archived_backgrounds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "archive_of"
@@ -208,7 +208,7 @@ ActiveRecord::Schema.define(version: 20180419230428) do
     t.bigint "user_id"
     t.integer "subsample"
     t.string "pipeline_branch"
-    t.float "sample_input_ng", limit: 24
+    t.float "sample_input_pg", limit: 24
     t.integer "sample_batch"
     t.text "sample_diagnosis"
     t.string "sample_organism"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20180419230428) do
+
   create_table "archived_backgrounds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "archive_of"
     t.text "data"


### PR DESCRIPTION
- I used the same key names where possible for simplicity..

New details page look:
![screen shot 2018-04-23 at 10 39 06 am](https://user-images.githubusercontent.com/5652739/39143380-9e95a95a-46e2-11e8-9680-e0154e42f28d.png)

Dropdown view:
![screen shot 2018-04-23 at 10 39 58 am](https://user-images.githubusercontent.com/5652739/39143414-b5b02ad4-46e2-11e8-8ff0-85b74581c67e.png)

BEFORE:
![screen shot 2018-04-23 at 9 53 55 am](https://user-images.githubusercontent.com/5652739/39141301-4af368b0-46dc-11e8-9862-fbe0af8650bd.png)


# Metadata changes
Sample collection date [column sample_date existed]
RNA/DNA input (ng) [new float column]
Library prep [column sample_library existed]
Sequencer [column sample_sequencer existed]
Batch [new integer column]
Diagnosis [new text column]
Organism [new string column]
Detection method [new string column]

# Migration
add_column :samples, :sample_input_ng, :float
add_column :samples, :sample_batch, :integer
add_column :samples, :sample_diagnosis, :text
add_column :samples, :sample_organism, :string
add_column :samples, :sample_detection, :string