### PR TITLE
Fix project report downloads

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -149,7 +149,7 @@ class SamplesController < ApplicationController
   # GET /samples/1.json
 
   def show
-    @pipeline_run = select_pipeline_run(@sample)
+    @pipeline_run = select_pipeline_run(@sample, params)
     @pipeline_version = @pipeline_run.pipeline_version || PipelineRun::PIPELINE_VERSION_WHEN_NULL if @pipeline_run
     @pipeline_versions = @sample.pipeline_versions
 
@@ -221,7 +221,7 @@ class SamplesController < ApplicationController
 
   def report_info
     expires_in 30.days
-    @pipeline_run = select_pipeline_run(@sample)
+    @pipeline_run = select_pipeline_run(@sample, params)
 
     ##################################################
     ## Duct tape for changing background id dynamically
@@ -244,7 +244,7 @@ class SamplesController < ApplicationController
   def search_list
     expires_in 30.days
 
-    @pipeline_run = select_pipeline_run(@sample)
+    @pipeline_run = select_pipeline_run(@sample, params)
     if @pipeline_run
       @search_list = fetch_lineage_info(@pipeline_run.id)
       render json: JSON.dump(@search_list)
@@ -564,14 +564,6 @@ class SamplesController < ApplicationController
       return background_id
     else
       raise "Not allowed to view background"
-    end
-  end
-
-  def select_pipeline_run(sample)
-    if params[:pipeline_version].blank?
-      sample.pipeline_runs.first
-    else
-      sample.pipeline_run_by_version(params[:pipeline_version])
     end
   end
 

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -959,7 +959,7 @@ module ReportHelper
     params[:is_csv] = 1
     params[:sort_by] = "highest_nt_aggregatescore"
     background_id = params[:background_id] || sample.default_background_id
-    pipeline_run = select_pipeline_run(sample)
+    pipeline_run = select_pipeline_run(sample, params)
     pipeline_run_id = pipeline_run ? pipeline_run.id : nil
     return "" if pipeline_run_id.nil? || pipeline_run.total_reads.nil? || pipeline_run.remaining_reads.nil?
     tax_details = taxonomy_details(pipeline_run_id, background_id, params)
@@ -986,6 +986,14 @@ module ReportHelper
           csv << data_values.values_at(*attribute_names.map(&:to_sym))
         end
       end
+    end
+  end
+
+  def select_pipeline_run(sample, params)
+    if params[:pipeline_version].blank?
+      sample.pipeline_runs.first
+    else
+      sample.pipeline_run_by_version(params[:pipeline_version])
     end
   end
 end


### PR DESCRIPTION
- As reported here: https://github.com/chanzuckerberg/idseq-web/issues/1324

- Fixes the Project-specific report CSV download
- Tested by clicking all the download buttons (table, report, gene counts) on the Project page, the Report page, and the All Samples page.