### PR TITLE
Forcing users to be created with names and emails

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -221,7 +221,7 @@ class ProjectsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def create_new_user_random_password(email)
-    user_params_with_password = { email: email }
+    user_params_with_password = { email: email, name: email }
     random_password = SecureRandom.hex(10)
     user_params_with_password[:password] = random_password
     user_params_with_password[:password_confirmation] = random_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   has_many :samples
   has_many :favorite_projects
   has_many :favorites, through: :favorite_projects, source: :project
+  validates :email, presence: true
+  validates :name, presence: true
   attr_accessor :email_arguments
   ROLE_ADMIN = 1
   DEMO_USER_EMAILS = ['idseq.guest@chanzuckerberg.com'].freeze


### PR DESCRIPTION
# Description

User model now requires name and email, and inviting an email to a project sets that user's name to the email

fixes #1298 

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Created some test users from the rails console w/ and w/o email / name
1. Created some test users from the invite flow and the admin user flow

## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?

- [ ] Login Screen
- [ ] Single Upload Page
- [ ] Batch Upload Page
- [ ] All Projects Page
- [x ] Sample Details Page
- [ ] Report Page


