### PR TITLE
Move rerun pipeline button to the admin page

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -505,14 +505,6 @@ class PipelineSampleReads extends React.Component {
               ? waitingSpinner
               : this.state.rerunStatusMessage}
           </h6>
-          <p>
-            {this.state.rerunStatus === "failed" && this.can_edit ? (
-              <a onClick={this.rerunPipeline} className="custom-button small">
-                <i className="fa fa-repeat left" />
-                RERUN PIPELINE
-              </a>
-            ) : null}
-          </p>
         </div>
       );
     }

--- a/app/views/samples/_samples.html.erb
+++ b/app/views/samples/_samples.html.erb
@@ -45,7 +45,8 @@
               <%= pipeline_run.job_status %>
               &nbsp;
               <% if pipeline_run.completed? %>
-                <%= button_to 'rerun', kickoff_pipeline_sample_path(sample), method: :put %>
+                <%= button_to 'rerun from top', kickoff_pipeline_sample_path(sample), method: :put %>
+                <%= button_to "rerun failed stage", retry_pipeline_sample_path(sample), method: :put %>
               <% end %>
             <% end %>
           </td>


### PR DESCRIPTION
- 'kickoff_pipeline' is "from the top"
- 'retry_pipeline' is from the failed stage