### PR TITLE
Expire old CLI versions

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -435,11 +435,11 @@ class SamplesController < ApplicationController
     # CLI client should provide a version string to-be-checked against the
     # minimum version here. Bulk upload from CLI goes to this method.
     client = params.delete(:client)
-    min_version = Gem::Version.new('0.3.0')
+    min_version = Gem::Version.new('0.5.0')
     unless client && (client == "web" || Gem::Version.new(client) >= min_version)
       render json: {
-        message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with pip2 to use python2 (required)",
-        status: :upgrade_required
+          message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.",
+          status: :upgrade_required
       }
       return
     end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -438,8 +438,8 @@ class SamplesController < ApplicationController
     min_version = Gem::Version.new('0.5.0')
     unless client && (client == "web" || Gem::Version.new(client) >= min_version)
       render json: {
-          message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.",
-          status: :upgrade_required
+        message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.",
+        status: :upgrade_required
       }
       return
     end


### PR DESCRIPTION
- Expire old CLI versions since there are still some people using the old CLI but get confused by the new instructions.
- They'll see the error message and then be able to upgrade painlessly hopefully.