### PR TITLE
Fix bug where heatmap broke if filter returned no rows.

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -222,35 +222,37 @@ class SamplesHeatmapView extends React.Component {
         host_genome_name: sample.host_genome_name,
         metadata: processMetadata(sample.metadata)
       };
-      for (let j = 0; j < sample.taxons.length; j++) {
-        let taxon = sample.taxons[j];
-        let taxonIndex;
-        if (!(taxon.tax_id in taxonDetails)) {
-          taxonIndex = taxonIds.length;
-          taxonIds.push(taxon.tax_id);
-          taxonDetails[taxon.tax_id] = {
-            id: taxon.tax_id,
-            index: taxonIndex,
-            name: taxon.name,
-            category: taxon.category_name,
-            phage: !!taxon.is_phage
-          };
-          taxonDetails[taxon.name] = taxonDetails[taxon.tax_id];
-        } else {
-          taxonIndex = taxonDetails[taxon.tax_id].index;
-        }
+      if (sample.taxons) {
+        for (let j = 0; j < sample.taxons.length; j++) {
+          let taxon = sample.taxons[j];
+          let taxonIndex;
+          if (!(taxon.tax_id in taxonDetails)) {
+            taxonIndex = taxonIds.length;
+            taxonIds.push(taxon.tax_id);
+            taxonDetails[taxon.tax_id] = {
+              id: taxon.tax_id,
+              index: taxonIndex,
+              name: taxon.name,
+              category: taxon.category_name,
+              phage: !!taxon.is_phage
+            };
+            taxonDetails[taxon.name] = taxonDetails[taxon.tax_id];
+          } else {
+            taxonIndex = taxonDetails[taxon.tax_id].index;
+          }
 
-        this.state.availableOptions.metrics.forEach(metric => {
-          let [metricType, metricName] = metric.value.split(".");
-          data[metric.value] = data[metric.value] || [];
-          data[metric.value][taxonIndex] = data[metric.value][taxonIndex] || [];
-          data[metric.value][taxonIndex][i] = taxon[metricType][metricName];
-        });
+          this.state.availableOptions.metrics.forEach(metric => {
+            let [metricType, metricName] = metric.value.split(".");
+            data[metric.value] = data[metric.value] || [];
+            data[metric.value][taxonIndex] =
+              data[metric.value][taxonIndex] || [];
+            data[metric.value][taxonIndex][i] = taxon[metricType][metricName];
+          });
+        }
       }
     }
 
     return {
-      sampleIds,
       sampleDetails,
       taxonIds,
       taxonDetails,
@@ -326,7 +328,7 @@ class SamplesHeatmapView extends React.Component {
       Object.values(this.state.data).every(e => !e.length) ||
       !this.state.metadataTypes
     ) {
-      return;
+      return <div className={cs.noDataMsg}>No data to render</div>;
     }
     let scaleIndex = this.state.selectedOptions.dataScaleIdx;
 
@@ -608,8 +610,7 @@ class SamplesHeatmapView extends React.Component {
   renderVisualization() {
     return (
       <div className="row visualization-content">
-        {this.state.loading && this.renderLoading()}
-        {this.renderHeatmap()}
+        {this.state.loading ? this.renderLoading() : this.renderHeatmap()}
       </div>
     );
   }

--- a/app/assets/src/components/views/compare/samples_heatmap_view.scss
+++ b/app/assets/src/components/views/compare/samples_heatmap_view.scss
@@ -18,8 +18,10 @@
     }
   }
 
-  .loadingIndicator {
+  .loadingIndicator,
+  .noDataMsg {
     margin: 50px;
     text-align: center;
+    color: $medium-grey;
   }
 }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -754,7 +754,6 @@ class SamplesController < ApplicationController
 
     taxon_ids = top_taxons_details(samples, background_id, num_results, sort_by, species_selected, categories, threshold_filters, read_specificity, include_phage).pluck("tax_id")
     taxon_ids -= removed_taxon_ids
-    return {} if taxon_ids.empty?
 
     samples_taxons_details(samples, taxon_ids, background_id, species_selected)
   end

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -443,6 +443,18 @@ module ReportHelper
   end
 
   def samples_taxons_details(samples, taxon_ids, background_id, species_selected)
+    # if there are no taxon ids, return just the samples data.
+    if taxon_ids.empty?
+      return samples.map do |sample|
+        {
+          sample: sample.id,
+          name: sample.name,
+          metadata: sample.metadata,
+          host_genome_name: sample.host_genome_name
+        }
+      end
+    end
+
     samples_by_id = Hash[samples.map { |s| [s.id, s] }]
     parent_ids = fetch_parent_ids(taxon_ids, samples)
     results_by_pr = fetch_samples_taxons_counts(samples, taxon_ids, parent_ids, background_id)


### PR DESCRIPTION
Previously, if a filter returned no matching rows, the sample objects wouldn't be passed
back in the request.

SamplesHeatmapView overwrote its current sample ids with whatever sample ids were passed back,
which means that after an empty filter, the sample ids permanently disappeared from
the heatmap view.

To fix this, we make sure SamplesHeatmapView preserves its original sample ids, regardless of what
is passed back in the data request.

We also have the samples_taxon endpoint pass back the samples (minus the taxon list) even if taxon_ids
is empty. This is so that the heatmap view can correctly compute the set of host genomes in the samples
when the page loads.

Also add a "No data" message.

![screen shot 2018-12-17 at 5 06 53 pm](https://user-images.githubusercontent.com/837004/50125542-34d29080-021e-11e9-9723-b9251a2d18db.png)
