### PR TITLE
Don't allow docker container to override files in local fs

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,9 @@ ActiveRecord::Schema.define(version: 20_181_107_235_404) do
     t.float "depth", limit: 24
     t.bigint "pipeline_run_id"
     t.string "drug_family"
+    t.integer "level"
+    t.float "drug_gene_coverage", limit: 24
+    t.float "drug_gene_depth", limit: 24
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["pipeline_run_id", "allele"], name: "index_amr_counts_on_pipeline_run_id_and_allele", unique: true
@@ -148,7 +151,7 @@ ActiveRecord::Schema.define(version: 20_181_107_235_404) do
   end
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "key", null: false
+    t.string "key", null: false, collation: "latin1_swedish_ci"
     t.integer "data_type", limit: 1, null: false
     t.string "text_raw_value"
     t.string "text_validated_value"
@@ -367,12 +370,12 @@ ActiveRecord::Schema.define(version: 20_181_107_235_404) do
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
   end
 
-  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
-    t.string "title"
-    t.text "summary"
-    t.text "description"
+    t.string "title", collation: "utf8mb4_general_ci"
+    t.text "summary", collation: "utf8mb4_general_ci"
+    t.text "description", collation: "utf8mb4_general_ci"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   webtest:
     image: chanzuckerberg/idseq-web:compose
     volumes:
-      - ~/.aws:/root/.aws
+      - ~/.aws:/root/.aws:ro
     ports:
       - "8000:8000"
     depends_on:
@@ -60,8 +60,11 @@ services:
     build: .
     image: chanzuckerberg/idseq-web:compose
     volumes:
-      - .:/app
-      - ~/.aws:/root/.aws
+      - .:/app:ro
+      - ./log:/app/log
+      - ./tmp:/app/tmp
+      - ./db:/app/db
+      - ~/.aws:/root/.aws:ro
     ports:
       - "3000:3000"
     depends_on:
@@ -108,8 +111,9 @@ services:
   resque:
     image: chanzuckerberg/idseq-web:compose
     volumes:
-      - .:/app
-      - ~/.aws:/root/.aws
+      - .:/app:ro
+      - ./log:/app/log
+      - ~/.aws:/root/.aws:ro
     depends_on:
       - db
       - redis
@@ -148,8 +152,9 @@ services:
   resque_result_monitor:
     image: chanzuckerberg/idseq-web:compose
     volumes:
-      - .:/app
-      - ~/.aws:/root/.aws
+      - .:/app:ro
+      - ./log:/app/log
+      - ~/.aws:/root/.aws:ro
     depends_on:
       - db
       - redis
@@ -188,8 +193,9 @@ services:
   resque_pipeline_monitor:
     image: chanzuckerberg/idseq-web:compose
     volumes:
-      - .:/app
-      - ~/.aws:/root/.aws
+      - .:/app:ro
+      - ./log:/app/log
+      - ~/.aws:/root/.aws:ro
     depends_on:
       - db
       - redis


### PR DESCRIPTION
# Description

Previously if you ran 'docker build' or 'docker-compose build' as the last step before committing files, you may overwrite package.json / package-lock.json (and possibly other files as well). We should load the local filesystem as read-only except for directories we expect rails to write to.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)
