### PR TITLE
Add RuboCop to precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "setupTestFrameworkScriptFile": "./enzyme_config.js"
   },
   "lint-staged": {
-    "*.{js,jsx,json,css,scss}": ["prettier --write", "git add"]
+    "*.{js,jsx,json,css,scss}": ["prettier --write", "git add"],
+    "*.rb": [
+      "rubocop --auto-correct --config .rubocop_todo.yml --display-cop-names --display-style-guide",
+      "git add"
+    ]
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
- Adds 'RuboCop autocorrect' to our 'husky' pre-commit hook for staged files since I think we've all wasted a few minutes by forgetting to run it and then failing Travis for a trivial reason.
- Can still be skipped with "git commit --no-verify", which is also suggested on a fail.