### PR TITLE
Bump to gp2 aegea batch volumes

### DIFF
--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -49,7 +49,7 @@ class PipelineRunStage < ApplicationRecord
         queue = pipeline_run.sample.job_queue
       end
     end
-    command += " --storage /mnt=#{Sample::DEFAULT_STORAGE_IN_GB} --ecr-image idseq_dag --memory #{memory} --queue #{queue} --vcpus #{vcpus} --job-role idseq-pipeline "
+    command += " --storage /mnt=#{Sample::DEFAULT_STORAGE_IN_GB} --volume-type gp2 --ecr-image idseq_dag --memory #{memory} --queue #{queue} --vcpus #{vcpus} --job-role idseq-pipeline "
     command
   end
 


### PR DESCRIPTION
- Set our batch volumes to use SSDs (used to be st1 default)
- Should help us avoid disk fragmentation issues and probably increase performance overall per Boris's recommendations

- Aegea change that enabled this: https://github.com/kislyuk/aegea/pull/41