### PR TITLE
[Alerts] Increase LongRunningSample time to 8 hours

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -846,7 +846,7 @@ class PipelineRun < ApplicationRecord
     MetricUtil.put_metric_now("samples.running.run_time", run_time, tags, "gauge")
 
     if alert_sent.zero?
-      threshold = 5.hours
+      threshold = 8.hours
       if run_time > threshold
         duration_hrs = (run_time / 60 / 60).round(2)
         msg = "LongRunningSampleEvent: Sample #{sample.id} has been running for #{duration_hrs} hours."


### PR DESCRIPTION
- Increasing from 5 hrs to 8 hrs to keep the alert high-signal and reduce alerting fatigue.
- Recent changes include the alignment machine scale down improvements + some longer run times for small sample batches (due to smaller clusters) and extra work from Assembly so the 5 hr mark isn't that big.
- I tried doing a multi-alert based on metrics in Datadog but I actually prefer the rolled-up log-based alert in Datadog (this one).