### PR TITLE
Modify zscore params

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1429,7 +1429,7 @@ function ReportTableHeader({ parent }) {
             {parent.render_column_header(
               "Score",
               `NT_aggregatescore`,
-              "Aggregate score: ( |genus.NT.Z| * species.NT.Z * species.NT.rPM ) + ( |genus.NR.Z| * species.NR.Z * species.NR.rPM )"
+              "Aggregate score: ( |genus.NT.Z| * species.NT.rPM ) + ( |genus.NR.Z| * species.NR.rPM )"
             )}
             {parent.render_column_header(
               "Z",

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -4,10 +4,12 @@ require 'open3'
 module ReportHelper
   # Truncate report table past this number of rows.
   TAXON_CATEGORY_OFFSET = 100_000_000
-  ZSCORE_MIN = -99
-  ZSCORE_MAX =  99
-  ZSCORE_WHEN_ABSENT_FROM_SAMPLE = -100
-  ZSCORE_WHEN_ABSENT_FROM_BACKGROUND = 100
+  # Large values here add weight in the aggregate score to taxons that have
+  # just a few reads but are absent from the background for whatever reason.
+  ZSCORE_MIN = -9
+  ZSCORE_MAX =  9
+  ZSCORE_WHEN_ABSENT_FROM_SAMPLE = -10
+  ZSCORE_WHEN_ABSENT_FROM_BACKGROUND = 10
 
   DEFAULT_SAMPLE_NEGLOGEVALUE = 0.0
   DEFAULT_SAMPLE_PERCENTIDENTITY = 0.0

--- a/app/models/taxon_scoring_model.rb
+++ b/app/models/taxon_scoring_model.rb
@@ -3,7 +3,7 @@
 # Currently the operators supported are addition (+), product (-) for nodes with multiple children and atomic transformation function for nodes with one children.
 # Here is an example of how the following scoring function can be translated to a json
 #
-# aggregate_score = |genus.NT.zscore|*species.NT.zscore*species.NT.rpm + |genus.NR.zscore|*species.NR.zscore*species.NR.rpm
+# aggregate_score = |genus.NT.zscore| * species.NT.rpm + |genus.NR.zscore| * species.NR.rpm
 # {
 #  "op" : "+",
 #  "on" : [
@@ -14,7 +14,6 @@
 #          "op": "abs",
 #          "on": { "op": "attr", "on": "genus.NT.zscore" }
 #        },
-#        { "op": "attr", "on": "species.NT.zscore" },
 #        { "op": "attr", "on": "species.NT.rpm" }
 #      ]
 #    },
@@ -25,7 +24,6 @@
 #          "op": "abs",
 #          "on": { "op": "attr", "on": "genus.NR.zscore" }
 #        },
-#        { "op": "attr", "on": "species.NR.zscore" },
 #        { "op": "attr", "on": "species.NR.rpm" }
 #      ]
 #    }

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -112,7 +112,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 209.0, species_result["NT"]["r"]
     assert_equal "186274.509", species_result["NT"]["rpm"]
     assert_equal 9.0, species_result["NT"]["zscore"]
-    assert_equal 2_428_411_754.8, species_result["NT"]["aggregatescore"].round(1)
+    assert_equal 20_069_518.6, species_result["NT"]["aggregatescore"].round(1)
     assert_equal 89.5641022, species_result["NT"]["neglogevalue"]
     assert_equal 69.0, species_result["NR"]["r"]
     assert_equal "61497.326", species_result["NR"]["rpm"]

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -111,23 +111,23 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 209.0, species_result["NT"]["r"]
     assert_equal "186274.509", species_result["NT"]["rpm"]
-    assert_equal 99.0, species_result["NT"]["zscore"]
+    assert_equal 9.0, species_result["NT"]["zscore"]
     assert_equal 2_428_411_754.8, species_result["NT"]["aggregatescore"].round(1)
     assert_equal 89.5641022, species_result["NT"]["neglogevalue"]
     assert_equal 69.0, species_result["NR"]["r"]
     assert_equal "61497.326", species_result["NR"]["rpm"]
-    assert_equal 99.0, species_result["NR"]["zscore"]
+    assert_equal 9.0, species_result["NR"]["zscore"]
     assert_equal 2_428_411_754.8, species_result["NR"]["aggregatescore"].round(1)
     assert_equal 16.9101009, species_result["NR"]["neglogevalue"]
 
     assert_equal 217.0, genus_result["NT"]["r"]
     assert_equal "193404.634", genus_result["NT"]["rpm"]
-    assert_equal 99.0, genus_result["NT"]["zscore"]
+    assert_equal 9.0, genus_result["NT"]["zscore"]
     assert_equal 2_428_411_754.8, genus_result["NT"]["aggregatescore"].round(1)
     assert_equal 89.5821991, genus_result["NT"]["neglogevalue"]
     assert_equal 87.0, genus_result["NR"]["r"]
     assert_equal "77540.106", genus_result["NR"]["rpm"]
-    assert_equal 99.0, genus_result["NR"]["zscore"]
+    assert_equal 9.0, genus_result["NR"]["zscore"]
     assert_equal 2_428_411_754.8, genus_result["NR"]["aggregatescore"].round(1)
     assert_equal 16.9874001, genus_result["NR"]["neglogevalue"]
 
@@ -137,7 +137,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 0, species_result["NT"]["r"]
     assert_equal 0, species_result["NT"]["rpm"]
-    assert_equal(-100, species_result["NT"]["zscore"])
+    assert_equal(-10, species_result["NT"]["zscore"])
     assert_equal 12_583.63, species_result["NT"]["aggregatescore"].round(2)
     assert_equal 0.0, species_result["NT"]["neglogevalue"]
     assert_equal 2.0, species_result["NR"]["r"]

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -149,12 +149,12 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 4.0, genus_result["NT"]["r"]
     assert_equal "3565.062", genus_result["NT"]["rpm"]
     assert_equal 2.2081236, genus_result["NT"]["zscore"]
-    assert_equal 73_603.777, genus_result["NT"]["aggregatescore"].round(3)
+    assert_equal 70_848.878, genus_result["NT"]["aggregatescore"].round(3)
     assert_equal 81.4779968, genus_result["NT"]["neglogevalue"]
     assert_equal 2.0, genus_result["NR"]["r"]
     assert_equal "1782.531", genus_result["NR"]["rpm"]
     assert_equal 1.6768345, genus_result["NR"]["zscore"]
-    assert_equal 73_603.777, genus_result["NR"]["aggregatescore"].round(3)
+    assert_equal 70_848.878, genus_result["NR"]["aggregatescore"].round(3)
     assert_equal 9.3000002, genus_result["NR"]["neglogevalue"]
   end
 

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -117,7 +117,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 69.0, species_result["NR"]["r"]
     assert_equal "61497.326", species_result["NR"]["rpm"]
     assert_equal 9.0, species_result["NR"]["zscore"]
-    assert_equal 2_428_411_754.8, species_result["NR"]["aggregatescore"].round(1)
+    assert_equal 20_069_518.6, species_result["NR"]["aggregatescore"].round(1)
     assert_equal 16.9101009, species_result["NR"]["neglogevalue"]
 
     assert_equal 217.0, genus_result["NT"]["r"]
@@ -128,7 +128,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 87.0, genus_result["NR"]["r"]
     assert_equal "77540.106", genus_result["NR"]["rpm"]
     assert_equal 9.0, genus_result["NR"]["zscore"]
-    assert_equal 2_428_411_754.8, genus_result["NR"]["aggregatescore"].round(1)
+    assert_equal 20_069_518.6, genus_result["NR"]["aggregatescore"].round(1)
     assert_equal 16.9874001, genus_result["NR"]["neglogevalue"]
 
     # Test species taxid 1313, which has genus taxid 1301

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -123,7 +123,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 217.0, genus_result["NT"]["r"]
     assert_equal "193404.634", genus_result["NT"]["rpm"]
     assert_equal 9.0, genus_result["NT"]["zscore"]
-    assert_equal 2_428_411_754.8, genus_result["NT"]["aggregatescore"].round(1)
+    assert_equal 20_069_518.6, genus_result["NT"]["aggregatescore"].round(1)
     assert_equal 89.5821991, genus_result["NT"]["neglogevalue"]
     assert_equal 87.0, genus_result["NR"]["r"]
     assert_equal "77540.106", genus_result["NR"]["rpm"]


### PR DESCRIPTION
- Based on Boris's recommendations for adjusting the zscores
(1) Adjust the parameter weights
(2) Remove species z-scores from the aggregate score

- I will make the actual TaxonScoringModel db change manually since it doesn't really make sense to do it in a migration.
- Hard to tell how much this denoises them but will look at it more after the background filters are fixed and I can find some good comparison samples.