### PR TITLE
Report Page: Fix highlighting for taxa name that links to a modal

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1052,12 +1052,14 @@ class PipelineSampleReport extends React.Component {
     if (tax_info.tax_id > 0) {
       if (report_details.taxon_fasta_flag) {
         taxonNameDisplay = (
-          <span>
+          <span className="taxon-modal-link">
             <a>{taxonNameDisplay}</a>
           </span>
         );
       } else {
-        taxonNameDisplay = <span>{taxonNameDisplay}</span>;
+        taxonNameDisplay = (
+          <span className="taxon-modal-link">{taxonNameDisplay}</span>
+        );
       }
       taxonNameDisplay = (
         <TaxonModal

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -333,10 +333,8 @@ input[type="number"] {
         visibility: visible;
       }
 
-      a {
-        span {
-          color: $primary-light;
-        }
+      span.taxon-modal-link {
+        color: $primary-light;
       }
     }
   }


### PR DESCRIPTION
Use an explicit class name to highlight taxa names.