### PR TITLE
Fix styling with long names in sample reads subheader.

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -864,7 +864,12 @@ class PipelineSampleReads extends React.Component {
     if (this.reportPresent) {
       report_buttons = (
         <Popup
-          trigger={<DownloadButton onClick={this.downloadCSV} />}
+          trigger={
+            <DownloadButton
+              onClick={this.downloadCSV}
+              className={cs.reportButton}
+            />
+          }
           content="Download Table as CSV"
           inverted
           on="hover"
@@ -872,7 +877,11 @@ class PipelineSampleReads extends React.Component {
       );
     } else if (this.sampleInfo.status === "created" || !this.reportPresent) {
       report_buttons = (
-        <PrimaryButton onClick={this.deleteSample} text="Delete Sample" />
+        <PrimaryButton
+          onClick={this.deleteSample}
+          text="Delete Sample"
+          className={cs.reportButton}
+        />
       );
     }
 
@@ -899,10 +908,10 @@ class PipelineSampleReads extends React.Component {
             </div>
             <div className={cs.topRow}>
               <div className={cs.breadcrumbs}>
-                <div className={cs.projectName}>
+                <div className={cs.projectNameContainer}>
                   <a
                     href={`/home?project_id=${this.projectInfo.id}`}
-                    className={cs.hover}
+                    className={cs.projectName}
                   >
                     {this.projectInfo.name}
                   </a>

--- a/app/assets/src/components/pipeline_sample_reads.scss
+++ b/app/assets/src/components/pipeline_sample_reads.scss
@@ -21,16 +21,26 @@
   }
 
   .breadcrumbs {
-    .projectName {
+    margin-right: 20px;
+
+    .projectNameContainer {
       font-size: $font-size-body;
       color: $medium-grey;
       font-weight: $font-weight-semibold;
       letter-spacing: 0.5px;
       margin-bottom: 8px;
+      display: flex;
 
-      .hover:hover {
-        /* Overwrite header.scss */
-        color: $primary-light !important;
+      .projectName {
+        max-width: 600px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+
+        &:hover {
+          /* Overwrite header.scss */
+          color: $primary-light !important;
+        }
       }
     }
 
@@ -47,6 +57,8 @@
       font-weight: $font-weight-semibold;
       letter-spacing: 1px;
       font-size: $font-size-h3;
+      word-break: break-all;
+      line-height: $line-height-h3;
     }
 
     .trigger {
@@ -57,5 +69,9 @@
         color: $primary-light;
       }
     }
+  }
+
+  .reportButton {
+    flex-shrink: 0;
   }
 }

--- a/app/assets/src/styles/_typography.scss
+++ b/app/assets/src/styles/_typography.scss
@@ -26,6 +26,9 @@ $font-size-h6: ceil(($font-size-base * 0.85)) !default; // ~12px
 $font-size-body: $font-size-base !default; // ~14px
 $font-size-caption: $font-size-h6 !default; // ~12px
 
+// TODO(mark): Add the other line heights as they are needed.
+$line-height-h3: ceil(($font-size-h3 * 1.4)) !default; // ~36px
+
 //Font Weights
 $font-weight-thin: 300;
 $font-weight-regular: 400;


### PR DESCRIPTION
Previously, long names would overflow and push the button away.

Now, the project name is truncated and ellipsed, and the sample name is wrapped. 

Before:
<img width="1464" alt="screen shot 2018-10-31 at 3 51 10 pm" src="https://user-images.githubusercontent.com/837004/47823285-d19ba600-dd24-11e8-8390-1f8134e9c7a2.png">

Now:
<img width="1363" alt="screen shot 2018-10-31 at 3 45 21 pm" src="https://user-images.githubusercontent.com/837004/47823259-b3ce4100-dd24-11e8-86d7-22f08ab164e7.png">
<img width="1367" alt="screen shot 2018-10-31 at 3 45 43 pm" src="https://user-images.githubusercontent.com/837004/47823262-b6309b00-dd24-11e8-9c46-47c1bc08181b.png">
