### PR TITLE
remove initializer, restore index

### DIFF
--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -70,12 +70,7 @@ class PhyloTreesController < ApplicationController
   end
 
   def choose_taxon
-    taxon_list = if defined?(TAXON_SEARCH_LIST) && !TAXON_SEARCH_LIST.empty?
-                   TAXON_SEARCH_LIST
-                 else
-                   TaxonLineage.taxon_search_list
-                 end
-    render json: taxon_list
+    render json: File.read("/app/app/lib/taxon_search_list.json")
   end
 
   def new

--- a/config/initializers/taxon_search.rb
+++ b/config/initializers/taxon_search.rb
@@ -1,5 +1,0 @@
-Rails.configuration.after_initialize do
-  if ActiveRecord::Base.connection.table_exists?(:taxon_lineages)
-    TAXON_SEARCH_LIST = TaxonLineage.taxon_search_list
-  end
-end

--- a/db/migrate/20181005164930_restore_index_on_taxon_byteranges.rb
+++ b/db/migrate/20181005164930_restore_index_on_taxon_byteranges.rb
@@ -1,0 +1,5 @@
+class RestoreIndexOnTaxonByteranges < ActiveRecord::Migration[5.1]
+  def change
+    add_index :taxon_byteranges, :taxid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_181_002_215_809) do
+ActiveRecord::Schema.define(version: 20_181_005_164_930) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 20_181_002_215_809) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "amr_counts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "amr_counts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "gene"
     t.string "allele"
     t.float "coverage", limit: 24
@@ -298,6 +298,7 @@ ActiveRecord::Schema.define(version: 20_181_002_215_809) do
     t.integer "tax_level"
     t.bigint "pipeline_run_id"
     t.index ["pipeline_run_id", "taxid", "hit_type", "tax_level"], name: "index_pr_tax_ht_level_tb", unique: true
+    t.index ["taxid"], name: "index_taxon_byteranges_on_taxid"
   end
 
   create_table "taxon_confirmations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -443,5 +444,4 @@ ActiveRecord::Schema.define(version: 20_181_002_215_809) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
 end

--- a/lib/tasks/update_lineagedb.rake
+++ b/lib/tasks/update_lineagedb.rake
@@ -70,4 +70,6 @@ task update_lineage_db: :environment do
    rm -rf #{local_taxonomy_path};
   `
   raise "lineage database update failed" unless $CHILD_STATUS.success?
+  puts "To complete this lineage update, you should now update PHAGE_FAMILIES_TAXIDS and PHAGE_TAXIDS in TaxonLineageHelper using the queries described therein."
+  puts "You should also overwrite app/lib/taxon_search_list.json with the output of TaxonLineage.taxon_search_list."
 end


### PR DESCRIPTION
(a) Temp fix: move taxon search list to a static file rather than generating it in initializer. Real fix will be to implement the typeahead search on the server side rather than sending all the data to the frontend.

(b) restore index on taxon_byteranges because it is needed during phylo_tree creation.