### PR TITLE
Update pipeline check for if the latest rerun fails

### DIFF
--- a/app/assets/src/components/views/SampleView/PipelineVersionSelect.jsx
+++ b/app/assets/src/components/views/SampleView/PipelineVersionSelect.jsx
@@ -44,12 +44,17 @@ class PipelineVersionSelect extends React.Component {
   };
 
   render() {
-    const { pipelineVersions, lastProcessedAt } = this.props;
+    const { pipelineVersions, lastProcessedAt, pipelineRun } = this.props;
 
     if (!lastProcessedAt) return null;
 
-    // No version select.
-    if (pipelineVersions.length <= 1) {
+    // Don't show selector if there's only 1 version and it's the current one.
+    // Note: If the latest/any run failed it won't be in the pipelineVersions.
+    if (
+      pipelineVersions.length === 0 ||
+      (pipelineVersions.length === 1 &&
+        pipelineVersions[0] === pipelineRun.pipeline_version)
+    ) {
       return (
         <span className={cs.pipelineVersionSelectContainer}>
           | {this.getLastProcessedString()}


### PR DESCRIPTION
- The bug was that if you had a rerun that failed and 1 previous successful run, you wouldn't get the switcher arrow because of (pipelineVersions.length <= 1) where pipelineVersions would just be the previous successful version number.

### BEFORE
![screen shot 2018-12-17 at 3 05 05 pm](https://user-images.githubusercontent.com/5652739/50121642-38f6b200-020e-11e9-813b-168c9682b826.png)

### AFTER
![screen shot 2018-12-17 at 3 05 22 pm](https://user-images.githubusercontent.com/5652739/50121647-3d22cf80-020e-11e9-9623-520715c03937.png)
