### PR TITLE
Refactor PipelineSampleReport

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -169,6 +169,7 @@ class PipelineSampleReport extends React.Component {
     this.fillUrlParams = this.fillUrlParams.bind(this);
     this.flash = this.flash.bind(this);
     this.getBackgroundIdByName = this.getBackgroundIdByName.bind(this);
+    this.getRowClass = this.getRowClass.bind(this);
     this.gotoAlignmentVizLink = this.gotoAlignmentVizLink.bind(this);
 
     // control handlers
@@ -191,6 +192,8 @@ class PipelineSampleReport extends React.Component {
     this.handleViewClicked = this.handleViewClicked.bind(this);
 
     this.renderMore = this.renderMore.bind(this);
+    this.renderName = this.renderName.bind(this);
+    this.renderNumber = this.renderNumber.bind(this);
     this.resetAllFilters = this.resetAllFilters.bind(this);
     this.setSortParams = this.setSortParams.bind(this);
     this.sortCompareFunction = this.sortCompareFunction.bind(this);
@@ -1003,7 +1006,7 @@ class PipelineSampleReport extends React.Component {
     return category_lowercase;
   }
 
-  render_name(tax_info, report_details, parent, openTaxonModal) {
+  renderName(tax_info, report_details, backgroundData, openTaxonModal) {
     let taxCommonName = tax_info["common_name"];
     const taxonName = getTaxonName(tax_info, this.state.name_type);
 
@@ -1017,7 +1020,7 @@ class PipelineSampleReport extends React.Component {
     const openTaxonModalHandler = () =>
       openTaxonModal({
         taxInfo: tax_info,
-        backgroundData: parent.state.backgroundData,
+        backgroundData,
         taxonName
       });
 
@@ -1079,7 +1082,7 @@ class PipelineSampleReport extends React.Component {
     return taxonDescription;
   }
 
-  render_number(
+  renderNumber(
     ntCount,
     nrCount,
     num_decimals,

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -194,6 +194,7 @@ class PipelineSampleReport extends React.Component {
     this.renderMore = this.renderMore.bind(this);
     this.renderName = this.renderName.bind(this);
     this.renderNumber = this.renderNumber.bind(this);
+    this.renderColumnHeader = this.renderColumnHeader.bind(this);
     this.resetAllFilters = this.resetAllFilters.bind(this);
     this.setSortParams = this.setSortParams.bind(this);
     this.sortCompareFunction = this.sortCompareFunction.bind(this);
@@ -1144,7 +1145,7 @@ class PipelineSampleReport extends React.Component {
     );
   }
 
-  render_column_header(
+  renderColumnHeader(
     visible_metric,
     column_name,
     tooltip_message,
@@ -1738,7 +1739,26 @@ class RenderMarkup extends React.Component {
                   </div>
                   {filter_row_stats}
                 </div>
-                {this.state.view == "table" && <ReportTable parent={parent} />}
+                {this.state.view == "table" && (
+                  <ReportTable
+                    taxons={parent.state.selected_taxons_top}
+                    taxonRowRefs={parent.taxon_row_refs}
+                    confirmedTaxIds={parent.props.confirmed_taxids}
+                    watchedTaxIds={parent.props.watched_taxids}
+                    renderName={parent.renderName}
+                    renderNumber={parent.renderNumber}
+                    displayHighlightTags={parent.displayHighlightTags}
+                    showConcordance={parent.showConcordance}
+                    getRowClass={parent.getRowClass}
+                    reportDetails={parent.report_details}
+                    backgroundData={parent.state.backgroundData}
+                    expandTable={parent.expandTable}
+                    collapseTable={parent.collapseTable}
+                    renderColumnHeader={parent.renderColumnHeader}
+                    countType={parent.state.countType}
+                    setCountType={countType => parent.setState({ countType })}
+                  />
+                )}
                 {this.renderTree()}
                 {parent.state.loading && (
                   <div className="loading-container">

--- a/app/assets/src/components/utils/propTypes.js
+++ b/app/assets/src/components/utils/propTypes.js
@@ -1,0 +1,51 @@
+import PropTypes from "prop-types";
+
+const TaxonDatabaseStats = PropTypes.shape({
+  aggregatescore: PropTypes.number.isRequired,
+  alignmentlength: PropTypes.number.isRequired,
+  count_type: PropTypes.string.isRequired,
+  maxzscore: PropTypes.number.isRequired,
+  neglogevalue: PropTypes.number.isRequired,
+  percentconcordant: PropTypes.number.isRequired,
+  percentidentity: PropTypes.number.isRequired,
+  r: PropTypes.number.isRequired,
+  r_pct: PropTypes.string,
+  // Right now, if rpm is 0, it is a number. Otherwise, a string.
+  rpm: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  rpm_bg: PropTypes.number,
+  zscore: PropTypes.number.isRequired
+});
+
+const Taxon = PropTypes.shape({
+  NR: TaxonDatabaseStats.isRequired,
+  NT: TaxonDatabaseStats.isRequired,
+  category_name: PropTypes.string.isRequired,
+  common_name: PropTypes.string,
+  family_taxid: PropTypes.number.isRequired,
+  genus_taxid: PropTypes.number.isRequired,
+  is_phage: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  pathogenTag: PropTypes.string,
+  species_count: PropTypes.number.isRequired,
+  species_taxid: PropTypes.number.isRequired,
+  tax_id: PropTypes.number.isRequired,
+  tax_level: PropTypes.number.isRequired,
+  topScoring: PropTypes.number
+});
+
+// TODO(mark): Complete signature.
+const ReportDetails = PropTypes.shape({
+  taxon_fasta_flag: PropTypes.bool.isRequired
+});
+
+const BackgroundData = PropTypes.shape({
+  id: PropTypes.number,
+  name: PropTypes.string
+});
+
+export default {
+  ReportDetails,
+  Taxon,
+  BackgroundData,
+  ...PropTypes
+};

--- a/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
+++ b/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
@@ -1,28 +1,35 @@
 import React from "react";
 
-const DetailCells = ({ parent, openTaxonModal }) => {
-  return parent.state.selected_taxons_top.map(taxInfo => (
+// TODO(mark): Use alias instead, to avoid dots.
+import PropTypes from "../../../utils/propTypes";
+
+const DetailCells = ({
+  taxons,
+  taxonRowRefs,
+  confirmedTaxIds,
+  watchedTaxIds,
+  renderName,
+  renderNumber,
+  displayHighlightTags,
+  showConcordance,
+  getRowClass,
+  openTaxonModal,
+  reportDetails,
+  backgroundData
+}) => {
+  return taxons.map(taxInfo => (
     <tr
       key={taxInfo.tax_id}
       id={`taxon-${taxInfo.tax_id}`}
       ref={elm => {
-        parent.taxon_row_refs[taxInfo.tax_id] = elm;
+        taxonRowRefs[taxInfo.tax_id] = elm;
       }}
-      className={parent.getRowClass(
-        taxInfo,
-        parent.props.confirmed_taxids,
-        parent.props.watched_taxids
-      )}
+      className={getRowClass(taxInfo, confirmedTaxIds, watchedTaxIds)}
     >
       <td>
-        {parent.render_name(
-          taxInfo,
-          parent.report_details,
-          parent,
-          openTaxonModal
-        )}
+        {renderName(taxInfo, reportDetails, backgroundData, openTaxonModal)}
       </td>
-      {parent.render_number(
+      {renderNumber(
         taxInfo.NT.aggregatescore,
         null,
         0,
@@ -30,29 +37,36 @@ const DetailCells = ({ parent, openTaxonModal }) => {
         undefined,
         taxInfo.topScoring == 1
       )}
-      {parent.render_number(taxInfo.NT.zscore, taxInfo.NR.zscore, 1)}
-      {parent.render_number(taxInfo.NT.rpm, taxInfo.NR.rpm, 1)}
-      {parent.render_number(taxInfo.NT.r, taxInfo.NR.r, 0)}
-      {parent.render_number(
-        taxInfo.NT.percentidentity,
-        taxInfo.NR.percentidentity,
-        1
-      )}
-      {parent.render_number(
-        taxInfo.NT.neglogevalue,
-        taxInfo.NR.neglogevalue,
-        0
-      )}
-      {parent.render_number(
+      {renderNumber(taxInfo.NT.zscore, taxInfo.NR.zscore, 1)}
+      {renderNumber(taxInfo.NT.rpm, taxInfo.NR.rpm, 1)}
+      {renderNumber(taxInfo.NT.r, taxInfo.NR.r, 0)}
+      {renderNumber(taxInfo.NT.percentidentity, taxInfo.NR.percentidentity, 1)}
+      {renderNumber(taxInfo.NT.neglogevalue, taxInfo.NR.neglogevalue, 0)}
+      {renderNumber(
         taxInfo.NT.percentconcordant,
         taxInfo.NR.percentconcordant,
         1,
         undefined,
-        parent.showConcordance
+        showConcordance
       )}
-      <td>{parent.displayHighlightTags(taxInfo)}</td>
+      <td>{displayHighlightTags(taxInfo)}</td>
     </tr>
   ));
+};
+
+DetailCells.propTypes = {
+  taxons: PropTypes.arrayOf(PropTypes.Taxon).isRequired,
+  taxonRowRefs: PropTypes.objectOf(PropTypes.any).isRequired, // These are DOM elements.
+  confirmedTaxIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  watchedTaxIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  renderName: PropTypes.func.isRequired,
+  renderNumber: PropTypes.func.isRequired,
+  displayHighlightTags: PropTypes.func.isRequired,
+  showConcordance: PropTypes.bool.isRequired,
+  openTaxonModal: PropTypes.func.isRequired,
+  getRowClass: PropTypes.func.isRequired,
+  reportDetails: PropTypes.ReportDetails,
+  backgroundData: PropTypes.BackgroundData
 };
 
 export default DetailCells;

--- a/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
+++ b/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
@@ -145,7 +145,20 @@ export default class ReportTable extends React.Component {
             </tr>
           </thead>
           <tbody>
-            <DetailCells parent={parent} openTaxonModal={this.openTaxonModal} />
+            <DetailCells
+              taxons={parent.state.selected_taxons_top}
+              taxonRowRefs={parent.taxon_row_refs}
+              confirmedTaxIds={parent.props.confirmed_taxids}
+              watchedTaxIds={parent.props.watched_taxids}
+              renderName={parent.renderName}
+              renderNumber={parent.renderNumber}
+              displayHighlightTags={parent.displayHighlightTags}
+              showConcordance={parent.showConcordance}
+              getRowClass={parent.getRowClass}
+              openTaxonModal={this.openTaxonModal}
+              reportDetails={parent.report_details}
+              backgroundData={parent.state.backgroundData}
+            />
           </tbody>
         </table>
       </div>

--- a/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
+++ b/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 import Tipsy from "react-tipsy";
 
+import PropTypes from "../../../utils/propTypes";
 import TaxonModal from "../TaxonModal";
 
 import DetailCells from "./DetailCells";
 
-// TODO(mark): Refactor to remove parent prop.
 export default class ReportTable extends React.Component {
   constructor(props) {
     super(props);
@@ -53,7 +53,24 @@ export default class ReportTable extends React.Component {
   }
 
   render() {
-    const { parent } = this.props;
+    const {
+      taxons,
+      taxonRowRefs,
+      confirmedTaxIds,
+      watchedTaxIds,
+      renderName,
+      renderNumber,
+      renderColumnHeader,
+      displayHighlightTags,
+      showConcordance,
+      getRowClass,
+      reportDetails,
+      backgroundData,
+      expandTable,
+      collapseTable,
+      countType,
+      setCountType
+    } = this.props;
 
     return (
       <div className="reports-main">
@@ -63,79 +80,69 @@ export default class ReportTable extends React.Component {
             <tr className="report-header">
               <th>
                 <span className="table-arrow">
-                  <i
-                    className="fa fa-angle-right"
-                    onClick={parent.expandTable}
-                  />
+                  <i className="fa fa-angle-right" onClick={expandTable} />
                 </span>
                 <span className="table-arrow hidden">
-                  <i
-                    className="fa fa-angle-down"
-                    onClick={parent.collapseTable}
-                  />
+                  <i className="fa fa-angle-down" onClick={collapseTable} />
                 </span>
                 Taxonomy
               </th>
-              {parent.render_column_header(
+              {renderColumnHeader(
                 "Score",
                 `NT_aggregatescore`,
                 "Aggregate score: ( |genus.NT.Z| * species.NT.Z * species.NT.rPM ) + ( |genus.NR.Z| * species.NR.Z * species.NR.rPM )"
               )}
-              {parent.render_column_header(
+              {renderColumnHeader(
                 "Z",
-                `${parent.state.countType}_zscore`,
+                `${countType}_zscore`,
                 `Z-score relative to background model for alignments to NCBI NT/NR`
               )}
-              {parent.render_column_header(
+              {renderColumnHeader(
                 "rPM",
-                `${parent.state.countType}_rpm`,
+                `${countType}_rpm`,
                 `Number of reads aligning to the taxon in the NCBI NT/NR database per million total input reads`
               )}
-              {parent.render_column_header(
+              {renderColumnHeader(
                 "r",
-                `${parent.state.countType}_r`,
+                `${countType}_r`,
                 `Number of reads aligning to the taxon in the NCBI NT/NR database`
               )}
-              {parent.render_column_header(
+              {renderColumnHeader(
                 "%id",
-                `${parent.state.countType}_percentidentity`,
+                `${countType}_percentidentity`,
                 `Average percent-identity of alignments to NCBI NT/NR`
               )}
-              {parent.render_column_header(
+              {renderColumnHeader(
                 "log(1/E)",
-                `${parent.state.countType}_neglogevalue`,
+                `${countType}_neglogevalue`,
                 `Average log-10-transformed expect value for alignments to NCBI NT/NR`
               )}
-              {parent.render_column_header(
+              {renderColumnHeader(
                 "%conc",
-                `${parent.state.countType}_percentconcordant`,
+                `${countType}_percentconcordant`,
                 `Percentage of aligned reads belonging to a concordantly mappped pair (NCBI NT/NR)`,
-                parent.showConcordance
+                showConcordance
               )}
               <th>
                 <Tipsy content="Switch count type" placement="top">
                   <div className="sort-controls center left">
                     <div
                       className={
-                        parent.state.countType === "NT"
+                        countType === "NT"
                           ? "active column-switcher"
                           : "column-switcher"
                       }
-                      onClick={() => {
-                        parent.setState({ countType: "NT" });
-                      }}
+                      onClick={() => setCountType("NT")}
                     >
                       NT
                     </div>
                     <div
                       className={
-                        parent.state.countType === "NR"
+                        countType === "NR"
                           ? "active column-switcher"
                           : "column-switcher"
                       }
-                      onClick={() => {
-                        parent.setState({ countType: "NR" });
-                      }}
+                      onClick={() => setCountType("NR")}
                     >
                       NR
                     </div>
@@ -146,18 +153,18 @@ export default class ReportTable extends React.Component {
           </thead>
           <tbody>
             <DetailCells
-              taxons={parent.state.selected_taxons_top}
-              taxonRowRefs={parent.taxon_row_refs}
-              confirmedTaxIds={parent.props.confirmed_taxids}
-              watchedTaxIds={parent.props.watched_taxids}
-              renderName={parent.renderName}
-              renderNumber={parent.renderNumber}
-              displayHighlightTags={parent.displayHighlightTags}
-              showConcordance={parent.showConcordance}
-              getRowClass={parent.getRowClass}
+              taxons={taxons}
+              taxonRowRefs={taxonRowRefs}
+              confirmedTaxIds={confirmedTaxIds}
+              watchedTaxIds={watchedTaxIds}
+              renderName={renderName}
+              renderNumber={renderNumber}
+              displayHighlightTags={displayHighlightTags}
+              showConcordance={showConcordance}
+              getRowClass={getRowClass}
               openTaxonModal={this.openTaxonModal}
-              reportDetails={parent.report_details}
-              backgroundData={parent.state.backgroundData}
+              reportDetails={reportDetails}
+              backgroundData={backgroundData}
             />
           </tbody>
         </table>
@@ -165,3 +172,22 @@ export default class ReportTable extends React.Component {
     );
   }
 }
+
+ReportTable.propTypes = {
+  taxons: PropTypes.arrayOf(PropTypes.Taxon).isRequired,
+  taxonRowRefs: PropTypes.objectOf(PropTypes.any).isRequired, // These are DOM elements.
+  confirmedTaxIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  watchedTaxIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  renderName: PropTypes.func.isRequired,
+  renderNumber: PropTypes.func.isRequired,
+  displayHighlightTags: PropTypes.func.isRequired,
+  showConcordance: PropTypes.bool.isRequired,
+  getRowClass: PropTypes.func.isRequired,
+  reportDetails: PropTypes.ReportDetails,
+  backgroundData: PropTypes.BackgroundData,
+  expandTable: PropTypes.func.isRequired,
+  collapseTable: PropTypes.func.isRequired,
+  renderColumnHeader: PropTypes.func.isRequired,
+  countType: PropTypes.string.isRequired,
+  setCountType: PropTypes.func.isRequired
+};


### PR DESCRIPTION
Remove the `parent` prop from ReportTable and DetailCells.

The plan is to move up the component tree and do this for every component.

This DOES hugely increase the number of props passed, but these props were all implicitly being used in these components anyways.
Will look into ways to reduce the props after this phase of the refactor (for example, by pushing certain logic and state down the component tree instead of keeping it all in the root component).