### PR TITLE
Add Contig and Contig Reads columns to sample table.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -64,14 +64,22 @@ const getAlignmentData = (sampleId, alignmentQuery, pipelineVersion) =>
 
 const deleteSample = id => deleteWithCSRF(`/samples/${id}.json`);
 
+const getSampleReportInfo = (id, params) =>
+  get(`/samples/${id}/report_info${params}`);
+
+const getSummaryContigCounts = (id, minContigSize) =>
+  get(`/samples/${id}/summary_contig_counts?min_contig_size=${minContigSize}`);
+
 export {
   get,
   getSampleMetadata,
+  getSampleReportInfo,
   saveSampleMetadata,
   getMetadataTypesByHostGenomeName,
   saveSampleName,
   saveSampleNotes,
   getAlignmentData,
   getURLParamString,
-  deleteSample
+  deleteSample,
+  getSummaryContigCounts
 };

--- a/app/assets/src/components/ui/containers/HelpIcon.jsx
+++ b/app/assets/src/components/ui/containers/HelpIcon.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import PropTypes from "prop-types";
+import cx from "classnames";
+import { Popup } from "semantic-ui-react";
+import cs from "./help_icon.scss";
+
+class HelpIcon extends React.Component {
+  render() {
+    return (
+      <Popup
+        trigger={
+          <i
+            className={cx(
+              "fa fa-question-circle",
+              cs.helpIcon,
+              this.props.className
+            )}
+          />
+        }
+        inverted
+        content={this.props.text}
+        horizontalOffset={13}
+      />
+    );
+  }
+}
+
+HelpIcon.propTypes = {
+  className: PropTypes.string,
+  text: PropTypes.string
+};
+
+export default HelpIcon;

--- a/app/assets/src/components/ui/containers/help_icon.scss
+++ b/app/assets/src/components/ui/containers/help_icon.scss
@@ -1,0 +1,5 @@
+@import "~styles/themes/colors";
+
+.helpIcon {
+  color: $light-grey;
+}

--- a/app/assets/src/components/ui/controls/dropdowns/common/DropdownTrigger.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/common/DropdownTrigger.jsx
@@ -5,7 +5,15 @@ import cs from "./dropdown_trigger.scss";
 
 class DropdownTrigger extends React.Component {
   render() {
-    const { label, value, rounded, active, disabled, className } = this.props;
+    const {
+      label,
+      value,
+      rounded,
+      active,
+      disabled,
+      className,
+      onClick
+    } = this.props;
     return (
       <div
         className={cx(
@@ -15,6 +23,7 @@ class DropdownTrigger extends React.Component {
           active && cs.active,
           disabled && cs.disabled
         )}
+        onClick={onClick}
       >
         <div className={cs.labelContainer}>
           <span className={cs.label}>{label}</span>
@@ -31,7 +40,8 @@ DropdownTrigger.propTypes = {
   value: PropTypes.node,
   rounded: PropTypes.bool,
   active: PropTypes.bool,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func
 };
 
 export default DropdownTrigger;

--- a/app/assets/src/components/utils/ThresholdMap.js
+++ b/app/assets/src/components/utils/ThresholdMap.js
@@ -1,3 +1,5 @@
+import { getTaxonMetric } from "~/components/views/report/utils/taxon";
+
 function ThresholdMap(options) {
   this.options = options;
 }
@@ -39,7 +41,7 @@ ThresholdMap.taxonPassThresholdFilter = function(taxon, rules) {
       let { metric, operator, value } = rule;
       let threshold = parseFloat(value);
       const [fieldType, fieldTitle] = metric.split("_");
-      const taxonValue = (taxon[fieldType] || {})[fieldTitle];
+      const taxonValue = getTaxonMetric(taxon, fieldType, fieldTitle);
       switch (operator) {
         case ">=":
           if (taxonValue < threshold) {

--- a/app/assets/src/components/utils/sample.js
+++ b/app/assets/src/components/utils/sample.js
@@ -1,8 +1,8 @@
 import last from "lodash/fp";
 
-export const pipelineHasAssembly = pipelineRun => {
-  if (!pipelineRun.pipeline_version) return false;
-  const versionNums = pipelineRun.pipeline_version.split(".");
+export const pipelineVersionHasAssembly = pipelineVersion => {
+  if (!pipelineVersion) return false;
+  const versionNums = pipelineVersion.split(".");
   return +versionNums[0] >= 3 && +versionNums[1] >= 1;
 };
 

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -5,7 +5,7 @@ import cx from "classnames";
 import { get } from "lodash/fp";
 import { getURLParamString } from "~/api";
 import PropTypes from "~/components/utils/propTypes";
-import { pipelineHasAssembly } from "~/components/utils/sample";
+import { pipelineVersionHasAssembly } from "~/components/utils/sample";
 import AMRView from "~/components/AMRView";
 import BasicPopup from "~/components/BasicPopup";
 import PipelineSampleReport from "~/components/PipelineSampleReport";
@@ -121,7 +121,7 @@ class SampleView extends React.Component {
 
     if (
       !this.pipelineInProgress() &&
-      pipelineHasAssembly(this.props.pipelineRun) &&
+      pipelineVersionHasAssembly(this.props.pipelineRun.pipeline_version) &&
       this.props.pipelineRun.assembled !== 1
     ) {
       warnings.push("The reads did not assemble for this run.");

--- a/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
+++ b/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { get } from "lodash/fp";
 
 // TODO(mark): Use alias instead, to avoid dots.
 import PropTypes from "../../../utils/propTypes";
@@ -12,7 +13,8 @@ const DetailCells = ({
   getRowClass,
   openTaxonModal,
   reportDetails,
-  backgroundData
+  backgroundData,
+  showAssemblyColumns
 }) => {
   return taxons.map(taxInfo => (
     <tr
@@ -32,11 +34,24 @@ const DetailCells = ({
         0,
         true,
         undefined,
-        taxInfo.topScoring == 1
+        taxInfo.topScoring == 1,
+        "score-column"
       )}
       {renderNumber(taxInfo.NT.zscore, taxInfo.NR.zscore, 1)}
       {renderNumber(taxInfo.NT.rpm, taxInfo.NR.rpm, 1)}
       {renderNumber(taxInfo.NT.r, taxInfo.NR.r, 0)}
+      {showAssemblyColumns &&
+        renderNumber(
+          get("summaryContigCounts.NT.contigs", taxInfo) || 0,
+          get("summaryContigCounts.NR.contigs", taxInfo) || 0,
+          0
+        )}
+      {showAssemblyColumns &&
+        renderNumber(
+          get("summaryContigCounts.NT.contigreads", taxInfo) || 0,
+          get("summaryContigCounts.NR.contigreads", taxInfo) || 0,
+          0
+        )}
       {renderNumber(taxInfo.NT.percentidentity, taxInfo.NR.percentidentity, 1)}
       {renderNumber(taxInfo.NT.neglogevalue, taxInfo.NR.neglogevalue, 0)}
       {renderNumber(
@@ -60,7 +75,8 @@ DetailCells.propTypes = {
   openTaxonModal: PropTypes.func.isRequired,
   getRowClass: PropTypes.func.isRequired,
   reportDetails: PropTypes.ReportDetails,
-  backgroundData: PropTypes.BackgroundData
+  backgroundData: PropTypes.BackgroundData,
+  showAssemblyColumns: PropTypes.bool
 };
 
 export default DetailCells;

--- a/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
+++ b/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
@@ -63,7 +63,8 @@ export default class ReportTable extends React.Component {
       expandTable,
       collapseTable,
       countType,
-      setCountType
+      setCountType,
+      showAssemblyColumns
     } = this.props;
 
     return (
@@ -101,6 +102,18 @@ export default class ReportTable extends React.Component {
                 `${countType}_r`,
                 `Number of reads aligning to the taxon in the NCBI NT/NR database`
               )}
+              {showAssemblyColumns &&
+                renderColumnHeader(
+                  "contig",
+                  `${countType}_contigs`,
+                  `Number of assembled contigs aligning to the taxon in the NCBI NT/NR database`
+                )}
+              {showAssemblyColumns &&
+                renderColumnHeader(
+                  "contig r",
+                  `${countType}_contigreads`,
+                  `Total number of reads across all assembled contigs`
+                )}
               {renderColumnHeader(
                 "%id",
                 `${countType}_percentidentity`,
@@ -156,6 +169,7 @@ export default class ReportTable extends React.Component {
               openTaxonModal={this.handleTaxonModalOpen}
               reportDetails={reportDetails}
               backgroundData={backgroundData}
+              showAssemblyColumns={showAssemblyColumns}
             />
           </tbody>
         </table>
@@ -177,5 +191,6 @@ ReportTable.propTypes = {
   collapseTable: PropTypes.func.isRequired,
   renderColumnHeader: PropTypes.func.isRequired,
   countType: PropTypes.string.isRequired,
-  setCountType: PropTypes.func.isRequired
+  setCountType: PropTypes.func.isRequired,
+  showAssemblyColumns: PropTypes.bool
 };

--- a/app/assets/src/components/views/report/filters/MinContigSizeFilter.jsx
+++ b/app/assets/src/components/views/report/filters/MinContigSizeFilter.jsx
@@ -1,0 +1,93 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Input from "~ui/controls/Input";
+import HelpIcon from "~ui/containers/HelpIcon";
+import cs from "./min_contig_size_filter.scss";
+import BareDropdown from "~ui/controls/dropdowns/BareDropdown";
+import DropdownTrigger from "../../../ui/controls/dropdowns/common/DropdownTrigger";
+
+class MinContigSizeFilter extends React.Component {
+  state = {
+    value: this.props.value,
+    previousValue: this.props.value
+  };
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.value !== this.props.value) {
+      this.setState({
+        value: this.props.value,
+        previousValue: this.props.value
+      });
+    }
+  }
+
+  handleChange = value => {
+    this.setState({ value });
+  };
+
+  handleBlur = () => {
+    const newValue = Number(this.state.value);
+
+    if (isNaN(newValue)) {
+      // Reset back to the previous value.
+      this.setState({
+        value: this.state.previousValue
+      });
+    } else {
+      if (this.props.onChange) {
+        this.props.onChange(newValue);
+      }
+    }
+  };
+
+  renderContents = () => {
+    const helpText = `
+      The contig and contig r columns will ignore contigs less than the Min Contig Size.
+      For example, if a single contig with 10 reads is assembled for a taxon but the Min Contig Size
+      is larger than 10, then contig and contig r will show 0 for that taxon.
+    `;
+
+    return (
+      <div className={cs.contents} onClick={e => e.stopPropagation()}>
+        <div className={cs.labelContainer}>
+          <span className={cs.label}>Set the Min Contig Size:</span>
+          <HelpIcon text={helpText} />
+        </div>
+        <Input
+          value={this.state.value}
+          onChange={this.handleChange}
+          onBlur={this.handleBlur}
+          type="number"
+          className={cs.input}
+        />
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <BareDropdown
+        className={cs.minContigSizeFilter}
+        trigger={
+          <DropdownTrigger
+            className={cs.dropdownTrigger}
+            label="Min Contig Size: "
+            value={this.state.value}
+            rounded
+          />
+        }
+        floating
+        arrowInsideTrigger
+      >
+        <BareDropdown.Menu>{this.renderContents()}</BareDropdown.Menu>
+      </BareDropdown>
+    );
+  }
+}
+
+MinContigSizeFilter.propTypes = {
+  value: PropTypes.number,
+  onChange: PropTypes.func
+};
+
+export default MinContigSizeFilter;

--- a/app/assets/src/components/views/report/filters/min_contig_size_filter.scss
+++ b/app/assets/src/components/views/report/filters/min_contig_size_filter.scss
@@ -1,0 +1,27 @@
+@import "~styles/themes/colors";
+
+.minContigSizeFilter {
+  &:global(.active) {
+    .dropdownTrigger {
+      border: 1px solid $primary-light;
+    }
+  }
+
+  .dropdownTrigger {
+    cursor: pointer;
+  }
+
+  .contents {
+    text-align: left;
+    padding: 10px 20px;
+  }
+
+  .labelContainer {
+    margin-bottom: 5px;
+  }
+
+  .label {
+    font-weight: 600;
+    margin-right: 3px;
+  }
+}

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -171,6 +171,10 @@ input[type="number"] {
     &.last-col {
       width: 30px;
     }
+
+    &.score-column {
+      width: 120px;
+    }
   }
 
   td:first-child {
@@ -297,7 +301,6 @@ input[type="number"] {
     }
     .report-top-filters {
       .filter-lists {
-        padding: 10px 0;
         width: 100%;
         & > div.filter-lists-element > li {
           color: $darkest-grey;
@@ -333,6 +336,7 @@ input[type="number"] {
         .filter-lists-element {
           display: inline-block;
           vertical-align: top;
+          margin: 4px 0;
 
           &:not(:last-child) {
             margin-right: 10px;

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1236,8 +1236,8 @@ class PipelineRun < ApplicationRecord
 
   def get_summary_contig_counts(min_contig_size)
     contig_counts.where("count >= #{min_contig_size} and taxid > 0 and contig_name != '*'")
-                 .select("taxid, COUNT(1) as contigs, SUM(count) AS contig_reads")
-                 .group(:taxid).as_json(except: :id)
+                 .select("taxid, COUNT(1) as contigs, SUM(count) AS contig_reads, count_type")
+                 .group(:taxid, :count_type).as_json(except: :id)
   end
 
   def get_taxid_list_with_contigs(min_contig_size = MIN_CONTIG_SIZE)


### PR DESCRIPTION
Also add min contig size filter.
Only show the new columns for Pipeline 3.1 and above.
Re-distribute the width of the columns to fit the new columns.
Enable sorting of the new columns.
Reload automatically when user sets a new min contig size.
Enable filtering by threshold for the new columns.

![screen shot 2018-12-11 at 4 16 34 pm](https://user-images.githubusercontent.com/837004/49838579-2a1c8500-fd60-11e8-8b04-752df535fa22.png)
