### PR TITLE
Bug fix for dot-backslash in local uploads

### DIFF
--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -8,6 +8,7 @@ import ObjectHelper from "../helpers/ObjectHelper";
 import Icon from "./ui/icons/Icon";
 import { Menu, MenuItem } from "./ui/controls/Menu";
 import UploadBox from "./ui/controls/UploadBox";
+import { cleanLocalFileName } from "./utils/sample";
 
 class SampleUpload extends React.Component {
   constructor(props, context) {
@@ -392,7 +393,7 @@ class SampleUpload extends React.Component {
   }
 
   baseName(str) {
-    let base = new String(str).substring(str.lastIndexOf("/") + 1);
+    let base = cleanLocalFileName(str).substring(str.lastIndexOf("/") + 1);
     if (base.lastIndexOf(".") != -1) {
       base = base.substring(0, base.lastIndexOf("."));
     }
@@ -702,8 +703,8 @@ class SampleUpload extends React.Component {
     this.state.localFilesToUpload.forEach(file => {
       inputFilesAttributes.push({
         source_type: "local",
-        source: file.name.trim(),
-        parts: file.name.trim()
+        source: cleanLocalFileName(file.name),
+        parts: cleanLocalFileName(file.name)
       });
     });
 

--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -392,13 +392,24 @@ class SampleUpload extends React.Component {
     }
   }
 
-  baseName(str) {
-    let base = cleanLocalFileName(str).substring(str.lastIndexOf("/") + 1);
-    if (base.lastIndexOf(".") != -1) {
+  baseName = str => {
+    let base = cleanLocalFileName(str);
+
+    let separator = "/";
+    if (base.includes("\\")) {
+      // If the name includes the backslash \ it's probably from Windows.
+      separator = "\\";
+    }
+
+    // Get the last piece
+    base = base.substring(base.lastIndexOf(separator) + 1);
+
+    if (base.includes(".")) {
+      // Leave off the extension
       base = base.substring(0, base.lastIndexOf("."));
     }
     return base;
-  }
+  };
 
   isFormInvalid() {
     const errors = {};

--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -8,7 +8,7 @@ import ObjectHelper from "../helpers/ObjectHelper";
 import Icon from "./ui/icons/Icon";
 import { Menu, MenuItem } from "./ui/controls/Menu";
 import UploadBox from "./ui/controls/UploadBox";
-import { cleanLocalFileName } from "./utils/sample";
+import { cleanLocalFilePath, baseName } from "./utils/sample";
 
 class SampleUpload extends React.Component {
   constructor(props, context) {
@@ -392,25 +392,6 @@ class SampleUpload extends React.Component {
     }
   }
 
-  baseName = str => {
-    let base = cleanLocalFileName(str);
-
-    let separator = "/";
-    if (base.includes("\\")) {
-      // If the name includes the backslash \ it's probably from Windows.
-      separator = "\\";
-    }
-
-    // Get the last piece
-    base = base.substring(base.lastIndexOf(separator) + 1);
-
-    if (base.includes(".")) {
-      // Leave off the extension
-      base = base.substring(0, base.lastIndexOf("."));
-    }
-    return base;
-  };
-
   isFormInvalid() {
     const errors = {};
 
@@ -714,8 +695,8 @@ class SampleUpload extends React.Component {
     this.state.localFilesToUpload.forEach(file => {
       inputFilesAttributes.push({
         source_type: "local",
-        source: cleanLocalFileName(file.name),
-        parts: cleanLocalFileName(file.name)
+        source: cleanLocalFilePath(file.name),
+        parts: cleanLocalFilePath(file.name)
       });
     });
 
@@ -756,7 +737,7 @@ class SampleUpload extends React.Component {
   };
 
   getSampleNameFromFileName = fname => {
-    let base = this.baseName(fname);
+    let base = baseName(fname);
     const fastqLabel = /.fastq*$|.fq*$|.fasta*$|.fa*$|.gz*$/gim;
     const readLabel = /_R1.*$|_R2.*$/gi;
     base = base.replace(fastqLabel, "").replace(readLabel, "");

--- a/app/assets/src/components/utils/sample.js
+++ b/app/assets/src/components/utils/sample.js
@@ -1,10 +1,32 @@
+import last from "lodash/fp";
+
 export const pipelineHasAssembly = pipelineRun => {
   if (!pipelineRun.pipeline_version) return false;
   const versionNums = pipelineRun.pipeline_version.split(".");
   return +versionNums[0] >= 3 && +versionNums[1] >= 1;
 };
 
-export const cleanLocalFileName = name => {
+// Get the basename from a file path
+export const baseName = str => {
+  let base = cleanLocalFilePath(str);
+
+  let separator = "/";
+  if (base.includes("\\")) {
+    // If the name includes the backslash \ it's probably from Windows.
+    separator = "\\";
+  }
+
+  // Get the last piece
+  base = last(base.split(separator));
+
+  if (base.includes(".")) {
+    // Leave off the extension
+    base = base.substring(0, base.lastIndexOf("."));
+  }
+  return base;
+};
+
+export const cleanLocalFilePath = name => {
   name = name.trim();
 
   // Remove ./ and .\ from the start of file paths

--- a/app/assets/src/components/utils/sample.js
+++ b/app/assets/src/components/utils/sample.js
@@ -3,3 +3,10 @@ export const pipelineHasAssembly = pipelineRun => {
   const versionNums = pipelineRun.pipeline_version.split(".");
   return +versionNums[0] >= 3 && +versionNums[1] >= 1;
 };
+
+export const cleanLocalFileName = name => {
+  name = name.trim();
+
+  // Remove ./ and .\ from the start of file paths
+  return name.replace(/^\.[\\|/]/, "");
+};


### PR DESCRIPTION
- Windows uses backslashes!
- cleanLocalFileName will trim the ./ and .\
- baseName will now check for backslashes and use those as the separator character if they're there.
- Tested locally, ex::

```
web_1                      | [2018-11-26T19:59:30] DEBUG ActiveRecord::Base :   SQL (1.9ms)  INSERT INTO `input_files` (`name`, `sample_id`, `created_at`, `updated_at`, `source_type`, `source`, `parts`) VALUES ('Blah9_S8_L001_R1_001.fastq.gz.fasta', 1170, '2018-11-26 19:59:30', '2018-11-26 19:59:30', 'local', 'Blah9_S8_L001_R1_001.fastq.gz.fasta', 'Blah9_S8_L001_R1_001.fastq.gz.fasta')
```