### PR TITLE
[Upload Page] Switch the default tab to local uploads

### DIFF
--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -106,7 +106,7 @@ class SampleUpload extends React.Component {
       consentChecked: false,
 
       // Local upload fields
-      localUploadMode: false,
+      localUploadMode: true,
       localFilesToUpload: [],
       localFilesDoneUploading: [],
       localUploadShouldStart: false,
@@ -809,18 +809,18 @@ class SampleUpload extends React.Component {
         <div className="menu-container">
           <Menu compact>
             <MenuItem
-              active={!this.state.localUploadMode}
-              onClick={() => this.setState({ localUploadMode: false })}
-            >
-              <Icon size="large" name="server" />
-              Upload from S3
-            </MenuItem>
-            <MenuItem
               active={this.state.localUploadMode}
               onClick={() => this.setState({ localUploadMode: true })}
             >
               <Icon size="large" name="folder open outline" />
               Upload from Your Computer
+            </MenuItem>
+            <MenuItem
+              active={!this.state.localUploadMode}
+              onClick={() => this.setState({ localUploadMode: false })}
+            >
+              <Icon size="large" name="server" />
+              Upload from S3
             </MenuItem>
           </Menu>
         </div>


### PR DESCRIPTION
- Makes the "Upload from Your Computer" the default tab
- Approved by Design
- All the new users use the local upload mode so it's better for them (and the Biohub users tend to use the CLI more)

![screen shot 2018-11-26 at 1 15 16 pm](https://user-images.githubusercontent.com/5652739/49043172-26dda280-f17f-11e8-80f6-70be5b095671.png)
