### PR TITLE
Impose lineage date check

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -114,3 +114,6 @@ Style/Next:
   # `MinBodyLength` defines the number of lines of the a body of an if / unless
   # needs to have to trigger this cop
   MinBodyLength: 25
+
+Rails/FindEach:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -114,6 +114,3 @@ Style/Next:
   # `MinBodyLength` defines the number of lines of the a body of an if / unless
   # needs to have to trigger this cop
   MinBodyLength: 25
-
-Rails/FindEach:
-  Enabled: false

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -273,7 +273,7 @@ class SamplesController < ApplicationController
 
     # Fill lineage details into report info
     tax_map = @report_info[:taxonomy_details][2]
-    @report_info[:taxonomy_details][2] = TaxonLineage.fill_lineage_details(tax_map)
+    @report_info[:taxonomy_details][2] = TaxonLineage.fill_lineage_details(tax_map, pipeline_run_id)
 
     render json: JSON.dump(@report_info)
   end

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -55,7 +55,7 @@ class TaxonLineage < ApplicationRecord
     # now, we only select the valid entry based on started_at and ended_at.
     # The valid lineage entry has start and end dates that include the valid
     # taxon count entry date.
-    TaxonLineage.where(taxid: tax_ids).where("started_at < ? AND ended_at > ?", valid_date, valid_date).each do |x|
+    TaxonLineage.where(taxid: tax_ids).where("started_at < ? AND ended_at > ?", valid_date, valid_date).find_each do |x|
       lineage_by_taxid[x.taxid] = x.as_json
     end
 

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -55,7 +55,7 @@ class TaxonLineage < ApplicationRecord
     # now, we only select the valid entry based on started_at and ended_at.
     # The valid lineage entry has start and end dates that include the valid
     # taxon count entry date.
-    TaxonLineage.where(taxid: tax_ids).where("started_at < ? AND ended_at > ?", valid_date, valid_date).find_each do |x|
+    TaxonLineage.where(taxid: tax_ids).where("started_at < ? AND ended_at > ?", valid_date, valid_date).each do |x|
       lineage_by_taxid[x.taxid] = x.as_json
     end
 


### PR DESCRIPTION
- Tested by clicking on a couple of samples and checking the results. Same as current report pages.
- Tested locally showing the right dates filled in to the ActiveRecord queries. Ex: ` 568386, 474942, 5148, 1890422, 563835, 1506295, 4637, 31984, 203492, 603431, 332247, 119093, 1639119, 403, 1962910, 1892254, 186827, 41873, 84107, 361606, 1799696, 1804623, 34450) AND (started_at < '2018-07-20 21:02:14' AND ended_at > '2018-07-20 21:02:14')`