### PR TITLE
disable rubocop "each -> find_each" rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -114,3 +114,6 @@ Style/Next:
   # `MinBodyLength` defines the number of lines of the a body of an if / unless
   # needs to have to trigger this cop
   MinBodyLength: 25
+
+Rails/FindEach:
+  Enabled: false

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -46,9 +46,8 @@ class TaxonLineage < ApplicationRecord
 
     # Get created_at date for our TaxonCount entries. Same for all TaxonCounts
     # in a PipelineRun.
-    # TODO: change this to get the created_at date from the smaller pipeline_run table.
-    #       And/or move the lineage selection mechanism into alignment_config.
-    valid_date = TaxonCount.where(pipeline_run_id: pipeline_run_id).select(:created_at).last.created_at
+    # TODO: Move the lineage selection mechanism into alignment_config.
+    valid_date = PipelineRun.find(pipeline_run_id).created_at
 
     # TODO: Should definitely be simplified with taxonomy/lineage refactoring.
     lineage_by_taxid = {}

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -46,6 +46,8 @@ class TaxonLineage < ApplicationRecord
 
     # Get created_at date for our TaxonCount entries. Same for all TaxonCounts
     # in a PipelineRun.
+    # TODO: change this to get the created_at date from the smaller pipeline_run table.
+    #       And/or move the lineage selection mechanism into alignment_config.
     valid_date = TaxonCount.where(pipeline_run_id: pipeline_run_id).select(:created_at).last.created_at
 
     # TODO: Should definitely be simplified with taxonomy/lineage refactoring.

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -46,7 +46,7 @@ class TaxonLineage < ApplicationRecord
 
     # Get created_at date for our TaxonCount entries. Same for all TaxonCounts
     # in a PipelineRun.
-    valid_date = PipelineRun.find(pipeline_run_id).taxon_counts.last.created_at
+    valid_date = TaxonCount.where(pipeline_run_id: pipeline_run_id).select(:created_at).last.created_at
 
     # TODO: Should definitely be simplified with taxonomy/lineage refactoring.
     lineage_by_taxid = {}

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -55,7 +55,7 @@ class TaxonLineage < ApplicationRecord
     # now, we only select the valid entry based on started_at and ended_at.
     # The valid lineage entry has start and end dates that include the valid
     # taxon count entry date.
-    TaxonLineage.where(taxid: tax_ids).where("started_at < ? AND ended_at > ?", valid_date, valid_date).find_each do |x|
+    TaxonLineage.where(taxid: tax_ids).where("started_at < ? AND ended_at > ?", valid_date, valid_date).each do |x|
       lineage_by_taxid[x.taxid] = x.as_json
     end
 

--- a/db/migrate/20180820164834_add_index_to_taxon_counts.rb
+++ b/db/migrate/20180820164834_add_index_to_taxon_counts.rb
@@ -1,0 +1,4 @@
+class AddIndexToTaxonCounts < ActiveRecord::Migration[5.1]
+  def change
+  end
+end

--- a/db/migrate/20180820164834_add_index_to_taxon_counts.rb
+++ b/db/migrate/20180820164834_add_index_to_taxon_counts.rb
@@ -1,4 +1,0 @@
-class AddIndexToTaxonCounts < ActiveRecord::Migration[5.1]
-  def change
-  end
-end


### PR DESCRIPTION
Rubocop's auto-conversion of `each` to `find_each` in https://github.com/chanzuckerberg/idseq-web/blob/4489573c2a973a8af90df09450f67a2a369679bd/app/models/taxon_lineage.rb#L58 more than doubles the load time of the report page.
Example: 
idseq-staging sample 905, on my local machine, takes 13 seconds to load with "each",
30 seconds with "find_each".

Also: each one of the TaxonLineage queries takes of order ~1 second. Next, will work on refactoring to change that.