### PR TITLE
Rename fq to fastq

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -215,10 +215,14 @@ class Sample < ApplicationRecord
     input_files.each do |input_file|
       fastq = input_file.source
       total_reads_json_path = File.join(File.dirname(fastq.to_s), TOTAL_READS_JSON)
+
+      name = input_file.name
+      name = name.sub(".fq", ".fastq")
+
       command = if fastq =~ /\.gz/
-                  "aws s3 cp #{fastq} - |gzip -dc |head -#{max_lines} | gzip -c | aws s3 cp - #{sample_input_s3_path}/#{input_file.name}"
+                  "aws s3 cp #{fastq} - |gzip -dc |head -#{max_lines} | gzip -c | aws s3 cp - #{sample_input_s3_path}/#{name}"
                 else
-                  "aws s3 cp #{fastq} #{sample_input_s3_path}/#{input_file.name}"
+                  "aws s3 cp #{fastq} #{sample_input_s3_path}/#{name}"
                 end
       _stdout, stderr, status = Open3.capture3(command)
       stderr_array << stderr unless status.exitstatus.zero?

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -216,11 +216,10 @@ class Sample < ApplicationRecord
       fastq = input_file.source
       total_reads_json_path = File.join(File.dirname(fastq.to_s), TOTAL_READS_JSON)
 
-      name = input_file.name
-      name = name.sub(".fq", ".fastq")
+      input_file.name = input_file.name.sub(".fq", ".fastq")
 
       command = if fastq =~ /\.gz/
-                  "aws s3 cp #{fastq} - |gzip -dc |head -#{max_lines} | gzip -c | aws s3 cp - #{sample_input_s3_path}/#{name}"
+                  "aws s3 cp #{fastq} - |gzip -dc |head -#{max_lines} | gzip -c | aws s3 cp - #{sample_input_s3_path}/#{input_file.name}"
                 else
                   "aws s3 cp #{fastq} #{sample_input_s3_path}/#{name}"
                 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -221,7 +221,7 @@ class Sample < ApplicationRecord
       command = if fastq =~ /\.gz/
                   "aws s3 cp #{fastq} - |gzip -dc |head -#{max_lines} | gzip -c | aws s3 cp - #{sample_input_s3_path}/#{input_file.name}"
                 else
-                  "aws s3 cp #{fastq} #{sample_input_s3_path}/#{name}"
+                  "aws s3 cp #{fastq} #{sample_input_s3_path}/#{input_file.name}"
                 end
       _stdout, stderr, status = Open3.capture3(command)
       stderr_array << stderr unless status.exitstatus.zero?


### PR DESCRIPTION
- Name sub of .fq to .fastq in case people upload with .fq. Our pipeline expects .fastq in a few locations apparently.