### PR TITLE
Add version check for CLI

### DIFF
--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -258,7 +258,8 @@ class SampleUpload extends React.Component {
           subsample: this.state.omitSubsamplingChecked ? 0 : 1,
           status: "created"
         },
-        authenticity_token: this.csrf
+        authenticity_token: this.csrf,
+        client: "web"
       })
       .then(response => {
         this.setState({

--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -256,10 +256,10 @@ class SampleUpload extends React.Component {
           pipeline_branch: this.state.selectedBranch,
           host_genome_id: this.state.selectedHostGenomeId,
           subsample: this.state.omitSubsamplingChecked ? 0 : 1,
-          status: "created"
+          status: "created",
+          client: "web"
         },
-        authenticity_token: this.csrf,
-        client: "web"
+        authenticity_token: this.csrf
       })
       .then(response => {
         this.setState({

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -388,7 +388,7 @@ class SamplesController < ApplicationController
     # CLI client should provide a version string to-be-checked against the
     # minimum version here. Bulk upload from CLI goes to this method.
     client = params.delete(:client)
-    min_version = Gem::Version.new('0.3.2')
+    min_version = Gem::Version.new('0.3.0')
     unless client && (client == "web" || Gem::Version.new(client) >= min_version)
       render json: {
         message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git `",

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -387,7 +387,7 @@ class SamplesController < ApplicationController
     # Check if the client is up-to-date. "web" is always valid whereas the
     # CLI client should provide a version string to-be-checked against the
     # minimum version here. Bulk upload from CLI goes to this method.
-    client = params[:client]
+    client = params.delete(:client)
     min_version = Gem::Version.new('0.3.2')
     unless client && (client == "web" || Gem::Version.new(client) >= min_version)
       render json: {

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -32,7 +32,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @joe_project.name, input_files_attributes: input_files, client: "web" } }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @joe_project.name, client: "web", input_files_attributes: input_files } }
     end
     assert_response :success
   end

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -83,7 +83,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_no_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @public_project.name, input_files_attributes: input_files } }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @public_project.name, input_files_attributes: input_files }, client: "web" }
     end
     assert_response 422
   end
@@ -135,7 +135,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_no_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files } }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }
     end
     assert_response 422
   end
@@ -181,7 +181,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_no_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files } }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }
     end
     assert_response 422
   end

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -83,7 +83,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_no_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @public_project.name, input_files_attributes: input_files, client: "web" } }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @public_project.name, client: "web", input_files_attributes: input_files } }
     end
     assert_response 422
   end
@@ -135,7 +135,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_no_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, client: "web", input_files_attributes: input_files } }
     end
     assert_response 422
   end
@@ -181,7 +181,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_no_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, client: "web", input_files_attributes: input_files } }
     end
     assert_response 422
   end

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -32,7 +32,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @joe_project.name, input_files_attributes: input_files }, client: "web" }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @joe_project.name, input_files_attributes: input_files, client: "web" } }
     end
     assert_response :success
   end
@@ -83,7 +83,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_no_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @public_project.name, input_files_attributes: input_files }, client: "web" }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @public_project.name, input_files_attributes: input_files, client: "web" } }
     end
     assert_response 422
   end
@@ -135,7 +135,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_no_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }
     end
     assert_response 422
   end
@@ -181,7 +181,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_no_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }
     end
     assert_response 422
   end

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -32,7 +32,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count') do
-      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @joe_project.name, input_files_attributes: input_files } }
+      post "#{samples_url}.json", params: { sample: { name: 'joe new sample', project_name: @joe_project.name, input_files_attributes: input_files }, client: "web" }
     end
     assert_response :success
   end

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -34,7 +34,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count') do
-      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }, headers: req_headers
+      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }, headers: req_headers
     end
     assert_redirected_to sample_url(Sample.last)
   end
@@ -47,7 +47,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count', 0) do
-      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }
+      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }
     end
     assert_redirected_to new_user_session_url
   end
@@ -88,7 +88,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count') do
-      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }
+      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }
     end
     assert_redirected_to sample_url(Sample.last)
   end

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -34,7 +34,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count') do
-      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }, headers: req_headers
+      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, client: "web", input_files_attributes: input_files } }, headers: req_headers
     end
     assert_redirected_to sample_url(Sample.last)
   end
@@ -47,7 +47,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count', 0) do
-      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }
+      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, client: "web", input_files_attributes: input_files } }
     end
     assert_redirected_to new_user_session_url
   end
@@ -88,7 +88,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count') do
-      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files, client: "web" } }
+      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, client: "web", input_files_attributes: input_files } }
     end
     assert_redirected_to sample_url(Sample.last)
   end

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -34,7 +34,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count') do
-      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files } }, headers: req_headers
+      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }, headers: req_headers
     end
     assert_redirected_to sample_url(Sample.last)
   end
@@ -47,7 +47,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count', 0) do
-      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files } }
+      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }
     end
     assert_redirected_to new_user_session_url
   end
@@ -88,7 +88,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
                      name: "RR004_water_2_S23_R2_001.fastq.gz",
                      source_type: "local" }]
     assert_difference('Sample.count') do
-      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files } }
+      post samples_url, params: { sample: { name: 'new sample', project_name: @project.name, input_files_attributes: input_files }, client: "web" }
     end
     assert_redirected_to sample_url(Sample.last)
   end


### PR DESCRIPTION
- Add a version check for samples_controller#create
- Tested locally, will test more once it makes it to staging
- The CLI for single and bulk uploads both hit samples_controller#create so it's the only thing that really needs a version flag.

- Accompanying CLI PR: https://github.com/chanzuckerberg/idseq-cli/pull/28