### PR TITLE
[Metadata] Make sample_type freetext

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -368,14 +368,11 @@ module SamplesHelper
   end
 
   def get_distinct_sample_types(samples)
-    types = Metadatum
-            .where(key: "sample_type")
-            .where(sample_id: samples.pluck(:id))
-            .pluck(:text_validated_value)
-            .uniq
-
-    # Only include valid sample types
-    types & Metadatum::KEY_TO_STRING_OPTIONS[:sample_type]
+    Metadatum
+      .where(key: "sample_type")
+      .where(sample_id: samples.pluck(:id))
+      .pluck(:text_validated_value)
+      .uniq
   end
 
   def get_metadata_types_by_host_genome_name(host_genome_name)

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -53,10 +53,6 @@ class Metadatum < ApplicationRecord
   # Key to the valid string options.
   KEY_TO_STRING_OPTIONS = {
     nucleotide_type: %w[DNA RNA],
-    sample_type: [
-      "Bronchoalveolar lavage", "Cerebrospinal fluid", "Nasopharyngeal swab",
-      "Plasma", "Serum", "Solid tissue", "Stool", "Synovial fluid", "Whole blood"
-    ],
     gender: %w[Female Male],
     race: ["Caucasian", "Asian", "African American", "Other"],
     admission_type: %w[ICU General],


### PR DESCRIPTION
- Maira messaged me directly and we clarified that sample_type wasn't really meant to be restricted to these options (e.g. they might have every single potential specimen body part). E.g. what they really want to put in is "Whole Mosquitos" right now.
- End goal for these similar fields later will be freetext and the auto-suggestions will help people self-dedup values but still allow custom values