### PR TITLE
Only send project email on first pipeline run

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -449,7 +449,8 @@ class PipelineRun < ApplicationRecord
   def handle_success
     # Check if this was the last run in a project and act accordingly:
     if sample.project.results_complete?
-      notify_users
+      # Ony send the project success email on the first pipeline run
+      notify_users if sample.pipeline_runs.count == 1
       sample.project.create_or_update_project_background if sample.project.background_flag == 1
     end
   end


### PR DESCRIPTION
- Only send the "project complete" email if this sample has 1 pipeline run (i.e. not a rerun of the sample).
- Bad user experience for everyone to get surprising project complete emails on reruns... since we do test reruns of random things sometimes and most reruns are very minor on the version changes.