### PR TITLE
Get rid of honeycomb errors in rails logs

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,3 +1,5 @@
+require 'libhoney'
+
 if ENV["IDSEQ_HONEYCOMB_WRITE_KEY"] && ENV["IDSEQ_HONEYCOMB_DATA_SET"] && ENV["IDSEQ_HONEYCOMB_DB_DATA_SET"]
   HoneycombRails.configure do |conf|
     conf.writekey = ENV["IDSEQ_HONEYCOMB_WRITE_KEY"]

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -13,5 +13,7 @@ if ENV["IDSEQ_HONEYCOMB_WRITE_KEY"] && ENV["IDSEQ_HONEYCOMB_DATA_SET"] && ENV["I
     end
   end
 else
-  conf.client = NullClient.new
+  HoneycombRails.configure do |conf|
+    conf.client = NullClient.new
+  end
 end

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,4 +1,3 @@
-
 if ENV["IDSEQ_HONEYCOMB_WRITE_KEY"] && ENV["IDSEQ_HONEYCOMB_DATA_SET"] && ENV["IDSEQ_HONEYCOMB_DB_DATA_SET"]
   HoneycombRails.configure do |conf|
     conf.writekey = ENV["IDSEQ_HONEYCOMB_WRITE_KEY"]
@@ -13,4 +12,6 @@ if ENV["IDSEQ_HONEYCOMB_WRITE_KEY"] && ENV["IDSEQ_HONEYCOMB_DATA_SET"] && ENV["I
       end
     end
   end
+else
+  conf.client = NullClient.new
 end

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -14,6 +14,6 @@ if ENV["IDSEQ_HONEYCOMB_WRITE_KEY"] && ENV["IDSEQ_HONEYCOMB_DATA_SET"] && ENV["I
   end
 else
   HoneycombRails.configure do |conf|
-    conf.client = NullClient.new
+    conf.client = Libhoney::NullClient.new
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,6 @@ services:
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - IDSEQ_AIRBRAKE_PROJECT_ID
       - IDSEQ_AIRBRAKE_PROJECT_KEY
-      - IDSEQ_HONEYCOMB_DB_DATA_SET
-      - IDSEQ_HONEYCOMB_DATA_SET
-      - IDSEQ_HONEYCOMB_WRITE_KEY
       - MAIL_GUN_API_KEY
       - CI
       - CONTINUOUS_INTEGRATION
@@ -119,9 +116,6 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - SAMPLES_BUCKET_NAME=idseq-samples-development
-      - IDSEQ_HONEYCOMB_DB_DATA_SET
-      - IDSEQ_HONEYCOMB_DATA_SET
-      - IDSEQ_HONEYCOMB_WRITE_KEY
       - CI
       - CONTINUOUS_INTEGRATION
       - RACK_ENV
@@ -202,9 +196,6 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - SAMPLES_BUCKET_NAME=idseq-samples-development
-      - IDSEQ_HONEYCOMB_DB_DATA_SET
-      - IDSEQ_HONEYCOMB_DATA_SET
-      - IDSEQ_HONEYCOMB_WRITE_KEY
       - CI
       - CONTINUOUS_INTEGRATION
       - RACK_ENV


### PR DESCRIPTION
Tired of seeing these in our error logs:
[2018-09-27T23:31:38] WARN  Rails : No write key defined! (Check your config's `writekey` value in config/initializers/honeycomb.rb) No events will be sent to Honeycomb.
