### PR TITLE
Taxon Tree: Bug fixes

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -68,10 +68,8 @@ class PipelineSampleReport extends React.Component {
       { text: "Aggregate Score", value: "aggregatescore" },
       { text: "NT r (total reads)", value: "nt_r" },
       { text: "NT rPM", value: "nt_rpm" },
-      { text: "NT Z Score", value: "nt_zscore" },
       { text: "NR r (total reads)", value: "nr_r" },
-      { text: "NR rPM", value: "nr_rpm" },
-      { text: "NR Z Score", value: "nr_zscore" }
+      { text: "NR rPM", value: "nr_rpm" }
     ];
 
     this.allThresholds = [

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -35,10 +35,8 @@ class TaxonTreeVis extends React.Component {
       },
       nt_r: { label: "NT r", agg: arr => arr.reduce((a, b) => a + b, 0) },
       nt_rpm: { label: "NT rpm", agg: arr => arr.reduce((a, b) => a + b, 0) },
-      nt_zscore: { label: "NT Z-Score", agg: arr => Math.max(...arr) },
       nr_r: { label: "NR r", agg: arr => arr.reduce((a, b) => a + b, 0) },
-      nr_rpm: { label: "NR rpm", agg: arr => arr.reduce((a, b) => a + b, 0) },
-      nr_zscore: { label: "NR Z-Score", agg: arr => Math.max(...arr) }
+      nr_rpm: { label: "NR rpm", agg: arr => arr.reduce((a, b) => a + b, 0) }
     };
 
     this.onNodeHover = this.onNodeHover.bind(this);
@@ -159,10 +157,12 @@ class TaxonTreeVis extends React.Component {
     taxa.forEach(taxon => {
       let parentId = nodes[0].id;
       for (let i = TaxonLevels.length - 1; i >= taxon.tax_level; i--) {
-        let nodeId = taxon.lineage[`${TaxonLevels[i]}_taxid`];
+        let taxId = taxon.lineage[`${TaxonLevels[i]}_taxid`];
+        let nodeId = taxId > 0 ? taxId : `${parentId}_${taxId}`;
         if (!seenNodes.has(nodeId)) {
           nodes.push({
             id: nodeId,
+            taxId: taxId,
             parentId: parentId,
             scientificName:
               taxon.lineage[`${TaxonLevels[i]}_name`] ||
@@ -177,6 +177,7 @@ class TaxonTreeVis extends React.Component {
       let nodeId = taxon.tax_id;
       nodes.push({
         id: nodeId,
+        taxId: nodeId,
         commonName: taxon.common_name,
         scientificName:
           taxon.tax_id > 0
@@ -198,7 +199,6 @@ class TaxonTreeVis extends React.Component {
       });
       seenNodes.add(nodeId);
     });
-
     return nodes;
   }
 

--- a/app/assets/src/components/visualizations/TidyTree.js
+++ b/app/assets/src/components/visualizations/TidyTree.js
@@ -93,7 +93,6 @@ export default class TidyTree {
         d.children = (d.children || [])
           .concat(d.collapsedChildren || [])
           .concat(d.hiddenChildren || []);
-        let a = d.children.length;
         d.children = d.children.filter(child => !child.isAggregated);
         d.collapsedChildren = null;
         d.hiddenChildren = null;

--- a/app/assets/src/components/visualizations/TidyTree.js
+++ b/app/assets/src/components/visualizations/TidyTree.js
@@ -87,7 +87,25 @@ export default class TidyTree {
     this.update();
   }
 
+  resetTree() {
+    let i = 0;
+    this.root.eachBefore(d => {
+      if (d.children || d.collapsedChildren || d.hiddenChildren) {
+        d.children = (d.children || [])
+          .concat(d.collapsedChildren || [])
+          .concat(d.hiddenChildren || []);
+        let a = d.children.length;
+        d.children = d.children.filter(child => !child.isAggregated);
+        d.collapsedChildren = null;
+        d.hiddenChildren = null;
+      }
+      d.isAggregated = false;
+    });
+  }
+
   sortAndScaleTree() {
+    this.resetTree();
+
     this.root.sort(
       (a, b) =>
         b.data.values[this.options.attribute] -
@@ -118,7 +136,9 @@ export default class TidyTree {
             collapsedScale(child.data.values[this.options.attribute]) <
               this.options.collapseThreshold
         );
-        if (d.collapsedChildren < this.options.minNonCollapsableChildren) {
+        if (
+          d.collapsedChildren.length < this.options.minNonCollapsableChildren
+        ) {
           d.collapsedChildren = null;
         } else {
           d.children = d.children.filter(
@@ -165,7 +185,6 @@ export default class TidyTree {
         node.collapsedChildren = node.hiddenChildren;
         node.hiddenChildren = null;
       }
-
       this.update(
         Object.assign(node, {
           x0: node.x,
@@ -370,9 +389,7 @@ export default class TidyTree {
         return `translate(${y},${x})`;
       });
 
-    let clickableNode = nodeEnter
-      .append("g")
-      .on("click", d => this.toggleCollapseNode(d));
+    let clickableNode = nodeEnter.append("g").attr("class", "clickable");
 
     clickableNode.append("circle").attr("r", 0);
 
@@ -466,6 +483,10 @@ export default class TidyTree {
           : null;
       })
       .style("fill-opacity", 1);
+
+    nodeUpdate
+      .select(".clickable")
+      .on("click", d => this.toggleCollapseNode(d));
 
     nodeUpdate
       .select("circle")

--- a/app/assets/src/components/visualizations/TidyTree.js
+++ b/app/assets/src/components/visualizations/TidyTree.js
@@ -88,7 +88,6 @@ export default class TidyTree {
   }
 
   resetTree() {
-    let i = 0;
     this.root.eachBefore(d => {
       if (d.children || d.collapsedChildren || d.hiddenChildren) {
         d.children = (d.children || [])


### PR DESCRIPTION
# Description:

* Remove z metrics: they tend to expand too many nodes and are not useful for the tree;
* Fix bug where descendants with uncategorized parents were attributed the wrong ancestors;
* Reset tree parameters that might change when options like metric and categories change ([Jira-447](https://jira.czi.team/browse/IDSEQ-447) was one of the consequences of not cleaning the tree);
* Move assignment of click action to update, so that it applies to all nodes.
* Fix a bug where parameter that defines the minimum number of nodes to trigger siblings collapse was not respected (e.g. would cause 1 node to be represented as collapased node).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

 
