### PR TITLE
Add rudimentary error log on failed sample report page

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -592,6 +592,12 @@ class PipelineSampleReads extends React.Component {
               ? waitingSpinner
               : this.state.rerunStatusMessage}
           </h6>
+          <div className="log-block">
+            {
+              "Rudimentary debugging information (from the end of the pipeline run logs):\n"
+            }
+            {this.props.logSummary}
+          </div>
         </div>
       );
     }

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -585,6 +585,17 @@ class PipelineSampleReads extends React.Component {
         </div>
       );
     } else {
+      let logBlock;
+      if (this.props.logSummary) {
+        logBlock = (
+          <div className="log-block">
+            {
+              "Rudimentary debugging information (from the end of the pipeline run logs):\n\n"
+            }
+            {this.props.logSummary}
+          </div>
+        );
+      }
       d_report = (
         <div className="center-align text-grey text-lighten-2 no-report">
           <h6 className={this.state.rerunStatus}>
@@ -592,12 +603,7 @@ class PipelineSampleReads extends React.Component {
               ? waitingSpinner
               : this.state.rerunStatusMessage}
           </h6>
-          <div className="log-block">
-            {
-              "Rudimentary debugging information (from the end of the pipeline run logs):\n"
-            }
-            {this.props.logSummary}
-          </div>
+          {logBlock}
         </div>
       );
     }

--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -1442,3 +1442,9 @@ input[type="button"] {
     font-weight: 600;
   }
 }
+
+.log-block {
+  white-space: pre-line;
+  text-align: left;
+  margin: 4%;
+}

--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -1447,4 +1447,6 @@ input[type="button"] {
   white-space: pre-line;
   text-align: left;
   margin: 4%;
+  font-family: monospace;
+  font-size: 0.9rem;
 }

--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -1446,7 +1446,7 @@ input[type="button"] {
 .log-block {
   white-space: pre-line;
   text-align: left;
-  margin: 4%;
+  margin: 3%;
   font-family: monospace;
   font-size: 0.9rem;
 }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -187,7 +187,7 @@ class SamplesController < ApplicationController
       end
     end
 
-    if @pipeline_run.failed?
+    if @pipeline_run && @pipeline_run.failed?
       @log_summary = fetch_run_log_summary(@pipeline_run)
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -583,10 +583,11 @@ class SamplesController < ApplicationController
       if job_log_id
         log_client = Aws::CloudWatchLogs::Client.new
         begin
+          # Fetch from the end of the CloudWatch logs
           resp = log_client.get_log_events(
             log_group_name: '/aws/batch/job',
             log_stream_name: job_log_id,
-            limit: 100
+            limit: 50
           )
           summary = resp.events.pluck(:message).join("\n")
           res = summary

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -247,7 +247,8 @@ class PipelineRun < ApplicationRecord
   end
 
   def report_ready?
-    output_states.find_by(output: REPORT_READY_OUTPUT).state == STATUS_LOADED
+    o_state = output_states.find_by(output: REPORT_READY_OUTPUT)
+    o_state && o_state.state == STATUS_LOADED
   end
 
   def succeeded?

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -906,4 +906,38 @@ class PipelineRun < ApplicationRecord
     end
     ret
   end
+
+  def fetch_run_log_summary
+    # For this pipeline run, find the last run stage that generated a log in
+    # CloudWatch and fetch lines from the end of it.
+    summary = nil
+    pipeline_run_stages.reverse.each do |stage|
+      if stage.log_summary
+        # Log summary was already fetched
+        summary = stage.log_summary
+        break
+      end
+
+      job_log_id = stage.job_log_id
+      if job_log_id
+        log_client = Aws::CloudWatchLogs::Client.new
+        begin
+          # Fetch from the end of the CloudWatch logs
+          resp = log_client.get_log_events(
+            log_group_name: '/aws/batch/job',
+            log_stream_name: job_log_id,
+            limit: 50
+          )
+          msgs = resp.events.pluck(:message).join("\n")
+          summary = msgs
+          stage.update(log_summary: summary)
+          break # Just the latest
+        rescue Aws::CloudWatchLogs::Errors::ResourceNotFoundException
+          Rails.logger.info "No logs found for #{job_log_id}"
+        end
+      end
+    end
+
+    summary
+  end
 end

--- a/app/views/samples/show.html.erb
+++ b/app/views/samples/show.html.erb
@@ -22,7 +22,8 @@
       can_see_align_viz: <%= !!@align_viz %>,
       pipeline_versions: <%= raw escape_json(@pipeline_versions) %>,
       ercc_comparison: JSON.parse('<%= raw escape_json(@ercc_comparison) %>'),
-      all_backgrounds: JSON.parse('<%= raw escape_json(@background_models) %>')
+      all_backgrounds: JSON.parse('<%= raw escape_json(@background_models) %>'),
+      logSummary: JSON.parse('<%= raw escape_json(@log_summary)%>'),
     }, 'PipelineSampleReads_page');
   <% end %>
 </div>

--- a/db/migrate/20180726002908_add_run_stage_log.rb
+++ b/db/migrate/20180726002908_add_run_stage_log.rb
@@ -1,0 +1,5 @@
+class AddRunStageLog < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pipeline_run_stages, :log_summary, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_180_724_235_332) do
+ActiveRecord::Schema.define(version: 20_180_726_002_908) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -52,7 +52,7 @@ ActiveRecord::Schema.define(version: 20_180_724_235_332) do
     t.index ["pipeline_output_id"], name: "index_backgrounds_pipeline_outputs_on_pipeline_output_id"
   end
 
-  create_table "backgrounds_pipeline_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "backgrounds_pipeline_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.bigint "background_id"
     t.bigint "pipeline_run_id"
     t.index %w[background_id pipeline_run_id], name: "index_bg_pr_id", unique: true
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 20_180_724_235_332) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "ercc_counts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "ercc_counts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.integer "count"
@@ -160,6 +160,7 @@ ActiveRecord::Schema.define(version: 20_180_724_235_332) do
     t.string "name"
     t.text "failed_jobs"
     t.text "dag_json"
+    t.text "log_summary"
     t.index %w[pipeline_run_id step_number], name: "index_pipeline_run_stages_on_pipeline_run_id_and_step_number"
     t.index ["pipeline_run_id"], name: "index_pipeline_run_stages_on_pipeline_run_id"
   end
@@ -200,7 +201,7 @@ ActiveRecord::Schema.define(version: 20_180_724_235_332) do
   end
 
   create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
+    t.string "name", collation: "latin1_swedish_ci"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "public_access", limit: 1
@@ -217,7 +218,7 @@ ActiveRecord::Schema.define(version: 20_180_724_235_332) do
   end
 
   create_table "samples", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
+    t.string "name", collation: "latin1_swedish_ci"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "project_id"
@@ -281,7 +282,7 @@ ActiveRecord::Schema.define(version: 20_180_724_235_332) do
     t.index ["taxid"], name: "index_taxon_child_parents_on_taxid", unique: true
   end
 
-  create_table "taxon_confirmations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "taxon_confirmations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "taxid"
     t.integer "sample_id"
     t.integer "user_id"
@@ -299,7 +300,7 @@ ActiveRecord::Schema.define(version: 20_180_724_235_332) do
     t.integer "count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name"
+    t.string "name", collation: "latin1_swedish_ci"
     t.string "count_type"
     t.float "percent_identity", limit: 24
     t.float "alignment_length", limit: 24
@@ -400,20 +401,20 @@ ActiveRecord::Schema.define(version: 20_180_724_235_332) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email"
-    t.string "name"
+    t.string "email", default: "", null: false, collation: "latin1_swedish_ci"
+    t.string "name", collation: "latin1_swedish_ci"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password"
-    t.string "reset_password_token"
+    t.string "encrypted_password", default: "", null: false, collation: "latin1_swedish_ci"
+    t.string "reset_password_token", collation: "latin1_swedish_ci"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.string "authentication_token", limit: 30
+    t.string "current_sign_in_ip", collation: "latin1_swedish_ci"
+    t.string "last_sign_in_ip", collation: "latin1_swedish_ci"
+    t.string "authentication_token", limit: 30, collation: "latin1_swedish_ci"
     t.integer "role"
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_180_726_002_908) do
+ActiveRecord::Schema.define(version: 20_180_724_235_332) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -52,7 +52,7 @@ ActiveRecord::Schema.define(version: 20_180_726_002_908) do
     t.index ["pipeline_output_id"], name: "index_backgrounds_pipeline_outputs_on_pipeline_output_id"
   end
 
-  create_table "backgrounds_pipeline_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "backgrounds_pipeline_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "background_id"
     t.bigint "pipeline_run_id"
     t.index %w[background_id pipeline_run_id], name: "index_bg_pr_id", unique: true
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 20_180_726_002_908) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "ercc_counts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "ercc_counts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.integer "count"
@@ -201,7 +201,7 @@ ActiveRecord::Schema.define(version: 20_180_726_002_908) do
   end
 
   create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", collation: "latin1_swedish_ci"
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "public_access", limit: 1
@@ -218,7 +218,7 @@ ActiveRecord::Schema.define(version: 20_180_726_002_908) do
   end
 
   create_table "samples", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", collation: "latin1_swedish_ci"
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "project_id"
@@ -282,7 +282,7 @@ ActiveRecord::Schema.define(version: 20_180_726_002_908) do
     t.index ["taxid"], name: "index_taxon_child_parents_on_taxid", unique: true
   end
 
-  create_table "taxon_confirmations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "taxon_confirmations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid"
     t.integer "sample_id"
     t.integer "user_id"
@@ -300,7 +300,7 @@ ActiveRecord::Schema.define(version: 20_180_726_002_908) do
     t.integer "count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name", collation: "latin1_swedish_ci"
+    t.string "name"
     t.string "count_type"
     t.float "percent_identity", limit: 24
     t.float "alignment_length", limit: 24
@@ -401,20 +401,20 @@ ActiveRecord::Schema.define(version: 20_180_726_002_908) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email", default: "", null: false, collation: "latin1_swedish_ci"
-    t.string "name", collation: "latin1_swedish_ci"
+    t.string "email"
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password", default: "", null: false, collation: "latin1_swedish_ci"
-    t.string "reset_password_token", collation: "latin1_swedish_ci"
+    t.string "encrypted_password"
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip", collation: "latin1_swedish_ci"
-    t.string "last_sign_in_ip", collation: "latin1_swedish_ci"
-    t.string "authentication_token", limit: 30, collation: "latin1_swedish_ci"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "authentication_token", limit: 30
     t.integer "role"
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
- Add a rudimentary error log to the failed sample report page
- Plan is to add lines to the pipeline code to add a cleaner log summary at the bottom that is more human interpretable, and then those will also show up here. Even as simple as "failed at the STAR_OUT step"
- This more raw information will be present in the hopefully rare failed samples so that users can get some feedback when we don't have a cleaner error message