### PR TITLE
Bug fix for report trying to load when sample is still pending

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -175,20 +175,20 @@ class SamplesController < ApplicationController
     @report_page_params = { pipeline_version: @pipeline_version, background_id: background_id } if background_id
     @report_page_params[:scoring_model] = params[:scoring_model] if params[:scoring_model]
 
-    # Report is ready if the pipeline run has results finalized and did not
-    # fail, or if all its output states are loaded.
-    if @pipeline_run && ((@pipeline_run.results_finalized? && !@pipeline_run.failed?) || @pipeline_run.report_ready?)
-      if background_id
-        @report_present = 1
-        @report_ts = @pipeline_run.updated_at.to_i
-        @all_categories = all_categories
-        @report_details = report_details(@pipeline_run, current_user.id)
-        @ercc_comparison = @pipeline_run.compare_ercc_counts
-      end
+    # Report is ready if pipeline run has results finalized and did not fail
+    # (success), or if all its output states are loaded successfully.
+    if @pipeline_run &&
+       ((@pipeline_run.results_finalized? && !@pipeline_run.failed?) || @pipeline_run.report_ready?) &&
+       background_id
+      @report_present = 1
+      @report_ts = @pipeline_run.updated_at.to_i
+      @all_categories = all_categories
+      @report_details = report_details(@pipeline_run, current_user.id)
+      @ercc_comparison = @pipeline_run.compare_ercc_counts
+    end
 
-      if @pipeline_run.failed?
-        @pipeline_run_retriable = true
-      end
+    if @pipeline_run && @pipeline_run.results_finalized? && @pipeline_run.failed?
+      @pipeline_run_retriable = true
     end
   end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -174,7 +174,10 @@ class SamplesController < ApplicationController
     background_id = check_background_id(@sample)
     @report_page_params = { pipeline_version: @pipeline_version, background_id: background_id } if background_id
     @report_page_params[:scoring_model] = params[:scoring_model] if params[:scoring_model]
-    if @pipeline_run && (((@pipeline_run.adjusted_remaining_reads.to_i > 0 || @pipeline_run.results_finalized?) && !@pipeline_run.failed?) || @pipeline_run.report_ready?)
+
+    # Report is ready if the pipeline run has results finalized and did not
+    # fail, or if all its output states are loaded.
+    if @pipeline_run && ((@pipeline_run.results_finalized? && !@pipeline_run.failed?) || @pipeline_run.report_ready?)
       if background_id
         @report_present = 1
         @report_ts = @pipeline_run.updated_at.to_i


### PR DESCRIPTION
Basically remove `@pipeline_run.adjusted_remaining_reads.to_i > 0` b/c that's generated on the fly and no longer indicates the report is ready.