### PR TITLE
Update web asset bucket name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [IDseq](https://idseq.net/) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/chanzuckerberg/idseq-web/blob/master/LICENSE) [![Build Status](https://travis-ci.org/chanzuckerberg/idseq-web.svg?branch=master)](https://travis-ci.org/chanzuckerberg/idseq-web) ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 
-![logo](https://s3-us-west-2.amazonaws.com/idseq-database/IDseq_logo.png)
+![logo](https://s3-us-west-2.amazonaws.com/idseq-web-assets/IDseq_logo.png)
 
 #### Infectious Disease Sequencing Platform
 IDseq is an unbiased global software platform that helps scientists identify pathogens in metagenomic sequencing data.

--- a/app/assets/src/components/Header.jsx
+++ b/app/assets/src/components/Header.jsx
@@ -106,7 +106,7 @@ class Header extends React.Component {
                         text="Terms of Use"
                         onClick={() =>
                           this.openNewTab(
-                            "https://s3-us-west-2.amazonaws.com/idseq-database/Terms.pdf"
+                            "https://s3-us-west-2.amazonaws.com/idseq-web-assets/Terms.pdf"
                           )
                         }
                       />
@@ -114,7 +114,7 @@ class Header extends React.Component {
                         text="Privacy Policy"
                         onClick={() =>
                           this.openNewTab(
-                            "https://s3-us-west-2.amazonaws.com/idseq-database/Privacy.pdf"
+                            "https://s3-us-west-2.amazonaws.com/idseq-web-assets/Privacy.pdf"
                           )
                         }
                       />

--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -580,7 +580,7 @@ class SampleUpload extends React.Component {
             }
           </span>
           <a
-            href="https://s3-us-west-2.amazonaws.com/idseq-database/Terms.pdf"
+            href="https://s3-us-west-2.amazonaws.com/idseq-web-assets/Terms.pdf"
             target="_blank"
             rel="noopener noreferrer"
             className="terms-link"
@@ -589,7 +589,7 @@ class SampleUpload extends React.Component {
           </a>
           {" and "}
           <a
-            href="https://s3-us-west-2.amazonaws.com/idseq-database/Privacy.pdf"
+            href="https://s3-us-west-2.amazonaws.com/idseq-web-assets/Privacy.pdf"
             target="_blank"
             rel="noopener noreferrer"
             className="terms-link"

--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -266,14 +266,14 @@ class Landing extends React.Component {
         <div className="footer-links">
           <a href={mailto}>Contact</a>
           <a
-            href="https://s3-us-west-2.amazonaws.com/idseq-database/Terms.pdf"
+            href="https://s3-us-west-2.amazonaws.com/idseq-web-assets/Terms.pdf"
             target="_blank"
             rel="noopener noreferrer"
           >
             Terms
           </a>
           <a
-            href="https://s3-us-west-2.amazonaws.com/idseq-database/Privacy.pdf"
+            href="https://s3-us-west-2.amazonaws.com/idseq-web-assets/Privacy.pdf"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   post 'feedback', to: 'home#feedback'
   post 'sign_up', to: 'home#sign_up'
   get 'terms' => redirect("https://s3-us-west-2.amazonaws.com/idseq-web-assets/Terms.pdf")
+  get 'privacy' => redirect("https://s3-us-west-2.amazonaws.com/idseq-web-assets/Privacy.pdf")
 
   resources :projects do
     get :make_project_reports_csv, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
   get 'taxon_descriptions', to: 'home#taxon_descriptions'
   post 'feedback', to: 'home#feedback'
   post 'sign_up', to: 'home#sign_up'
-  get 'terms' => redirect("https://s3-us-west-2.amazonaws.com/idseq-database/Terms.pdf")
+  get 'terms' => redirect("https://s3-us-west-2.amazonaws.com/idseq-web-assets/Terms.pdf")
 
   resources :projects do
     get :make_project_reports_csv, on: :member


### PR DESCRIPTION
- The asset files are copied for now so this can go out seamlessly later.
- ALSO add link for idseq.net/privacy so it can be linked from the CLI instructions.