### PR TITLE
[perf] max 2 concurrent gsnap jobs per i3.metal instance

### DIFF
--- a/app/lib/dags/non_host_alignment.json.erb
+++ b/app/lib/dags/non_host_alignment.json.erb
@@ -48,7 +48,7 @@
         "service": "gsnap",
         "chunks_in_flight": 32,
         "chunk_size": 15000,
-        "max_concurrent": 3,
+        "max_concurrent": 2,
         "environment": "prod"
         <% if @attribute_dict[:index_dir_suffix] %>
           ,"index_dir_suffix": "<%= @attribute_dict[:index_dir_suffix] %>"


### PR DESCRIPTION
extensive testing shows 2 run at the same speed as 1 because this machine
has 2 numa nodes;  3 may be more aggressive than necessary;  choosing
to be more conservative, to see if the outlier chunks will disappear, particularly
after defrag has been disabled in the machine init