### PR TITLE
Bug fix for #metadata

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -172,9 +172,18 @@ class SamplesController < ApplicationController
   # GET /samples/1/metadata
   # GET /samples/1/metadata.json
   def metadata
-    pipeline_run = select_pipeline_run(@sample, params)
-    pipeline_run_id = pipeline_run ? pipeline_run.id : nil
-    job_stats_hash = job_stats_get(pipeline_run_id)
+    pr = select_pipeline_run(@sample, params)
+    summary_stats = nil
+    pr_display = nil
+    ercc_comparison = nil
+    if pr
+      job_stats_hash = job_stats_get(pr.id)
+      if job_stats_hash.present?
+        summary_stats = get_summary_stats(job_stats_hash, pr)
+      end
+      pr_display = curate_pipeline_run_display(pr)
+      ercc_comparison = pr.compare_ercc_counts
+    end
 
     render json: {
       metadata: @sample.metadata,
@@ -184,9 +193,9 @@ class SamplesController < ApplicationController
         upload_date: @sample.created_at,
         project_name: @sample.project.name,
         project_id: @sample.project_id,
-        pipeline_run: curate_pipeline_run_display(pipeline_run),
-        ercc_comparison: pipeline_run.compare_ercc_counts,
-        summary_stats: job_stats_hash.present? ? get_summary_stats(job_stats_hash, pipeline_run) : nil,
+        pipeline_run: pr_display,
+        ercc_comparison: ercc_comparison,
+        summary_stats: summary_stats,
         notes: @sample.sample_notes
       }
     }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -176,13 +176,15 @@ class SamplesController < ApplicationController
     summary_stats = nil
     pr_display = nil
     ercc_comparison = nil
+
     if pr
+      pr_display = curate_pipeline_run_display(pr)
+      ercc_comparison = pr.compare_ercc_counts
+
       job_stats_hash = job_stats_get(pr.id)
       if job_stats_hash.present?
         summary_stats = get_summary_stats(job_stats_hash, pr)
       end
-      pr_display = curate_pipeline_run_display(pr)
-      ercc_comparison = pr.compare_ercc_counts
     end
 
     render json: {


### PR DESCRIPTION
- Was getting
```
web_1                      | [2018-11-09T21:46:09] DEBUG ActiveRecord::Base :   Project Load (0.9ms)  SELECT  `projects`.* FROM `projects` WHERE `projects`.`id` = 25 LIMIT 1
web_1                      | [2018-11-09T21:46:09] DEBUG Rails :   Query Trace > app/controllers/samples_controller.rb:185:in `metadata'
web_1                      | [2018-11-09T21:46:09] INFO  ActionController::Base : Completed 500 Internal Server Error in 131ms (ActiveRecord: 18.4ms)
web_1                      |
web_1                      |
web_1                      | [2018-11-09T21:46:09] FATAL Rails :
web_1                      | [2018-11-09T21:46:09] FATAL Rails : NoMethodError (undefined method `compare_ercc_counts' for nil:NilClass):
web_1                      | [2018-11-09T21:46:09] FATAL Rails :
web_1                      | [2018-11-09T21:46:09] FATAL Rails : app/controllers/samples_controller.rb:188:in `metadata'
web_1                      | [2018-11-09T21:46:09] INFO  ActionView::Base :   Rendering /usr/local/bundle/gems/actionpack-5.1.6/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout
web_1                      | [2018-11-09T21:46:09] INFO  ActionView::Base :   Rendering /usr/local/bundle/gems/actionpack-5.1.6/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
```

so I just consolidated the pipeline_run checks