### PR TITLE
Modify "Read Specificity" filter behavior on Report Page

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -128,7 +128,9 @@ class PipelineSampleReport extends React.Component {
       loading: true,
       activeThresholds: this.defaultThresholdValues,
       countType: "NT",
-      readSpecificity: cachedReadSpecificity ? cachedReadSpecificity : 0
+      readSpecificity: cachedReadSpecificity
+        ? parseInt(cachedReadSpecificity)
+        : 0
     };
 
     this.expandAll = false;
@@ -295,8 +297,7 @@ class PipelineSampleReport extends React.Component {
     let selected_taxons = [];
     const thresholded_taxons = input_taxons || this.state.thresholded_taxons;
     const active_thresholds = this.state.activeThresholds;
-    const specificOnly =
-      this.state.readSpecificity.toLowerCase() === "specific only";
+    const specificOnly = this.state.readSpecificity === 1;
 
     if (searchTaxonId > 0) {
       // ignore all the thresholds

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -333,7 +333,7 @@ class PipelineSampleReport extends React.Component {
 
           // Skip if excluding non-specific rows
           if (this.state.readSpecificity.toLowerCase() === "specific only") {
-            if (taxon.tax_level === 2 && taxon.tax_id < 0) {
+            if (taxon.tax_id < 0) {
               continue;
             }
           }
@@ -372,7 +372,7 @@ class PipelineSampleReport extends React.Component {
       // Skip if excluding non-specific rows
       if (this.state.readSpecificity.toLowerCase() === "specific only") {
         for (let tax_info of thresholded_taxons) {
-          if (tax_info.tax_level !== 2 || tax_info.tax_id > 0) {
+          if (tax_info.tax_id > 0) {
             selected_taxons.push(tax_info);
           }
         }
@@ -398,6 +398,9 @@ class PipelineSampleReport extends React.Component {
     }
 
     selected_taxons = this.updateSpeciesCount(selected_taxons);
+    if (this.state.readSpecificity.toLowerCase() === "specific only") {
+      selected_taxons = this.removeEmptyGenusRows(selected_taxons);
+    }
 
     this.setState({
       loading: false,
@@ -433,6 +436,10 @@ class PipelineSampleReport extends React.Component {
       }
     }
     return res;
+  }
+
+  removeEmptyGenusRows(rows) {
+    return rows.filter(r => r.tax_level === 1 || r.species_count > 0);
   }
 
   //Load more samples on scroll

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -128,7 +128,7 @@ class PipelineSampleReport extends React.Component {
       loading: true,
       activeThresholds: this.defaultThresholdValues,
       countType: "NT",
-      readSpecificity: cachedReadSpecificity ? cachedReadSpecificity : "All"
+      readSpecificity: cachedReadSpecificity ? cachedReadSpecificity : 0
     };
 
     this.expandAll = false;
@@ -276,7 +276,7 @@ class PipelineSampleReport extends React.Component {
         ),
         pagesRendered: 1,
         rows_passing_filters: this.state.taxonomy_details.length,
-        readSpecificity: "All"
+        readSpecificity: 0
       },
       () => {
         ThresholdMap.saveThresholdFilters([]);
@@ -1661,8 +1661,8 @@ function BackgroundModelFilter({ parent }) {
 
 function SpecificityFilter({ parent }) {
   const specificityOptions = [
-    { text: "All", value: "All" },
-    { text: "Specific Only", value: "Specific Only" }
+    { text: "All", value: 0 },
+    { text: "Specific Only", value: 1 }
   ];
   return (
     <OurDropdown


### PR DESCRIPTION
- Changes the behavior to remove the species-level lines like "Non-species-specific reads in genus X".
- Also removes empty Genus rows when enabled like "Plantibacter (0 bacterial species)" would go away.

- See: https://jira.czi.team/browse/IDSEQ-313

![sep-11-2018 10-19-07](https://user-images.githubusercontent.com/5652739/45376231-27b55e00-b5ac-11e8-8207-37adeb09046e.gif)
