### PR TITLE
Color sample names and color NCBI References as dark gray.

### DIFF
--- a/app/assets/src/components/views/phylo_tree/PhyloTreeVis.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeVis.jsx
@@ -35,6 +35,7 @@ class PhyloTreeVis extends React.Component {
     let tree = Tree.fromNewickString(this.props.newick, this.props.nodeData);
     this.treeVis = new Dendogram(this.treeContainer, tree, {
       defaultColor: "#cccccc",
+      absentColor: "#999999",
       colormapName: "viridis",
       colorGroupAttribute: "project_name",
       colorGroupLegendTitle: "Project Name",

--- a/app/assets/src/components/visualizations/dendrogram/Dendogram.js
+++ b/app/assets/src/components/visualizations/dendrogram/Dendogram.js
@@ -17,6 +17,7 @@ export default class Dendogram {
       {
         curvedEdges: false,
         defaultColor: "#cccccc",
+        absentColor: "#000000", // The color when an attribute is absent.
         colorGroupAttribute: null,
         colorGroupLegendTitle: null,
         colorGroupAbsentName: null,
@@ -197,6 +198,13 @@ export default class Dendogram {
     // Set up colors array
     this.colors = new CategoricalColormap().getNScale(allVals.length);
     this.colors = [this.options.defaultColor].concat(this.colors);
+
+    // Add the absentColor at the same index as the absentName.
+    const absentNameIndex = allVals.indexOf(absentName);
+
+    if (absentNameIndex > -1) {
+      this.colors.splice(absentNameIndex, 0, this.options.absentColor);
+    }
 
     function colorNode(head) {
       // Color the nodes based on the attribute values
@@ -555,6 +563,9 @@ export default class Dendogram {
       .select("text")
       .transition()
       .duration(500)
+      .attr("stroke", function(d) {
+        return this.colors[d.data.colorIndex];
+      })
       .attr("x", function(d) {
         return d.depth === 0
           ? -(this.getBBox().width + 15)

--- a/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
+++ b/app/assets/src/styles/views/phylo_tree/phylo_tree_vis.scss
@@ -20,10 +20,6 @@
       opacity: 1;
     }
 
-    .node text {
-      fill: $black;
-    }
-
     .node.highlight text {
       font-weight: 700;
     }


### PR DESCRIPTION
Previously, NCBI References was colored as a normal category. We now color it dark grey. 

We also color the text now.

<img width="1127" alt="screen shot 2018-11-28 at 6 36 35 pm" src="https://user-images.githubusercontent.com/837004/49195701-0b1ffb00-f33d-11e8-804e-6c8848b1dfd6.png">
