### PR TITLE
Update AlignmentConfig::DEFAULT_NAME to come from the environment

### DIFF
--- a/app/models/alignment_config.rb
+++ b/app/models/alignment_config.rb
@@ -1,5 +1,5 @@
 class AlignmentConfig < ApplicationRecord
   # configuration for alignment database for pipelines
-  DEFAULT_NAME = '2018-04-01'.freeze
+  DEFAULT_NAME = ENV["ALIGNMENT_CONFIG_DEFAULT_NAME"]
   has_many :pipeline_runs
 end

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 
-if test -z "$ENVIRONMENT"; then
-    # If ENVIRONMENT not set (e.g. local development), don't call chamber
-    exec bundle exec "$@"
-else
-    # Use Chamber to inject secrets via environment variables.
-    exec chamber exec idseq-$ENVIRONMENT-web -- bundle exec "$@"
-fi
+echo $(printenv)
+
+exec chamber exec idseq-prod-web -- bundle exec "$@"
+
+#if test -z "$ENVIRONMENT"; then
+#    # If ENVIRONMENT not set (e.g. local development), don't call chamber
+#    echo "NOT CALLING CHAMBER"
+#    exec bundle exec "$@"
+#else
+#    echo "CALLING WITH CHAMBER"
+#    # Use Chamber to inject secrets via environment variables.
+#    exec chamber exec idseq-$ENVIRONMENT-web -- bundle exec "$@"
+#fi

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if test -z "$ENVIRONMENT"; then
-    # If ENVIRONMENT not set (e.g. local development), don't call chamber
-    exec bundle exec "$@"
+    # If ENVIRONMENT not set, use "dev" env
+    exec chamber exec idseq-dev-web -- bundle exec "$@"
 else
     # Use Chamber to inject secrets via environment variables.
     exec chamber exec idseq-$ENVIRONMENT-web -- bundle exec "$@"

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,15 +1,9 @@
 #!/bin/sh
 
-echo $(printenv)
-
-exec chamber exec idseq-prod-web -- bundle exec "$@"
-
-#if test -z "$ENVIRONMENT"; then
-#    # If ENVIRONMENT not set (e.g. local development), don't call chamber
-#    echo "NOT CALLING CHAMBER"
-#    exec bundle exec "$@"
-#else
-#    echo "CALLING WITH CHAMBER"
-#    # Use Chamber to inject secrets via environment variables.
-#    exec chamber exec idseq-$ENVIRONMENT-web -- bundle exec "$@"
-#fi
+if test -z "$ENVIRONMENT"; then
+    # If ENVIRONMENT not set (e.g. local development), don't call chamber
+    exec bundle exec "$@"
+else
+    # Use Chamber to inject secrets via environment variables.
+    exec chamber exec idseq-$ENVIRONMENT-web -- bundle exec "$@"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - db
       - redis
     environment:
-      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
+      - ALIGNMENT_CONFIG_DEFAULT_NAME
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - AIRBRAKE_PROJECT_ID
       - AIRBRAKE_PROJECT_KEY
@@ -79,7 +79,7 @@ services:
       # override the values here.
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
-      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
+      - ALIGNMENT_CONFIG_DEFAULT_NAME
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - AIRBRAKE_PROJECT_ID
       - AIRBRAKE_PROJECT_KEY
@@ -173,7 +173,7 @@ services:
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
-      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
+      - ALIGNMENT_CONFIG_DEFAULT_NAME
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - CI
       - CONTINUOUS_INTEGRATION
@@ -217,7 +217,7 @@ services:
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
-      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
+      - ALIGNMENT_CONFIG_DEFAULT_NAME
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - CI
       - CONTINUOUS_INTEGRATION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,8 +75,6 @@ services:
       - db
       - redis
     environment:
-      # Chamber is not used in development, but in staging/prod Chamber will
-      # override the values here.
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - ALIGNMENT_CONFIG_DEFAULT_NAME
@@ -129,7 +127,7 @@ services:
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
-      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
+      - ALIGNMENT_CONFIG_DEFAULT_NAME
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - CI
       - CONTINUOUS_INTEGRATION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       - db
       - redis
     environment:
+      # Chamber is not used in development, but in staging/prod Chamber will
+      # override the provided values.
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - SAMPLES_BUCKET_NAME=idseq-samples-development
@@ -111,6 +113,7 @@ services:
       - TRAVIS_SECURE_ENV_VARS
       - TRAVIS_TAG
       - TRAVIS
+      - ALIGNMENT_CONFIG_DEFAULT_NAME
     command: bash -c "rm -f tmp/pids/server.pid && rails server -b 0.0.0.0 -p 3000"
   resque:
     image: chanzuckerberg/idseq-web:compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - db
       - redis
     environment:
+      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - AIRBRAKE_PROJECT_ID
       - AIRBRAKE_PROJECT_KEY
@@ -75,9 +76,10 @@ services:
       - redis
     environment:
       # Chamber is not used in development, but in staging/prod Chamber will
-      # override the provided values.
+      # override the values here.
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - AIRBRAKE_PROJECT_ID
       - AIRBRAKE_PROJECT_KEY
@@ -113,7 +115,6 @@ services:
       - TRAVIS_SECURE_ENV_VARS
       - TRAVIS_TAG
       - TRAVIS
-      - ALIGNMENT_CONFIG_DEFAULT_NAME
     command: bash -c "rm -f tmp/pids/server.pid && rails server -b 0.0.0.0 -p 3000"
   resque:
     image: chanzuckerberg/idseq-web:compose
@@ -128,6 +129,7 @@ services:
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - CI
       - CONTINUOUS_INTEGRATION
@@ -171,6 +173,7 @@ services:
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - CI
       - CONTINUOUS_INTEGRATION
@@ -214,6 +217,7 @@ services:
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
       - SAMPLES_BUCKET_NAME=idseq-samples-development
       - CI
       - CONTINUOUS_INTEGRATION


### PR DESCRIPTION
- Infra PR to add the keys to Parameter Store: https://github.com/chanzuckerberg/idseq-infra/pull/166
- The Docker container launches -> Chamber is run in the entrypoint and loads everything from Parameter Store, overriding the default values -> The server is started with the env values
- No addition is needed to czecs.json because the keys are done in the idseq-infra modules
- How to test in your local console: `docker exec -it 3f835726a9e4 chamber exec idseq-dev-web -- bundle exec rails console`

Output shown:
```
web_1                      | RUBY_MAJOR=2.4 BUNDLER_VERSION=1.16.5 ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01 HOSTNAME=... RUBYGEMS_VERSION=2.7.7 HOME=/root BUNDLE_APP_CONFIG=/usr/local/bundle SAMPLES_BUCKET_NAME=idseq-samples-development RUBY_VERSION=2.4.4 GIT_VERSION= PATH=/usr/local/bundle/bin:/usr/local/bundle/gems/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin BUNDLE_PATH=/usr/local/bundle GEM_HOME=/usr/local/bundle RUBY_DOWNLOAD_SHA256=... PWD=/app BUNDLE_SILENCE_ROOT_WARNING=1
web_1                      | warning: overwriting environment variable SAMPLES_BUCKET_NAME
```

```
irb(main):002:0> ENV["ALIGNMENT_CONFIG_DEFAULT_NAME"]
=> "2018-04-01"
irb(main):004:0> AlignmentConfig::DEFAULT_NAME
=> "2018-04-01"
```