### PR TITLE
fix blank report with hit calling and support non-genus-specific hits

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -247,7 +247,7 @@ class PipelineRun < ApplicationRecord
   def update_names
     # The names from the taxon_lineages table are preferred, but, not always
     # available;  this code merges them into taxon_counts.name.
-    %w[species genus].each do |level|
+    %w[species genus family].each do |level|
       level_id = TaxonCount::NAME_2_LEVEL[level]
       TaxonCount.connection.execute("
         UPDATE taxon_counts, taxon_lineages
@@ -271,6 +271,16 @@ class PipelineRun < ApplicationRecord
       WHERE taxon_counts.pipeline_run_id=#{id} AND
             (taxon_counts.created_at BETWEEN taxon_lineages.started_at AND taxon_lineages.ended_at) AND
             taxon_lineages.taxid = taxon_counts.tax_id
+    ")
+  end
+
+  def update_superkingdoms
+    TaxonCount.connection.execute("
+      UPDATE taxon_counts, taxon_lineages
+      SET taxon_counts.superkingdom_taxid = taxon_lineages.superkingdom_taxid
+      WHERE taxon_counts.pipeline_run_id=#{id} AND
+            (taxon_counts.created_at BETWEEN taxon_lineages.started_at AND taxon_lineages.ended_at) AND
+            taxon_lineages.taxid = taxon_counts.family_taxid
     ")
   end
 

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -257,8 +257,9 @@ class PipelineRunStage < ApplicationRecord
     pipeline_run.multihit? ? PipelineRun::MULTIHIT_OUTPUT_JSON_NAME : PipelineRun::OUTPUT_JSON_NAME
   end
 
-  def invalid_genus_call?(tcnt)
-    tcnt['genus_taxid'].to_i < TaxonLineage::INVALID_CALL_BASE_ID
+  def invalid_family_call?(tcnt)
+    # TODO:  Better family support.
+    tcnt['family_taxid'].to_i < TaxonLineage::INVALID_CALL_BASE_ID
   rescue
     false
   end
@@ -293,8 +294,10 @@ class PipelineRunStage < ApplicationRecord
     taxon_counts_attributes_filtered = []
     acceptable_tax_levels = [TaxonCount::TAX_LEVEL_SPECIES]
     acceptable_tax_levels << TaxonCount::TAX_LEVEL_GENUS if pr.multihit?
+    acceptable_tax_levels << TaxonCount::TAX_LEVEL_FAMILY if pr.multihit?
     pipeline_output_dict['taxon_counts_attributes'].each do |tcnt|
-      if acceptable_tax_levels.include?(tcnt['tax_level'].to_i) && !invalid_genus_call?(tcnt)
+      # TODO:  Better family support.
+      if acceptable_tax_levels.include?(tcnt['tax_level'].to_i) && !invalid_family_call?(tcnt)
         taxon_counts_attributes_filtered << tcnt
       end
     end
@@ -308,8 +311,12 @@ class PipelineRunStage < ApplicationRecord
     pr.generate_aggregate_counts('genus') unless pr.multihit?
     # merge more accurate name information from lineages table
     pr.update_names
-    # denormalize genus_taxid and superkingdom_taxid into taxon_counts
-    pr.update_genera
+    # denormalize superkingdom_taxid into taxon_counts
+    if pr.multihit?
+      pr.update_superkingdoms
+    else
+      pr.update_genera
+    end
     # label taxa as phage or non-phage
     pr.update_is_phage
 


### PR DESCRIPTION
the blank reports were caused by lineage map version drift between
pipeline and webapp, e.g., species 1173061 got reclassified from
genus 43987 to genus 27316;  and also by a pipeline bug fixed in 1.6

non-genus-specific hits are important e.g. for some species of
escheria coli where the identical genome is uploaded to NCBI
under two distinct species under two distinct genera
