### PR TITLE
submit benchmark samples based on time or code change triggers

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -481,6 +481,10 @@ class Sample < ApplicationRecord
     end
   end
 
+  def self.pipeline_commit(branch)
+    `git ls-remote https://github.com/chanzuckerberg/idseq-dag.git | grep refs/heads/#{branch}`.split[0]
+  end
+
   def kickoff_pipeline
     # only kickoff pipeline when no active pipeline_run running
     return unless pipeline_runs.in_progress.empty?
@@ -492,7 +496,7 @@ class Sample < ApplicationRecord
     # but was made an integer type in case we want to allow users to enter the desired number
     # of reads to susbample to in the future
     pr.pipeline_branch = pipeline_branch.blank? ? "master" : pipeline_branch
-    pr.pipeline_commit = `git ls-remote https://github.com/chanzuckerberg/idseq-dag.git | grep refs/heads/#{pr.pipeline_branch}`.split[0]
+    pr.pipeline_commit = Sample.pipeline_commit(pr.pipeline_branch)
 
     pr.alignment_config = AlignmentConfig.find_by(name: alignment_config_name) if alignment_config_name
     pr.alignment_config ||= AlignmentConfig.find_by(name: AlignmentConfig::DEFAULT_NAME)

--- a/config/idseq-bench-config.json
+++ b/config/idseq-bench-config.json
@@ -1,0 +1,55 @@
+{
+  "README": [
+    "********************************************************************************",
+    " This file is under version control at idseq-web/config/idseq-bench-config.json ",
+    " It is consumed by pipeline_monitor.rake.                                       ",
+    "                                                                                ",
+    " You can test and deploy changes to it by running                               ",
+    "                                                                                ",
+    "    aws s3 cp idseq-bench-config.json s3://idseq-web/config.json                ",
+    "                                                                                ",
+    " This process allows changing webapp configuration without the cost             ",
+    " and disruption of a production push.                                           ",
+    "                                                                                ",
+    " The recommended process for deploying a new benchmark is as follows:           ",
+    "                                                                                ",
+    "    1. Branch idseq-bench, adjust to taste, commit all changes.                 ",
+    "                                                                                ",
+    "    2. aws s3 cp --recursive <idseq-bench-output> s3://idseq-bench/<number>     ",
+    "                                                                                ",
+    "    3. Deploy s3://idseq-bench/<number> by prepending to active_benchmarks.     ",
+    "                                                                                ",
+    "    4. After a day or two, move any older entries to retired_benchmarks.        ",
+    "                                                                                ",
+    "********************************************************************************"
+  ],
+  "defaults": {
+    "how_to_use_these_defaults":
+      "These properties may be overridden in each entry of active_benchmarks below.",
+    "project_name": "IDSeq Bench",
+    "user_email": "bdimitrov@chanzuckerberg.com",
+    "frequency_hours": 24,
+    "trigger_on_webapp_change": true,
+    "trigger_on_pipeline_change": true,
+    "pipeline_branch": "master",
+    "host": "Human",
+    "comment":
+      "No comment provided for this benchmark in s3://idseq-bench/config.json."
+  },
+  "active_benchmarks": {
+    "s3://idseq-bench/4": {
+      "comment":
+        "Comprehensive general benchmark built with idseq-bench.  Deployed 2018-10-11.",
+      "environments": ["prod", "staging"]
+    }
+  },
+  "retired_benchmarks": {
+    "s3://idseq-bench/3": {
+      "comment":
+        "A tiny pseudo-benchmark meant for exercising the job control logic.  Deployed 2018-10-11",
+      "environments": ["development"],
+      "project_name": "IDSeq Bench Development",
+      "frequency_hours": 1.0
+    }
+  }
+}

--- a/db/migrate/20181011230229_add_commits_to_samples_for_benchmarking.rb
+++ b/db/migrate/20181011230229_add_commits_to_samples_for_benchmarking.rb
@@ -1,0 +1,6 @@
+class AddCommitsToSamplesForBenchmarking < ActiveRecord::Migration[5.1]
+  def change
+    add_column :samples, :web_commit, :string, null: "", default: ""
+    add_column :samples, :pipeline_commit, :string, null: "", default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_181_004_180_225) do
+ActiveRecord::Schema.define(version: 20_181_011_230_229) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -285,6 +285,8 @@ ActiveRecord::Schema.define(version: 20_181_004_180_225) do
     t.string "sample_organism"
     t.string "sample_detection"
     t.string "alignment_config_name"
+    t.string "web_commit", default: ""
+    t.string "pipeline_commit", default: ""
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
     t.index ["user_id"], name: "index_samples_on_user_id"
   end

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -1,8 +1,15 @@
 # Jos to check the status of pipeline runs
 require 'English'
 
-IDSEQ_BENCH_CONFIG = "s3://idseq-bench/config.json"
-BENCHMARK_UPDATE_MIN_FREQUENCY = 600
+# Benchmark status will not be updated faster than this.
+IDSEQ_BENCH_UPDATE_FREQUENCY_SECONDS = 600
+
+# A benchmark sample will not be resubmitted faster than this.
+IDSEQ_BENCH_MIN_FREQUENCY_HOURS = 1.0
+
+# This is under version control at idseq-web/config/idseq-bench-config.json, and deployed
+# by copying to the S3 location below.
+IDSEQ_BENCH_CONFIG = "s3://idseq-bench/config.json".freeze
 
 class CheckPipelineRuns
   @sleep_quantum = 5.0
@@ -73,43 +80,101 @@ class CheckPipelineRuns
     autoscaling_state
   end
 
-  def self.create_sample_for_benchmark(s3path)
-    metadata = JSON.parse(`aws s3 cp #{s3path}/metadata.json -`)
+  def self.benchmark_sample_name(s3path, timestamp_str, metadata_prefix)
+    # Benchmark sample names start with a prefix determined uniquely from the s3 path,
+    # like so: "idseq-bench-1|".  This enables finding quickly all samples submitted for
+    # a given benchmark.  That text is followed by a unix timestamp of the creation time,
+    # only because within a project, sample names must be unique.  Finally, a long metadata_prefix
+    # describes the benchmark contents.  The whole thing looks like
+    # "idseq-bench-1|1539204106|norg_1|nacc_1|uniform_weight_per_organism|hiseq_reads|viruses|chikungunya|37124|v4"
+    items = s3path.split("/")
+    result = items[-2] + "-" + items[-1] + "|"
+    return result if timestamp_str.blank?
+    result = result + timestamp_str + "|"
+    return result if metadata_prefix.blank?
+    result + metadata_prefix.gsub("__", "|") # vertical bars are prettier
+  end
+
+  def self.benchmark_sample_name_prefix(s3path)
+    benchmark_sample_name(s3path, "", "")
+  end
+
+  def self.create_sample_for_benchmark(s3path, pipeline_commit, web_commit, bm_pipeline_branch, bm_user, bm_project, bm_host, bm_comment, t_now)
+    # metadata.json is produced by idseq-bench
+    raw_metadata = `aws s3 cp #{s3path}/metadata.json -`
+    metadata = JSON.parse(raw_metadata)
+    input_files_attributes = metadata['fastqs'].map do |fq|
+      {
+        name: fq,
+        source: s3path + "/" + fq,
+        source_type: "s3"
+      }
+    end
+    unless metadata['idseq_bench_reproducible'] && metadata['idseq_bench_git_hash'].length == 40
+      raise "Refusing to create sample for irreproducible benchmark #{s3path}"
+    end
+    Rails.logger.info("Creating benchmark sample from #{s3path} with #{metadata['verified_total_reads']} reads.")
+    bm_sample_name = benchmark_sample_name(s3path, t_now.floor.to_s, metadata['prefix'])
+    # Add benchmark comment to existing metadata, and dump metadata json into sample_notes.
+    # Tags added here are capitalized.  If a COMMENT tag already exists in metadata, prepend to it.
+    existing_comment = metadata['COMMENT']
+    comment_separator = "\n"
+    comment_separator = "" if existing_comment.blank?
+    comment_separator = "" if bm_comment.blank?
+    metadata['COMMENT'] = (bm_comment || "") + comment_separator + (existing_comment || "")
+    metadata['ORIGIN'] = s3path
+    known_organisms = metadata['verified_contents'].pluck('genome').join(", ")
+    bm_sample_params = {
+      name: bm_sample_name,
+      host_genome_id: bm_host.id,
+      project_id: bm_project.id,
+      user_id: bm_user.id,
+      input_files_attributes: input_files_attributes,
+      sample_organism: known_organisms,
+      web_commit: web_commit,
+      pipeline_commit: pipeline_commit,
+      pipeline_branch: bm_pipeline_branch,
+      sample_notes: JSON.pretty_generate(metadata)
+    }
+    @bm_sample = Sample.new(bm_sample_params)
+    # HACK: Not really sure why we have to manually set the status to STATUS_CREATED here,
+    # but if we don't, the sample is never picked up by the uploader.
+    @bm_sample.status ||= Sample::STATUS_CREATED
+    unless @bm_sample.save
+      raise "Error creating benchmark sample with #{JSON.pretty_generate(bm_sample_params)}."
+    end
+    Rails.logger.info("Benchmark sample #{@bm_sample.id} created successfully.")
+  end
+
+  def self.prop_get(dict, property, defaults)
+    return dict[property] if dict.key?(property)
+    defaults[property]
   end
 
   def self.benchmark_update(t_now)
     Rails.logger.info("Benchmark update.")
     config = JSON.parse(`aws s3 cp #{IDSEQ_BENCH_CONFIG} -`)
-    # example config.json
-    # {
-    #   "active_benchmarks": {
-    #     "s3://idseq-bench/1": {
-    #       "project_name": "IDSeq Bench",
-    #       "frequency_hours": 24,
-    #       "environments": ["prod", "staging"]
-    #     },
-    #     "s3://idseq-bench/2": {
-    #       "project_name": "IDSeq Bench",
-    #       "frequency_hours": 168,
-    #       "environments": ["prod"]
-    #     }
-    #   }
-    # }
-    config["active_benchmarks"].each do |s3path, bm_props|
-      unless bm_props["environments"].include?(Rails.env)
+    defaults = config['defaults']
+    web_commit = ENV['GIT_VERSION'] || ""
+    config['active_benchmarks'].each do |s3path, bm_props|
+      bm_environments = prop_get(bm_props, 'environments', defaults)
+      unless bm_environments.include?(Rails.env)
         Rails.logger.info("Benchmark does not apply to #{Rails.env} environment: #{s3path}")
         next
       end
-      bm_proj = Project.find_by_name(bm_props["project_name"])
+      bm_project_name = prop_get(bm_props, 'project_name', defaults)
+      bm_proj = Project.find_by(name: bm_project_name)
       unless bm_proj
-        Rails.logger.info("Benchmark requires non-existent project #{bm_props["project_name"]}: #{s3path}")
+        Rails.logger.info("Benchmark requires non-existent project #{bm_project_name}: #{s3path}")
         next
       end
-      frequency_seconds = bm_props["frequency_hours"] * 3600
-      unless frequency_seconds >= 3600
-        Rails.logger.info("Benchmark frequency under 1 hour: #{s3path}")
+      bm_frequency_hours = prop_get(bm_props, 'frequency_hours', defaults)
+      bm_frequency_seconds = bm_frequency_hours * 3600
+      unless bm_frequency_hours >= IDSEQ_BENCH_MIN_FREQUENCY_HOURS
+        Rails.logger.info("Benchmark frequency under #{IDSEQ_BENCH_MIN_FREQUENCY_HOURS} hour: #{s3path}")
         next
       end
+      bm_name_prefix = benchmark_sample_name_prefix(s3path)
       sql_query = "
         SELECT
           id,
@@ -117,19 +182,36 @@ class CheckPipelineRuns
           unix_timestamp(created_at) as unixtime_of_creation
         FROM samples
         WHERE
-          project_id = #{bm_proj.id} AND
-          created_at > from_unixtime(#{t_now - frequency_seconds})
+              project_id = #{bm_proj.id}
+          AND created_at > from_unixtime(#{t_now - bm_frequency_seconds})
+          AND name LIKE \"#{bm_name_prefix}%\"
       "
+      bm_pipeline_branch = prop_get(bm_props, "pipeline_branch", defaults)
+      pipeline_commit = Sample.pipeline_commit(bm_pipeline_branch) || ""
+      commit_filter = ""
+      if pipeline_commit.present? && prop_get(bm_props, "trigger_on_pipeline_change", defaults)
+        sql_query += "    AND pipeline_commit = \"#{pipeline_commit}\""
+        commit_filter += "on " + pipeline_commit
+      end
+      if web_commit.present? && prop_get(bm_props, "trigger_on_webapp_change", defaults)
+        sql_query += "    AND web_commit = \"#{web_commit}\""
+        commit_filter += "-" + web_commit
+      end
       sql_results = Sample.connection.select_all(sql_query).to_hash
       unless sql_results.empty?
-        most_recent_submission = sql_results.pluck("unixtime_of_creation").max
-        hours_since_last_run = Integer((t_now - most_recent_submission)/360) / 10.0
-        Rails.logger.info("Benchmark last ran #{hours_since_last_run} hours ago: #{s3path}")
+        most_recent_submission = sql_results.pluck('unixtime_of_creation').max
+        hours_since_last_run = Integer((t_now - most_recent_submission) / 360) / 10.0
+        Rails.logger.info("Benchmark last ran #{hours_since_last_run} hours ago #{commit_filter}: #{s3path}")
         next
       end
-      Rails.logger.info("Benchmark last ran over #{bm_props["frequency_hours"]} hours ago, or never before: #{s3path}")
+      Rails.logger.info("Submitting benchmark: #{s3path}")
+      bm_user_email = prop_get(bm_props, 'user_email', defaults)
+      bm_user = User.find_by(email: bm_user_email)
+      bm_host_name = prop_get(bm_props, 'host', defaults)
+      bm_host = HostGenome.find_by(name: bm_host_name)
+      bm_comment = prop_get(bm_props, 'comment', defaults)
       begin
-        self.create_sample_for_benchmark(s3path)
+        create_sample_for_benchmark(s3path, pipeline_commit, web_commit, bm_pipeline_branch, bm_user, bm_proj, bm_host, bm_comment, t_now)
       rescue => exception
         LogUtil.log_err_and_airbrake("Failed to create sample for benchmark #{s3path}")
         LogUtil.log_backtrace(exception)
@@ -138,11 +220,10 @@ class CheckPipelineRuns
   end
 
   def self.benchmark_update_safely_and_not_too_often(benchmark_state, t_now)
-    # Do not check faster than every 10 minutes
-    unless benchmark_state && t_now - benchmark_state[:t_last] < BENCHMARK_UPDATE_MIN_FREQUENCY
-      benchmark_state = {:t_last => t_now}
+    unless benchmark_state && t_now - benchmark_state[:t_last] < IDSEQ_BENCH_UPDATE_FREQUENCY_SECONDS
+      benchmark_state = { t_last: t_now }
       begin
-        self.benchmark_update(t_now)
+        benchmark_update(t_now)
       rescue => exception
         LogUtil.log_err_and_airbrake("Failed to update benchmarks")
         LogUtil.log_backtrace(exception)
@@ -207,9 +288,10 @@ task "pipeline_monitor", [:duration] => :environment do |_t, args|
     CheckPipelineRuns.run(respawn_interval - wait_before_respawn, 60.0 / checks_per_minute)
   else
     # infinite duration
-    # HACK
-    Rails.logger.info("HACK: Sleeping 30 seconds on daemon startup for prior incarnations to drain.")
-    sleep 30
+    if cloud_env
+      Rails.logger.info("HACK: Sleeping 30 seconds on daemon startup for prior incarnations to drain.")
+      sleep 30
+    end
     until CheckPipelineRuns.shutdown_requested
       system("rake pipeline_monitor[finite_duration]")
       sleep wait_before_respawn


### PR DESCRIPTION
Submit benchmark samples with specified frequency based on config and input files in s3 generated by idseq-bench.