### PR TITLE
Re-enable honeycomb logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'coffee-rails', '~> 4.2', '>= 4.2.2'
 gem 'consul', '>= 0.13.1'
 gem 'devise', '4.3.0'
 gem "health_check", ">= 2.7.0"
-gem 'honeycomb-rails', '0.7.1'
+gem 'honeycomb-rails', '0.4.1'
 gem 'mailgun_rails', '>= 0.9.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -643,8 +643,8 @@ GEM
       activesupport (>= 4.2.0)
     health_check (3.0.0)
       railties (>= 5.0)
-    honeycomb-rails (0.7.1)
-      libhoney (>= 1.5.0)
+    honeycomb-rails (0.4.1)
+      libhoney (>= 1.3.2)
       rails (>= 3.0.0)
     http (2.2.2)
       addressable (~> 2.3)
@@ -662,7 +662,7 @@ GEM
       multi_json (>= 1.2)
     jmespath (1.3.1)
     json (2.1.0)
-    libhoney (1.8.1)
+    libhoney (1.4.1)
       http (~> 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -885,7 +885,7 @@ DEPENDENCIES
   devise (= 4.3.0)
   flamegraph
   health_check (>= 2.7.0)
-  honeycomb-rails (= 0.7.1)
+  honeycomb-rails (= 0.4.1)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   logger
@@ -918,4 +918,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -4,17 +4,10 @@ if ENV["IDSEQ_HONEYCOMB_WRITE_KEY"] && ENV["IDSEQ_HONEYCOMB_DATA_SET"] && ENV["I
     conf.writekey = ENV["IDSEQ_HONEYCOMB_WRITE_KEY"]
     conf.dataset = ENV["IDSEQ_HONEYCOMB_DATA_SET"]
     conf.db_dataset = ENV["IDSEQ_HONEYCOMB_DB_DATA_SET"]
-    conf.sample_rate = proc do |event_type, payload|
-      case event_type
-      when 'sql.active_record'
-        1
-      when 'process_action.action_controller'
-        case payload[:controller]
-        when 'HealthCheck::HealthCheckController'
-          60
-        else
-          1
-        end
+    conf.sample_rate = proc do |payload|
+      case payload[:controller]
+      when 'HealthCheck::HealthCheckController'
+        60
       else
         1
       end


### PR DESCRIPTION
# Description

For whatever reason, upgrading to latest honeycomb gem caused logging to stop. Reverting to old version get the logs flowing again.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Ran in docker in development environment and saw logs coming through
1. Will do same on staging