### PR TITLE
Fix default values in ThresholdFilterDropdown and MultipleDropdown.

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx
@@ -84,10 +84,15 @@ class MultipleDropdown extends React.Component {
   }
 }
 
+MultipleDropdown.defaultProps = {
+  value: []
+};
+
 MultipleDropdown.propTypes = {
   label: PropTypes.string,
   onChange: PropTypes.func.isRequired,
-  options: PropTypes.arrayOf(PropTypes.object)
+  options: PropTypes.arrayOf(PropTypes.object),
+  value: PropTypes.array
 };
 
 export default MultipleDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
@@ -242,6 +242,10 @@ const ThresholdFilterDropdownLabel = props => {
   );
 };
 
+ThresholdFilterDropdown.defaultProps = {
+  thresholds: []
+};
+
 ThresholdFilterDropdownLabel.propType = forbidExtraProps({
   disabled: PropTypes.bool,
   label: PropTypes.string,


### PR DESCRIPTION
# Description

ThresholdFilterDropdown and MultipleDropdown are checking props when they change, and they might not have a default value.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)


