### PR TITLE
JIRA-657: remove retry button

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -37,7 +37,6 @@ class PipelineSampleReads extends React.Component {
     this.reportTime = props.reportTime;
     this.allCategories = props.allCategories;
     this.reportDetails = props.reportDetails;
-    this.pipelineRunRetriable = props.pipelineRunRetriable;
     this.pipelineVersions = props.pipeline_versions;
 
     this.jobStatistics = props.jobStatistics;
@@ -839,27 +838,6 @@ class PipelineSampleReads extends React.Component {
         version_display + ", NT/NR: " + this.pipelineRun.version.alignment_db;
     }
 
-    let retriable = this.pipelineRunRetriable ? (
-      <div className="row">
-        <div className="col s12">
-          <div className="content-title">Retry Pipeline</div>
-          <h6 className={this.state.rerunStatus}>
-            {this.state.rerunStatus === "success" ? waitingSpinner : null}
-          </h6>
-          <p>
-            Pipeline was not 100% successful. Sample status:{" "}
-            <b>{this.pipelineStatus}</b> <br />
-            {this.state.rerunStatus === "failed" && this.can_edit ? (
-              <a onClick={this.rerunPipeline} className="custom-button small">
-                <i className="fa fa-repeat" />
-                RETRY PIPELINE
-              </a>
-            ) : null}
-          </p>
-        </div>
-      </div>
-    ) : null;
-
     let report_buttons = null;
     if (this.reportPresent) {
       report_buttons = (
@@ -1054,7 +1032,6 @@ class PipelineSampleReads extends React.Component {
                   </div>
                 </div>
                 {this.renderERCC()}
-                {retriable}
               </div>
 
               <div className="col s3 download-area">

--- a/app/views/samples/show.html.erb
+++ b/app/views/samples/show.html.erb
@@ -8,7 +8,6 @@
       sampleInfo: JSON.parse('<%= raw escape_json(@sample) %>'),
       projectInfo: JSON.parse('<%= raw escape_json(@project_info) %>'),
       pipelineRun: JSON.parse('<%= raw escape_json(@pipeline_run_display) %>'),
-      pipelineRunRetriable: <%= @pipeline_run_retriable ? true : false  %>,
       jobStatistics: JSON.parse('<%= raw escape_json(@job_stats) %>'),
       project_sample_ids_names: JSON.parse('<%= raw escape_json(@project_sample_ids_names) %>'),
       host_genome: JSON.parse('<%= raw escape_json(@host_genome) %>'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8903,7 +8903,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
       "integrity":
-        "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+        "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
     },
     "merge-stream": {
       "version": "1.0.1",


### PR DESCRIPTION
There is a problem where the sample succeeded but refined_taxon_counts status shows as failed. Maybe due to the fact that that part can get retried. For this reason, the "not 100% successful -- retry" button is showing on successful new samples, which is confusing for new users. We decided some time ago that we don't want users to do retries by themselves, so let's just remove the button.