### PR TITLE
require minimum LZW vocabulary length (JIRA-625)

### DIFF
--- a/app/lib/dags/host_filter.json.erb
+++ b/app/lib/dags/host_filter.json.erb
@@ -94,7 +94,7 @@
       "class": "PipelineStepRunLZW",
       "module": "idseq_dag.steps.run_lzw",
       "additional_files": {},
-      "additional_attributes": { "thresholds": [0.45, 0.42] }
+      "additional_attributes": { "thresholds": [67.5, 63.0] }
     },
     {
       "in": ["lzw_out"],


### PR DESCRIPTION
Removes read length from the picture. New thresholds are old thresholds multiplied by 150. So filtering behavior should be the same as before for 150-bp reads but more lenient with longer reads.
Goes with https://github.com/chanzuckerberg/idseq-dag/pull/88