### PR TITLE
Charles/project page

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -155,7 +155,8 @@ class SamplesController < ApplicationController
 
     @pipeline_run_display = curate_pipeline_run_display(@pipeline_run)
     @sample_status = @pipeline_run ? @pipeline_run.job_status : nil
-    job_stats_hash = make_job_stats_hash([@pipeline_run.id])[@pipeline_run.id]
+    pipeline_run_id = @pipeline_run ? @pipeline_run.id : nil
+    job_stats_hash = make_job_stats_hash([pipeline_run_id])[pipeline_run_id]
     @summary_stats = job_stats_hash.present? ? get_summary_stats(job_stats_hash, @pipeline_run) : nil
     @project_info = @sample.project ? @sample.project : nil
     @project_sample_ids_names = @sample.project ? Hash[current_power.project_samples(@sample.project).map { |s| [s.id, s.name] }] : nil

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -68,7 +68,7 @@ class SamplesController < ApplicationController
     results = filter_by_tissue_type(results, tissue_type_query) if tissue_type_query.present?
     results = filter_by_host(results, host_query) if host_query.present?
 
-    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || PAGE_SIZE).includes([:user, :host_genome, :input_files, :pipeline_runs])
+    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || PAGE_SIZE).includes([:user, :host_genome, :pipeline_runs])
     @samples_count = results.size
     @all_samples = format_samples(@samples)
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -68,7 +68,7 @@ class SamplesController < ApplicationController
     results = filter_by_tissue_type(results, tissue_type_query) if tissue_type_query.present?
     results = filter_by_host(results, host_query) if host_query.present?
 
-    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || PAGE_SIZE).includes([:user, :host_genome, :pipeline_runs])
+    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || PAGE_SIZE).includes([:user, :host_genome, :pipeline_runs, :input_files])
     @samples_count = results.size
     @all_samples = format_samples(@samples)
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -156,7 +156,7 @@ class SamplesController < ApplicationController
     @pipeline_run_display = curate_pipeline_run_display(@pipeline_run)
     @sample_status = @pipeline_run ? @pipeline_run.job_status : nil
     pipeline_run_id = @pipeline_run ? @pipeline_run.id : nil
-    job_stats_hash = make_job_stats_hash([pipeline_run_id])[pipeline_run_id]
+    job_stats_hash = job_stats_db_get(pipeline_run_id)
     @summary_stats = job_stats_hash.present? ? get_summary_stats(job_stats_hash, @pipeline_run) : nil
     @project_info = @sample.project ? @sample.project : nil
     @project_sample_ids_names = @sample.project ? Hash[current_power.project_samples(@sample.project).map { |s| [s.id, s.name] }] : nil

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -68,7 +68,7 @@ class SamplesController < ApplicationController
     results = filter_by_tissue_type(results, tissue_type_query) if tissue_type_query.present?
     results = filter_by_host(results, host_query) if host_query.present?
 
-    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || PAGE_SIZE).includes([:user, :host_genome, :input_files], pipeline_runs: :pipeline_run_stages)
+    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || PAGE_SIZE).includes([:user, :host_genome, :input_files, :pipeline_runs])
     @samples_count = results.size
     @all_samples = format_samples(@samples)
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -156,7 +156,7 @@ class SamplesController < ApplicationController
     @pipeline_run_display = curate_pipeline_run_display(@pipeline_run)
     @sample_status = @pipeline_run ? @pipeline_run.job_status : nil
     pipeline_run_id = @pipeline_run ? @pipeline_run.id : nil
-    job_stats_hash = job_stats_db_get(pipeline_run_id)
+    job_stats_hash = job_stats_get(pipeline_run_id)
     @summary_stats = job_stats_hash.present? ? get_summary_stats(job_stats_hash, @pipeline_run) : nil
     @project_info = @sample.project ? @sample.project : nil
     @project_sample_ids_names = @sample.project ? Hash[current_power.project_samples(@sample.project).map { |s| [s.id, s.name] }] : nil

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -68,7 +68,7 @@ class SamplesController < ApplicationController
     results = filter_by_tissue_type(results, tissue_type_query) if tissue_type_query.present?
     results = filter_by_host(results, host_query) if host_query.present?
 
-    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || PAGE_SIZE).includes([:user, :input_files], pipeline_runs: [:job_stats, :pipeline_run_stages])
+    @samples = sort_by(results, sort).paginate(page: params[:page], per_page: params[:per_page] || PAGE_SIZE).includes([:user, :host_genome, :input_files], pipeline_runs: :pipeline_run_stages)
     @samples_count = results.size
     @all_samples = format_samples(@samples)
 
@@ -155,8 +155,8 @@ class SamplesController < ApplicationController
 
     @pipeline_run_display = curate_pipeline_run_display(@pipeline_run)
     @sample_status = @pipeline_run ? @pipeline_run.job_status : nil
-    @job_stats = @pipeline_run ? @pipeline_run.job_stats : nil
-    @summary_stats = @job_stats ? get_summary_stats(@job_stats) : nil
+    job_stats_hash = make_job_stats_hash([@pipeline_run.id])[@pipeline_run.id]
+    @summary_stats = job_stats_hash.present? ? get_summary_stats(job_stats_hash, @pipeline_run) : nil
     @project_info = @sample.project ? @sample.project : nil
     @project_sample_ids_names = @sample.project ? Hash[current_power.project_samples(@sample.project).map { |s| [s.id, s.name] }] : nil
     @host_genome = @sample.host_genome ? @sample.host_genome : nil

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -271,7 +271,8 @@ module SamplesHelper
     output_data
   end
 
-  def job_stats_db_multiget(pipeline_run_ids)
+  def job_stats_multiget(pipeline_run_ids)
+    # get job_stats from db
     all_job_stats = JobStat.where(pipeline_run_id: pipeline_run_ids)
     job_stats_by_pipeline_run_id = {}
     all_job_stats.each do |entry|
@@ -281,12 +282,13 @@ module SamplesHelper
     job_stats_by_pipeline_run_id
   end
 
-  def job_stats_db_get(pipeline_run_id)
-    job_stats_db_multiget([pipeline_run_id])[pipeline_run_id]
+  def job_stats_get(pipeline_run_id)
+    # get job_stats from db
+    job_stats_multiget([pipeline_run_id])[pipeline_run_id]
   end
 
-  def report_ready_db_multiget(pipeline_run_ids)
-    # get ids of pipeline_runs for which "report_ready?" is true
+  def report_ready_multiget(pipeline_run_ids)
+    # query db to get ids of pipeline_runs for which "report_ready?" is true
     PipelineRun.where(id: pipeline_run_ids).where("job_status = '#{PipelineRun::STATUS_CHECKED}' or id in (select pipeline_run_id from pipeline_run_stages where pipeline_run_stages.step_number = pipeline_runs.ready_step and pipeline_run_stages.job_status = '#{PipelineRun::STATUS_LOADED}')").pluck(:id)
   end
 
@@ -298,8 +300,8 @@ module SamplesHelper
     sample_ids = samples.map(&:id)
     pipeline_run_ids = PipelineRun.where("id in (select max(id) from pipeline_runs where
                   sample_id in (#{sample_ids.join(',')}) group by sample_id)").pluck(:id)
-    job_stats_by_pipeline_run_id = job_stats_db_multiget(pipeline_run_ids)
-    report_ready_pipeline_run_ids = report_ready_db_multiget(pipeline_run_ids)
+    job_stats_by_pipeline_run_id = job_stats_multiget(pipeline_run_ids)
+    report_ready_pipeline_run_ids = report_ready_multiget(pipeline_run_ids)
 
     # Massage data into the right format
     samples.each_with_index do |sample|

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -287,6 +287,9 @@ module SamplesHelper
   end
 
   def format_samples(samples)
+    formatted_samples = []
+    return formatted_samples if samples.empty?
+
     # Do major SQL queries
     sample_ids = samples.map(&:id)
     pipeline_run_ids = PipelineRun.where("id in (select max(id) from pipeline_runs where
@@ -295,7 +298,6 @@ module SamplesHelper
     report_ready_pipeline_run_ids = check_report_ready(pipeline_run_ids)
 
     # Massage data into the right format
-    formatted_samples = []
     samples.each_with_index do |sample|
       job_info = {}
       job_info[:db_sample] = sample

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -271,7 +271,7 @@ module SamplesHelper
     output_data
   end
 
-  def make_job_stats_hash(pipeline_run_ids)
+  def job_stats_db_multiget(pipeline_run_ids)
     all_job_stats = JobStat.where(pipeline_run_id: pipeline_run_ids)
     job_stats_by_pipeline_run_id = {}
     all_job_stats.each do |entry|
@@ -281,7 +281,11 @@ module SamplesHelper
     job_stats_by_pipeline_run_id
   end
 
-  def check_report_ready(pipeline_run_ids)
+  def job_stats_db_get(pipeline_run_id)
+    job_stats_db_multiget([pipeline_run_id])[pipeline_run_id]
+  end
+
+  def report_ready_db_multiget(pipeline_run_ids)
     # get ids of pipeline_runs for which "report_ready?" is true
     PipelineRun.where(id: pipeline_run_ids).where("job_status = '#{PipelineRun::STATUS_CHECKED}' or id in (select pipeline_run_id from pipeline_run_stages where pipeline_run_stages.step_number = pipeline_runs.ready_step and pipeline_run_stages.job_status = '#{PipelineRun::STATUS_LOADED}')").pluck(:id)
   end
@@ -294,8 +298,8 @@ module SamplesHelper
     sample_ids = samples.map(&:id)
     pipeline_run_ids = PipelineRun.where("id in (select max(id) from pipeline_runs where
                   sample_id in (#{sample_ids.join(',')}) group by sample_id)").pluck(:id)
-    job_stats_by_pipeline_run_id = make_job_stats_hash(pipeline_run_ids)
-    report_ready_pipeline_run_ids = check_report_ready(pipeline_run_ids)
+    job_stats_by_pipeline_run_id = job_stats_db_multiget(pipeline_run_ids)
+    report_ready_pipeline_run_ids = report_ready_db_multiget(pipeline_run_ids)
 
     # Massage data into the right format
     samples.each_with_index do |sample|

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -271,8 +271,7 @@ module SamplesHelper
     output_data
   end
 
-  def format_samples(samples)
-    sample_ids = samples.map(&:id)
+  def make_job_stats_hash(sample_ids)
     pipeline_run_ids = PipelineRun.top_completed_runs.where(sample_id: sample_ids)
     all_job_stats = JobStat.where(pipeline_run_id: pipeline_run_ids).as_json
     job_stats_by_pipeline_run_id = {}
@@ -280,6 +279,12 @@ module SamplesHelper
       job_stats_by_pipeline_run_id[entry['pipeline_run_id']] ||= {}
       job_stats_by_pipeline_run_id[entry['pipeline_run_id']][entry['task']] = entry
     end
+    job_stats_by_pipeline_run_id
+  end
+
+  def format_samples(samples)
+    sample_ids = samples.map(&:id)
+    job_stats_by_pipeline_run_id = make_job_stats_hash(sample_ids)
 
     formatted_samples = []
     samples.each_with_index do |sample|

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -402,7 +402,7 @@ class PipelineRun < ApplicationRecord
   end
 
   def assembly?
-    after(pipeline_version || fetch_pipeline_version, "1000.1000")
+    after(pipeline_version, "1000.1000")
     # Very big version number so we don't accidentally start going into assembly mode.
     # Once we decide to deploy the assembly pipeline, change "1000.1000" to the relevant version number of idseq-pipeline.
   end


### PR DESCRIPTION
Speed up the project page:
- only 1 SQL query for job_stats
- only 1 SQL query for pipeline_run_stages
- do not poll S3 to retrieve pipeline_version for each sample...

Tested locally, looking at query traces with `tail -f log/development.log`. Speed-up very noticeable.