### PR TITLE
more RAM means less IO

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -26,8 +26,8 @@ class Sample < ApplicationRecord
 
   # TODO: Make all these params configurable without code change
   DEFAULT_STORAGE_IN_GB = 500
-  DEFAULT_MEMORY_IN_MB = 59_000 # sorry, hacky
-  HOST_FILTERING_MEMORY_IN_MB = 60_000
+  DEFAULT_MEMORY_IN_MB = 120_000 # sorry, hacky
+  HOST_FILTERING_MEMORY_IN_MB = 240_000
 
   DEFAULT_QUEUE = 'idseq'.freeze
   DEFAULT_VCPUS = 8


### PR DESCRIPTION
IOPS are severaly constrained in docker/batch/EBS, so increasing
RAM lets is keep files in cache and makes jobs actually complete
that would otherwise stall for 24+ hours
