### PR TITLE
Fix background selection for bulk report downloads

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1255,7 +1255,7 @@ class PipelineSampleReport extends React.Component {
     return url.searchParams.get(param);
   }
 
-  // Select the background with the matching name.
+  // Select the background ID with the matching name.
   getBackgroundIdByName(name) {
     let match = this.all_backgrounds.filter(b => b["name"] === name);
     if (match && match[0] && match[0]["id"]) {

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -21,6 +21,7 @@ import numberWithCommas from "../helpers/strings";
 import ProjectSelection from "./ProjectSelection";
 import StringHelper from "../helpers/StringHelper";
 import IconComponent from "./IconComponent";
+import Cookies from "js-cookie";
 
 class Samples extends React.Component {
   constructor(props, context) {
@@ -66,6 +67,7 @@ class Samples extends React.Component {
     this.displayReportProgress = this.displayReportProgress.bind(this);
     this.deleteProject = this.deleteProject.bind(this);
     this.toggleBackgroundFlag = this.toggleBackgroundFlag.bind(this);
+    this.getBackgroundIdByName = this.getBackgroundIdByName.bind(this);
     this.state = {
       invite_status: null,
       project: null,
@@ -312,8 +314,15 @@ class Samples extends React.Component {
     let status_action = e.target.getAttribute("data-status-action");
     let retrieve_action = e.target.getAttribute("data-retrieve-action");
     this.nanobar.go(30);
+
+    let url = `/projects/${this.state.selectedProjectId}/${make_action}`;
+    const bg_name = Cookies.get("background_name");
+    if (bg_name) {
+      const bg_id = this.getBackgroundIdByName(bg_name);
+      if (bg_id) url += `?background_id=${bg_id}`;
+    }
     axios
-      .get(`/projects/${this.state.selectedProjectId}/${make_action}`)
+      .get(url)
       .then(res => {
         this.setState({
           project_id_download_in_progress: this.state.selectedProjectId
@@ -1287,6 +1296,14 @@ class Samples extends React.Component {
     });
   }
 
+  // Select the background ID with the matching name.
+  getBackgroundIdByName(name) {
+    let match = this.props.allBackgrounds.filter(b => b["name"] === name);
+    if (match && match[0] && match[0]["id"]) {
+      return match[0]["id"];
+    }
+  }
+
   render() {
     const project_section = (
       <ProjectSelection
@@ -1344,7 +1361,12 @@ function LabelTagMarkup({
   );
 }
 
-function FilterItemMarkup({ status, filterSelect, status_filter_css_classes, pos }) {
+function FilterItemMarkup({
+  status,
+  filterSelect,
+  status_filter_css_classes,
+  pos
+}) {
   return (
     <li
       className="filter-item"
@@ -1352,7 +1374,10 @@ function FilterItemMarkup({ status, filterSelect, status_filter_css_classes, pos
       data-status={status}
       onClick={filterSelect}
     >
-      <a data-status={status} className={"filter-item " + status_filter_css_classes[pos]}>
+      <a
+        data-status={status}
+        className={"filter-item " + status_filter_css_classes[pos]}
+      >
         {status}
       </a>
       <i data-status={status} className="filter fa fa-check hidden" />
@@ -1913,7 +1938,11 @@ function TableColumnHeaders({ sort, colMap, filterStatus, state, parent }) {
   );
 }
 
-function JobStatusFilters({ status_filter_options, filterSelect, status_filter_css_classes }) {
+function JobStatusFilters({
+  status_filter_options,
+  filterSelect,
+  status_filter_css_classes
+}) {
   return (
     <div className="dropdown-status-filtering">
       <li>

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,6 +10,7 @@ class HomeController < ApplicationController
     @editable_project_ids = current_power.updatable_projects.pluck(:id)
     @host_genomes = HostGenome.all.reject { |hg| hg.name.downcase.include?("__test__") }
     @user_is_admin = current_user.role == 1 ? 1 : 0
+    @background_models = current_power.backgrounds
     render 'home'
   end
 

--- a/app/jobs/generate_project_reports_csv.rb
+++ b/app/jobs/generate_project_reports_csv.rb
@@ -1,6 +1,7 @@
 class GenerateProjectReportsCsv
   @queue = :q03_pipeline_run
   def self.perform(params)
+    params = HashWithIndifferentAccess.new(params)
     project = Project.find(params["id"])
     project.bulk_report_csvs_from_params(params)
   end

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -957,7 +957,8 @@ module ReportHelper
   def report_csv_from_params(sample, params)
     params[:is_csv] = 1
     params[:sort_by] = "highest_nt_aggregatescore"
-    background_id = params[:background_id] || sample.default_background_id
+    background_id = params[:background_id] || params["background_id"] || sample.default_background_id
+    background_id = background_id.to_i
     pipeline_run = select_pipeline_run(sample, params)
     pipeline_run_id = pipeline_run ? pipeline_run.id : nil
     return "" if pipeline_run_id.nil? || pipeline_run.total_reads.nil? || pipeline_run.remaining_reads.nil?

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -957,7 +957,7 @@ module ReportHelper
   def report_csv_from_params(sample, params)
     params[:is_csv] = 1
     params[:sort_by] = "highest_nt_aggregatescore"
-    background_id = params[:background_id] || params["background_id"] || sample.default_background_id
+    background_id = params[:background_id] || sample.default_background_id
     background_id = background_id.to_i
     pipeline_run = select_pipeline_run(sample, params)
     pipeline_run_id = pipeline_run ? pipeline_run.id : nil

--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -7,7 +7,8 @@
       editableProjects: <%= @editable_project_ids %>,
       favorites: JSON.parse('<%= raw escape_json(@favorite_projects) %>'),
       projects: JSON.parse('<%= raw escape_json(@projects)%>'),
-      hostGenomes: JSON.parse('<%= raw escape_json(@host_genomes)%>')
+      hostGenomes: JSON.parse('<%= raw escape_json(@host_genomes)%>'),
+      allBackgrounds: JSON.parse('<%= raw escape_json(@background_models) %>')
     }, 'samples_page');
   <% end %>
 </div>


### PR DESCRIPTION
- More of a feature than a bug fix but lets the users bulk download with the background model stored in Cookies.
- Fetching background ID by name since we store the name in the Cookies
- Asked for by Akshaya
- Tested locally a couple of ways