### PR TITLE
Add margin-bottom to let the tooltips show without page "flickering"

### DIFF
--- a/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
+++ b/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
@@ -5,10 +5,6 @@
     padding: 20px;
     margin-bottom: 30rem;
 
-    svg {
-      width: 100%;
-    }
-
     .node {
       cursor: pointer;
     }

--- a/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
+++ b/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
@@ -3,6 +3,7 @@
 .phylo-tree-vis {
   &__tree-container {
     padding: 20px;
+    margin-bottom: 30rem;
 
     svg {
       width: 100%;

--- a/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
+++ b/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
@@ -4,6 +4,7 @@
   &__tree-container {
     padding: 20px;
     margin-bottom: 30rem;
+    overflow: auto;
 
     .node {
       cursor: pointer;

--- a/app/assets/src/styles/views/taxon_tree_vis.scss
+++ b/app/assets/src/styles/views/taxon_tree_vis.scss
@@ -3,6 +3,8 @@
 .taxon-tree-vis {
   &__container {
     position: relative;
+    margin-bottom: 15rem;
+    overflow: auto;
 
     .node-overlay {
       opacity: 0;
@@ -23,7 +25,6 @@
     padding: 10px;
     pointer-events: none;
     position: absolute;
-    margin-bottom: 15rem;
 
     &.visible {
       display: block;

--- a/app/assets/src/styles/views/taxon_tree_vis.scss
+++ b/app/assets/src/styles/views/taxon_tree_vis.scss
@@ -23,6 +23,7 @@
     padding: 10px;
     pointer-events: none;
     position: absolute;
+    margin-bottom: 15rem;
 
     &.visible {
       display: block;

--- a/app/assets/src/styles/visualization.scss
+++ b/app/assets/src/styles/visualization.scss
@@ -98,6 +98,8 @@
 }
 .heatmap {
   overflow: auto;
+  margin-bottom: 10rem;
+
   .node circle {
     fill: #fff;
     stroke: steelblue;


### PR DESCRIPTION
- Add some slack to the bottoms of the pages
- Also means that people will always be able to see the tooltips hanging off the bottom of the visualizations
- Set overflow auto so that people can scroll side to side when the tree expands widely horizontally