### PR TITLE
Phylo Tree: Tweaks to reduce likelihood of clashing with long names

### DIFF
--- a/app/assets/src/components/views/phylo_tree/PhyloTreeVis.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeVis.jsx
@@ -36,7 +36,7 @@ class PhyloTreeVis extends React.Component {
       // Name for the legend when the attribute is missing / other
       colorGroupAbsentName: "NCBI References",
       legendX: 880,
-      legendY: 50,
+      legendY: -150,
       tooltipContainer: this.tooltipContainer,
       onNodeTextClick: this.handleNodeClick,
       onNodeHover: this.handleNodeHover,

--- a/app/assets/src/components/visualizations/dendrogram/Dendogram.js
+++ b/app/assets/src/components/visualizations/dendrogram/Dendogram.js
@@ -11,6 +11,7 @@ export default class Dendogram {
     this.container = container;
     this.tree = null;
     this.root = null;
+    this.legend = null;
 
     this.options = Object.assign(
       {
@@ -242,41 +243,54 @@ export default class Dendogram {
     }
 
     let allVals = this.allColorAttributeValues;
-    let legend = this.g.select(".legend");
-    if (legend.empty()) {
-      legend = this.g.append("g").attr("class", "legend");
+    this.legend = this.g.select(".legend");
+    if (this.legend.empty()) {
+      this.legend = this.g.append("g").attr("class", "legend");
       let x = this.options.legendX;
       let y = this.options.legendY;
 
       // Set legend title
       let legendTitle = (this.options.colorGroupLegendTitle || "Legend") + ":";
-      legend
+      this.legend
         .append("text")
+        .attr("class", "legend-title")
         .attr("x", x)
         .attr("y", y)
-        .attr("class", "title")
         .text(legendTitle);
 
       x += 5;
       y += 25;
+
       for (let i = 1; i < allVals.length; i++, y += 30) {
         // First of values and colors is the placeholder for 'Uncolored'
 
         // Add color circle
         let color = this.colors[i];
-        legend
+        this.legend
           .append("circle")
           .attr("r", 5)
           .attr("transform", `translate(${x}, ${y})`)
           .style("fill", color);
 
         // Add text label
-        legend
+        this.legend
           .append("text")
           .attr("x", x + 15)
           .attr("y", y + 5)
           .text(allVals[i]);
       }
+
+      // background rectangle
+      let bbox = this.legend.node().getBBox();
+      let bgMargin = 10;
+      this.legend
+        .append("rect")
+        .attr("class", "legend-background")
+        .attr("x", bbox.x - bgMargin)
+        .attr("y", bbox.y - bgMargin)
+        .attr("width", bbox.width + 2 * bgMargin)
+        .attr("height", bbox.height + 2 * bgMargin)
+        .lower();
     }
   }
 
@@ -625,5 +639,8 @@ export default class Dendogram {
       // override D3 styling.
       this.g.selectAll(".node").style("fill", this.options.defaultColor);
     }
+
+    // legend on top
+    this.legend.raise();
   }
 }

--- a/app/assets/src/components/visualizations/dendrogram/Dendogram.js
+++ b/app/assets/src/components/visualizations/dendrogram/Dendogram.js
@@ -21,7 +21,7 @@ export default class Dendogram {
         colorGroupLegendTitle: null,
         colorGroupAbsentName: null,
         legendX: 880,
-        legendY: 50,
+        legendY: 0,
         onNodeTextClick: null,
         onNodeClick: null,
         onNodeHover: null,
@@ -40,7 +40,7 @@ export default class Dendogram {
     // margin top
     this.margins = {
       // includes scale legend
-      top: 140,
+      top: 160,
       // includes second half of nodes
       bottom: 20,
       // includes root label on the left of the node
@@ -422,9 +422,9 @@ export default class Dendogram {
     // Set scale label
     scale
       .append("text")
+      .attr("class", "scale-label")
       .attr("x", x + 78)
       .attr("y", y - 30)
-      .attr("class", "title")
       .text(this.options.scaleLabel);
   }
 

--- a/app/assets/src/components/visualizations/dendrogram/Dendogram.js
+++ b/app/assets/src/components/visualizations/dendrogram/Dendogram.js
@@ -52,7 +52,7 @@ export default class Dendogram {
 
     this.nodeSize = {
       width: 1,
-      height: 16
+      height: 25
     };
 
     this._highlighted = new Set();
@@ -641,6 +641,6 @@ export default class Dendogram {
     }
 
     // legend on top
-    this.legend.raise();
+    this.legend && this.legend.raise();
   }
 }

--- a/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
+++ b/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
@@ -63,7 +63,14 @@
     }
 
     .legend {
-      .title {
+      background-color: $white;
+
+      .legend-background {
+        fill: $white;
+        fill-opacity: 0.8;
+      }
+
+      .legend-title {
         font-weight: bold;
       }
     }

--- a/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
+++ b/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
@@ -1,6 +1,8 @@
 @import "../../themes/colors";
 
 .phylo-tree-vis {
+  font-size: 13px;
+
   &__tree-container {
     padding: 20px;
     margin-bottom: 30rem;
@@ -20,7 +22,6 @@
 
     .node text {
       fill: $black;
-      font-size: 14px;
     }
 
     .node.highlight text {


### PR DESCRIPTION
- Tweaks to reduce likelihood of overlapping of long sample and NCBI reference names with other elements:
  * Reposition the legend further up (most of the legend will not in front of any samples;
  * Slightly increase top margin;
  * Reduce font size;
  * Add semi-transparent background to legend and bring legend to front in case it still overlaps with names;
- Increase space between nodes for large trees.