### PR TITLE
Add babel plugin to remove need for bind statements.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": ["env", "react"],
-  "plugins": ["transform-object-rest-spread"]
+  "plugins": ["transform-object-rest-spread", "transform-class-properties"]
 }
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,15 +6,9 @@
     "es6": true,
     "mocha": true
   },
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module",
-    "ecmaFeatures": {
-      "jsx": true
-    }
-  },
+  "parser": "babel-eslint",
   "extends": [
-    "standard", 
+    "standard",
     "eslint:recommended",
     "plugin:react/recommended"
   ],

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -162,50 +162,6 @@ class PipelineSampleReport extends React.Component {
     this.expandAll = false;
     this.expandedGenera = [];
     this.thresholded_taxons = [];
-
-    this.anyFilterSet = this.anyFilterSet.bind(this);
-    this.applyFilters = this.applyFilters.bind(this);
-    this.collapseGenus = this.collapseGenus.bind(this);
-    this.collapseTable = this.collapseTable.bind(this);
-    this.displayHighlightTags = this.displayHighlightTags.bind(this);
-    this.downloadFastaUrl = this.downloadFastaUrl.bind(this);
-    this.expandGenusClick = this.expandGenusClick.bind(this);
-    this.expandTable = this.expandTable.bind(this);
-    this.fillUrlParams = this.fillUrlParams.bind(this);
-    this.flash = this.flash.bind(this);
-    this.getBackgroundIdByName = this.getBackgroundIdByName.bind(this);
-    this.getRowClass = this.getRowClass.bind(this);
-    this.gotoAlignmentVizLink = this.gotoAlignmentVizLink.bind(this);
-    this.handleSearch = this.handleSearch.bind(this);
-
-    // control handlers
-    this.handleBackgroundModelChange = this.handleBackgroundModelChange.bind(
-      this
-    );
-    this.handleIncludedCategoriesChange = this.handleIncludedCategoriesChange.bind(
-      this
-    );
-    this.handleNameTypeChange = this.handleNameTypeChange.bind(this);
-    this.handleRemoveCategory = this.handleRemoveCategory.bind(this);
-    this.handleRemoveThresholdFilter = this.handleRemoveThresholdFilter.bind(
-      this
-    );
-    this.handleSpecificityChange = this.handleSpecificityChange.bind(this);
-    this.handleThresholdFiltersChange = this.handleThresholdFiltersChange.bind(
-      this
-    );
-    this.handleTreeMetricChange = this.handleTreeMetricChange.bind(this);
-    this.handleViewClicked = this.handleViewClicked.bind(this);
-
-    this.renderMore = this.renderMore.bind(this);
-    this.renderName = this.renderName.bind(this);
-    this.renderNumber = this.renderNumber.bind(this);
-    this.renderColumnHeader = this.renderColumnHeader.bind(this);
-    this.resetAllFilters = this.resetAllFilters.bind(this);
-    this.setSortParams = this.setSortParams.bind(this);
-    this.sortResults = this.sortResults.bind(this);
-    this.isTaxonExpanded = this.isTaxonExpanded.bind(this);
-
     this.initializeTooltip();
   }
 
@@ -236,16 +192,16 @@ class PipelineSampleReport extends React.Component {
     );
   }
 
-  setupFilterModal(activateDiv, modalDiv) {
+  setupFilterModal = (activateDiv, modalDiv) => {
     const filtersModal = $(modalDiv);
     const filtersActivate = $(activateDiv);
 
     filtersActivate.on("click", e => {
       filtersModal.slideToggle(200);
     });
-  }
+  };
 
-  fetchSearchList() {
+  fetchSearchList = () => {
     axios
       .get(
         `/samples/${this.sample_id}/search_list?report_ts=${
@@ -260,11 +216,11 @@ class PipelineSampleReport extends React.Component {
           search_keys_in_sample: search_list
         });
       });
-  }
+  };
 
   // fetchReportData loads the actual report information with another call to
   // the API endpoint.
-  fetchReportData() {
+  fetchReportData = () => {
     this.nanobar.go(30);
     this.setState({
       loading: true
@@ -299,9 +255,9 @@ class PipelineSampleReport extends React.Component {
         }
       );
     });
-  }
+  };
 
-  anyFilterSet() {
+  anyFilterSet = () => {
     return (
       this.state.search_taxon_id > 0 ||
       this.state.includedCategories.length > 0 ||
@@ -309,9 +265,9 @@ class PipelineSampleReport extends React.Component {
       (this.state.activeThresholds.length > 0 &&
         ThresholdMap.isThresholdValid(this.state.activeThresholds[0]))
     );
-  }
+  };
 
-  resetAllFilters() {
+  resetAllFilters = () => {
     this.setState(
       {
         activeThresholds: [Object.assign({}, this.defaultThreshold)],
@@ -334,9 +290,9 @@ class PipelineSampleReport extends React.Component {
         Cookies.set("includedSubcategories", "[]");
       }
     );
-  }
+  };
 
-  applyFilters(recomputeThresholdedTaxons = false) {
+  applyFilters = (recomputeThresholdedTaxons = false) => {
     //
     // Threshold filters
     //
@@ -473,9 +429,9 @@ class PipelineSampleReport extends React.Component {
       pagesRendered: 1,
       rows_passing_filters: selected_taxons.length
     });
-  }
+  };
 
-  updateSpeciesCount(res) {
+  updateSpeciesCount = res => {
     for (let i = 0; i < res.length; i++) {
       let isGenus = res[i].genus_taxid == res[i].tax_id;
       if (isGenus) {
@@ -494,9 +450,9 @@ class PipelineSampleReport extends React.Component {
       }
     }
     return res;
-  }
+  };
 
-  filterNonSpecific(rows) {
+  filterNonSpecific = rows => {
     let filtered = [];
     for (let i = 0; i < rows.length; i++) {
       let cur = rows[i];
@@ -515,16 +471,16 @@ class PipelineSampleReport extends React.Component {
       }
     }
     return filtered;
-  }
+  };
 
-  removeEmptyGenusRows(rows) {
+  removeEmptyGenusRows = rows => {
     // Remove rows unless they have a species tax level or a species count
     // under them of greater than 0.
     return rows.filter(r => r.tax_level === 1 || r.species_count > 0);
-  }
+  };
 
   //Load more samples on scroll
-  scrollDown() {
+  scrollDown = () => {
     var that = this;
     $(window).scroll(function() {
       if (
@@ -539,9 +495,9 @@ class PipelineSampleReport extends React.Component {
         return false;
       }
     });
-  }
+  };
 
-  renderMore() {
+  renderMore = () => {
     let selected_taxons = this.state.selected_taxons;
     let currentPage = this.state.pagesRendered;
     let rowsPerPage = this.max_rows_to_render;
@@ -555,9 +511,9 @@ class PipelineSampleReport extends React.Component {
         pagesRendered: currentPage + 1
       }));
     }
-  }
+  };
 
-  flash() {
+  flash = () => {
     let sel = $(".filter-message");
     sel.removeClass("flash");
     const el = document.getElementById("filter-message");
@@ -566,9 +522,9 @@ class PipelineSampleReport extends React.Component {
       /* trigger reflow */
     }
     sel.addClass("flash");
-  }
+  };
 
-  initializeTooltip() {
+  initializeTooltip = () => {
     // only updating the tooltip offset when the component is loaded
     $(() => {
       const tooltipIdentifier = $("[rel='tooltip']");
@@ -586,18 +542,16 @@ class PipelineSampleReport extends React.Component {
         }
       });
     });
-  }
+  };
 
-  // applySort needs to be bound at time of use, not in constructor above
-  // TODO(yf): fix this
-  applySort(sort_by) {
+  applySort = sort_by => {
     if (sort_by.toLowerCase() != this.state.sort_by) {
       this.state.sort_by = sort_by.toLowerCase();
       this.sortResults();
     }
-  }
+  };
 
-  setSortParams() {
+  setSortParams = () => {
     const primary_sort = this.state.sort_by.split("_");
     primary_sort[0] = primary_sort[0].toUpperCase();
     const secondary_sort = this.default_sort_by.split("_");
@@ -606,12 +560,12 @@ class PipelineSampleReport extends React.Component {
       primary: primary_sort,
       secondary: secondary_sort
     };
-  }
+  };
 
-  handleIncludedCategoriesChange(
+  handleIncludedCategoriesChange = (
     newIncludedCategories,
     newIncludedSubcategories
-  ) {
+  ) => {
     let includedSubcategories = [];
     for (let category in newIncludedSubcategories) {
       if (newIncludedSubcategories.hasOwnProperty(category)) {
@@ -638,9 +592,9 @@ class PipelineSampleReport extends React.Component {
         this.applyFilters();
       }
     );
-  }
+  };
 
-  handleRemoveCategory(categoryToRemove) {
+  handleRemoveCategory = categoryToRemove => {
     let newIncludedCategories = this.state.includedCategories.filter(
       category => {
         return category != categoryToRemove;
@@ -650,9 +604,9 @@ class PipelineSampleReport extends React.Component {
       newIncludedCategories,
       this.state.includedSubcategories
     );
-  }
+  };
 
-  handleRemoveSubcategory(subcategoryToRemove) {
+  handleRemoveSubcategory = subcategoryToRemove => {
     let newIncludedSubcategories = this.state.includedSubcategories.filter(
       subcategory => {
         return subcategory != subcategoryToRemove;
@@ -662,9 +616,9 @@ class PipelineSampleReport extends React.Component {
       this.state.includedCategories,
       newIncludedSubcategories
     );
-  }
+  };
 
-  sortResults() {
+  sortResults = () => {
     this.setSortParams();
     let selected_taxons = this.state.selected_taxons;
     const taxonSortComparator = getTaxonSortComparator(
@@ -682,22 +636,22 @@ class PipelineSampleReport extends React.Component {
     this.state.taxonomy_details = this.state.taxonomy_details.sort(
       taxonSortComparator
     );
-  }
+  };
 
-  handleThresholdFiltersChange(activeThresholds) {
+  handleThresholdFiltersChange = activeThresholds => {
     ThresholdMap.saveThresholdFilters(activeThresholds);
     this.setState({ activeThresholds }, () => {
       this.applyFilters(true);
     });
-  }
+  };
 
-  handleRemoveThresholdFilter(pos) {
+  handleRemoveThresholdFilter = pos => {
     const activeThresholds = Object.assign([], this.state.activeThresholds);
     activeThresholds.splice(pos, 1);
     this.handleThresholdFiltersChange(activeThresholds);
-  }
+  };
 
-  handleBackgroundModelChange(_, data) {
+  handleBackgroundModelChange = (_, data) => {
     if (data.value === this.state.backgroundData.id) {
       // Skip if no change
       return;
@@ -719,31 +673,31 @@ class PipelineSampleReport extends React.Component {
         this.props.refreshPage({ background_id: data.value });
       }
     );
-  }
+  };
 
-  handleNameTypeChange(_, data) {
+  handleNameTypeChange = (_, data) => {
     Cookies.set("name_type", data.value);
     this.setState({ name_type: data.value });
-  }
+  };
 
-  handleSpecificityChange(_, data) {
+  handleSpecificityChange = (_, data) => {
     Cookies.set("readSpecificity", data.value);
     this.setState({ readSpecificity: data.value }, () => {
       this.applyFilters();
     });
-  }
+  };
 
-  handleTreeMetricChange(_, data) {
+  handleTreeMetricChange = (_, data) => {
     Cookies.set("treeMetric", data.value);
     this.setState({ treeMetric: data.value });
-  }
+  };
 
-  handleViewClicked(_, data) {
+  handleViewClicked = (_, data) => {
     this.setState({ view: data.name });
-  }
+  };
 
   // path to NCBI
-  gotoNCBI(e) {
+  gotoNCBI = e => {
     const taxId = e.target.getAttribute("data-tax-id");
     let num = parseInt(taxId);
     if (num < -1e8) {
@@ -752,18 +706,18 @@ class PipelineSampleReport extends React.Component {
     num = num.toString();
     const ncbiLink = `https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=${num}`;
     window.open(ncbiLink, "hide_referrer");
-  }
+  };
 
   // download Fasta
-  downloadFastaUrl(e) {
+  downloadFastaUrl = e => {
     const taxLevel = e.target.getAttribute("data-tax-level");
     const taxId = e.target.getAttribute("data-tax-id");
     location.href = `/samples/${
       this.sample_id
     }/fasta/${taxLevel}/${taxId}/NT_or_NR`;
-  }
+  };
 
-  gotoAlignmentVizLink(e) {
+  gotoAlignmentVizLink = e => {
     const taxId = e.target.getAttribute("data-tax-id");
     const taxLevel = e.target.getAttribute("data-tax-level");
     const pipeline_version = this.props.reportPageParams.pipeline_version;
@@ -772,9 +726,9 @@ class PipelineSampleReport extends React.Component {
         this.sample_id
       }/alignment_viz/nt_${taxLevel}_${taxId}?pipeline_version=${pipeline_version}`
     );
-  }
+  };
 
-  displayHoverActions(taxInfo, reportDetails) {
+  displayHoverActions = (taxInfo, reportDetails) => {
     let tax_level_str = "";
     let ncbiDot, fastaDot, alignmentVizDot, phyloTreeDot;
     if (taxInfo.tax_level == 1) tax_level_str = "species";
@@ -847,9 +801,9 @@ class PipelineSampleReport extends React.Component {
         />
       </span>
     );
-  }
+  };
 
-  displayHighlightTags(taxInfo) {
+  displayHighlightTags = taxInfo => {
     const watchDot = (
       <i
         data-tax-id={taxInfo.tax_id}
@@ -883,9 +837,9 @@ class PipelineSampleReport extends React.Component {
         ) : null}
       </div>
     );
-  }
+  };
 
-  renderName(tax_info, report_details, backgroundData, openTaxonModal) {
+  renderName = (tax_info, report_details, backgroundData, openTaxonModal) => {
     let taxCommonName = tax_info["common_name"];
     const taxonName = getTaxonName(tax_info, this.state.name_type);
 
@@ -959,16 +913,16 @@ class PipelineSampleReport extends React.Component {
       );
     }
     return taxonDescription;
-  }
+  };
 
-  renderNumber(
+  renderNumber = (
     ntCount,
     nrCount,
     num_decimals,
     isAggregate = false,
     visible_flag = true,
     showInsight = false
-  ) {
+  ) => {
     if (!visible_flag) {
       return null;
     }
@@ -997,42 +951,42 @@ class PipelineSampleReport extends React.Component {
         {nrCountLabel}
       </td>
     );
-  }
+  };
 
-  switchClassName(countType, countValue) {
+  switchClassName = (countType, countValue) => {
     const isCountBlank = countValue === 0 || countValue === -100 ? "blank" : "";
     const isActive = this.state.countType === countType ? "active" : "";
     return `${isActive} ${isCountBlank} count-type`;
-  }
+  };
 
-  isSortedActive(columnName) {
+  isSortedActive = columnName => {
     const desiredSort = columnName.toLowerCase();
     return this.state.sort_by == desiredSort ? "active" : "";
-  }
+  };
 
-  render_sort_arrow(column, desired_sort_direction, arrow_direction) {
+  render_sort_arrow = (column, desired_sort_direction, arrow_direction) => {
     let className = `${this.isSortedActive(
       column
     )} fa fa-chevron-${arrow_direction}`;
     return (
       <i
-        onClick={this.applySort.bind(this, column)}
+        onClick={() => this.applySort(column)}
         className={className}
         key={column.toLowerCase()}
       />
     );
-  }
+  };
 
-  renderColumnHeader(
+  renderColumnHeader = (
     visible_metric,
     column_name,
     tooltip_message,
     visible_flag = true
-  ) {
+  ) => {
     let element = (
       <div
         className="sort-controls"
-        onClick={this.applySort.bind(this, column_name)}
+        onClick={() => this.applySort(column_name)}
       >
         <span
           className={`${this.isSortedActive(column_name)} table-head-label`}
@@ -1048,16 +1002,16 @@ class PipelineSampleReport extends React.Component {
         <BasicPopup trigger={element} content={tooltip_message} />
       </th>
     );
-  }
+  };
 
-  isTaxonExpanded(taxInfo) {
+  isTaxonExpanded = taxInfo => {
     return (
       (this.expandAll && taxInfo.genus_taxid > 0) ||
       this.expandedGenera.indexOf(taxInfo.genus_taxid.toString()) >= 0
     );
-  }
+  };
 
-  getRowClass(taxInfo, confirmedTaxIds, watchedTaxIds) {
+  getRowClass = (taxInfo, confirmedTaxIds, watchedTaxIds) => {
     const topScoringRow = taxInfo.topScoring === 1;
 
     let taxonStatusClass = "";
@@ -1083,25 +1037,25 @@ class PipelineSampleReport extends React.Component {
       taxonStatusClass,
       topScoringRow && "top-scoring-row"
     );
-  }
+  };
 
-  expandGenusClick(e) {
+  expandGenusClick = e => {
     const className = e.target.attributes.class.nodeValue;
     const attr = className.split(" ");
     const taxId = attr[2];
     this.expandGenus(taxId);
-  }
+  };
 
-  expandGenus(taxId) {
+  expandGenus = taxId => {
     const taxIdIdx = this.expandedGenera.indexOf(taxId);
     if (taxIdIdx < 0) {
       this.expandedGenera.push(taxId);
     }
     $(`.report-row-species.${taxId}`).removeClass("hidden");
     $(`.report-arrow.${taxId}`).toggleClass("hidden");
-  }
+  };
 
-  collapseGenus(e) {
+  collapseGenus = e => {
     const className = e.target.attributes.class.nodeValue;
     const attr = className.split(" ");
     const taxId = attr[2];
@@ -1111,9 +1065,9 @@ class PipelineSampleReport extends React.Component {
     }
     $(`.report-row-species.${taxId}`).addClass("hidden");
     $(`.report-arrow.${taxId}`).toggleClass("hidden");
-  }
+  };
 
-  expandTable(e) {
+  expandTable = e => {
     // expand all real genera
     this.expandAll = true;
     this.expandedGenera = [];
@@ -1121,9 +1075,9 @@ class PipelineSampleReport extends React.Component {
     $(".report-arrow-down").removeClass("hidden");
     $(".report-arrow-right").addClass("hidden");
     $(".table-arrow").toggleClass("hidden");
-  }
+  };
 
-  collapseTable(e) {
+  collapseTable = e => {
     // collapse all genera (real or negative)
     this.expandAll = false;
     this.expandedGenera = [];
@@ -1131,15 +1085,15 @@ class PipelineSampleReport extends React.Component {
     $(".report-arrow-down").addClass("hidden");
     $(".report-arrow-right").removeClass("hidden");
     $(".table-arrow").toggleClass("hidden");
-  }
+  };
 
-  handleSearch(e) {
+  handleSearch = e => {
     this.setState({
       searchKey: e.target.value
     });
-  }
+  };
 
-  searchSelectedTaxon(value, item) {
+  searchSelectedTaxon = (value, item) => {
     let searchId = item[1];
     this.setState(
       {
@@ -1150,7 +1104,7 @@ class PipelineSampleReport extends React.Component {
         this.applyFilters();
       }
     );
-  }
+  };
 
   // Fill in desired URL parameters so user's can copy and paste URLs.
   // Ex: Add ?pipeline_version=1.7&background_id=4 to /samples/545
@@ -1161,7 +1115,7 @@ class PipelineSampleReport extends React.Component {
   // (1) URL parameter specified
   // (2) saved background name in frontend cookie
   // (3) the default background
-  fillUrlParams() {
+  fillUrlParams = () => {
     // Skip if report is not present or a background ID and pipeline version
     // are explicitly specified in the URL.
     if (
@@ -1189,20 +1143,20 @@ class PipelineSampleReport extends React.Component {
     params["background_id"] = this.props.reportPageParams.background_id;
     // Modify the URL in place without triggering a page reload.
     history.replaceState(null, null, `?${stringer.stringify(params)}`);
-  }
+  };
 
-  fetchParams(param) {
+  fetchParams = param => {
     let url = new URL(window.location);
     return url.searchParams.get(param);
-  }
+  };
 
   // Select the background ID with the matching name.
-  getBackgroundIdByName(name) {
+  getBackgroundIdByName = name => {
     let match = this.all_backgrounds.filter(b => b["name"] === name);
     if (match && match[0] && match[0]["id"]) {
       return match[0]["id"];
     }
-  }
+  };
 
   render() {
     const filter_stats = `${

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
   },
   "dependencies": {
     "axios": "^0.17.1",
+    "babel-eslint": "^10.0.1",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "classnames": "^2.2.6",
     "clusterfck": "git+https://github.com/chanzuckerberg/clusterfck.git#master",


### PR DESCRIPTION
The transform-class-properties plugin is added.

The plugin technically just enables the "=" syntax. The arrow function is already enabled.

```
class Cat {
  getBreed = function() {
    return 'Meow'
  }
}
```

is now transformed by Babel to:
```
class Cat {
  constructor() {
    this.getBreed = function() {
       return 'Meow'
    }
  }
}
```

Combined with the existing arrow function (which already does not create a new `this` context) allows us to remove the bind statements.
