### PR TITLE
Turn on SampleDetailsSidebar and hide old Details Tab.

### DIFF
--- a/app/assets/src/components/PipelineSampleReads.jsx
+++ b/app/assets/src/components/PipelineSampleReads.jsx
@@ -887,6 +887,7 @@ class PipelineSampleReads extends React.Component {
         <AMRView amr={this.amr} />
       </div>
     ) : null;
+    const multipleTabs = show_amr;
 
     // Refresh the page every 5 minutes while in progress. Purpose is so that
     // users with the page open will get some sense of updated status and see
@@ -922,42 +923,40 @@ class PipelineSampleReads extends React.Component {
                 onClick: () => window.open(`/samples/${sampleId}`, "_self")
               }))}
             />
-            {this.props.admin && (
-              <div className={cs.sampleDetailsLinkContainer}>
-                <span
-                  className={cs.sampleDetailsLink}
-                  onClick={this.toggleSampleDetailsSidebar}
-                >
-                  Sample Details
-                </span>
-              </div>
-            )}
+            <div className={cs.sampleDetailsLinkContainer}>
+              <span
+                className={cs.sampleDetailsLink}
+                onClick={this.toggleSampleDetailsSidebar}
+              >
+                Sample Details
+              </span>
+            </div>
           </ViewHeader.Content>
           <ViewHeader.Controls>{report_buttons}</ViewHeader.Controls>
         </ViewHeader>
 
-        <div className="sub-header-navigation">
-          <div className="nav-content">
-            <ul className="tabs tabs-transparent">
-              <li className="tab">
-                <a href="#reports" className="active">
-                  Report
-                </a>
-              </li>
-              <li className="tab">
-                <a href="#details" className="">
-                  Details
-                </a>
-              </li>
-              {amr_tab}
-            </ul>
+        {multipleTabs && (
+          <div className="sub-header-navigation">
+            <div className="nav-content">
+              <ul className="tabs tabs-transparent">
+                <li className="tab">
+                  <a href="#reports" className="active">
+                    Report
+                  </a>
+                </li>
+                {amr_tab}
+              </ul>
+            </div>
           </div>
-        </div>
-        <Divider className="reports-divider" />
+        )}
+        <Divider
+          className={cx(cs.reportsDivider, multipleTabs && cs.hasTabs)}
+        />
 
         {amr_table}
 
-        <div id="details" className="tab-screen col s12">
+        {/* TODO(mark): Remove all old Sample Details code once new sidebar goes live */}
+        <div id="details" className={cx("tab-screen col s12", cs.detailsTab)}>
           <div className="center">
             <span className="note-action-feedback note-saved-success" />
             <span className="note-action-feedback note-save-failed" />
@@ -1080,14 +1079,12 @@ class PipelineSampleReads extends React.Component {
         >
           {d_report}
         </div>
-        {this.props.admin && (
-          <SampleDetailsSidebar
-            visible={this.state.sampleDetailsSidebarVisible}
-            onClose={this.toggleSampleDetailsSidebar}
-            sample={this.props.sampleInfo}
-            onNameUpdate={newName => this.setState({ sample_name: newName })}
-          />
-        )}
+        <SampleDetailsSidebar
+          visible={this.state.sampleDetailsSidebarVisible}
+          onClose={this.toggleSampleDetailsSidebar}
+          sample={this.props.sampleInfo}
+          onNameUpdate={newName => this.setState({ sample_name: newName })}
+        />
       </div>
     );
   }

--- a/app/assets/src/components/pipeline_sample_reads.scss
+++ b/app/assets/src/components/pipeline_sample_reads.scss
@@ -41,3 +41,18 @@
     margin-bottom: 0;
   }
 }
+
+.reportsDivider {
+  background-color: $off-white;
+  height: 8px !important;
+  border-top: 1px solid $white !important;
+
+  &.hasTabs {
+    margin-top: -5px !important;
+  }
+}
+
+// TODO(mark): Remove all old Sample Details code once new sidebar goes live
+.detailsTab {
+  display: none;
+}

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -21,12 +21,6 @@ input[type="number"] {
 
 //Report Sidebar and Filters Styling
 
-.reports-divider {
-  background-color: $off-white;
-  height: 8px !important;
-  border-top: 1px solid $white !important;
-  margin-top: -0.4rem !important;
-}
 #details table tr td {
   padding: 2px;
 }


### PR DESCRIPTION
Also hide the tabs if there is only one tab.

New normal view:

<img width="1399" alt="screen shot 2018-11-13 at 6 12 48 pm" src="https://user-images.githubusercontent.com/837004/48455494-3f59c000-e770-11e8-9566-b7cdfdf91dcf.png">


New "admin" view:

<img width="1462" alt="screen shot 2018-11-13 at 6 09 49 pm" src="https://user-images.githubusercontent.com/837004/48455487-35d05800-e770-11e8-81c7-defe8c0ae53f.png">

