### PR TITLE
only one aggregatescore on heatmap metric selector

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -75,19 +75,6 @@ class PipelineSampleReport extends React.Component {
       { text: "NR Z Score", value: "nr_zscore" }
     ];
 
-    this.allThresholds = [
-      "NT_aggregatescore",
-      "NT_zscore",
-      "NT_rpm",
-      "NT_r",
-      "NT_percentidentity",
-      "NT_neglogevalue",
-      "NR_zscore",
-      "NR_r",
-      "NR_rpm",
-      "NR_percentidentity",
-      "NR_neglogevalue"
-    ];
     this.categoryChildParent = { Phage: "Viruses" };
     this.categoryParentChild = { Viruses: ["Phage"] };
     this.genus_map = {};
@@ -95,7 +82,7 @@ class PipelineSampleReport extends React.Component {
     this.INVALID_CALL_BASE_TAXID = -1e8;
 
     this.defaultThreshold = {
-      metric: this.allThresholds[0],
+      metric: "NT_aggregatescore",
       operator: ">=",
       value: ""
     };
@@ -1907,10 +1894,6 @@ class RenderMarkup extends React.Component {
                       </div>
                       <div className="filter-lists-element">
                         <ThresholdFilterDropdown
-                          options={{
-                            targets: parent.allThresholds,
-                            operators: [">=", "<="]
-                          }}
                           thresholds={parent.state.activeThresholds}
                           onApply={parent.handleThresholdFiltersChange}
                         />

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -21,7 +21,11 @@ import PhyloTreeCreationModal from "./views/phylo_tree/PhyloTreeCreationModal";
 import PhyloTreeChecks from "./views/phylo_tree/PhyloTreeChecks";
 import TaxonModal from "./views/report/TaxonModal";
 import TaxonTreeVis from "./views/TaxonTreeVis";
-import { METRIC_NAMES } from "./utils/Metrics";
+import {
+  METRIC_NAMES,
+  TREE_METRICS,
+  MetricTextAndValue
+} from "./utils/Metrics";
 
 class PipelineSampleReport extends React.Component {
   constructor(props) {
@@ -65,15 +69,7 @@ class PipelineSampleReport extends React.Component {
 
     this.showConcordance = false;
 
-    this.treeMetrics = [
-      { text: "Aggregate Score", value: "aggregatescore" },
-      { text: "NT r (total reads)", value: "nt_r" },
-      { text: "NT rPM", value: "nt_rpm" },
-      { text: "NT Z Score", value: "nt_zscore" },
-      { text: "NR r (total reads)", value: "nr_r" },
-      { text: "NR rPM", value: "nr_rpm" },
-      { text: "NR Z Score", value: "nr_zscore" }
-    ];
+    this.treeMetrics = MetricTextAndValue(TREE_METRICS);
 
     this.categoryChildParent = { Phage: "Viruses" };
     this.categoryParentChild = { Viruses: ["Phage"] };
@@ -1770,7 +1766,7 @@ function SpecificityFilter({ parent }) {
   );
 }
 
-function MetricPicker({ parent }) {
+function TreeMetricPicker({ parent }) {
   return (
     <OurDropdown
       options={parent.treeMetrics}
@@ -1903,7 +1899,7 @@ class RenderMarkup extends React.Component {
                       </div>
                       {this.state.view == "tree" && (
                         <div className="filter-lists-element">
-                          <MetricPicker parent={parent} />
+                          <TreeMetricPicker parent={parent} />
                         </div>
                       )}
                     </div>

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -21,6 +21,7 @@ import PhyloTreeCreationModal from "./views/phylo_tree/PhyloTreeCreationModal";
 import PhyloTreeChecks from "./views/phylo_tree/PhyloTreeChecks";
 import TaxonModal from "./views/report/TaxonModal";
 import TaxonTreeVis from "./views/TaxonTreeVis";
+import { METRIC_NAMES } from "./utils/Metrics";
 
 class PipelineSampleReport extends React.Component {
   constructor(props) {
@@ -75,17 +76,17 @@ class PipelineSampleReport extends React.Component {
     ];
 
     this.allThresholds = [
-      { text: "Score", value: "NT_aggregatescore" },
-      { text: "NT Z Score", value: "NT_zscore" },
-      { text: "NT rPM", value: "NT_rpm" },
-      { text: "NT r (total reads)", value: "NT_r" },
-      { text: "NT %id", value: "NT_percentidentity" },
-      { text: "NT log(1/e)", value: "NT_neglogevalue" },
-      { text: "NR Z Score", value: "NR_zscore" },
-      { text: "NR r (total reads)", value: "NR_r" },
-      { text: "NR rPM", value: "NR_rpm" },
-      { text: "NR %id", value: "NR_percentidentity" },
-      { text: "R log(1/e)", value: "NR_neglogevalue" }
+      "NT_aggregatescore",
+      "NT_zscore",
+      "NT_rpm",
+      "NT_r",
+      "NT_percentidentity",
+      "NT_neglogevalue",
+      "NR_zscore",
+      "NR_r",
+      "NR_rpm",
+      "NR_percentidentity",
+      "NR_neglogevalue"
     ];
     this.categoryChildParent = { Phage: "Viruses" };
     this.categoryParentChild = { Viruses: ["Phage"] };
@@ -93,15 +94,8 @@ class PipelineSampleReport extends React.Component {
 
     this.INVALID_CALL_BASE_TAXID = -1e8;
 
-    this.thresholdTextByValue = this.allThresholds.reduce(
-      (metrics, threshold) => {
-        metrics[threshold.value] = threshold.text;
-        return metrics;
-      },
-      {}
-    );
     this.defaultThreshold = {
-      metric: this.allThresholds[0]["value"],
+      metric: this.allThresholds[0],
       operator: ">=",
       value: ""
     };
@@ -1509,8 +1503,8 @@ function AdvancedFilterTagList({ threshold, i, parent }) {
         size="tiny"
         key={`advanced_filter_tag_${i}`}
       >
-        {parent.thresholdTextByValue[threshold["metric"]]}{" "}
-        {threshold["operator"]} {threshold["value"]}
+        {METRIC_NAMES[threshold["metric"]]} {threshold["operator"]}{" "}
+        {threshold["value"]}
         <Icon
           name="close"
           onClick={() => {

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -2021,13 +2021,7 @@ function ProjectInfoHeading({
       </div>
     )
   };
-  if (proj && canEditProject(proj.id)) {
-    phyloProps["projectId"] = proj.id;
-    phyloProps["projectName"] = proj.name;
-  }
-  let phyloTreeModal = (
-    <PhyloTreeCreationModal {...phyloProps} />
-  );
+  let phyloTreeModal = <PhyloTreeCreationModal {...phyloProps} />;
 
   return (
     <div className="row download-section">

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1941,16 +1941,6 @@ class AddUserModal extends React.Component {
             {this.props.state.project ? this.props.state.project.name : null}
           </div>
           <AddUserModalMemberArea state={this.props.state} parent={this} />
-          <input
-            type="checkbox"
-            id="background_flag"
-            onChange={this.props.parent.toggleBackgroundFlag}
-            className="filled-in checkbox"
-            checked={this.props.state.project.background_flag}
-          />
-          <label htmlFor="background_flag">
-            Expose project-specific background
-          </label>
         </Modal.Content>
         <Modal.Actions>
           <PrimaryButton text="Close" onClick={this.handleClose} />

--- a/app/assets/src/components/SamplesHeatmap.jsx
+++ b/app/assets/src/components/SamplesHeatmap.jsx
@@ -52,7 +52,6 @@ class SamplesHeatmap extends React.Component {
         ) {
           return { text: taxonLevelName, value: index };
         }),
-        thresholdFilters: this.props.thresholdFilters,
         // Client side options
         scales: [["Log", symlog], ["Lin", d3.scale.linear]],
         taxonsPerSample: {
@@ -520,7 +519,6 @@ class SamplesHeatmap extends React.Component {
   renderAdvancedFilterPicker() {
     return (
       <ThresholdFilterDropdown
-        options={this.state.availableOptions.thresholdFilters}
         thresholds={this.state.selectedOptions.thresholdFilters}
         onApply={this.onThresholdFilterApply}
         disabled={!this.state.data}

--- a/app/assets/src/components/SamplesHeatmap.jsx
+++ b/app/assets/src/components/SamplesHeatmap.jsx
@@ -19,6 +19,7 @@ import Slider from "./ui/controls/Slider";
 import TaxonTooltip from "./TaxonTooltip";
 import ThresholdFilterDropdown from "./ui/controls/dropdowns/ThresholdFilterDropdown";
 import { Colormap } from "./utils/colormaps/Colormap";
+import { METRIC_NAMES } from "./utils/Metrics";
 
 class SamplesHeatmap extends React.Component {
   // TODO: do not make another request if values did not change
@@ -493,7 +494,7 @@ class SamplesHeatmap extends React.Component {
 
   renderMetricPicker() {
     let options = this.state.availableOptions.metrics.map(function(metric) {
-      return { text: metric, value: metric };
+      return { text: METRIC_NAMES[metric], value: metric };
     });
 
     return (

--- a/app/assets/src/components/SamplesHeatmap.jsx
+++ b/app/assets/src/components/SamplesHeatmap.jsx
@@ -60,7 +60,7 @@ class SamplesHeatmap extends React.Component {
         }
       },
       selectedOptions: {
-        metric: this.urlParams.metric || this.props.metrics[0],
+        metric: this.urlParams.metric || "NT.r",
         categories: this.urlParams.categories || [],
         subcategories: this.urlParams.subcategories || {},
         background:

--- a/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
@@ -3,13 +3,17 @@ import { forbidExtraProps } from "airbnb-prop-types";
 import PrimaryButton from "../buttons/PrimaryButton";
 import PropTypes from "prop-types";
 import RemoveIcon from "../../icons/RemoveIcon";
+import { METRIC_NAMES } from "../../../utils/Metrics";
 import React from "react";
 
 class ThresholdFilterDropdown extends React.Component {
   constructor(props) {
     super(props);
 
-    this.metrics = (this.props.options || {}).targets || [];
+    let targets = (this.props.options || {}).targets || [];
+    this.metrics = targets.map(metric => {
+      return { text: METRIC_NAMES[metric], value: metric };
+    });
     this.operators = (this.props.options || {}).operators || [];
     this.label = this.props.label || "Threshold Filters:";
 

--- a/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
@@ -4,7 +4,6 @@ import PrimaryButton from "../buttons/PrimaryButton";
 import PropTypes from "prop-types";
 import RemoveIcon from "../../icons/RemoveIcon";
 import {
-  METRIC_NAMES,
   THRESHOLD_METRICS,
   MetricTextAndValue
 } from "../../../utils/Metrics";

--- a/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
@@ -3,16 +3,18 @@ import { forbidExtraProps } from "airbnb-prop-types";
 import PrimaryButton from "../buttons/PrimaryButton";
 import PropTypes from "prop-types";
 import RemoveIcon from "../../icons/RemoveIcon";
-import { METRIC_NAMES, THRESHOLD_METRICS } from "../../../utils/Metrics";
+import {
+  METRIC_NAMES,
+  THRESHOLD_METRICS,
+  MetricTextAndValue
+} from "../../../utils/Metrics";
 import React from "react";
 
 class ThresholdFilterDropdown extends React.Component {
   constructor(props) {
     super(props);
 
-    this.metrics = THRESHOLD_METRICS.map(metric => {
-      return { text: METRIC_NAMES[metric], value: metric };
-    });
+    this.metrics = MetricTextAndValue(THRESHOLD_METRICS);
     this.operators = [">=", "<="];
     this.label = this.props.label || "Threshold Filters:";
 

--- a/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
@@ -3,18 +3,17 @@ import { forbidExtraProps } from "airbnb-prop-types";
 import PrimaryButton from "../buttons/PrimaryButton";
 import PropTypes from "prop-types";
 import RemoveIcon from "../../icons/RemoveIcon";
-import { METRIC_NAMES } from "../../../utils/Metrics";
+import { METRIC_NAMES, THRESHOLD_METRICS } from "../../../utils/Metrics";
 import React from "react";
 
 class ThresholdFilterDropdown extends React.Component {
   constructor(props) {
     super(props);
 
-    let targets = (this.props.options || {}).targets || [];
-    this.metrics = targets.map(metric => {
+    this.metrics = THRESHOLD_METRICS.map(metric => {
       return { text: METRIC_NAMES[metric], value: metric };
     });
-    this.operators = (this.props.options || {}).operators || [];
+    this.operators = [">=", "<="];
     this.label = this.props.label || "Threshold Filters:";
 
     this.state = {

--- a/app/assets/src/components/utils/Metrics.js
+++ b/app/assets/src/components/utils/Metrics.js
@@ -1,4 +1,4 @@
-const metric_names = {
+const metricNames = {
   "NT.aggregatescore": "Score",
   "NT.rpm": "NT rPM",
   "NT.r": "NT r (reads)",
@@ -12,15 +12,15 @@ const metric_names = {
   "NR.percentidentity": "NR %id",
   "NR.neglogevalue": "NR log(1/e)"
 };
-const metric_names_augmented = {};
-for (var m in metric_names) {
-  metric_names_augmented[m] = metric_names[m];
-  metric_names_augmented[m.replace(".", "_")] = metric_names[m];
-  metric_names_augmented[m.replace(".", "_").toLowerCase()] = metric_names[m];
+const metricNamesAugmented = {};
+for (var m in metricNames) {
+  metricNamesAugmented[m] = metricNames[m];
+  metricNamesAugmented[m.replace(".", "_")] = metricNames[m];
+  metricNamesAugmented[m.replace(".", "_").toLowerCase()] = metricNames[m];
 }
-metric_names_augmented["aggregatescore"] =
-  metric_names_augmented["NT.aggregatescore"];
-export const METRIC_NAMES = metric_names_augmented;
+metricNamesAugmented["aggregatescore"] =
+  metricNamesAugmented["NT.aggregatescore"];
+export const METRIC_NAMES = metricNamesAugmented;
 
 export const THRESHOLD_METRICS = [
   "NT_aggregatescore",

--- a/app/assets/src/components/utils/Metrics.js
+++ b/app/assets/src/components/utils/Metrics.js
@@ -18,3 +18,17 @@ for (var m in metric_names) {
   metric_names_augmented[m.replace(".", "_")] = metric_names[m];
 }
 export const METRIC_NAMES = metric_names_augmented;
+
+export const THRESHOLD_METRICS = [
+  "NT_aggregatescore",
+  "NT_zscore",
+  "NT_rpm",
+  "NT_r",
+  "NT_percentidentity",
+  "NT_neglogevalue",
+  "NR_zscore",
+  "NR_r",
+  "NR_rpm",
+  "NR_percentidentity",
+  "NR_neglogevalue"
+];

--- a/app/assets/src/components/utils/Metrics.js
+++ b/app/assets/src/components/utils/Metrics.js
@@ -1,0 +1,20 @@
+let metric_names = {
+  "NT.aggregatescore": "Score",
+  "NT.rpm": "NT rPM",
+  "NT.r": "NT r (reads)",
+  "NT.zscore": "NT z-score",
+  "NT.maxzscore": "Max z-score",
+  "NT.percentidentity": "NT %id",
+  "NT.neglogevalue": "NT log(1/e)",
+  "NR.rpm": "NR rPM",
+  "NR.r": "NR r (reads)",
+  "NR.zscore": "NR z-score",
+  "NR.percentidentity": "NR %id",
+  "NR.neglogevalue": "NR log(1/e)"
+};
+let metric_names_augmented = {};
+for (var m in metric_names) {
+  metric_names_augmented[m] = metric_names[m];
+  metric_names_augmented[m.replace(".", "_")] = metric_names[m];
+}
+export const METRIC_NAMES = metric_names_augmented;

--- a/app/assets/src/components/utils/Metrics.js
+++ b/app/assets/src/components/utils/Metrics.js
@@ -1,4 +1,4 @@
-let metric_names = {
+const metric_names = {
   "NT.aggregatescore": "Score",
   "NT.rpm": "NT rPM",
   "NT.r": "NT r (reads)",
@@ -12,11 +12,14 @@ let metric_names = {
   "NR.percentidentity": "NR %id",
   "NR.neglogevalue": "NR log(1/e)"
 };
-let metric_names_augmented = {};
+const metric_names_augmented = {};
 for (var m in metric_names) {
   metric_names_augmented[m] = metric_names[m];
   metric_names_augmented[m.replace(".", "_")] = metric_names[m];
+  metric_names_augmented[m.replace(".", "_").toLowerCase()] = metric_names[m];
 }
+metric_names_augmented["aggregatescore"] =
+  metric_names_augmented["NT.aggregatescore"];
 export const METRIC_NAMES = metric_names_augmented;
 
 export const THRESHOLD_METRICS = [
@@ -32,3 +35,20 @@ export const THRESHOLD_METRICS = [
   "NR_percentidentity",
   "NR_neglogevalue"
 ];
+
+export const TREE_METRICS = [
+  "aggregatescore",
+  "nt_r",
+  "nt_rpm",
+  "nt_zscore",
+  "nr_r",
+  "nr_rpm",
+  "nr_zscore"
+];
+
+export function MetricTextAndValue(desiredMetrics) {
+  let result = desiredMetrics.map(metric => {
+    return { text: METRIC_NAMES[metric], value: metric };
+  });
+  return result;
+}

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import TidyTree from "../visualizations/TidyTree";
 import PathogenLabel from "../ui/labels/PathogenLabel";
+import { METRIC_NAMES } from "../utils/Metrics";
 
 const TaxonLevels = [
   "species",
@@ -30,15 +31,33 @@ class TaxonTreeVis extends React.Component {
 
     this.metrics = {
       aggregatescore: {
-        label: "Aggregate Score",
+        label: METRIC_NAMES["aggregatescore"],
         agg: arr => Math.max(...arr)
       },
-      nt_r: { label: "NT r", agg: arr => arr.reduce((a, b) => a + b, 0) },
-      nt_rpm: { label: "NT rpm", agg: arr => arr.reduce((a, b) => a + b, 0) },
-      nt_zscore: { label: "NT Z-Score", agg: arr => Math.max(...arr) },
-      nr_r: { label: "NR r", agg: arr => arr.reduce((a, b) => a + b, 0) },
-      nr_rpm: { label: "NR rpm", agg: arr => arr.reduce((a, b) => a + b, 0) },
-      nr_zscore: { label: "NR Z-Score", agg: arr => Math.max(...arr) }
+      nt_r: {
+        label: METRIC_NAMES["nt_r"],
+        agg: arr => arr.reduce((a, b) => a + b, 0)
+      },
+      nt_rpm: {
+        label: METRIC_NAMES["nt_rpm"],
+        agg: arr => arr.reduce((a, b) => a + b, 0)
+      },
+      nt_zscore: {
+        label: METRIC_NAMES["nt_zscore"],
+        agg: arr => Math.max(...arr)
+      },
+      nr_r: {
+        label: METRIC_NAMES["nr_r"],
+        agg: arr => arr.reduce((a, b) => a + b, 0)
+      },
+      nr_rpm: {
+        label: METRIC_NAMES["nr_rpm"],
+        agg: arr => arr.reduce((a, b) => a + b, 0)
+      },
+      nr_zscore: {
+        label: METRIC_NAMES["nr_zscore"],
+        agg: arr => Math.max(...arr)
+      }
     };
 
     this.onNodeHover = this.onNodeHover.bind(this);

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -31,31 +31,24 @@ class TaxonTreeVis extends React.Component {
 
     this.metrics = {
       aggregatescore: {
-        label: METRIC_NAMES["aggregatescore"],
         agg: arr => Math.max(...arr)
       },
       nt_r: {
-        label: METRIC_NAMES["nt_r"],
         agg: arr => arr.reduce((a, b) => a + b, 0)
       },
       nt_rpm: {
-        label: METRIC_NAMES["nt_rpm"],
         agg: arr => arr.reduce((a, b) => a + b, 0)
       },
       nt_zscore: {
-        label: METRIC_NAMES["nt_zscore"],
         agg: arr => Math.max(...arr)
       },
       nr_r: {
-        label: METRIC_NAMES["nr_r"],
         agg: arr => arr.reduce((a, b) => a + b, 0)
       },
       nr_rpm: {
-        label: METRIC_NAMES["nr_rpm"],
         agg: arr => arr.reduce((a, b) => a + b, 0)
       },
       nr_zscore: {
-        label: METRIC_NAMES["nr_zscore"],
         agg: arr => Math.max(...arr)
       }
     };
@@ -237,7 +230,7 @@ class TaxonTreeVis extends React.Component {
             }`}
           >
             <div className="taxon_tooltip__row__label">
-              {this.metrics[metric].label}:
+              {METRIC_NAMES[metric]}:
             </div>
             <div className="taxon_tooltip__row__value">
               {Math.round(node.data.values[metric]).toLocaleString()}

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -29,28 +29,14 @@ class TaxonTreeVis extends React.Component {
     this.tree = null;
     this.treeVis = null;
 
-    this.metrics = {
-      aggregatescore: {
-        agg: arr => Math.max(...arr)
-      },
-      nt_r: {
-        agg: arr => arr.reduce((a, b) => a + b, 0)
-      },
-      nt_rpm: {
-        agg: arr => arr.reduce((a, b) => a + b, 0)
-      },
-      nt_zscore: {
-        agg: arr => Math.max(...arr)
-      },
-      nr_r: {
-        agg: arr => arr.reduce((a, b) => a + b, 0)
-      },
-      nr_rpm: {
-        agg: arr => arr.reduce((a, b) => a + b, 0)
-      },
-      nr_zscore: {
-        agg: arr => Math.max(...arr)
-      }
+    this.metrics = { // metrics and their aggregation functions
+      aggregatescore: arr => Math.max(...arr),
+      nt_r: arr => arr.reduce((a, b) => a + b, 0),
+      nt_rpm: arr => arr.reduce((a, b) => a + b, 0),
+      nt_zscore: arr => Math.max(...arr),
+      nr_r: arr => arr.reduce((a, b) => a + b, 0),
+      nr_rpm: arr => arr.reduce((a, b) => a + b, 0),
+      nr_zscore: arr => Math.max(...arr)
     };
 
     this.onNodeHover = this.onNodeHover.bind(this);
@@ -153,7 +139,7 @@ class TaxonTreeVis extends React.Component {
           this.metrics.hasOwnProperty(metric) &&
           !node.data.values.hasOwnProperty(metric)
         ) {
-          node.data.values[metric] = this.metrics[metric].agg(
+          node.data.values[metric] = this.metrics[metric](
             node.children
               .filter(child => child.data.values[metric])
               .map(child => child.data.values[metric])

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -223,32 +223,31 @@ class SamplesController < ApplicationController
         Viruses: ["Phage"]
       },
       metrics: [
+        "NT.r", # first entry will be default selection
         "NT.aggregatescore",
         "NT.rpm",
-        "NT.r",
         "NT.zscore",
         "NT.maxzscore",
         "NR.rpm",
         "NR.r",
-        "NR.zscore",
-        "NR.maxzscore"
+        "NR.zscore"
       ],
       backgrounds: current_power.backgrounds.map do |background|
         { name: background.name, value: background.id }
       end,
       thresholdFilters: {
         targets: [
-          { text: "Aggregate Score", value: "NT_aggregatescore" },
-          { text: "NT Z Score", value: "NT_zscore" },
-          { text: "NT rPM", value: "NT_rpm" },
-          { text: "NT r (total reads)", value: "NT_r" },
-          { text: "NT %id", value: "NT_percentidentity" },
-          { text: "NT log(1/e)", value: "NT_neglogevalue" },
-          { text: "NR Z Score", value: "NR_zscore" },
-          { text: "NR r (total reads)", value: "NR_r" },
-          { text: "NR rPM", value: "NR_rpm" },
-          { text: "NR %id", value: "NR_percentidentity" },
-          { text: "R log(1/e)", value: "NR_neglogevalue" }
+          "NT_aggregatescore",
+          "NT_zscore",
+          "NT_rpm",
+          "NT_r",
+          "NT_percentidentity",
+          "NT_neglogevalue",
+          "NR_zscore",
+          "NR_r",
+          "NR_rpm",
+          "NR_percentidentity",
+          "NR_neglogevalue"
         ],
         operators: [">=", "<="]
       }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -228,7 +228,6 @@ class SamplesController < ApplicationController
         "NT.r",
         "NT.zscore",
         "NT.maxzscore",
-        "NR.aggregatescore",
         "NR.rpm",
         "NR.r",
         "NR.zscore",

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -223,7 +223,7 @@ class SamplesController < ApplicationController
         Viruses: ["Phage"]
       },
       metrics: [
-        "NT.r", # first entry will be default selection
+        "NT.r",
         "NT.aggregatescore",
         "NT.rpm",
         "NT.zscore",

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -234,23 +234,7 @@ class SamplesController < ApplicationController
       ],
       backgrounds: current_power.backgrounds.map do |background|
         { name: background.name, value: background.id }
-      end,
-      thresholdFilters: {
-        targets: [
-          "NT_aggregatescore",
-          "NT_zscore",
-          "NT_rpm",
-          "NT_r",
-          "NT_percentidentity",
-          "NT_neglogevalue",
-          "NR_zscore",
-          "NR_r",
-          "NR_rpm",
-          "NR_percentidentity",
-          "NR_neglogevalue"
-        ],
-        operators: [">=", "<="]
-      }
+      end
     }
   end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -223,9 +223,9 @@ class SamplesController < ApplicationController
         Viruses: ["Phage"]
       },
       metrics: [
-        "NT.r",
         "NT.aggregatescore",
         "NT.rpm",
+        "NT.r",
         "NT.zscore",
         "NT.maxzscore",
         "NR.rpm",


### PR DESCRIPTION
Show only one aggregatescore, not NT.aggregatescore and NR.aggregatescore (they are the same) -- JIRA-337. 
Tiago's & Jonathan's comment that I should define a display name led to the realization that such names are defined 5 times over in different parts of the app. This is a first attempt at standardization so we only need to change code in 1 place and all metric names are consistent.