### PR TITLE
Use fargate

### DIFF
--- a/czecs-resque.json
+++ b/czecs-resque.json
@@ -1,13 +1,16 @@
 {
   "family": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}",
+  "cpu": "1024",
+  "memoryReservation": "3072",
   "containerDefinitions": [
     {
       "name": "idseq-{{ .Values.name }}",
       "image": "chanzuckerberg/idseq-web:{{ .Values.tag }}",
-      "cpu": 1024,
-      "memoryReservation": 3072,
       "essential": true,
-      "command": ["rake", "{{ .Values.rake_command }}"],
+      "command": [
+        "rake",
+        "{{ .Values.rake_command }}"
+      ],
       "environment": [
         {
           "name": "RAILS_ENV",
@@ -60,5 +63,10 @@
       }
     }
   ],
-  "taskRoleArn": "{{ .Values.project }}-web-{{ .Values.env }}"
+  "taskRoleArn": "{{ .Values.project }}-{{ .Values.env }}-web",
+  "executionRoleArn": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}-execution-role",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "networkMode": "awsvpc"
 }

--- a/czecs.json
+++ b/czecs.json
@@ -1,16 +1,16 @@
 {
   "family": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}",
+  "cpu": "2048",
+  "memory": "7168",
   "containerDefinitions": [
     {
       "name": "rails",
       "image": "chanzuckerberg/idseq-web:{{ .Values.tag }}",
-      "cpu": 2048,
-      "memoryReservation": 7168,
       "essential": true,
       "portMappings": [
         {
           "containerPort": 3000,
-          "hostPort": 0
+          "hostPort": 3000
         }
       ],
       "environment": [
@@ -53,5 +53,10 @@
       }
     }
   ],
-  "taskRoleArn": "{{ .Values.project }}-web-{{ .Values.env }}"
+  "taskRoleArn": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}",
+  "executionRoleArn": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}-execution-role",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "networkMode": "awsvpc"
 }


### PR DESCRIPTION
This PR changes idseq web to use Fargate instead of EC2. It is paired with chanzuckerberg/idseq-infra#142 and both must be committed/deployed together.

Fargate allows deployment of Docker containers without having to worry about the underlying EC2 instances; all that is managed by AWS directly. This means that we would no longer have to worry about properly sizing the cluster, making sure the autoscale parameters are correct, and continually patching and draining/replacing the underlying instances. Although dollar per dollar on a fully loaded cluster Fargate is more expensive, a typical cluster is typically underutilized to give it some slack space for future tasks, and that slack tends to eat into potential capital cost savings, and of course there are the maintenance saving from what was described above.

This PR makes the appropriate changes to the czecs task definitions to make the task definition compatible with Fargate, including moving the CPU/memory up to the task definition level instead of container definition level, setting up the network to be Fargate compatible, and forcing the hostPort to match the containerPort as required by Fargate.

We also rename the `idseq-web-${env}` task IAM roles to `idseq-${env}-web`, to follow the naming schemes from CZI's naming standards. (This is what truly necessitates the coordinated release of the PR.)

A potential downside with Fargate is that there is no longer any machine to SSH into for maintenance, which also means there is no more ability to run docker exec inside an existing container. Future maintenance may require creating a persistent side EC2 instance/ECS container that can be SSHed into or that exposes maintenance APIs, setting up tunnels through a bastion to be able to run the maintenance from a local machine, or creating proper maintenance container tasks to perform any one-off maintenance. Although we believe this to be better in the long term, this may disrupt your current day-to-day usage.

Feel free to reject this PR and the corresponding one; just getting the small changes out there for review and to begin the discussion.