### PR TITLE
Use more efficient sourcemap for webpack dev build.

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -13,7 +13,7 @@ const config = {
     path: path.resolve(__dirname, "app/assets/"),
     filename: "dist/bundle.min.js"
   },
-  devtool: "source-map",
+  devtool: "cheap-module-eval-source-map",
   target: "web",
   resolve: {
     extensions: [".js", ".jsx"]


### PR DESCRIPTION
Increases CSS rebuild speed by factor of 3 and JS by factor of 5.

The trade-off is the dev output file is much larger.
We keep prod the same.