### PR TITLE
Closes #1282: disallow uploads

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -401,6 +401,7 @@ class SamplesController < ApplicationController
     end
 
     params[:input_files_attributes] = params[:input_files_attributes].reject { |f| f["source"] == '' }
+    params[:input_files_attributes] = params[:input_files_attributes].reject { |f| f["source"].include?(SAMPLES_BUCKET_NAME) } unless current_user && current_user.role == 1
     @sample = Sample.new(params)
     @sample.project = project if project
     @sample.input_files.each { |f| f.name ||= File.basename(f.source) }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -400,7 +400,7 @@ class SamplesController < ApplicationController
       host_genome = HostGenome.find_by(name: host_genome_name)
     end
 
-    params[:input_files_attributes].reject! { |f| f["source"] == '' || !current_user.can_upload(f["source"]) }
+    params[:input_files_attributes].select! { |f| f["source"] != '' && current_user.can_upload(f["source"]) }
     @sample = Sample.new(params)
     @sample.project = project if project
     @sample.input_files.each { |f| f.name ||= File.basename(f.source) }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -400,8 +400,7 @@ class SamplesController < ApplicationController
       host_genome = HostGenome.find_by(name: host_genome_name)
     end
 
-    params[:input_files_attributes] = params[:input_files_attributes].reject { |f| f["source"] == '' }
-    params[:input_files_attributes] = params[:input_files_attributes].reject { |f| f["source"].include?(SAMPLES_BUCKET_NAME) } unless current_user && current_user.role == 1
+    params[:input_files_attributes].reject! { |f| f["source"] == '' || !current_user.can_upload(f["source"]) }
     @sample = Sample.new(params)
     @sample.project = project if project
     @sample.input_files.each { |f| f.name ||= File.basename(f.source) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,8 +30,6 @@ class User < ApplicationRecord
 
   def can_upload(s3_path)
     user_bucket = s3_path.split("/")[2] # get "bucket" from "s3://bucket/path/to/file"
-    all_envs = %w[production alpha development]
-    forbidden_buckets = all_envs.map { |env| SAMPLES_BUCKET_NAME.gsub(Regexp.union(*all_envs), env) }
-    !forbidden_buckets.include?(user_bucket) || admin?
+    user_bucket != SAMPLES_BUCKET_NAME || admin?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ApplicationRecord
 
   def can_upload(s3_path)
     user_bucket = s3_path.split("/")[2] # get "bucket" from "s3://bucket/path/to/file"
-    all_envs = ['production', 'alpha', 'development']
+    all_envs = %w[production alpha development]
     forbidden_buckets = all_envs.map { |env| SAMPLES_BUCKET_NAME.gsub(Regexp.union(*all_envs), env) }
     !forbidden_buckets.include?(user_bucket) || admin?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,4 +27,8 @@ class User < ApplicationRecord
   def demo_user?
     DEMO_USER_EMAILS.include?(email)
   end
+
+  def can_upload(s3_path)
+    admin? || !s3_path.include?(SAMPLES_BUCKET_NAME)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,8 +29,9 @@ class User < ApplicationRecord
   end
 
   def can_upload(s3_path)
-    bucket = s3_path.split("/")[2] # get "bucket" from "s3://bucket/path/to/file"
-    samples_bucket_base = SAMPLES_BUCKET_NAME.gsub(Regexp.union('production', 'alpha', 'development'), '') # Hack: remove env so guard applies to all envs
-    !bucket.include?(samples_bucket_base) || admin?
+    user_bucket = s3_path.split("/")[2] # get "bucket" from "s3://bucket/path/to/file"
+    all_envs = ['production', 'alpha', 'development']
+    forbidden_buckets = all_envs.map { |env| SAMPLES_BUCKET_NAME.gsub(Regexp.union(*all_envs), env) }
+    !forbidden_buckets.include?(user_bucket) || admin?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,6 @@ class User < ApplicationRecord
   end
 
   def can_upload(s3_path)
-    admin? || !s3_path.include?(SAMPLES_BUCKET_NAME)
+    !s3_path.include?(SAMPLES_BUCKET_NAME) || admin?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,8 @@ class User < ApplicationRecord
   end
 
   def can_upload(s3_path)
-    !s3_path.include?(SAMPLES_BUCKET_NAME) || admin?
+    bucket = s3_path.split("/")[2] # get "bucket" from "s3://bucket/path/to/file"
+    samples_bucket_base = SAMPLES_BUCKET_NAME.gsub(Regexp.union('production', 'alpha', 'development'), '') # Hack: remove env so guard applies to all envs
+    !bucket.include?(samples_bucket_base) || admin?
   end
 end


### PR DESCRIPTION
Prevents non-admins from choosing files in the private idseq S3 bucket as inputs for their own samples