### PR TITLE
Can't escape environment variables with syscall

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -523,9 +523,7 @@ class PipelineRun < ApplicationRecord
     taxon_byteranges_csv_file = "#{local_json_path}/taxon_byteranges"
     hash_array_json2csv(downloaded_byteranges_path, taxon_byteranges_csv_file, %w[taxid hit_type first_byte last_byte])
     Syscall.run_in_dir(local_json_path, "sed", "-e", "s/$/,#{id}/", "-i", "taxon_byteranges")
-    Syscall.run_in_dir(local_json_path, "mysqlimport", "--replace", "--local", "--user=$DB_USERNAME", "--host=#{rds_host}",
-                       "--password=$DB_PASSWORD", "--columns=taxid,hit_type,first_byte,last_byte,pipeline_run_id", "--fields-terminated-by=','",
-                       "idseq_#{Rails.env}", "taxon_byteranges")
+    Syscall.run_in_dir(local_json_path, "mysqlimport --user=$DB_USERNAME --host=#{rds_host} --password=$DB_PASSWORD --fields-terminated-by=',' --replace --local --columns=taxid,hit_type,first_byte,last_byte,pipeline_run_id idseq_#{Rails.env} taxon_byteranges")
     Syscall.run("rm", "-f", downloaded_byteranges_path)
   end
 


### PR DESCRIPTION
$RDS_ADDRESS and $DB_PASSWORD were being escaped by Open3.capture

Since these are not user-inputted fields, it's safe to just run the original command as a single string (no escaping)
