### PR TITLE
Make row hover actions always visible, with a disabled state.

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -27,10 +27,10 @@ import MetricPicker from "./views/report/filters/MetricPicker";
 import SpecificityFilter from "./views/report/filters/SpecificityFilter";
 import NameTypeFilter from "./views/report/filters/NameTypeFilter";
 import ReportSearchBox from "./views/report/filters/ReportSearchBox";
-import PhyloTreeCreationModal from "./views/phylo_tree/PhyloTreeCreationModal";
 import PhyloTreeChecks from "./views/phylo_tree/PhyloTreeChecks";
 import TaxonTreeVis from "./views/TaxonTreeVis";
 import LoadingLabel from "./ui/labels/LoadingLabel";
+import HoverActions from "./views/report/ReportTable/HoverActions";
 
 class PipelineSampleReport extends React.Component {
   constructor(props) {
@@ -702,87 +702,39 @@ class PipelineSampleReport extends React.Component {
   };
 
   displayHoverActions = (taxInfo, reportDetails) => {
-    let tax_level_str = "";
-    let ncbiDot, fastaDot, alignmentVizDot, phyloTreeDot, contigVizDot;
-    if (taxInfo.tax_level == 1) tax_level_str = "species";
-    else tax_level_str = "genus";
-
-    let valid_tax_id =
+    const validTaxId =
       taxInfo.tax_id < this.INVALID_CALL_BASE_TAXID || taxInfo.tax_id > 0;
-    if (valid_tax_id)
-      ncbiDot = (
-        <i
-          data-tax-id={taxInfo.tax_id}
-          onClick={this.gotoNCBI}
-          className="fa fa-link action-dot"
-          aria-hidden="true"
-        />
-      );
-    if (reportDetails.taxon_fasta_flag)
-      fastaDot = (
-        <i
-          data-tax-level={taxInfo.tax_level}
-          data-tax-id={taxInfo.tax_id}
-          onClick={this.downloadFastaUrl}
-          className="fa fa-download action-dot"
-          aria-hidden="true"
-        />
-      );
-    if (this.canSeeAlignViz && valid_tax_id && taxInfo.NT.r > 0)
-      alignmentVizDot = (
-        <i
-          data-tax-level={tax_level_str}
-          data-tax-id={taxInfo.tax_id}
-          onClick={this.gotoAlignmentVizLink}
-          className="fa fa-bars action-dot"
-          aria-hidden="true"
-        />
-      );
-    if (this.state.contigTaxidList.indexOf(taxInfo.tax_id) >= 0)
-      contigVizDot = (
-        <i
-          data-tax-id={taxInfo.tax_id}
-          onClick={this.downloadContigUrl}
-          className="fa fa-puzzle-piece action-dot"
-          aria-hidden="true"
-        />
-      );
-    if (
+    const ncbiEnabled = validTaxId;
+    const fastaEnabled = reportDetails.taxon_fasta_flag;
+    const contigVizEnabled =
+      this.state.contigTaxidList.indexOf(taxInfo.tax_id) >= 0;
+    const alignmentVizEnabled =
+      this.canSeeAlignViz && validTaxId && taxInfo.NT.r > 0;
+    const phyloTreeEnabled =
       this.allowPhyloTree &&
       taxInfo.tax_id > 0 &&
-      PhyloTreeChecks.passesCreateCondition(taxInfo.NT.r, taxInfo.NR.r)
-    )
-      phyloTreeDot = (
-        <PhyloTreeCreationModal
-          admin={parseInt(this.admin)}
-          csrf={this.csrf}
-          trigger={
-            <i className="fa fa-code-fork action-dot" aria-hidden="true" />
-          }
-          taxonId={taxInfo.tax_id}
-          taxonName={taxInfo.name}
-          projectId={this.projectId}
-          projectName={this.projectName}
-        />
-      );
+      PhyloTreeChecks.passesCreateCondition(taxInfo.NT.r, taxInfo.NR.r);
+
     return (
-      <span className="link-tag">
-        <BasicPopup trigger={ncbiDot} content={"NCBI Taxonomy Browser"} />
-        <BasicPopup trigger={fastaDot} content={"FASTA Download"} />
-        <BasicPopup trigger={contigVizDot} content={"Contigs Download"} />
-        <BasicPopup
-          trigger={alignmentVizDot}
-          content={"Alignment Visualization"}
-        />
-        <BasicPopup
-          trigger={phyloTreeDot}
-          content={
-            <div>
-              Phylogenetic Analysis <BetaLabel />
-            </div>
-          }
-        />
-      </span>
+      <HoverActions
+        className="link-tag"
+        admin={parseInt(this.admin)}
+        csrf={this.csrf}
+        projectId={this.projectId}
+        projectName={this.projectName}
+        taxId={taxInfo.tax_id}
+        taxLevel={taxInfo.tax_level}
+        taxName={taxInfo.name}
+        ncbiEnabled={ncbiEnabled}
+        onNcbiActionClick={this.gotoNCBI}
+        fastaEnabled={fastaEnabled}
+        onFastaActionClick={this.downloadFastaUrl}
+        alignmentVizEnabled={alignmentVizEnabled}
+        onAlignmentVizClick={this.gotoAlignmentVizLink}
+        contigVizEnabled={contigVizEnabled}
+        onContigVizClick={this.downloadContigUrl}
+        phyloTreeEnabled={phyloTreeEnabled}
+      />
     );
   };
 

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -152,7 +152,8 @@ class Samples extends React.Component {
         "sample_diagnosis",
         "sample_organism",
         "sample_detection"
-      ]
+      ],
+      phyloTreeCreationModalOpen: false
     };
 
     this.sortCount = 0;
@@ -1967,16 +1968,24 @@ function ProjectInfoHeading({
   selectedSampleIds,
   numTotalSamples
 }) {
+  const handlePhyloModalOpen = () => {
+    parent.setState({ phyloTreeCreationModalOpen: true });
+  };
+
+  const handlePhyloModalClose = () => {
+    parent.setState({ phyloTreeCreationModalOpen: false });
+  };
+
   let phyloProps = {
     admin: parseInt(parent.admin),
-    csrf: parent.csrf,
-    trigger: (
-      <div className="button-container">
-        <PhylogenyButton />
-      </div>
-    )
+    csrf: parent.csrf
   };
-  let phyloTreeModal = <PhyloTreeCreationModal {...phyloProps} />;
+
+  let phyloModalTrigger = (
+    <div className="button-container">
+      <PhylogenyButton onClick={handlePhyloModalOpen} />
+    </div>
+  );
 
   return (
     <div className="row download-section">
@@ -2005,7 +2014,7 @@ function ProjectInfoHeading({
       <div className="col s7 download-section-btns">
         {state.selectedProjectId ? project_menu : null}
         {table_download_dropdown}
-        {phyloTreeModal}
+        {phyloModalTrigger}
         {compare_button}
         <BackgroundModal
           parent={parent}
@@ -2018,6 +2027,12 @@ function ProjectInfoHeading({
           ? delete_project_button
           : null}
       </div>
+      {state.phyloTreeCreationModalOpen && (
+        <PhyloTreeCreationModal
+          {...phyloProps}
+          onClose={handlePhyloModalClose}
+        />
+      )}
     </div>
   );
 }

--- a/app/assets/src/components/ui/containers/Modal.jsx
+++ b/app/assets/src/components/ui/containers/Modal.jsx
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
+import { forbidExtraProps } from "airbnb-prop-types";
 import { Modal as SemanticModal } from "semantic-ui-react";
 import RemoveIcon from "../icons/RemoveIcon";
 import cs from "./modal.scss";
@@ -11,7 +12,7 @@ class Modal extends React.Component {
 
   render() {
     return (
-      <SemanticModal className={cs.modal} {...this.props}>
+      <SemanticModal className={cs.modal} {...this.props} trigger={<span />}>
         {this.props.title && (
           <SemanticModal.Header>{this.props.title}</SemanticModal.Header>
         )}
@@ -24,14 +25,14 @@ class Modal extends React.Component {
   }
 }
 
-Modal.propTypes = {
+Modal.propTypes = forbidExtraProps({
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired,
   onClose: PropTypes.func,
   title: PropTypes.string,
-  trigger: PropTypes.node.isRequired
-};
+  open: PropTypes.bool
+});
 
 export default Modal;

--- a/app/assets/src/components/views/AlignmentViz.jsx
+++ b/app/assets/src/components/views/AlignmentViz.jsx
@@ -3,6 +3,7 @@ import cx from "classnames";
 import { Popup } from "semantic-ui-react";
 import { getSampleMetadata, getAlignmentData } from "~/api";
 import AccessionViz from "../AccessionViz";
+import { pipelineHasAssembly } from "../utils/sample";
 import cs from "./alignment_viz.scss";
 
 class AlignmentViz extends React.Component {
@@ -52,7 +53,7 @@ class AlignmentViz extends React.Component {
           {this.taxName ? this.taxName + " (" + this.taxLevel + ")" : ""}
           Alignment ({alignmentData.length} unique accessions)
           {pipelineRun &&
-            pipelineRun.assembled === 1 && (
+            pipelineHasAssembly(pipelineRun) && (
               <Popup
                 trigger={
                   <i

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -306,7 +306,7 @@ class TaxonTreeVis extends React.Component {
         }
         background={this.props.backgroundData}
         taxonName={taxonName}
-        handleClose={this.handleTaxonModalClose}
+        onClose={this.handleTaxonModalClose}
       />
     );
   }

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -640,7 +640,9 @@ PhyloTreeCreation.propTypes = {
   csrf: PropTypes.string.isRequired,
   onComplete: PropTypes.func,
   projectId: PropTypes.number,
-  taxonId: PropTypes.number
+  projectName: PropTypes.string,
+  taxonId: PropTypes.number,
+  taxonName: PropTypes.string
 };
 
 export default PhyloTreeCreation;

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreationModal.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreationModal.jsx
@@ -1,48 +1,29 @@
+import { forbidExtraProps } from "airbnb-prop-types";
 import Modal from "../../ui/containers/Modal";
 import PhyloTreeCreation from "./PhyloTreeCreation";
 import PropTypes from "prop-types";
 import React from "react";
 
 class PhyloTreeCreationModal extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      open: false
-    };
-
-    this.handleOpen = this.handleOpen.bind(this);
-    this.handleClose = this.handleClose.bind(this);
-  }
-
-  handleOpen() {
-    this.setState({ open: true });
-  }
-
-  handleClose() {
-    this.setState({ open: false });
-  }
-
   render() {
+    // <PhyloTreeCreationModal> is always open when rendered.
+    // To hide <PhyloTreeCreationModal>, we simply don't render it.
     return (
-      <Modal
-        trigger={<span onClick={this.handleOpen}>{this.props.trigger}</span>}
-        open={this.state.open}
-        onClose={this.handleClose}
-      >
-        <PhyloTreeCreation
-          onComplete={() => {
-            this.setState({ open: false });
-          }}
-          {...this.props}
-        />
+      <Modal open onClose={this.props.onClose}>
+        <PhyloTreeCreation onComplete={this.props.onClose} {...this.props} />
       </Modal>
     );
   }
 }
 
-PhyloTreeCreationModal.propTypes = {
-  trigger: PropTypes.node
-};
+PhyloTreeCreationModal.propTypes = forbidExtraProps({
+  onClose: PropTypes.func.isRequired,
+  admin: PropTypes.number,
+  csrf: PropTypes.string.isRequired,
+  projectId: PropTypes.number,
+  projectName: PropTypes.string,
+  taxonId: PropTypes.number,
+  taxonName: PropTypes.string
+});
 
 export default PhyloTreeCreationModal;

--- a/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
+++ b/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
@@ -1,0 +1,151 @@
+// These are the buttons that appear on a Report table row when hovered.
+import React from "react";
+import cx from "classnames";
+// TODO(mark): Move BasicPopup into /ui.
+import BasicPopup from "~/components/BasicPopup";
+import PhyloTreeCreationModal from "~/components/views/phylo_tree/PhyloTreeCreationModal";
+import BetaLabel from "~/components/ui/labels/BetaLabel";
+import PropTypes from "~/components/utils/propTypes";
+import cs from "./hover_actions.scss";
+
+class HoverActions extends React.Component {
+  state = {
+    phyloTreeCreationModalOpen: false
+  };
+
+  handlePhyloModalOpen = () => {
+    this.setState({ phyloTreeCreationModalOpen: true });
+  };
+
+  handlePhyloModalClose = () => {
+    this.setState({ phyloTreeCreationModalOpen: false });
+  };
+
+  // Metadata for each of the hover actions.
+  getHoverActions = () => [
+    {
+      message: "NCBI Taxonomy Browser",
+      icon: "fa-link",
+      handleClick: this.props.onNcbiActionClick,
+      enabled: this.props.ncbiEnabled,
+      disabledMessage: "NCBI Taxonomy Not Found"
+    },
+    {
+      message: "FASTA Download",
+      icon: "fa-download",
+      handleClick: this.props.onFastaActionClick,
+      enabled: this.props.fastaEnabled,
+      disabledMessage: "FASTA Download Not Available",
+      extraProps: {
+        "data-tax-level": this.props.taxLevel
+      }
+    },
+    {
+      message: "Contigs Download",
+      icon: "fa-puzzle-piece",
+      handleClick: this.props.onContigVizClick,
+      enabled: this.props.contigVizEnabled,
+      disabledMessage: "No Contigs Available"
+    },
+    {
+      message: "Alignment Visualization",
+      icon: "fa-bars",
+      handleClick: this.props.onAlignmentVizClick,
+      enabled: this.props.alignmentVizEnabled,
+      disabledMessage: "Requires at least one read in NT",
+      extraProps: {
+        "data-tax-level": this.props.taxLevel === 1 ? "species" : "genus"
+      }
+    },
+    {
+      message: (
+        <div>
+          Phylogenetic Analysis <BetaLabel />
+        </div>
+      ),
+      icon: "fa-code-fork",
+      handleClick: this.handlePhyloModalOpen,
+      enabled: this.props.phyloTreeEnabled,
+      disabledMessage: "Requires 100 reads in NT or NR"
+    }
+  ];
+
+  // Render the hover action according to metadata.
+  renderHoverAction = hoverAction => {
+    const { taxId } = this.props;
+    let trigger, tooltipMessage;
+    if (hoverAction.enabled) {
+      trigger = (
+        <i
+          data-tax-id={taxId}
+          onClick={hoverAction.handleClick}
+          className={cx("fa", hoverAction.icon, cs.actionDot)}
+          aria-hidden="true"
+          {...hoverAction.extraProps}
+        />
+      );
+      tooltipMessage = hoverAction.message;
+    } else {
+      trigger = (
+        <i
+          className={cx("fa", hoverAction.icon, cs.actionDot, cs.disabled)}
+          aria-hidden="true"
+        />
+      );
+      tooltipMessage = hoverAction.disabledMessage;
+    }
+
+    return <BasicPopup trigger={trigger} content={tooltipMessage} />;
+  };
+
+  render() {
+    const {
+      admin,
+      csrf,
+      taxId,
+      taxName,
+      projectId,
+      projectName,
+      className
+    } = this.props;
+
+    return (
+      <span className={cx(cs.hoverActions, className)}>
+        {this.getHoverActions().map(this.renderHoverAction)}
+        {this.state.phyloTreeCreationModalOpen && (
+          <PhyloTreeCreationModal
+            admin={admin}
+            csrf={csrf}
+            taxonId={taxId}
+            taxonName={taxName}
+            projectId={projectId}
+            projectName={projectName}
+            onClose={this.handlePhyloModalClose}
+          />
+        )}
+      </span>
+    );
+  }
+}
+
+HoverActions.propTypes = {
+  className: PropTypes.string,
+  admin: PropTypes.number,
+  csrf: PropTypes.string,
+  projectId: PropTypes.number,
+  projectName: PropTypes.string,
+  taxId: PropTypes.number,
+  taxLevel: PropTypes.number,
+  taxName: PropTypes.string,
+  ncbiEnabled: PropTypes.bool,
+  onNcbiActionClick: PropTypes.func.isRequired,
+  fastaEnabled: PropTypes.bool,
+  onFastaActionClick: PropTypes.func.isRequired,
+  alignmentVizEnabled: PropTypes.bool,
+  onAlignmentVizClick: PropTypes.func.isRequired,
+  contigVizEnabled: PropTypes.bool,
+  onContigVizClick: PropTypes.func.isRequired,
+  phyloTreeEnabled: PropTypes.bool
+};
+
+export default HoverActions;

--- a/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
+++ b/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
@@ -13,9 +13,6 @@ export default class ReportTable extends React.Component {
     this.state = {
       taxonModalData: null
     };
-
-    this.openTaxonModal = this.openTaxonModal.bind(this);
-    this.closeTaxonModal = this.closeTaxonModal.bind(this);
   }
 
   renderTaxonModal() {
@@ -35,22 +32,22 @@ export default class ReportTable extends React.Component {
         }
         background={backgroundData}
         taxonName={taxonName}
-        handleClose={this.closeTaxonModal}
+        onClose={this.handleTaxonModalClose}
       />
     );
   }
 
-  openTaxonModal(taxonModalData) {
+  handleTaxonModalOpen = taxonModalData => {
     this.setState({
       taxonModalData
     });
-  }
+  };
 
-  closeTaxonModal() {
+  handleTaxonModalClose = () => {
     this.setState({
       taxonModalData: null
     });
-  }
+  };
 
   render() {
     const {
@@ -162,7 +159,7 @@ export default class ReportTable extends React.Component {
               displayHighlightTags={displayHighlightTags}
               showConcordance={showConcordance}
               getRowClass={getRowClass}
-              openTaxonModal={this.openTaxonModal}
+              openTaxonModal={this.handleTaxonModalOpen}
               reportDetails={reportDetails}
               backgroundData={backgroundData}
             />

--- a/app/assets/src/components/views/report/ReportTable/hover_actions.scss
+++ b/app/assets/src/components/views/report/ReportTable/hover_actions.scss
@@ -1,0 +1,16 @@
+@import "~styles/typography";
+@import "~styles/themes/colors";
+
+.hoverActions {
+  color: $primary-light;
+  font-size: $font-size-base;
+
+  .actionDot {
+    margin-left: 7px;
+    font-size: 15px;
+  }
+
+  .disabled {
+    color: $light-grey;
+  }
+}

--- a/app/assets/src/components/views/report/TaxonModal.jsx
+++ b/app/assets/src/components/views/report/TaxonModal.jsx
@@ -136,15 +136,9 @@ class TaxonModal extends React.Component {
   }
 
   render() {
-    // The Modal component always expects a 'trigger', even though it doesn't make sense in our use case.
     // <TaxonModal> is always open when rendered. To hide <TaxonModal>, we simply don't render it.
     return (
-      <Modal
-        title={this.props.taxonName}
-        trigger={<span />}
-        open
-        onClose={this.props.handleClose}
-      >
+      <Modal title={this.props.taxonName} open onClose={this.props.onClose}>
         <div className="taxon-info">
           <div className="taxon-info__label" />
           {this.state.taxonDescription && (
@@ -222,7 +216,8 @@ TaxonModal.propTypes = {
   parentTaxonId: PropTypes.number,
   taxonId: PropTypes.number,
   taxonName: PropTypes.string,
-  taxonValues: PropTypes.object
+  taxonValues: PropTypes.object,
+  onClose: PropTypes.func
 };
 
 export default TaxonModal;

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -363,15 +363,6 @@ input[type="number"] {
   .link-tag {
     visibility: hidden;
     padding-left: 10px;
-    color: $primary-light;
-    font-size: $font-size-base;
-    cursor: text;
-    .fa {
-      margin-left: 7px;
-    }
-    .action-dot {
-      font-size: 15px;
-    }
   }
 }
 


### PR DESCRIPTION
Also show tooltips when disabled.

Fix issue where phylo button had no tooltip.

Refactor PhyloTreeCreationModal to take open prop instead of trigger prop.

![screen shot 2018-11-20 at 3 40 31 pm](https://user-images.githubusercontent.com/837004/48809722-acbea100-ecda-11e8-8d5a-b5c9da4ab56f.png)

![screen shot 2018-11-20 at 3 40 38 pm](https://user-images.githubusercontent.com/837004/48809724-adefce00-ecda-11e8-8ab0-db92c72f4e2c.png)
