### PR TITLE
Only allow editing in Sidebar if user has edit permissions.

### DIFF
--- a/app/assets/src/components/views/report/SampleDetailsSidebar/MetadataSection.jsx
+++ b/app/assets/src/components/views/report/SampleDetailsSidebar/MetadataSection.jsx
@@ -61,7 +61,10 @@ class MetadataSection extends React.Component {
     } = this.props;
     return (
       <div className={cx(cs.metadataSection, className)}>
-        <div className={cs.header} onClick={onToggle}>
+        <div
+          className={cx(cs.header, toggleable && cs.toggleable)}
+          onClick={onToggle}
+        >
           <div className={cs.title}>{title}</div>
           {editable &&
             (editing ? (

--- a/app/assets/src/components/views/report/SampleDetailsSidebar/MetadataTab.jsx
+++ b/app/assets/src/components/views/report/SampleDetailsSidebar/MetadataTab.jsx
@@ -166,7 +166,7 @@ class MetadataTab extends React.Component {
         {METADATA_SECTIONS.map(section => (
           <MetadataSection
             key={section.name}
-            editable
+            editable={this.props.additionalInfo.editable}
             toggleable
             onToggle={() => this.toggleSection(section)}
             open={this.state.sectionOpen[section.name]}
@@ -195,7 +195,8 @@ MetadataTab.propTypes = {
     name: PropTypes.string,
     project_name: PropTypes.string,
     upload_date: PropTypes.string,
-    host_genome_name: PropTypes.string
+    host_genome_name: PropTypes.string,
+    editable: PropTypes.bool
   })
 };
 

--- a/app/assets/src/components/views/report/SampleDetailsSidebar/NotesTab.jsx
+++ b/app/assets/src/components/views/report/SampleDetailsSidebar/NotesTab.jsx
@@ -16,13 +16,19 @@ class NotesTab extends React.Component {
   };
 
   render() {
-    const { notes, onNoteChange, onNoteSave, savePending } = this.props;
+    const {
+      notes,
+      onNoteChange,
+      onNoteSave,
+      savePending,
+      editable
+    } = this.props;
 
     const notesEmpty = !notes || notes.length === 0;
 
     return (
       <MetadataSection
-        editable
+        editable={editable}
         onEditToggle={() => this.toggleEditing()}
         editing={this.state.editing}
         title="Notes"
@@ -53,6 +59,7 @@ class NotesTab extends React.Component {
 
 NotesTab.propTypes = {
   notes: PropTypes.string,
+  editable: PropTypes.bool,
   onNoteChange: PropTypes.func.isRequired,
   onNoteSave: PropTypes.func.isRequired,
   savePending: PropTypes.bool

--- a/app/assets/src/components/views/report/SampleDetailsSidebar/SampleDetailsSidebar.jsx
+++ b/app/assets/src/components/views/report/SampleDetailsSidebar/SampleDetailsSidebar.jsx
@@ -160,6 +160,7 @@ class SampleDetailsSidebar extends React.Component {
           {this.state.currentTab === "Notes" && (
             <NotesTab
               notes={additionalInfo.notes}
+              editable={additionalInfo.editable}
               onNoteChange={val => this.handleMetadataChange("notes", val)}
               onNoteSave={() => this.handleMetadataSave("notes")}
               savePending={savePending}

--- a/app/assets/src/components/views/report/SampleDetailsSidebar/metadata_section.scss
+++ b/app/assets/src/components/views/report/SampleDetailsSidebar/metadata_section.scss
@@ -6,7 +6,10 @@
   height: 50px;
   align-items: center;
   border-bottom: 1px solid $light-grey;
-  cursor: pointer;
+
+  &.toggleable {
+    cursor: pointer;
+  }
 
   .title {
     color: $black;

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -184,6 +184,8 @@ class SamplesController < ApplicationController
     pr_display = nil
     ercc_comparison = nil
 
+    editable = current_power.updatable_sample?(@sample)
+
     if pr
       pr_display = curate_pipeline_run_display(pr)
       ercc_comparison = pr.compare_ercc_counts
@@ -198,6 +200,7 @@ class SamplesController < ApplicationController
       metadata: @sample.metadata,
       additional_info: {
         name: @sample.name,
+        editable: editable,
         host_genome_name: @sample.host_genome_name,
         upload_date: @sample.created_at,
         project_name: @sample.project.name,


### PR DESCRIPTION
Previously, the sidebar metadata was always editable.
Now it is only editable if the user has permissions.

Also fix a tiny style bug. Don't do `cursor: pointer` if metadata section isn't toggleable.