### PR TITLE
Bump unicode-display_width

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -864,7 +864,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.4.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     warden (1.2.7)
@@ -940,4 +940,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.16.5
+   1.16.6


### PR DESCRIPTION
```
web_1                      | NOTE: Gem.gunzip is deprecated; use Gem::Util.gunzip instead. It will be removed on or after 2018-12-01.
web_1                      | Gem.gunzip called from /usr/local/bundle/gems/unicode-display_width-1.3.0/lib/unicode/display_width/index.rb:5.
```