### PR TITLE
Fix user name display for phylo_trees

### DIFF
--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -248,7 +248,7 @@ class PhyloTreeCreation extends React.Component {
   parsePhyloTreeData(phyloTreeData) {
     return phyloTreeData.map(row => ({
       name: row.name,
-      user: row.user ? row.user.name : null,
+      user: (row.user || {}).name,
       last_update: <Moment fromNow date={row.updated_at} />,
       view: <a href={`/phylo_trees/index?treeId=${row.id}`}>View</a>
     }));

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -248,7 +248,7 @@ class PhyloTreeCreation extends React.Component {
   parsePhyloTreeData(phyloTreeData) {
     return phyloTreeData.map(row => ({
       name: row.name,
-      user: row.user.name,
+      user: row.user ? row.user.name : null,
       last_update: <Moment fromNow date={row.updated_at} />,
       view: <a href={`/phylo_trees/index?treeId=${row.id}`}>View</a>
     }));

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -53,10 +53,11 @@ class PhyloTreesController < ApplicationController
 
     @phylo_trees = @phylo_trees.as_json(include: { user: { only: [:id, :name] } })
 
-    # Augment tree data with sample attributes and number of pipeline_runs
+    # Augment tree data with sample attributes, number of pipeline_runs, user name
     @phylo_trees.each do |pt|
       sample_details = PhyloTree.sample_details_by_tree_id[pt["id"]]
       pt["sampleDetailsByNodeName"] = sample_details
+      pt["user"] = PhyloTree.users_by_tree_id[pt["id"]]
     end
 
     respond_to do |format|

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -53,7 +53,7 @@ class PhyloTreesController < ApplicationController
 
     @phylo_trees = @phylo_trees.as_json(include: { user: { only: [:id, :name] } })
 
-    # Augment tree data with sample attributes, number of pipeline_runs, user name
+    # Augment tree data with sample attributes, number of pipeline_runs and user name
     @phylo_trees.each do |pt|
       sample_details = PhyloTree.sample_details_by_tree_id[pt["id"]]
       pt["sampleDetailsByNodeName"] = sample_details

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -185,6 +185,15 @@ class PhyloTree < ApplicationRecord
     save
   end
 
+  def self.users_by_tree_id
+    ActiveRecord::Base.connection.select_all("
+      select phylo_trees.id as phylo_tree_id, users.id, users.name
+      from phylo_trees, users
+      where phylo_trees.user_id = users.id
+      order by phylo_tree_id
+    ").index_by { |entry| entry["phylo_tree_id"] }
+  end
+
   def self.sample_details_by_tree_id
     query_results = ActiveRecord::Base.connection.select_all("
       select phylo_tree_id, pipeline_run_id, ncbi_metadata, sample_id, samples.*, projects.name as project_name


### PR DESCRIPTION
(a) Prevent the site from breaking if there is no user for a phylo_tree
(b) Fix an inefficiency in the way the usernames are retrieved