### PR TITLE
Bump volume size

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -27,7 +27,7 @@ class Sample < ApplicationRecord
   LOCAL_INPUT_PART_PATH = '/app/tmp/input_parts'.freeze
 
   # TODO: Make all these params configurable without code change
-  DEFAULT_STORAGE_IN_GB = 500
+  DEFAULT_STORAGE_IN_GB = 1000
   DEFAULT_MEMORY_IN_MB = 120_000 # sorry, hacky
   HOST_FILTERING_MEMORY_IN_MB = 240_000
 


### PR DESCRIPTION
- Bump volume size to try to mitigate S3 volume fragmentation issues when running programs like gsnap
- Disks with about 64% utilization seemed to become very IOPS limited with programs with dozens of threads potentially writing to file or sync commands called