### PR TITLE
Consolidate docker-compose and ALIGNMENT_CONFIG_DEFAULT_NAME

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if test -z "$ENVIRONMENT"; then
-    # If ENVIRONMENT not set, use "dev" env
-    exec chamber exec idseq-dev-web -- bundle exec "$@"
+    # If ENVIRONMENT not set (e.g. local development), don't call chamber
+    exec bundle exec "$@"
 else
     # Use Chamber to inject secrets via environment variables.
     exec chamber exec idseq-$ENVIRONMENT-web -- bundle exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 # Shared variables using Docker x- extension and YAML merging syntax.
+
 x-web-variables: &web-variables
   ? ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
   ? SAMPLES_BUCKET_NAME=idseq-samples-development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,52 @@
-version: '3'
+# Shared variables using Docker x- extension and YAML merging syntax.
+x-web-variables: &web-variables
+  ? ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
+  ? SAMPLES_BUCKET_NAME=idseq-samples-development
+  ? AIRBRAKE_PROJECT_ID
+  ? AIRBRAKE_PROJECT_KEY
+  ? MAIL_GUN_API_KEY
+  ? DATADOG_API_KEY
+  ? RACK_ENV
+  ? RAILS_ENV
+
+x-aws-variables: &aws-variables
+  ? AWS_ACCESS_KEY_ID
+  ? AWS_SECRET_ACCESS_KEY
+
+x-travis-variables: &travis-variables
+  ? CI
+  ? CONTINUOUS_INTEGRATION
+  ? TRAVIS_ALLOW_FAILURE
+  ? TRAVIS_BRANCH
+  ? TRAVIS_BUILD_DIR
+  ? TRAVIS_BUILD_ID
+  ? TRAVIS_BUILD_NUMBER
+  ? TRAVIS_COMMIT
+  ? TRAVIS_COMMIT_MESSAGE
+  ? TRAVIS_COMMIT_RANGE
+  ? TRAVIS_EVENT_TYPE
+  ? TRAVIS_FILTERED
+  ? TRAVIS_JOB_ID
+  ? TRAVIS_JOB_NUMBER
+  ? TRAVIS_LANGUAGE
+  ? TRAVIS_OS_NAME
+  ? TRAVIS_PRE_CHEF_BOOTSTRAP_TIME
+  ? TRAVIS_PULL_REQUEST_BRANCH
+  ? TRAVIS_PULL_REQUEST
+  ? TRAVIS_PULL_REQUEST_SHA
+  ? TRAVIS_PULL_REQUEST_SLUG
+  ? TRAVIS_REPO_SLUG
+  ? TRAVIS_SECURE_ENV_VARS
+  ? TRAVIS_TAG
+  ? TRAVIS
+
+x-honeycomb-variables: &honeycomb-variables
+  ? IDSEQ_HONEYCOMB_DB_DATA_SET
+  ? IDSEQ_HONEYCOMB_DATA_SET
+  ? IDSEQ_HONEYCOMB_WRITE_KEY
+
+
+version: '3.4'
 services:
   db:
     image: mysql:5.6
@@ -24,39 +72,8 @@ services:
       - db
       - redis
     environment:
-      - ALIGNMENT_CONFIG_DEFAULT_NAME
-      - SAMPLES_BUCKET_NAME=idseq-samples-development
-      - AIRBRAKE_PROJECT_ID
-      - AIRBRAKE_PROJECT_KEY
-      - MAIL_GUN_API_KEY
-      - CI
-      - CONTINUOUS_INTEGRATION
-      - DATADOG_API_KEY
-      - RACK_ENV
-      - RAILS_ENV
-      - TRAVIS_ALLOW_FAILURE
-      - TRAVIS_BRANCH
-      - TRAVIS_BUILD_DIR
-      - TRAVIS_BUILD_ID
-      - TRAVIS_BUILD_NUMBER
-      - TRAVIS_COMMIT
-      - TRAVIS_COMMIT_MESSAGE
-      - TRAVIS_COMMIT_RANGE
-      - TRAVIS_EVENT_TYPE
-      - TRAVIS_FILTERED
-      - TRAVIS_JOB_ID
-      - TRAVIS_JOB_NUMBER
-      - TRAVIS_LANGUAGE
-      - TRAVIS_OS_NAME
-      - TRAVIS_PRE_CHEF_BOOTSTRAP_TIME
-      - TRAVIS_PULL_REQUEST_BRANCH
-      - TRAVIS_PULL_REQUEST
-      - TRAVIS_PULL_REQUEST_SHA
-      - TRAVIS_PULL_REQUEST_SLUG
-      - TRAVIS_REPO_SLUG
-      - TRAVIS_SECURE_ENV_VARS
-      - TRAVIS_TAG
-      - TRAVIS
+      <<: *web-variables
+      <<: *travis-variables
     command: bash
   web:
     build: .
@@ -75,44 +92,10 @@ services:
       - db
       - redis
     environment:
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - ALIGNMENT_CONFIG_DEFAULT_NAME
-      - SAMPLES_BUCKET_NAME=idseq-samples-development
-      - AIRBRAKE_PROJECT_ID
-      - AIRBRAKE_PROJECT_KEY
-      - IDSEQ_HONEYCOMB_DB_DATA_SET
-      - IDSEQ_HONEYCOMB_DATA_SET
-      - IDSEQ_HONEYCOMB_WRITE_KEY
-      - MAIL_GUN_API_KEY
-      - CI
-      - CONTINUOUS_INTEGRATION
-      - DATADOG_API_KEY
-      - RACK_ENV
-      - RAILS_ENV
-      - TRAVIS_ALLOW_FAILURE
-      - TRAVIS_BRANCH
-      - TRAVIS_BUILD_DIR
-      - TRAVIS_BUILD_ID
-      - TRAVIS_BUILD_NUMBER
-      - TRAVIS_COMMIT
-      - TRAVIS_COMMIT_MESSAGE
-      - TRAVIS_COMMIT_RANGE
-      - TRAVIS_EVENT_TYPE
-      - TRAVIS_FILTERED
-      - TRAVIS_JOB_ID
-      - TRAVIS_JOB_NUMBER
-      - TRAVIS_LANGUAGE
-      - TRAVIS_OS_NAME
-      - TRAVIS_PRE_CHEF_BOOTSTRAP_TIME
-      - TRAVIS_PULL_REQUEST_BRANCH
-      - TRAVIS_PULL_REQUEST
-      - TRAVIS_PULL_REQUEST_SHA
-      - TRAVIS_PULL_REQUEST_SLUG
-      - TRAVIS_REPO_SLUG
-      - TRAVIS_SECURE_ENV_VARS
-      - TRAVIS_TAG
-      - TRAVIS
+      <<: *web-variables
+      <<: *aws-variables
+      <<: *travis-variables
+      <<: *honeycomb-variables
     command: bash -c "rm -f tmp/pids/server.pid && rails server -b 0.0.0.0 -p 3000"
   resque:
     image: chanzuckerberg/idseq-web:compose
@@ -125,38 +108,9 @@ services:
       - db
       - redis
     environment:
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - ALIGNMENT_CONFIG_DEFAULT_NAME
-      - SAMPLES_BUCKET_NAME=idseq-samples-development
-      - CI
-      - CONTINUOUS_INTEGRATION
-      - DATADOG_API_KEY
-      - RACK_ENV
-      - RAILS_ENV
-      - TRAVIS_ALLOW_FAILURE
-      - TRAVIS_BRANCH
-      - TRAVIS_BUILD_DIR
-      - TRAVIS_BUILD_ID
-      - TRAVIS_BUILD_NUMBER
-      - TRAVIS_COMMIT
-      - TRAVIS_COMMIT_MESSAGE
-      - TRAVIS_COMMIT_RANGE
-      - TRAVIS_EVENT_TYPE
-      - TRAVIS_FILTERED
-      - TRAVIS_JOB_ID
-      - TRAVIS_JOB_NUMBER
-      - TRAVIS_LANGUAGE
-      - TRAVIS_OS_NAME
-      - TRAVIS_PRE_CHEF_BOOTSTRAP_TIME
-      - TRAVIS_PULL_REQUEST_BRANCH
-      - TRAVIS_PULL_REQUEST
-      - TRAVIS_PULL_REQUEST_SHA
-      - TRAVIS_PULL_REQUEST_SLUG
-      - TRAVIS_REPO_SLUG
-      - TRAVIS_SECURE_ENV_VARS
-      - TRAVIS_TAG
-      - TRAVIS
+      <<: *web-variables
+      <<: *aws-variables
+      <<: *travis-variables
     command: bundle exec "QUEUE=* COUNT=5 rake resque:workers"
   resque_result_monitor:
     image: chanzuckerberg/idseq-web:compose
@@ -169,38 +123,9 @@ services:
       - db
       - redis
     environment:
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - ALIGNMENT_CONFIG_DEFAULT_NAME
-      - SAMPLES_BUCKET_NAME=idseq-samples-development
-      - CI
-      - CONTINUOUS_INTEGRATION
-      - DATADOG_API_KEY
-      - RACK_ENV
-      - RAILS_ENV
-      - TRAVIS_ALLOW_FAILURE
-      - TRAVIS_BRANCH
-      - TRAVIS_BUILD_DIR
-      - TRAVIS_BUILD_ID
-      - TRAVIS_BUILD_NUMBER
-      - TRAVIS_COMMIT
-      - TRAVIS_COMMIT_MESSAGE
-      - TRAVIS_COMMIT_RANGE
-      - TRAVIS_EVENT_TYPE
-      - TRAVIS_FILTERED
-      - TRAVIS_JOB_ID
-      - TRAVIS_JOB_NUMBER
-      - TRAVIS_LANGUAGE
-      - TRAVIS_OS_NAME
-      - TRAVIS_PRE_CHEF_BOOTSTRAP_TIME
-      - TRAVIS_PULL_REQUEST_BRANCH
-      - TRAVIS_PULL_REQUEST
-      - TRAVIS_PULL_REQUEST_SHA
-      - TRAVIS_PULL_REQUEST_SLUG
-      - TRAVIS_REPO_SLUG
-      - TRAVIS_SECURE_ENV_VARS
-      - TRAVIS_TAG
-      - TRAVIS
+      <<: *web-variables
+      <<: *aws-variables
+      <<: *travis-variables
     command: bundle exec "rake result_monitor"
   resque_pipeline_monitor:
     image: chanzuckerberg/idseq-web:compose
@@ -213,36 +138,7 @@ services:
       - db
       - redis
     environment:
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - ALIGNMENT_CONFIG_DEFAULT_NAME
-      - SAMPLES_BUCKET_NAME=idseq-samples-development
-      - CI
-      - CONTINUOUS_INTEGRATION
-      - DATADOG_API_KEY
-      - RACK_ENV
-      - RAILS_ENV
-      - TRAVIS_ALLOW_FAILURE
-      - TRAVIS_BRANCH
-      - TRAVIS_BUILD_DIR
-      - TRAVIS_BUILD_ID
-      - TRAVIS_BUILD_NUMBER
-      - TRAVIS_COMMIT
-      - TRAVIS_COMMIT_MESSAGE
-      - TRAVIS_COMMIT_RANGE
-      - TRAVIS_EVENT_TYPE
-      - TRAVIS_FILTERED
-      - TRAVIS_JOB_ID
-      - TRAVIS_JOB_NUMBER
-      - TRAVIS_LANGUAGE
-      - TRAVIS_OS_NAME
-      - TRAVIS_PRE_CHEF_BOOTSTRAP_TIME
-      - TRAVIS_PULL_REQUEST_BRANCH
-      - TRAVIS_PULL_REQUEST
-      - TRAVIS_PULL_REQUEST_SHA
-      - TRAVIS_PULL_REQUEST_SLUG
-      - TRAVIS_REPO_SLUG
-      - TRAVIS_SECURE_ENV_VARS
-      - TRAVIS_TAG
-      - TRAVIS
+      <<: *web-variables
+      <<: *aws-variables
+      <<: *travis-variables
     command: bundle exec "rake pipeline_monitor"


### PR DESCRIPTION
- It seemed really hard to try to try/catch the chamber call and/or timeout it in entrypoint.sh so I just reverted it back to what it used to be. Doesn't seem like a good developer experience to rely on the chamber call.


- Tiago brought up issues with loading chamber all the time (shouldn't be so coupled for local dev / wouldn't work with poor internet connection / bad for outside collaborators) so this PR reverts entrypoint.sh so that you don't load chamber in development.
- Adds back default in docker-compose ALIGNMENT_CONFIG_DEFAULT_NAME=2018-04-01
- Consolidates all the docker-compose variables so the default is easy to upgrade every so often. The interpreted YAML is the same as before after the key merging.
- YAML merging example: https://stackoverflow.com/a/9525884