### PR TITLE
Makes the bin/shell script compatible with bless

### DIFF
--- a/bin/clam
+++ b/bin/clam
@@ -24,4 +24,4 @@ MACHINE=`bin/get_private_ip $ENV`
 
 CONTAINER=`ssh $MACHINE "sudo docker ps | grep ecs-idseq-$ENV-web | head -1" | awk '{print $NF}'`
 
-ssh ec2-user@$MACHINE 'sudo docker exec '$CONTAINER' bin/entrypoint.sh '"'$*'"
+ssh $MACHINE 'sudo docker exec '$CONTAINER' bin/entrypoint.sh '"'$*'"

--- a/bin/clam
+++ b/bin/clam
@@ -22,6 +22,6 @@ shift
 
 MACHINE=`bin/get_private_ip $ENV`
 
-CONTAINER=`ssh ec2-user@$MACHINE "docker ps | grep ecs-idseq-$ENV-web | head -1" | awk '{print $NF}'`
+CONTAINER=`ssh $MACHINE "sudo docker ps | grep ecs-idseq-$ENV-web | head -1" | awk '{print $NF}'`
 
-ssh ec2-user@$MACHINE 'docker exec '$CONTAINER' bin/entrypoint.sh '"'$*'"
+ssh ec2-user@$MACHINE 'sudo docker exec '$CONTAINER' bin/entrypoint.sh '"'$*'"

--- a/bin/shell
+++ b/bin/shell
@@ -31,4 +31,4 @@ resp = ec2_client.describe_instances(instance_ids: [instances.container_instance
 
 private_ip = resp.reservations.first.instances.first.private_ip_address
 
-exec %(ssh -t ec2-user@#{private_ip} "docker exec -it \\`docker ps | grep ecs-idseq-#{env}-web | head -1 | awk '{print \\$NF}'\\` bin/entrypoint.sh #{command} ")
+exec %(ssh -t #{private_ip} "sudo docker exec -it \\`sudo docker ps | grep ecs-idseq-#{env}-web | head -1 | awk '{print \\$NF}'\\` bin/entrypoint.sh #{command} ")


### PR DESCRIPTION
# Description
Removing the hardcoded `ec2-user` instead relies on the system ssh config. Also prefixing calls to docker with sudo so we don't assume membership to the docker group. This breaks systems with misconfigured ssh configs.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. ./shell <env> 
