### PR TITLE
Rename sample host to sample id to reflect usage

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -822,7 +822,7 @@ class PipelineSampleReads extends React.Component {
                           )}
                           {this.render_metadata_textfield(
                             "Unique ID",
-                            "sample_host"
+                            "sample_id"
                           )}
                           {this.render_metadata_textfield(
                             "Sample collection date",

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -822,7 +822,7 @@ class PipelineSampleReads extends React.Component {
                           )}
                           {this.render_metadata_textfield(
                             "Unique ID",
-                            "sample_id"
+                            "sample_unique_id"
                           )}
                           {this.render_metadata_textfield(
                             "Sample collection date",

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -37,7 +37,7 @@ class Sample < ApplicationRecord
   # These zombies keep coming back, so we now expressly fail submissions to them.
   DEPRECATED_QUEUES = %w[idseq_alpha_stg1 aegea_batch_ondemand idseq_production_high_pri_stg1].freeze
 
-  METADATA_FIELDS = [:sample_id, # this has been repurposed to be 'Unique ID' (e.g. in human case, patient ID -- nothing to do with host genome)
+  METADATA_FIELDS = [:sample_unique_id, # 'Unique ID' (e.g. in human case, patient ID)
                      :sample_location, :sample_date, :sample_tissue,
                      :sample_template, # this refers to nucleotide type (RNA or DNA)
                      :sample_library, :sample_sequencer, :sample_notes, :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection].freeze
@@ -107,7 +107,7 @@ class Sample < ApplicationRecord
         OR samples.sample_tissue LIKE :search
         OR samples.sample_location LIKE :search
         OR samples.sample_notes LIKE :search
-        OR samples.sample_id', search: "%#{search}%")
+        OR samples.sample_unique_id', search: "%#{search}%")
     else
       scoped
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -37,7 +37,7 @@ class Sample < ApplicationRecord
   # These zombies keep coming back, so we now expressly fail submissions to them.
   DEPRECATED_QUEUES = %w[idseq_alpha_stg1 aegea_batch_ondemand idseq_production_high_pri_stg1].freeze
 
-  METADATA_FIELDS = [:sample_host, # this has been repurposed to be 'Unique ID' (e.g. in human case, patient ID -- nothing to do with host genome)
+  METADATA_FIELDS = [:sample_id, # this has been repurposed to be 'Unique ID' (e.g. in human case, patient ID -- nothing to do with host genome)
                      :sample_location, :sample_date, :sample_tissue,
                      :sample_template, # this refers to nucleotide type (RNA or DNA)
                      :sample_library, :sample_sequencer, :sample_notes, :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection].freeze
@@ -107,7 +107,7 @@ class Sample < ApplicationRecord
         OR samples.sample_tissue LIKE :search
         OR samples.sample_location LIKE :search
         OR samples.sample_notes LIKE :search
-        OR samples.sample_host', search: "%#{search}%")
+        OR samples.sample_id', search: "%#{search}%")
     else
       scoped
     end

--- a/db/migrate/20180430224826_rename_sample_host.rb
+++ b/db/migrate/20180430224826_rename_sample_host.rb
@@ -1,0 +1,5 @@
+class RenameSampleHost < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :samples, :sample_host, :sample_id
+  end
+end

--- a/db/migrate/20180430224826_rename_sample_host.rb
+++ b/db/migrate/20180430224826_rename_sample_host.rb
@@ -1,5 +1,5 @@
 class RenameSampleHost < ActiveRecord::Migration[5.1]
   def change
-    rename_column :samples, :sample_host, :sample_id
+    rename_column :samples, :sample_host, :sample_unique_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180423230428) do
+ActiveRecord::Schema.define(version: 20180430224826) do
 
   create_table "archived_backgrounds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "archive_of"
@@ -191,7 +191,7 @@ ActiveRecord::Schema.define(version: 20180423230428) do
     t.datetime "updated_at", null: false
     t.bigint "project_id"
     t.string "status"
-    t.string "sample_host"
+    t.string "sample_id"
     t.string "sample_location"
     t.string "sample_date"
     t.string "sample_tissue"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -191,7 +191,7 @@ ActiveRecord::Schema.define(version: 20180430224826) do
     t.datetime "updated_at", null: false
     t.bigint "project_id"
     t.string "status"
-    t.string "sample_id"
+    t.string "sample_unique_id"
     t.string "sample_location"
     t.string "sample_date"
     t.string "sample_tissue"


### PR DESCRIPTION
- Sample_host was repurposed to be like "unique ID"