### PR TITLE
Always show the results folder, even for failed runs

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -706,6 +706,12 @@ class PipelineSampleReads extends React.Component {
     let download_section = (
       <div>
         <ResultButton
+          url={`/samples/${this.sampleInfo.id}/fastqs_folder`}
+          icon="fa-folder-open"
+          label="Source Data"
+          visible={true}
+        />
+        <ResultButton
           url={`/samples/${this.sampleInfo.id}/nonhost_fasta`}
           icon="fa-cloud-download"
           label="Non-Host Reads"
@@ -721,7 +727,7 @@ class PipelineSampleReads extends React.Component {
           url={`/samples/${this.sampleInfo.id}/results_folder`}
           icon="fa-folder-open"
           label="Results Folder"
-          visible={stage2_complete}
+          visible={true}
         />
         <ResultButton
           url={`/samples/${this.sampleInfo.id}/assembly/all`}
@@ -998,13 +1004,6 @@ class PipelineSampleReads extends React.Component {
 
               <div className="col s3 download-area">
                 <div className="download-title">Download Reads</div>
-                <a
-                  className="custom-button"
-                  href={`/samples/${this.sampleInfo.id}/fastqs_folder`}
-                >
-                  <i className="fa fa-folder-open" />
-                  Source Data
-                </a>
                 {download_section}
               </div>
             </div>


### PR DESCRIPTION
# Description

We should always show a link to the results folder, even in case of samples being processed or failed pipeline runs, so that the user can have some inkling as to what happened w/o needing to contact us.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce

Ran on development and uploaded a new sample, checking results folder periodically

# Checklist:

- [x ] I have run through the testing script to make sure current functionality is unchanged
- [ x] I have done relevant tests that prove my fix is effective or that my feature works
- [ x] I have spent time testing out edge cases for my feature
- [ x] I have updated the test script or pull request template if necessary
- [ x] New and existing unit tests pass locally with my changes

