### PR TITLE
Show TaxonModal on Taxonomic Tree View.

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -6,7 +6,7 @@ import Tipsy from "react-tipsy";
 import ReactAutocomplete from "react-autocomplete";
 import { Label, Menu, Icon, Popup } from "semantic-ui-react";
 import numberWithCommas from "../helpers/strings";
-import StringHelper from "../helpers/StringHelper";
+import { getTaxonName } from "../helpers/taxon";
 import ThresholdMap from "./utils/ThresholdMap";
 import Nanobar from "nanobar";
 import BasicPopup from "./BasicPopup";
@@ -1034,57 +1034,42 @@ class PipelineSampleReport extends React.Component {
     return category_lowercase;
   }
 
-  render_name(tax_info, report_details, parent) {
-    let tax_scientific_name = tax_info["name"];
+  render_name(tax_info, report_details, parent, openTaxonModal) {
     let tax_common_name = tax_info["common_name"];
-    let taxonName;
+    const taxonName = getTaxonName(tax_info, this.state.name_type);
     let taxonNameDisplay;
 
     if (this.state.name_type.toLowerCase() == "common name") {
       if (!tax_common_name || tax_common_name.trim() == "") {
-        taxonName = tax_scientific_name;
         taxonNameDisplay = <span className="count-info">{taxonName}</span>;
       } else {
-        taxonName = tax_common_name;
-        taxonNameDisplay = (
-          <span>{StringHelper.capitalizeFirstLetter(taxonName)}</span>
-        );
+        taxonNameDisplay = <span>{taxonName}</span>;
       }
     } else {
-      taxonName = tax_scientific_name;
-      taxonNameDisplay = <span>{tax_scientific_name}</span>;
+      taxonNameDisplay = <span>{taxonName}</span>;
     }
+
+    const openTaxonModalHandler = () =>
+      openTaxonModal({
+        taxInfo: tax_info,
+        parent,
+        taxonName
+      });
 
     if (tax_info.tax_id > 0) {
       if (report_details.taxon_fasta_flag) {
         taxonNameDisplay = (
-          <span className="taxon-modal-link">
+          <span className="taxon-modal-link" onClick={openTaxonModalHandler}>
             <a>{taxonNameDisplay}</a>
           </span>
         );
       } else {
         taxonNameDisplay = (
-          <span className="taxon-modal-link">{taxonNameDisplay}</span>
+          <span className="taxon-modal-link" onClick={openTaxonModalHandler}>
+            {taxonNameDisplay}
+          </span>
         );
       }
-      taxonNameDisplay = (
-        <TaxonModal
-          taxonId={tax_info.tax_id}
-          taxonValues={{
-            NT: tax_info.NT,
-            NR: tax_info.NR
-          }}
-          parentTaxonId={
-            tax_info.tax_level === 1 ? tax_info.genus_taxid : undefined
-          }
-          background={{
-            name: parent.state.backgroundName,
-            id: parent.state.backgroundId
-          }}
-          taxonName={taxonName}
-          trigger={taxonNameDisplay}
-        />
-      );
     } else {
       taxonNameDisplay = <i>{taxonNameDisplay}</i>;
     }
@@ -1524,7 +1509,7 @@ function AdvancedFilterTagList({ threshold, i, parent }) {
   }
 }
 
-function DetailCells({ parent }) {
+function DetailCells({ parent, openTaxonModal }) {
   return parent.state.selected_taxons_top.map(tax_info => (
     <tr
       key={tax_info.tax_id}
@@ -1538,7 +1523,14 @@ function DetailCells({ parent }) {
         parent.props.watched_taxids
       )}
     >
-      <td>{parent.render_name(tax_info, parent.report_details, parent)}</td>
+      <td>
+        {parent.render_name(
+          tax_info,
+          parent.report_details,
+          parent,
+          openTaxonModal
+        )}
+      </td>
       {parent.render_number(
         tax_info.NT.aggregatescore,
         null,
@@ -1572,98 +1564,154 @@ function DetailCells({ parent }) {
   ));
 }
 
-function ReportTableHeader({ parent }) {
-  return (
-    <div className="reports-main">
-      <table id="report-table" className="bordered report-table">
-        <thead>
-          <tr className="report-header">
-            <th>
-              <span className={`table-arrow ""`}>
-                <i className="fa fa-angle-right" onClick={parent.expandTable} />
-              </span>
-              <span className="table-arrow hidden">
-                <i
-                  className="fa fa-angle-down"
-                  onClick={parent.collapseTable}
-                />
-              </span>
-              Taxonomy
-            </th>
-            {parent.render_column_header(
-              "Score",
-              `NT_aggregatescore`,
-              "Aggregate score: ( |genus.NT.Z| * species.NT.Z * species.NT.rPM ) + ( |genus.NR.Z| * species.NR.Z * species.NR.rPM )"
-            )}
-            {parent.render_column_header(
-              "Z",
-              `${parent.state.countType}_zscore`,
-              `Z-score relative to background model for alignments to NCBI NT/NR`
-            )}
-            {parent.render_column_header(
-              "rPM",
-              `${parent.state.countType}_rpm`,
-              `Number of reads aligning to the taxon in the NCBI NT/NR database per million total input reads`
-            )}
-            {parent.render_column_header(
-              "r",
-              `${parent.state.countType}_r`,
-              `Number of reads aligning to the taxon in the NCBI NT/NR database`
-            )}
-            {parent.render_column_header(
-              "%id",
-              `${parent.state.countType}_percentidentity`,
-              `Average percent-identity of alignments to NCBI NT/NR`
-            )}
-            {parent.render_column_header(
-              "log(1/E)",
-              `${parent.state.countType}_neglogevalue`,
-              `Average log-10-transformed expect value for alignments to NCBI NT/NR`
-            )}
-            {parent.render_column_header(
-              "%conc",
-              `${parent.state.countType}_percentconcordant`,
-              `Percentage of aligned reads belonging to a concordantly mappped pair (NCBI NT/NR)`,
-              parent.showConcordance
-            )}
-            <th>
-              <Tipsy content="Switch count type" placement="top">
-                <div className="sort-controls center left">
-                  <div
-                    className={
-                      parent.state.countType === "NT"
-                        ? "active column-switcher"
-                        : "column-switcher"
-                    }
-                    onClick={() => {
-                      parent.setState({ countType: "NT" });
-                    }}
-                  >
-                    NT
+class ReportTableHeader extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      taxonModalData: null
+    };
+
+    this.openTaxonModal = this.openTaxonModal.bind(this);
+    this.closeTaxonModal = this.closeTaxonModal.bind(this);
+  }
+
+  renderTaxonModal() {
+    const { taxonModalData } = this.state;
+    if (!taxonModalData) return;
+
+    const { taxInfo, parent, taxonName } = taxonModalData;
+    return (
+      <TaxonModal
+        taxonId={taxInfo.tax_id}
+        taxonValues={{
+          NT: taxInfo.NT,
+          NR: taxInfo.NR
+        }}
+        parentTaxonId={
+          taxInfo.tax_level === 1 ? taxInfo.genus_taxid : undefined
+        }
+        background={{
+          name: parent.state.backgroundName,
+          id: parent.state.backgroundId
+        }}
+        taxonName={taxonName}
+        handleClose={this.closeTaxonModal}
+      />
+    );
+  }
+
+  openTaxonModal(taxonModalData) {
+    this.setState({
+      taxonModalData
+    });
+  }
+
+  closeTaxonModal() {
+    this.setState({
+      taxonModalData: null
+    });
+  }
+
+  render() {
+    const { parent } = this.props;
+
+    return (
+      <div className="reports-main">
+        {this.renderTaxonModal()}
+        <table id="report-table" className="bordered report-table">
+          <thead>
+            <tr className="report-header">
+              <th>
+                <span className={`table-arrow ""`}>
+                  <i
+                    className="fa fa-angle-right"
+                    onClick={parent.expandTable}
+                  />
+                </span>
+                <span className="table-arrow hidden">
+                  <i
+                    className="fa fa-angle-down"
+                    onClick={parent.collapseTable}
+                  />
+                </span>
+                Taxonomy
+              </th>
+              {parent.render_column_header(
+                "Score",
+                `NT_aggregatescore`,
+                "Aggregate score: ( |genus.NT.Z| * species.NT.Z * species.NT.rPM ) + ( |genus.NR.Z| * species.NR.Z * species.NR.rPM )"
+              )}
+              {parent.render_column_header(
+                "Z",
+                `${parent.state.countType}_zscore`,
+                `Z-score relative to background model for alignments to NCBI NT/NR`
+              )}
+              {parent.render_column_header(
+                "rPM",
+                `${parent.state.countType}_rpm`,
+                `Number of reads aligning to the taxon in the NCBI NT/NR database per million total input reads`
+              )}
+              {parent.render_column_header(
+                "r",
+                `${parent.state.countType}_r`,
+                `Number of reads aligning to the taxon in the NCBI NT/NR database`
+              )}
+              {parent.render_column_header(
+                "%id",
+                `${parent.state.countType}_percentidentity`,
+                `Average percent-identity of alignments to NCBI NT/NR`
+              )}
+              {parent.render_column_header(
+                "log(1/E)",
+                `${parent.state.countType}_neglogevalue`,
+                `Average log-10-transformed expect value for alignments to NCBI NT/NR`
+              )}
+              {parent.render_column_header(
+                "%conc",
+                `${parent.state.countType}_percentconcordant`,
+                `Percentage of aligned reads belonging to a concordantly mappped pair (NCBI NT/NR)`,
+                parent.showConcordance
+              )}
+              <th>
+                <Tipsy content="Switch count type" placement="top">
+                  <div className="sort-controls center left">
+                    <div
+                      className={
+                        parent.state.countType === "NT"
+                          ? "active column-switcher"
+                          : "column-switcher"
+                      }
+                      onClick={() => {
+                        parent.setState({ countType: "NT" });
+                      }}
+                    >
+                      NT
+                    </div>
+                    <div
+                      className={
+                        parent.state.countType === "NR"
+                          ? "active column-switcher"
+                          : "column-switcher"
+                      }
+                      onClick={() => {
+                        parent.setState({ countType: "NR" });
+                      }}
+                    >
+                      NR
+                    </div>
                   </div>
-                  <div
-                    className={
-                      parent.state.countType === "NR"
-                        ? "active column-switcher"
-                        : "column-switcher"
-                    }
-                    onClick={() => {
-                      parent.setState({ countType: "NR" });
-                    }}
-                  >
-                    NR
-                  </div>
-                </div>
-              </Tipsy>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <DetailCells parent={parent} />
-        </tbody>
-      </table>
-    </div>
-  );
+                </Tipsy>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <DetailCells parent={parent} openTaxonModal={this.openTaxonModal} />
+          </tbody>
+        </table>
+      </div>
+    );
+  }
 }
 
 function CategoryFilter({ parent }) {
@@ -1870,6 +1918,8 @@ class RenderMarkup extends React.Component {
           metric={parent.state.treeMetric}
           nameType={parent.state.name_type}
           onNodeTextClicked={this._nodeTextClicked}
+          backgroundId={parent.state.backgroundId}
+          backgroundName={parent.state.backgroundName}
         />
       </div>
     );

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1035,24 +1035,23 @@ class PipelineSampleReport extends React.Component {
   }
 
   render_name(tax_info, report_details, parent, openTaxonModal) {
-    let tax_common_name = tax_info["common_name"];
+    let taxCommonName = tax_info["common_name"];
     const taxonName = getTaxonName(tax_info, this.state.name_type);
-    let taxonNameDisplay;
 
-    if (this.state.name_type.toLowerCase() == "common name") {
-      if (!tax_common_name || tax_common_name.trim() == "") {
-        taxonNameDisplay = <span className="count-info">{taxonName}</span>;
-      } else {
-        taxonNameDisplay = <span>{taxonName}</span>;
-      }
-    } else {
-      taxonNameDisplay = <span>{taxonName}</span>;
-    }
+    const grayOut =
+      this.state.name_type.toLowerCase() == "common name" &&
+      (!taxCommonName || taxCommonName.trim() == "");
+    let taxonNameDisplay = (
+      <span className={grayOut ? "count-info" : ""}>{taxonName}</span>
+    );
 
     const openTaxonModalHandler = () =>
       openTaxonModal({
         taxInfo: tax_info,
-        parent,
+        backgroundData: {
+          name: parent.state.backgroundName,
+          id: parent.state.backgroundId
+        },
         taxonName
       });
 
@@ -1564,7 +1563,7 @@ function DetailCells({ parent, openTaxonModal }) {
   ));
 }
 
-class ReportTableHeader extends React.Component {
+class ReportTable extends React.Component {
   constructor(props) {
     super(props);
 
@@ -1580,7 +1579,7 @@ class ReportTableHeader extends React.Component {
     const { taxonModalData } = this.state;
     if (!taxonModalData) return;
 
-    const { taxInfo, parent, taxonName } = taxonModalData;
+    const { taxInfo, backgroundData, taxonName } = taxonModalData;
     return (
       <TaxonModal
         taxonId={taxInfo.tax_id}
@@ -1591,10 +1590,7 @@ class ReportTableHeader extends React.Component {
         parentTaxonId={
           taxInfo.tax_level === 1 ? taxInfo.genus_taxid : undefined
         }
-        background={{
-          name: parent.state.backgroundName,
-          id: parent.state.backgroundId
-        }}
+        background={backgroundData}
         taxonName={taxonName}
         handleClose={this.closeTaxonModal}
       />
@@ -1623,7 +1619,7 @@ class ReportTableHeader extends React.Component {
           <thead>
             <tr className="report-header">
               <th>
-                <span className={`table-arrow ""`}>
+                <span className="table-arrow">
                   <i
                     className="fa fa-angle-right"
                     onClick={parent.expandTable}
@@ -1988,9 +1984,7 @@ class RenderMarkup extends React.Component {
                   </div>
                   {filter_row_stats}
                 </div>
-                {this.state.view == "table" && (
-                  <ReportTableHeader parent={parent} />
-                )}
+                {this.state.view == "table" && <ReportTable parent={parent} />}
                 {this.renderTree()}
                 {parent.state.loading && (
                   <div className="loading-container">

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -42,9 +42,9 @@ class TaxonTreeVis extends React.Component {
       nr_rpm: { label: "NR rpm", agg: arr => arr.reduce((a, b) => a + b, 0) }
     };
 
-    this.onNodeHover = this.onNodeHover.bind(this);
-    this.onNodeLabelClick = this.onNodeLabelClick.bind(this);
-    this.closeTaxonModal = this.closeTaxonModal.bind(this);
+    this.handleNodeHover = this.handleNodeHover.bind(this);
+    this.handleNodeLabelClick = this.handleNodeLabelClick.bind(this);
+    this.handleTaxonModalClose = this.handleTaxonModalClose.bind(this);
     this.fillNodeValues = this.fillNodeValues.bind(this);
     this.renderTooltip = this.renderTooltip.bind(this);
   }
@@ -56,8 +56,8 @@ class TaxonTreeVis extends React.Component {
       {
         attribute: this.metric,
         useCommonName: this.isCommonNameActive(),
-        onNodeHover: this.onNodeHover,
-        onNodeLabelClick: this.onNodeLabelClick,
+        onNodeHover: this.handleNodeHover,
+        onNodeLabelClick: this.handleNodeLabelClick,
         onCreatedTree: this.fillNodeValues,
         tooltipContainer: this.treeTooltip
       }
@@ -94,17 +94,17 @@ class TaxonTreeVis extends React.Component {
     };
   }
 
-  onNodeHover(node) {
+  handleNodeHover(node) {
     this.setState({ nodeHover: node });
   }
 
-  onNodeLabelClick(node) {
+  handleNodeLabelClick(node) {
     this.setState({
       taxonModalData: node.data.modalData || null
     });
   }
 
-  closeTaxonModal() {
+  handleTaxonModalClose() {
     this.setState({
       taxonModalData: null
     });
@@ -309,7 +309,7 @@ class TaxonTreeVis extends React.Component {
           id: this.props.backgroundId
         }}
         taxonName={taxonName}
-        handleClose={this.closeTaxonModal}
+        handleClose={this.handleTaxonModalClose}
       />
     );
   }
@@ -344,7 +344,7 @@ TaxonTreeVis.propTypes = {
   nameType: PropTypes.string,
   taxa: PropTypes.array,
   topTaxa: PropTypes.array,
-  backgroundId: PropTypes.string,
+  backgroundId: PropTypes.number,
   backgroundName: PropTypes.string
 };
 

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -1,7 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import TidyTree from "../visualizations/TidyTree";
+import TaxonModal from "../views/report/TaxonModal";
 import PathogenLabel from "../ui/labels/PathogenLabel";
+import { getTaxonName } from "../../helpers/taxon";
 
 const TaxonLevels = [
   "species",
@@ -18,7 +20,8 @@ class TaxonTreeVis extends React.Component {
     super(props);
 
     this.state = {
-      nodeHover: null
+      nodeHover: null,
+      taxonModalData: null
     };
 
     this.nameType = this.props.nameType;
@@ -40,6 +43,8 @@ class TaxonTreeVis extends React.Component {
     };
 
     this.onNodeHover = this.onNodeHover.bind(this);
+    this.onNodeLabelClick = this.onNodeLabelClick.bind(this);
+    this.closeTaxonModal = this.closeTaxonModal.bind(this);
     this.fillNodeValues = this.fillNodeValues.bind(this);
     this.renderTooltip = this.renderTooltip.bind(this);
   }
@@ -52,6 +57,7 @@ class TaxonTreeVis extends React.Component {
         attribute: this.metric,
         useCommonName: this.isCommonNameActive(),
         onNodeHover: this.onNodeHover,
+        onNodeLabelClick: this.onNodeLabelClick,
         onCreatedTree: this.fillNodeValues,
         tooltipContainer: this.treeTooltip
       }
@@ -90,6 +96,18 @@ class TaxonTreeVis extends React.Component {
 
   onNodeHover(node) {
     this.setState({ nodeHover: node });
+  }
+
+  onNodeLabelClick(node) {
+    this.setState({
+      taxonModalData: node.data.modalData || null
+    });
+  }
+
+  closeTaxonModal() {
+    this.setState({
+      taxonModalData: null
+    });
   }
 
   getParentTaxId(taxon) {
@@ -179,7 +197,7 @@ class TaxonTreeVis extends React.Component {
       nodes.push({
         id: nodeId,
         taxId: taxon.tax_id,
-        commonName: taxon.common_name,
+        commonName: this.capitalize(taxon.common_name),
         scientificName:
           taxon.tax_id > 0
             ? taxon.name
@@ -196,6 +214,9 @@ class TaxonTreeVis extends React.Component {
           nr_r: taxon.NR.r,
           nr_rpm: parseFloat(taxon.NR.rpm),
           nr_zscore: taxon.NR.zscore
+        },
+        modalData: {
+          taxInfo: taxon
         }
       });
       seenNodes.add(nodeId);
@@ -250,6 +271,7 @@ class TaxonTreeVis extends React.Component {
   }
 
   capitalize(str) {
+    if (!str) return str;
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
 
@@ -262,6 +284,34 @@ class TaxonTreeVis extends React.Component {
         <PathogenLabel type={taxon.pathogenTag} />
       </div>
     ));
+  }
+
+  renderTaxonModal() {
+    const { taxonModalData } = this.state;
+    if (!taxonModalData) return;
+
+    const { taxInfo } = taxonModalData;
+
+    const taxonName = getTaxonName(taxInfo, this.props.nameType);
+
+    return (
+      <TaxonModal
+        taxonId={taxInfo.tax_id}
+        taxonValues={{
+          NT: taxInfo.NT,
+          NR: taxInfo.NR
+        }}
+        parentTaxonId={
+          taxInfo.tax_level === 1 ? taxInfo.genus_taxid : undefined
+        }
+        background={{
+          name: this.props.backgroundName,
+          id: this.props.backgroundId
+        }}
+        taxonName={taxonName}
+        handleClose={this.closeTaxonModal}
+      />
+    );
   }
 
   render() {
@@ -283,6 +333,7 @@ class TaxonTreeVis extends React.Component {
         >
           {this.renderTooltip()}
         </div>
+        {this.renderTaxonModal()}
       </div>
     );
   }
@@ -292,7 +343,9 @@ TaxonTreeVis.propTypes = {
   metric: PropTypes.string,
   nameType: PropTypes.string,
   taxa: PropTypes.array,
-  topTaxa: PropTypes.array
+  topTaxa: PropTypes.array,
+  backgroundId: PropTypes.string,
+  backgroundName: PropTypes.string
 };
 
 export default TaxonTreeVis;

--- a/app/assets/src/components/views/report/TaxonModal.jsx
+++ b/app/assets/src/components/views/report/TaxonModal.jsx
@@ -9,7 +9,6 @@ class TaxonModal extends React.Component {
     super(props);
 
     this.state = {
-      open: false,
       background: this.props.background,
       showHistogram: false,
       taxonDescription: "",
@@ -18,15 +17,12 @@ class TaxonModal extends React.Component {
       wikiUrl: null
     };
 
-    this.loadedBackground = this.handleOpen = this.handleOpen.bind(this);
-    this.handleClose = () => this.setState({ open: false });
     this.linkTo = this.linkTo.bind(this);
   }
 
-  handleOpen() {
+  componentWillMount() {
     this.loadTaxonInfo();
     this.loadBackgroundInfo();
-    this.setState({ open: true });
   }
 
   loadTaxonInfo() {
@@ -140,82 +136,82 @@ class TaxonModal extends React.Component {
   }
 
   render() {
+    // The Modal component always expects a 'trigger', even though it doesn't make sense in our use case.
+    // <TaxonModal> is always open when rendered. To hide <TaxonModal>, we simply don't render it.
     return (
       <Modal
         title={this.props.taxonName}
-        trigger={<span onClick={this.handleOpen}>{this.props.trigger}</span>}
-        open={this.state.open}
-        onClose={this.handleClose}
+        trigger={<span />}
+        open
+        onClose={this.props.handleClose}
       >
-        {this.state.open && (
-          <div className="taxon-info">
-            <div className="taxon-info__label" />
-            {this.state.taxonDescription && (
-              <div>
-                <div className="taxon-info__subtitle">Description</div>
-                <div className="taxon-info__text">
-                  {this.state.taxonDescription}
-                </div>
+        <div className="taxon-info">
+          <div className="taxon-info__label" />
+          {this.state.taxonDescription && (
+            <div>
+              <div className="taxon-info__subtitle">Description</div>
+              <div className="taxon-info__text">
+                {this.state.taxonDescription}
               </div>
-            )}
-            {this.state.taxonParentName && (
-              <div>
-                <div className="taxon-info__subtitle">
-                  Genus: {this.state.taxonParentName}
-                </div>
-                <div className="taxon-info__text">
-                  {this.state.taxonParentDescription}
-                </div>
-              </div>
-            )}
-            {this.state.showHistogram && (
-              <div>
-                <div className="taxon-info__subtitle">
-                  Reference Background: {this.state.background.name}
-                </div>
-                <div
-                  className="taxon-info__histogram"
-                  ref={histogramContainer => {
-                    this.histogramContainer = histogramContainer;
-                  }}
-                />
-              </div>
-            )}
-            <div className="taxon-info__subtitle">Links</div>
-            <div className="taxon-info__links-section">
-              <ul className="taxon-info__links-list">
-                <li
-                  className="taxon-info__link"
-                  onClick={() => this.linkTo("ncbi")}
-                >
-                  NCBI
-                </li>
-                <li
-                  className="taxon-info__link"
-                  onClick={() => this.linkTo("google")}
-                >
-                  Google
-                </li>
-              </ul>
-              <ul className="taxon-info__links-list">
-                {this.state.wikiUrl && (
-                  <li
-                    className="taxon-info__link"
-                    onClick={() => this.linkTo("wikipedia")}
-                  >
-                    Wikipedia
-                  </li>
-                )}
-                <li
-                  className="taxon-info__link"
-                  onClick={() => this.linkTo("pubmed")}
-                >
-                  Pubmed
-                </li>
-              </ul>
             </div>
+          )}
+          {this.state.taxonParentName && (
+            <div>
+              <div className="taxon-info__subtitle">
+                Genus: {this.state.taxonParentName}
+              </div>
+              <div className="taxon-info__text">
+                {this.state.taxonParentDescription}
+              </div>
+            </div>
+          )}
+          {this.state.showHistogram && (
+            <div>
+              <div className="taxon-info__subtitle">
+                Reference Background: {this.state.background.name}
+              </div>
+              <div
+                className="taxon-info__histogram"
+                ref={histogramContainer => {
+                  this.histogramContainer = histogramContainer;
+                }}
+              />
+            </div>
+          )}
+          <div className="taxon-info__subtitle">Links</div>
+          <div className="taxon-info__links-section">
+            <ul className="taxon-info__links-list">
+              <li
+                className="taxon-info__link"
+                onClick={() => this.linkTo("ncbi")}
+              >
+                NCBI
+              </li>
+              <li
+                className="taxon-info__link"
+                onClick={() => this.linkTo("google")}
+              >
+                Google
+              </li>
+            </ul>
+            <ul className="taxon-info__links-list">
+              {this.state.wikiUrl && (
+                <li
+                  className="taxon-info__link"
+                  onClick={() => this.linkTo("wikipedia")}
+                >
+                  Wikipedia
+                </li>
+              )}
+              <li
+                className="taxon-info__link"
+                onClick={() => this.linkTo("pubmed")}
+              >
+                Pubmed
+              </li>
+            </ul>
           </div>
-        )}
+        </div>
       </Modal>
     );
   }
@@ -226,8 +222,7 @@ TaxonModal.propTypes = {
   parentTaxonId: PropTypes.number,
   taxonId: PropTypes.number,
   taxonName: PropTypes.string,
-  taxonValues: PropTypes.object,
-  trigger: PropTypes.node
+  taxonValues: PropTypes.object
 };
 
 export default TaxonModal;

--- a/app/assets/src/components/views/report/TaxonModal.jsx
+++ b/app/assets/src/components/views/report/TaxonModal.jsx
@@ -20,7 +20,7 @@ class TaxonModal extends React.Component {
     this.linkTo = this.linkTo.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadTaxonInfo();
     this.loadBackgroundInfo();
   }

--- a/app/assets/src/helpers/taxon.js
+++ b/app/assets/src/helpers/taxon.js
@@ -1,0 +1,12 @@
+import StringHelper from "./StringHelper";
+
+export const getTaxonName = (taxInfo, nameType) => {
+  const scientificName = taxInfo["name"];
+  const commonName = taxInfo["common_name"];
+
+  return nameType.toLowerCase() !== "common name" ||
+    !commonName ||
+    commonName.trim() === ""
+    ? scientificName
+    : StringHelper.capitalizeFirstLetter(commonName);
+};


### PR DESCRIPTION
TaxonModal is now always open when rendered.
To hide the modal, don't render it in the JSX.
This change allows compatibility with D3, where providing a trigger element is difficult.

Also did a small fix to capitalize common names on the Taxon Tree.

Related to issue: IDSEQ-467

![oct-12-2018 15-09-18](https://user-images.githubusercontent.com/837004/46896214-df9a8d00-ce30-11e8-8a3f-53de21c46c96.gif)
