### PR TITLE
Add remote ip and user id to logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Rails method for adding to logging
+  def append_info_to_payload(payload)
+    super
+    payload[:remote_ip] = request.remote_ip
+    payload[:user_id] = current_user.try(:id) if current_user
+  end
+
   protected
 
   def assert_access

--- a/config/environments/prod.rb
+++ b/config/environments/prod.rb
@@ -98,6 +98,8 @@ Rails.application.configure do
   config.lograge.custom_options = lambda do |event|
     { time: event.time,
       ddsource: ["ruby"],
+      remote_ip: event.payload[:remote_ip],
+      user_id: event.payload[:user_id],
       params: event.payload[:params].reject { |k| %w[controller action].include? k } }
   end
   config.colorize_logging = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -96,6 +96,8 @@ Rails.application.configure do
   config.lograge.custom_options = lambda do |event|
     { time: event.time,
       ddsource: ["ruby"],
+      remote_ip: event.payload[:remote_ip],
+      user_id: event.payload[:user_id],
       params: event.payload[:params].reject { |k| %w[controller action].include? k } }
   end
   config.colorize_logging = false


### PR DESCRIPTION
Ex:

web_1                      | {"method":"GET","path":"/home","format":"html","controller":"HomeController","action":"index","status":200,"duration":297.91,"view":157.78,"db":22.6,"time":"2018-10-05 20:46:13 +0000","ddsource":["ruby"],"remote_ip":"172.18.0.1","user_id":26,"params":{}}