### PR TITLE
Fix host filtering to himem settings

### DIFF
--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -47,20 +47,10 @@ module PipelineRunsHelper
   def aegea_batch_submit_command(base_command,
                                  memory: Sample::DEFAULT_MEMORY_IN_MB,
                                  vcpus: Sample::DEFAULT_VCPUS,
-                                 job_queue: nil,
+                                 job_queue: Sample::DEFAULT_QUEUE,
                                  docker_image: "idseq_dag")
     command = "aegea batch submit --command=\"#{base_command}\" "
-    if memory <= Sample::DEFAULT_MEMORY_IN_MB
-      # Use default memory, vCPUs, and queue if below the default memory threshold.
-      queue = Sample::DEFAULT_QUEUE
-    else
-      vcpus = Sample::DEFAULT_VCPUS_HIMEM
-      queue = Sample::DEFAULT_QUEUE_HIMEM
-    end
-    if job_queue.present?
-      queue = job_queue
-    end
-    command += " --storage /mnt=#{Sample::DEFAULT_STORAGE_IN_GB} --volume-type gp2 --ecr-image #{docker_image} --memory #{memory} --queue #{queue} --vcpus #{vcpus} --job-role idseq-pipeline "
+    command += " --storage /mnt=#{Sample::DEFAULT_STORAGE_IN_GB} --volume-type gp2 --ecr-image #{docker_image} --memory #{memory} --queue #{job_queue} --vcpus #{vcpus} --job-role idseq-pipeline "
     command
   end
 

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -185,8 +185,8 @@ class PipelineRunStage < ApplicationRecord
 
     batch_command = [install_pipeline(pipeline_run.pipeline_commit), upload_version(pipeline_run.pipeline_version_file), dag_commands].join("; ")
 
-    # Dispatch job
-    aegea_batch_submit_command(batch_command)
+    # Dispatch job. Use the himem settings for host filtering.
+    aegea_batch_submit_command(batch_command, vcpus: Sample::DEFAULT_VCPUS_HIMEM, job_queue: Sample::DEFAULT_QUEUE_HIMEM, memory: Sample::HIMEM_IN_MB)
   end
 
   def alignment_command
@@ -244,7 +244,7 @@ class PipelineRunStage < ApplicationRecord
     dag_commands = prepare_dag("postprocess", attribute_dict)
     batch_command = [install_pipeline(pipeline_run.pipeline_commit), dag_commands].join("; ")
     # Dispatch job with himem number of vCPUs and to the himem queue.
-    aegea_batch_submit_command(batch_command, vcpus: Sample::DEFAULT_VCPUS_HIMEM, job_queue: Sample::DEFAULT_QUEUE_HIMEM, memory: Sample::POSTPROCESSING_MEMORY_IN_MB)
+    aegea_batch_submit_command(batch_command, vcpus: Sample::DEFAULT_VCPUS_HIMEM, job_queue: Sample::DEFAULT_QUEUE_HIMEM, memory: Sample::HIMEM_IN_MB)
   end
 
   def experimental_command

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -20,7 +20,7 @@ class Sample < ApplicationRecord
   # TODO: Make all these params configurable without code change
   DEFAULT_STORAGE_IN_GB = 500
   DEFAULT_MEMORY_IN_MB = 120_000 # sorry, hacky
-  POSTPROCESSING_MEMORY_IN_MB = 240_000
+  HIMEM_IN_MB = 240_000
 
   DEFAULT_QUEUE = (Rails.env == 'prod' ? 'idseq-prod-lomem' : 'idseq-staging-lomem').freeze
   DEFAULT_VCPUS = 16


### PR DESCRIPTION
- Simplify the pattern in aegea_batch_submit_command and just have default params to be overridden to reduce confusion.
- Host filtering and postprocessing will use: `aegea_batch_submit_command(batch_command, vcpus: Sample::DEFAULT_VCPUS_HIMEM, job_queue: Sample::DEFAULT_QUEUE_HIMEM, memory: Sample::HIMEM_IN_MB)`
- Test run submitted locally that works:

```
irb(main):008:0> PipelineRun.last.pipeline_run_stages[0].job_command
[2018-12-14T19:33:55] DEBUG ActiveRecord::Base :   PipelineRun Load (0.9ms)  SELECT  `pipeline_runs`.* FROM `pipeline_runs` ORDER BY `pipeline_runs`.`id` DESC LIMIT 1
[2018-12-14T19:33:55] DEBUG ActiveRecord::Base :   PipelineRunStage Load (1.2ms)  SELECT `pipeline_run_stages`.* FROM `pipeline_run_stages` WHERE `pipeline_run_stages`.`pipeline_run_id` = 1644
=> "aegea batch submit --command=\"pip install --upgrade git+git://github.com/chanzuckerberg/s3mi.git; cd /mnt; git clone https://github.com/chanzuckerberg/idseq-dag.git; cd idseq-dag; git checkout 0b70f96bcbd6507afcdb25a62e3559ac41c1f3ca; pip3 install -e . --upgrade; idseq_dag --version | cut -f2 -d ' ' | aws s3 cp  - s3://idseq-samples-development/samples/67/1269/results/pipeline_version.txt; aws s3 cp s3://idseq-samples-development/samples/67/1269/results/host_filter.json /mnt/host_filter.json;idseq_dag  /mnt/host_filter.json;echo done | aws s3 cp - s3://idseq-samples-development/samples/67/1269/results/\\$AWS_BATCH_JOB_ID.succeeded\"  --storage /mnt=500 --volume-type gp2 --ecr-image idseq_dag --memory 240000 --queue idseq-staging-himem --vcpus 32 --job-role idseq-pipeline "
```

![screen shot 2018-12-14 at 11 33 10 am](https://user-images.githubusercontent.com/5652739/50023717-e199dd00-ff94-11e8-8c76-15748add3135.png)
