### PR TITLE
Tweak modal for phylo trees

### DIFF
--- a/app/assets/src/components/ui/containers/Wizard.jsx
+++ b/app/assets/src/components/ui/containers/Wizard.jsx
@@ -159,7 +159,7 @@ class Page extends React.Component {
 
   render() {
     return (
-      <div className={`wizard__page$`}>
+      <div className={`wizard__page`}>
         {React.Children.toArray(this.props.children)}
       </div>
     );

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -59,7 +59,7 @@ class PhyloTreeCreation extends React.Component {
       tissue: "Tissue",
       location: "Location",
       date: "Date",
-      reads: "Read Count"
+      reads: "Read Count\n(NT | NR)"
     };
 
     this.otherSamplesHeaders = {
@@ -83,7 +83,6 @@ class PhyloTreeCreation extends React.Component {
     this.canContinueWithTaxonAndProject = this.canContinueWithTaxonAndProject.bind(
       this
     );
-
     this.handleBranchChange = this.handleBranchChange.bind(this);
     this.handleChangedProjectSamples = this.handleChangedProjectSamples.bind(
       this

--- a/app/assets/src/loader.scss
+++ b/app/assets/src/loader.scss
@@ -47,12 +47,12 @@
 
 // views
 @import "styles/views/landing";
-@import "styles/views/playground_controls";
-@import "styles/views/phylo_tree/phylo_tree_by_path_creation";
-@import "styles/views/report/pathogen_summary";
-@import "styles/views/report/taxon_modal";
+@import "styles/views/phylo_tree/phylo_tree_creation";
 @import "styles/views/phylo_tree/phylo_tree_list_view";
 @import "styles/views/phylo_tree/phylo_tree_vis";
+@import "styles/views/playground_controls";
+@import "styles/views/report/pathogen_summary";
+@import "styles/views/report/taxon_modal";
 @import "styles/views/taxon_tree_vis";
 
 // visualizations

--- a/app/assets/src/styles/views/phylo_tree/phylo_tree_creation.scss
+++ b/app/assets/src/styles/views/phylo_tree/phylo_tree_creation.scss
@@ -1,6 +1,10 @@
 @import "../../themes/colors";
 
 .wizard {
+  &__page {
+    min-height: 410px;
+  }
+
   &__page-1,
   &__page-2,
   &__page-3,
@@ -27,7 +31,7 @@
       .data-table {
         // applies to header and data
         .column-name {
-          width: 350px;
+          width: 250px;
           text-align: left;
         }
 


### PR DESCRIPTION
Few tweaks to modals for creating phylo trees.
* Correct scss file name
* Impose min-height for wizard pages
* Adjust fixed-width column names
* Sync header title for same type of fields