### PR TITLE
print backtrace on rescues that do not rerase

### DIFF
--- a/app/lib/log_util.rb
+++ b/app/lib/log_util.rb
@@ -3,4 +3,7 @@ class LogUtil
     Rails.logger.error(msg)
     Airbrake.notify(msg)
   end
+  def self.log_backtrace(exception)
+    Rails.logger.error("Backtrace:\n\t#{exception.backtrace.join("\n\t")}")
+  end
 end

--- a/app/lib/log_util.rb
+++ b/app/lib/log_util.rb
@@ -3,6 +3,7 @@ class LogUtil
     Rails.logger.error(msg)
     Airbrake.notify(msg)
   end
+  
   def self.log_backtrace(exception)
     Rails.logger.error("Backtrace:\n\t#{exception.backtrace.join("\n\t")}")
   end

--- a/app/lib/log_util.rb
+++ b/app/lib/log_util.rb
@@ -3,7 +3,7 @@ class LogUtil
     Rails.logger.error(msg)
     Airbrake.notify(msg)
   end
-  
+
   def self.log_backtrace(exception)
     Rails.logger.error("Backtrace:\n\t#{exception.backtrace.join("\n\t")}")
   end

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -16,8 +16,9 @@ class CheckPipelineRuns
         break if @shutdown_requested
         Rails.logger.info("  Checking pipeline run #{pr.id} for sample #{pr.sample_id}") unless silent
         pr.update_job_status
-      rescue
+      rescue => exception
         LogUtil.log_err_and_airbrake("Failed to update pipeline run #{pr.id}")
+        LogUtil.log_backtrace(exception)
       end
     end
 
@@ -26,8 +27,9 @@ class CheckPipelineRuns
         break if @shutdown_requested
         Rails.logger.info("Monitoring job for phylo_tree #{pt.id}") unless silent
         pt.monitor_job
-      rescue
+      rescue => exception
         LogUtil.log_err_and_airbrake("Failed monitor job for phylo_tree #{pt.id}")
+        LogUtil.log_backtrace(exception)
       end
     end
   end

--- a/lib/tasks/result_monitor.rake
+++ b/lib/tasks/result_monitor.rake
@@ -16,8 +16,9 @@ class MonitorPipelineResults
         break if @shutdown_requested
         Rails.logger.info("Monitoring results: pipeline run #{pr.id}, sample #{pr.sample_id}") unless silent
         pr.monitor_results
-      rescue
+      rescue => exception
         LogUtil.log_err_and_airbrake("Failed monitor results for pipeline run #{pr.id}")
+        LogUtil.log_backtrace(exception)
       end
     end
 
@@ -26,8 +27,9 @@ class MonitorPipelineResults
         break if @shutdown_requested
         Rails.logger.info("Monitoring results for phylo_tree #{pt.id}") unless silent
         pt.monitor_results
-      rescue
+      rescue => exception
         LogUtil.log_err_and_airbrake("Failed monitor results for phylo_tree #{pt.id}")
+        LogUtil.log_backtrace(exception)
       end
     end
   end


### PR DESCRIPTION
a rescue should either reraise its exception or print a backtrace,
to include sufficient debugging detail in the error logs
