### PR TITLE
Improve background dropdown

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -830,9 +830,15 @@ class PipelineSampleReport extends React.Component {
   }
 
   handleBackgroundModelChange(_, data) {
+    if (data.value === this.state.backgroundId) {
+      // Skip if no change
+      return;
+    }
+
     const backgroundName = data.options.find(function(option) {
       return option.text == data.value;
     });
+
     Cookies.set("background_name", backgroundName);
     this.setState(
       {
@@ -1760,7 +1766,7 @@ function BackgroundModelFilter({ parent }) {
   return (
     <OurDropdown
       options={backgroundOptions}
-      value={parent.state.backgroundId}
+      value={parseInt(parent.state.backgroundId)}
       disabled={disabled}
       label="Background: "
       onChange={parent.handleBackgroundModelChange}

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -110,7 +110,7 @@ class PipelineSampleReport extends React.Component {
       ? savedThresholdFilters
       : [Object.assign({}, this.defaultThreshold)];
 
-    let defaultBackgroundId = this.fetchParams("background_id");
+    let defaultBackgroundId = parseInt(this.fetchParams("background_id"));
     // we should only keep dynamic data in the state
     // Starting state is default values which are to be set later.
     this.state = {
@@ -836,8 +836,8 @@ class PipelineSampleReport extends React.Component {
     }
 
     const backgroundName = data.options.find(function(option) {
-      return option.text == data.value;
-    });
+      return option.value === data.value;
+    }).text;
 
     Cookies.set("background_name", backgroundName);
     this.setState(
@@ -1766,7 +1766,7 @@ function BackgroundModelFilter({ parent }) {
   return (
     <OurDropdown
       options={backgroundOptions}
-      value={parseInt(parent.state.backgroundId)}
+      value={parent.state.backgroundId}
       disabled={disabled}
       label="Background: "
       onChange={parent.handleBackgroundModelChange}


### PR DESCRIPTION
- Won't reload the page if the value didn't change.

- Fixes an issue where the current "value" wasn't being passed down as an int, so the first option was always selected on menu open (and could lead to accidentally changing backgrounds):
 
Before (sorry, hard to see the highlighting on the gif):
![oct-11-2018 16-54-08](https://user-images.githubusercontent.com/5652739/46840104-4eff7680-cd76-11e8-82aa-abbb26486637.gif)
![screen shot 2018-10-11 at 4 45 11 pm](https://user-images.githubusercontent.com/5652739/46840111-54f55780-cd76-11e8-9541-a11e7cc0b0d2.png)


After:
![screen shot 2018-10-11 at 4 53 19 pm](https://user-images.githubusercontent.com/5652739/46840079-2d9e8a80-cd76-11e8-90f0-12b945dffa63.png)