### PR TITLE
Fix up overflowing names in heatmap selectors

### DIFF
--- a/app/assets/src/styles/visualization.scss
+++ b/app/assets/src/styles/visualization.scss
@@ -54,6 +54,16 @@
     border-width: 1px 0;
     background: #fff;
     margin: 0;
+
+    .s2 {
+      width: auto;
+      min-width: 15%;
+    }
+
+    .s3 {
+      width: auto;
+      min-width: 20%;
+    }
   }
   .visualization-content {
     margin-top: 2em;


### PR DESCRIPTION
BEFORE:
![screen shot 2018-10-05 at 4 45 07 pm](https://user-images.githubusercontent.com/5652739/46564742-3dbdf200-c8be-11e8-8d5a-55225104095b.png)

AFTER:
![oct-05-2018 16-43-59](https://user-images.githubusercontent.com/5652739/46564745-41517900-c8be-11e8-9fe2-4228fc2a6bbf.gif)