### PR TITLE
Add CSS module capabilities and refactor cli_user_instructions.scss.

### DIFF
--- a/app/assets/src/components/views/CliUserInstructions.jsx
+++ b/app/assets/src/components/views/CliUserInstructions.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Form, TextArea } from "semantic-ui-react";
 import PropTypes from "prop-types";
+import cx from "classnames";
+import cs from "./cli_user_instructions.scss";
 
 class CliUserInstructions extends React.Component {
   render() {
@@ -15,21 +17,21 @@ class CliUserInstructions extends React.Component {
     const genomesList = `'${this.props.hostGenomes.join("', '")}'`;
 
     return (
-      <div className="instruction-container">
-        <p className="instruction-heading">
+      <div className={cs.instructionContainer}>
+        <p className={cs.instructionHeading}>
           {
             "(1) Install and configure the Amazon Web Services Command Line Interface (AWS CLI): "
           }
         </p>
         <div>
           For macOS users: We recommend trying the Homebrew package manager to
-          install <span className="code">awscli</span>. You can install by
+          install <span className={cs.code}>awscli</span>. You can install by
           running these commands:
-          <div className="code-bullet">
+          <div className={cs.codeBullet}>
             /usr/bin/ruby -e "$(curl -fsSL
             https://raw.githubusercontent.com/Homebrew/install/master/install)"
           </div>
-          <div className="code-bullet">brew install awscli</div>
+          <div className={cs.codeBullet}>brew install awscli</div>
         </div>
         <p>
           {`- Otherwise follow the AWS installation instructions `}
@@ -44,59 +46,61 @@ class CliUserInstructions extends React.Component {
           {`. `}
         </p>
         <p>
-          - Verify it works by running <span className="code">aws help</span>,
+          - Verify it works by running <span className={cs.code}>aws help</span>,
           which should display usage instructions. You do not need to set up AWS
           credentials unless you're using the bulk upload mode.
         </p>
-        <p className="instruction-heading">(2) Install the IDseq CLI:</p>
+        <p className={cs.instructionHeading}>(2) Install the IDseq CLI:</p>
         <div>
-          <span className="code">
+          <span className={cs.code}>
             pip install git+https://github.com/chanzuckerberg/idseq-cli.git
             --upgrade
           </span>
-          <p className="instruction-medium-margin-top">
+          <p className={cs.instructionMediumMarginTop}>
             - Tips: Make sure you have Python 2 or 3 installed already. Try
-            running <span className="code">pip --version</span> or{" "}
-            <span className="code">python --version</span>.
+            running <span className={cs.code}>pip --version</span> or{" "}
+            <span className={cs.code}>python --version</span>.
           </p>
           <p>
-            - Try running with <span className="code">pip2</span> or{" "}
-            <span className="code">pip3</span> depending on your configuration.
-            Try <span className="code">sudo pip</span> if you run into
-            permissions errors (anything like OSError: [Errno 13] Permission
-            denied). You can use this same command in the future to update the
-            CLI if needed.
+            - Try running with <span className={cs.code}>pip2</span> or{" "}
+            <span className={cs.code}>pip3</span> depending on your
+            configuration. Try <span className={cs.code}>sudo pip</span> if you
+            run into permissions errors (anything like OSError: [Errno 13]
+            Permission denied). You can use this same command in the future to
+            update the CLI if needed.
           </p>
         </div>
         <p />
-        <p className="instruction-heading">(3) Upload a single sample:</p>
-        <div className="code center-code">
+        <p className={cs.instructionHeading}>(3) Upload a single sample:</p>
+        <div className={cx(cs.code, cs.center)}>
           <p>
-            idseq -e <span className="code-personal">{this.props.email}</span>{" "}
-            -t <span className="code-personal">{this.props.authToken}</span> -p
+            idseq -e <span className={cs.codePersonal}>{this.props.email}</span>{" "}
+            -t <span className={cs.codePersonal}>{this.props.authToken}</span>{" "}
+            -p
             {"'"}
-            <span className="code-to-edit">Your Project Name</span>
+            <span className={cs.codeToEdit}>Your Project Name</span>
             {"' -s '"}
-            <span className="code-to-edit">Your Sample Name</span>
+            <span className={cs.codeToEdit}>Your Sample Name</span>
             {"'"} \
-            <br /> --r1 <span className="code-to-edit">
+            <br /> --r1 <span className={cs.codeToEdit}>
               your_sample_R1
             </span>.fastq.gz --r2{" "}
-            <span className="code-to-edit">your_sample_R2</span>.fastq.gz
-            --host-genome-name <span className="code-to-edit">{"'Human'"}</span>
+            <span className={cs.codeToEdit}>your_sample_R2</span>.fastq.gz
+            --host-genome-name{" "}
+            <span className={cs.codeToEdit}>{"'Human'"}</span>
           </p>
         </div>
-        <div className="instruction-medium-margin-top">
+        <div className={cs.instructionMediumMarginTop}>
           Edit the command in this text box and copy-and-paste:
-          <Form className="instruction-medium-margin-top">
+          <Form className={cs.instructionMediumMarginTop}>
             <TextArea
-              className="code-personal"
+              className={cs.codePersonal}
               defaultValue={singleUploadCmd}
               autoHeight
             />
           </Form>
         </div>
-        <p className="instruction-medium-margin-top">
+        <p className={cs.instructionMediumMarginTop}>
           {
             "- Supported file types: .fastq/.fq/.fasta/.fa or .fastq.gz/.fq.gz/.fasta.gz/.fa.gz"
           }
@@ -104,7 +108,7 @@ class CliUserInstructions extends React.Component {
         <p>{`- Supported host genome values: ${genomesList}`}</p>
         <p>
           {"- Your authentication token for uploading is: "}
-          <span className="code-personal">{this.props.authToken}</span>
+          <span className={cs.codePersonal}>{this.props.authToken}</span>
           {"  Keep this private like a password!"}
         </p>
         <p>
@@ -119,9 +123,9 @@ class CliUserInstructions extends React.Component {
         </p>
         <p>
           - New to using a command line? You will need to use{" "}
-          <span className="code">cd</span> and <span className="code">ls</span>{" "}
-          to navigate to the folder on your computer containing the source files
-          you want to upload.{" "}
+          <span className={cs.code}>cd</span> and{" "}
+          <span className={cs.code}>ls</span> to navigate to the folder on your
+          computer containing the source files you want to upload.{" "}
           <a
             href="https://courses.cs.washington.edu/courses/cse140/13wi/shell-usage.html"
             target="_blank"
@@ -131,51 +135,54 @@ class CliUserInstructions extends React.Component {
             Guide here
           </a>.
         </p>
-        <p className="instruction-heading">
+        <p className={cs.instructionHeading}>
           (Optional) Run the program in interactive mode:
         </p>
         <p>
-          Having trouble? Just run <span className="code">idseq</span> without
-          any parameters and the program will guide you through the process.
+          Having trouble? Just run <span className={cs.code}>idseq</span>{" "}
+          without any parameters and the program will guide you through the
+          process.
         </p>
-        <p className="instruction-heading">
+        <p className={cs.instructionHeading}>
           (Optional) Upload samples in bulk mode by specifying a folder:
         </p>
-        <div className="code center-code">
+        <div className={cx(cs.code, cs.center)}>
           <p>
-            idseq -e <span className="code-personal">{this.props.email}</span>{" "}
-            -t <span className="code-personal">{this.props.authToken}</span> -p
+            idseq -e <span className={cs.codePersonal}>{this.props.email}</span>{" "}
+            -t <span className={cs.codePersonal}>{this.props.authToken}</span>{" "}
+            -p
             {"'"}
-            <span className="code-to-edit">Your Project Name</span>
+            <span className={cs.codeToEdit}>Your Project Name</span>
             {"'"} \
             <br /> --bulk{" "}
-            <span className="code-to-edit">
+            <span className={cs.codeToEdit}>
               /path/to/your/folder{" "}
             </span>--host-genome-name{" "}
-            <span className="code-to-edit">{"'Human'"}</span>
+            <span className={cs.codeToEdit}>{"'Human'"}</span>
           </p>
         </div>
-        <div className="instruction-medium-margin-top">
+        <div className={cs.instructionMediumMarginTop}>
           Edit the command in this text box and copy-and-paste:
-          <Form className="instruction-medium-margin-top">
+          <Form className={cs.instructionMediumMarginTop}>
             <TextArea
-              className="code-personal"
+              className={cs.codePersonal}
               defaultValue={bulkUploadCmd}
               autoHeight
             />
           </Form>
         </div>
-        <p className="instruction-medium-margin-top">
+        <p className={cs.instructionMediumMarginTop}>
           {
             "- The '.' refers to the current folder in your terminal. The program will try to auto-detect files in the folder."
           }
         </p>
-        <p className="upload-question">
+        <p className={cs.uploadQuestion}>
           For more information on the IDseq CLI, have a look at its{" "}
           <a
             href="https://github.com/chanzuckerberg/idseq-cli"
             target="_blank"
             rel="noopener noreferrer"
+            className={cs.link}
           >
             GitHub repository
           </a>.

--- a/app/assets/src/components/views/cli_user_instructions.scss
+++ b/app/assets/src/components/views/cli_user_instructions.scss
@@ -1,0 +1,65 @@
+@import "~styles/typography";
+@import "~styles/themes/colors";
+
+.instructionContainer {
+  margin: 5%;
+}
+
+.instructionHeading {
+  margin-top: 2.2rem;
+  font-weight: $font-weight-bold;
+  font-size: 1.2rem;
+}
+
+.instructionMediumMarginTop {
+  margin-top: 1rem;
+}
+
+.codeBullet {
+  width: fit-content;
+  background-color: $primary-lightest;
+  white-space: nowrap;
+  font-family: monospace;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.code {
+  background-color: $primary-lightest;
+  white-space: nowrap;
+  font-family: monospace;
+  &.center {
+    width: -webkit-fit-content;
+    width: fit-content;
+  }
+  p {
+    font-family: monospace;
+  }
+}
+
+.codeToEdit {
+  color: $primary-lighter;
+  font-family: monospace;
+  font-weight: $font-weight-bold;
+}
+
+.codePersonal {
+  font-family: monospace;
+  font-weight: $font-weight-bold;
+}
+
+.uploadQuestion {
+  color: $darkest-grey;
+  font-size: $font-size-small;
+  margin-top: 20px;
+  margin-bottom: 25px;
+
+  .link {
+    font-weight: $font-weight-semibold;
+
+    &:hover {
+      // Important due to a { color: inherit !important; } in header.scss.
+      color: $primary-light !important;
+    }
+  }
+}

--- a/app/assets/src/styles/_header.scss
+++ b/app/assets/src/styles/_header.scss
@@ -27,6 +27,7 @@ body {
   overflow-x: hidden;
 }
 
+// TODO(mark): Refactor all <a> elements into a <Link> component, and remove.
 a {
   color: inherit !important;
 }
@@ -193,30 +194,6 @@ a {
     color: $medium-grey;
     font-size: $font-size-base;
   }
-}
-
-.code {
-  background-color: $primary-lightest;
-  white-space: nowrap;
-  font-family: monospace;
-  &.center-code {
-    width: -webkit-fit-content;
-    width: fit-content;
-  }
-  p {
-    font-family: monospace;
-  }
-}
-
-.code-to-edit {
-  color: $primary-lighter;
-  font-family: monospace;
-  font-weight: $font-weight-bold;
-}
-
-.code-personal {
-  font-family: monospace;
-  font-weight: $font-weight-bold;
 }
 
 .modal-overlay {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,7 +1,15 @@
 const path = require("path");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
+var STYLE_DIR = path.resolve(__dirname, "app/assets/src/styles");
+
 const config = {
+  resolve: {
+    extensions: [".js", ".jsx"],
+    alias: {
+      styles: STYLE_DIR
+    }
+  },
   plugins: [
     new MiniCssExtractPlugin({
       filename: "dist/bundle.min.css"
@@ -15,9 +23,6 @@ const config = {
   },
   devtool: "source-map",
   target: "web",
-  resolve: {
-    extensions: [".js", ".jsx"]
-  },
   module: {
     rules: [
       {
@@ -31,8 +36,41 @@ const config = {
         loader: "babel-loader"
       },
       {
-        // sass / scss loader for webpack
+        // Use CSS modules for new files.
         test: /\.(sa|sc|c)ss$/,
+        exclude: [
+          path.resolve(__dirname, "node_modules/"),
+          path.resolve(__dirname, "app/assets/src/styles"),
+          path.resolve(__dirname, "app/assets/src/loader.scss")
+        ],
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: "css-loader",
+            options: {
+              minimize: true,
+              sourceMap: true,
+              modules: true,
+              localIdentName: "[local]-[hash:base64:5]"
+            }
+          },
+          {
+            loader: "sass-loader",
+            options: {
+              minimize: true,
+              sourceMap: true
+            }
+          }
+        ]
+      },
+      {
+        // Legacy files in assets/src/styles.
+        test: /\.(sa|sc|c)ss$/,
+        include: [
+          path.resolve(__dirname, "node_modules/"),
+          path.resolve(__dirname, "app/assets/src/styles"),
+          path.resolve(__dirname, "app/assets/src/loader.scss")
+        ],
         use: [
           MiniCssExtractPlugin.loader,
           {


### PR DESCRIPTION
This is a new proposal for using CSS modules to scope our CSS classes. I've refactored cli_user_instructions.scss to demonstrate this.

The output now looks like this. The CSS classes have a hash appended to them.

![screen shot 2018-10-22 at 6 25 03 pm](https://user-images.githubusercontent.com/837004/47329113-594c2b00-d628-11e8-8039-4c60f98ce257.png)

The styling of the page is unchanged.
![screen shot 2018-10-22 at 6 34 35 pm](https://user-images.githubusercontent.com/837004/47329341-27879400-d629-11e8-8bf0-96a153eeadae.png)

This allows us to use simpler CSS classes going forward without worrying about name conflicts with 3rd party libraries, or other CSS classes.

Note that the new CSS modules are only applied to files **outside of the traditional style directory**.
This allows us to move the existing CSS to CSS modules incrementally. The existing CSS still works.

Finally, some people warn against using CSS modules with SCSS.
https://medium.com/jsdownunder/webpack-build-performance-pitfall-of-using-sass-with-css-modules-ba32f89efdcb

Specifically, the webpack start-up time is supposed to get really slow as the number of SCSS entry points goes up. It's not clear if these issues have been addressed, but `sass-loader` does seem to have improved recently.
I tested with 7 SCSS entry points and didn't notice any increase in initial build time, so I think we are okay for the time being. If the webpack start-up time starts going up, we can move to PostCSS (which should be more much more performant) with minimal refactoring. 

