### PR TITLE
Bulk import recursive

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -139,7 +139,8 @@ module SamplesHelper
                            host_genome_id: host_genome_id,
                            status: 'created' }
     s3_path.chomp!('/')
-    s3_output, _stderr, status = Open3.capture3("aws", "s3", "ls", "#{s3_path}/")
+    s3_bucket = 's3://' + s3_path.sub('s3://', '').split('/')[0]
+    s3_output, _stderr, status = Open3.capture3("aws", "s3", "ls", "--recursive", "#{s3_path}/")
     return unless status.exitstatus.zero?
     s3_output.chomp!
     entries = s3_output.split("\n").reject { |line| line.include? "Undetermined" }
@@ -157,11 +158,11 @@ module SamplesHelper
         next
       end
       source = matched[0]
-      name = matched[1]
+      name = matched[1].split('/')[-1]
       samples[name] ||= default_attributes.clone
       samples[name][:input_files_attributes] ||= []
-      samples[name][:input_files_attributes][read_idx] = { name: source,
-                                                           source: "#{s3_path}/#{source}",
+      samples[name][:input_files_attributes][read_idx] = { name: source.split('/')[-1],
+                                                           source: "#{s3_bucket}/#{source}",
                                                            source_type: InputFile::SOURCE_TYPE_S3 }
     end
 


### PR DESCRIPTION
# Issue:

Within the directory Amy_Kistler, there is a file for each sample that contains R1.fastqz and R2.fastqz - eg, s3://czb-seqbot/fastqs/180926_A00111_0214_AHC7KJDSXX/Amy_Kistler/CMS001-026a-R2/CMS01-026_S225_L004_R1_001.fastq.gz and s3://czb-seqbot/fastqs/180926_A00111_0214_AHC7KJDSXX/Amy_Kistler/CMS001-026a-R2/CMS01-026_S225_L004_R2_001.fastq.gz (edited)
The following path for bulk upload via website & CLI fails s3://czb-seqbot/fastqs/180926_A00111_0214_AHC7KJDSXX/Amy_Kistler/MOS002*/*.fastq.gz
I’m not sure why my data were output with this extra layer of directory…
This may be an edge case - a p arallel directory from that same sequencing run (s3://czb-seqbot/fastqs/180926_A00111_0214_AHC7KJDSXX/Amy_Lyden/) holds *R1.fastq.gz and *R2.fastq.gz, so much simpler to bulk upload.
Single sample upload works fine if I enter full path, for R1 & R2, eg - Within the directory Amy_Kistler, there is a file for each sample that contains R1.fastqz and R2.fastqz - eg, s3://czb-seqbot/fastqs/180926_A00111_0214_AHC7KJDSXX/Amy_Kistler/CMS001-026a-R2/CMS01-026_S225_L004_R1_001.fastq.gz and s3://czb-seqbot/fastqs/180926_A00111_0214_AHC7KJDSXX/Amy_Kistler/CMS001-026a-R2/CMS01-026_S225_L004_R2_001.fastq.gz

# Solution

Search path recursively

# Test plan

rails c --sandbox
s = SamplesController.new
list = s.parsed_samples_for_s3_path('s3://czb-seqbot/fastqs/180926_A00111_0214_AHC7KJDSXX/Amy_Kistler/', 1, 1); nil
list[0]

Also did this for a separate directory without subfolders and verified that the output was identical to the pre-changed function