### PR TITLE
Tweak to allow users to delete failed samples

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -834,7 +834,6 @@ class PipelineSampleReads extends React.Component {
           </div>
         </div>
       );
-
     return (
       <div>
         <SubHeader>
@@ -848,8 +847,7 @@ class PipelineSampleReads extends React.Component {
                   {this.projectInfo.name + " "}
                 </a>
                 > {sample_dropdown}
-                {this.sampleInfo.status === "created" ||
-                this.state.rerunStatus === "failed"
+                {this.sampleInfo.status === "created" || !this.reportPresent
                   ? delete_sample_button
                   : null}
               </div>

--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -848,7 +848,8 @@ class PipelineSampleReads extends React.Component {
                   {this.projectInfo.name + " "}
                 </a>
                 > {sample_dropdown}
-                {this.sampleInfo.status == "created"
+                {this.sampleInfo.status === "created" ||
+                this.state.rerunStatus === "failed"
                   ? delete_sample_button
                   : null}
               </div>

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -497,9 +497,10 @@ class SamplesController < ApplicationController
   def destroy
     # Will also delete from job_stats, ercc_counts, backgrounds_pipeline_runs, pipeline_runs, input_files, and backgrounds_samples
     deletable = @sample.deletable?(current_user)
-    @sample.destroy if deletable
+    success = false
+    success = @sample.destroy if deletable
     respond_to do |format|
-      if deletable
+      if deletable && success
         format.html { redirect_to samples_url, notice: 'Sample was successfully destroyed.' }
         format.json { head :no_content }
       else

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -495,15 +495,14 @@ class SamplesController < ApplicationController
   # DELETE /samples/1
   # DELETE /samples/1.json
   def destroy
-    deletable = @sample.pipeline_runs.empty?
-    @sample.destroy if deletable
+    # Will also delete from job_stats, ercc_counts, backgrounds_pipeline_runs, pipeline_runs, input_files, and backgrounds_samples
     respond_to do |format|
-      if deletable
+      if @sample.destroy
         format.html { redirect_to samples_url, notice: 'Sample was successfully destroyed.' }
         format.json { head :no_content }
       else
         format.html { render :edit }
-        format.json { render json: { message: 'Cannot delete this sample' }, status: :unprocessable_entity }
+        format.json { render json: { message: 'Cannot delete this sample. Something went wrong.' }, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -500,7 +500,7 @@ class SamplesController < ApplicationController
     success = false
     success = @sample.destroy if deletable
     respond_to do |format|
-      if deletable && success
+      if success
         format.html { redirect_to samples_url, notice: 'Sample was successfully destroyed.' }
         format.json { head :no_content }
       else

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -496,9 +496,7 @@ class SamplesController < ApplicationController
   # DELETE /samples/1.json
   def destroy
     # Will also delete from job_stats, ercc_counts, backgrounds_pipeline_runs, pipeline_runs, input_files, and backgrounds_samples
-    # Current job_status values look like "1.Host Filtering-FAILED" or "2.GSNAPL/RAPSEARCH alignment-FAILED"
-    # Allow deletion if pipeline runs are empty or the latest run failed, and the sample belongs to you, or you're an admin.
-    deletable = ((@sample.pipeline_runs.empty? || @sample.pipeline_runs[0].job_status.include?("FAILED")) && @sample.user_id == current_user.id) || current_user.admin?
+    deletable = @sample.deletable?(current_user)
     @sample.destroy if deletable
     respond_to do |format|
       if deletable

--- a/app/helpers/pipeline_outputs_helper.rb
+++ b/app/helpers/pipeline_outputs_helper.rb
@@ -185,18 +185,18 @@ module PipelineOutputsHelper
     h = states_by_output_hash
     if [PipelineRun::FINALIZED_SUCCESS, PipelineRun::FINALIZED_FAIL].include?(results_finalized_var)
       # No steps are running anymore
-      if [h[PipelineRun::ALIGNMENT_OUTPUT], h[PipelineRun::POSTPROCESS_OUTPUT]].all? { |s| s == PipelineRun::STATUS_LOADED }
+      if [h["taxon_byteranges"], h["taxon_counts"]].all? { |s| s == PipelineRun::STATUS_LOADED }
         "COMPLETE"
-      elsif h[PipelineRun::ALIGNMENT_OUTPUT] == PipelineRun::STATUS_LOADED
+      elsif h["taxon_counts"] == PipelineRun::STATUS_LOADED
         # Alignment succeeded, postprocess failed
         "COMPLETE*"
       else
         "FAILED"
       end
-    elsif h[PipelineRun::ALIGNMENT_OUTPUT] == PipelineRun::STATUS_LOADED
+    elsif h["taxon_counts"] == PipelineRun::STATUS_LOADED
       # Alignment succeeded, postprocessing in progress
       "POST PROCESSING"
-    elsif h[PipelineRun::HOST_FILTERING_OUTPUT] == PipelineRun::STATUS_LOADED
+    elsif h["ercc_counts"] == PipelineRun::STATUS_LOADED
       # Host-filtering succeeded, alignment in progress
       "ALIGNMENT"
     else

--- a/app/helpers/pipeline_outputs_helper.rb
+++ b/app/helpers/pipeline_outputs_helper.rb
@@ -184,21 +184,23 @@ module PipelineOutputsHelper
     # Status display for the frontend.
     h = states_by_output_hash
     if [PipelineRun::FINALIZED_SUCCESS, PipelineRun::FINALIZED_FAIL].include?(results_finalized_var)
-      if [h["taxon_byteranges"], h["taxon_counts"]].all? { |s| s == PipelineRun::STATUS_LOADED }
+      # No steps are running anymore
+      if [h[PipelineRun::ALIGNMENT_OUTPUT], h[PipelineRun::POSTPROCESS_OUTPUT]].all? { |s| s == PipelineRun::STATUS_LOADED }
         "COMPLETE"
-      elsif h["taxon_counts"] == PipelineRun::STATUS_LOADED
+      elsif h[PipelineRun::ALIGNMENT_OUTPUT] == PipelineRun::STATUS_LOADED
+        # Alignment succeeded, postprocess failed
         "COMPLETE*"
       else
         "FAILED"
       end
-    elsif h["taxon_counts"] == PipelineRun::STATUS_LOADED
-      # alignment succeeded, postprocessing in progress
+    elsif h[PipelineRun::ALIGNMENT_OUTPUT] == PipelineRun::STATUS_LOADED
+      # Alignment succeeded, postprocessing in progress
       "POST PROCESSING"
-    elsif h["ercc_counts"] == PipelineRun::STATUS_LOADED
-      # host-filtering succeeded, alignment in progress
+    elsif h[PipelineRun::HOST_FILTERING_OUTPUT] == PipelineRun::STATUS_LOADED
+      # Host-filtering succeeded, alignment in progress
       "ALIGNMENT"
     else
-      # host-filtering in progress
+      # Host-filtering in progress
       "HOST FILTERING"
     end
   end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -252,6 +252,11 @@ class PipelineRun < ApplicationRecord
     output_states.find_by(output: REPORT_READY_OUTPUT).state == STATUS_LOADED
   end
 
+  def report_failed?
+    # If the report ready output was marked as STATUS_FAILED
+    output_states.find_by(output: REPORT_READY_OUTPUT).state == STATUS_FAILED
+  end
+
   def succeeded?
     job_status == STATUS_CHECKED
   end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -82,10 +82,7 @@ class PipelineRun < ApplicationRecord
                         "taxon_byteranges" => "db_load_byteranges" }.freeze
   # Note: reads_before_priceseqfilter, reads_after_priceseqfilter, reads_after_cdhitdup
   #       are the only "job_stats" we actually need for web display.
-  HOST_FILTERING_OUTPUT = "ercc_counts".freeze
-  ALIGNMENT_OUTPUT = "taxon_counts".freeze
-  POSTPROCESS_OUTPUT = "taxon_byteranges".freeze
-  REPORT_READY_OUTPUT = ALIGNMENT_OUTPUT
+  REPORT_READY_OUTPUT = "taxon_counts".freeze
 
   # Values for results_finalized are as follows.
   # Note we don't put a default on results_finalized in the schema, so that we can
@@ -257,11 +254,9 @@ class PipelineRun < ApplicationRecord
 
   def report_failed?
     # The report failed if host filtering or alignment failed.
-    host_filtering_status = output_states.find_by(output: HOST_FILTERING_OUTPUT).state
-    alignment_status = output_states.find_by(output: ALIGNMENT_OUTPUT).state
-    if host_filtering_status == STATUS_FAILED || alignment_status == STATUS_FAILED
-      true
-    end
+    host_filtering_status = output_states.find_by(output: "ercc_counts").state
+    alignment_status = output_states.find_by(output: "taxon_byteranges").state
+    host_filtering_status == STATUS_FAILED || alignment_status == STATUS_FAILED
   end
 
   def succeeded?

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -82,7 +82,10 @@ class PipelineRun < ApplicationRecord
                         "taxon_byteranges" => "db_load_byteranges" }.freeze
   # Note: reads_before_priceseqfilter, reads_after_priceseqfilter, reads_after_cdhitdup
   #       are the only "job_stats" we actually need for web display.
-  REPORT_READY_OUTPUT = "taxon_counts".freeze
+  HOST_FILTERING_OUTPUT = "ercc_counts".freeze
+  ALIGNMENT_OUTPUT = "taxon_counts".freeze
+  POSTPROCESS_OUTPUT = "taxon_byteranges".freeze
+  REPORT_READY_OUTPUT = ALIGNMENT_OUTPUT
 
   # Values for results_finalized are as follows.
   # Note we don't put a default on results_finalized in the schema, so that we can
@@ -253,8 +256,12 @@ class PipelineRun < ApplicationRecord
   end
 
   def report_failed?
-    # If the report ready output was marked as STATUS_FAILED
-    output_states.find_by(output: REPORT_READY_OUTPUT).state == STATUS_FAILED
+    # The report failed if host filtering or alignment failed.
+    host_filtering_status = output_states.find_by(output: HOST_FILTERING_OUTPUT).state
+    alignment_status = output_states.find_by(output: ALIGNMENT_OUTPUT).state
+    if host_filtering_status == STATUS_FAILED || alignment_status == STATUS_FAILED
+      true
+    end
   end
 
   def succeeded?

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -387,6 +387,21 @@ class Sample < ApplicationRecord
     end
   end
 
+  def deletable?(user)
+    if user.admin?
+      return true
+    elsif user_id == user.id
+      # Sample belongs to the user
+      if pipeline_runs.empty? ||
+         (pipeline_runs[0].job_status.include?("Filtering-FAILED") || pipeline_runs[0].job_status.include?("alignment-FAILED"))
+        # Allow deletion if no pipeline runs, or host filtering or alignment failed.
+        # Current job_status values look like "1.Host Filtering-FAILED" or "2.GSNAPL/RAPSEARCH alignment-FAILED".
+        return true
+      end
+    end
+    false
+  end
+
   def self.public_samples
     joins("INNER JOIN projects ON samples.project_id = projects.id")
       .where("(projects.public_access = 1 or

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -392,10 +392,8 @@ class Sample < ApplicationRecord
       return true
     elsif user_id == user.id
       # Sample belongs to the user
-      if pipeline_runs.empty? ||
-         (pipeline_runs[0].job_status.include?("Filtering-FAILED") || pipeline_runs[0].job_status.include?("alignment-FAILED"))
-        # Allow deletion if no pipeline runs, or host filtering or alignment failed.
-        # Current job_status values look like "1.Host Filtering-FAILED" or "2.GSNAPL/RAPSEARCH alignment-FAILED".
+      if pipeline_runs.empty? || pipeline_runs[0].report_failed?
+        # Allow deletion if no pipeline runs, or report ready output failed.
         return true
       end
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -393,7 +393,12 @@ class Sample < ApplicationRecord
     elsif user_id == user.id
       # Sample belongs to the user
       # Allow deletion if no pipeline runs, or report failed.
-      pipeline_runs.empty? || pipeline_runs[0].report_failed?
+      unless pipeline_runs.empty?
+        pipeline_runs.each do |prun|
+          return false unless prun.report_failed?
+        end
+      end
+      true
     end
   end
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -393,7 +393,7 @@ class Sample < ApplicationRecord
     elsif user_id == user.id
       # Sample belongs to the user
       if pipeline_runs.empty? || pipeline_runs[0].report_failed?
-        # Allow deletion if no pipeline runs, or report ready output failed.
+        # Allow deletion if no pipeline runs, or report failed.
         return true
       end
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -389,15 +389,12 @@ class Sample < ApplicationRecord
 
   def deletable?(user)
     if user.admin?
-      return true
+      true
     elsif user_id == user.id
       # Sample belongs to the user
-      if pipeline_runs.empty? || pipeline_runs[0].report_failed?
-        # Allow deletion if no pipeline runs, or report failed.
-        return true
-      end
+      # Allow deletion if no pipeline runs, or report failed.
+      pipeline_runs.empty? || pipeline_runs[0].report_failed?
     end
-    false
   end
 
   def self.public_samples

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -45,7 +45,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     assert @joe_sample.sample_tissue == 'bone'
   end
 
-  test 'joe can see samples  in joe_project' do
+  test 'joe can see samples in joe_project' do
     @joe_project = projects(:joe_project)
     get "/samples.json?project_id=#{@joe_project.id}"
     assert_response :success
@@ -56,6 +56,19 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     @joe_sample = samples(:joe_sample)
     get sample_url(@joe_sample)
     assert_response :success
+  end
+
+  test 'joe can delete his own sample' do
+    @joe_sample = samples(:joe_sample)
+    delete sample_url(@joe_sample)
+    assert_response :success
+  end
+
+  test 'joe cannot delete public_sample' do
+    @public_sample = samples(:public_sample)
+    assert_raises(ActiveRecord::RecordNotFound) do
+      delete sample_url(@public_sample)
+    end
   end
 
   # public projects


### PR DESCRIPTION
- This is a tweak that Product's been asking for for awhile. Allowing users to delete failed samples (same as when they can delete right after uploading for a short bit).
- A lot of users ask for this when they upload like an incorrect file and then try to upload again but run into the name conflict. Probably cleaner for their project view too to not have the failed samples.
- The trade off is that the failed run info will also go away. I'm thinking this is OK b/c usually users will delete for minor things like uploading with the wrong name or uploading an index file. We can discourage people from using it if they end up using it too much.