### PR TITLE
[Report Page] Simplify report_ready check to fix blank table when Alignment is running

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -283,6 +283,8 @@ class SamplesController < ApplicationController
     background_id = get_background_id(@sample)
     @report_page_params = { pipeline_version: @pipeline_version, background_id: background_id } if background_id
     @report_page_params[:scoring_model] = params[:scoring_model] if params[:scoring_model]
+
+    # Check if the report table should actually show
     if @pipeline_run && (((@pipeline_run.adjusted_remaining_reads.to_i > 0 || @pipeline_run.results_finalized?) && !@pipeline_run.failed?) || @pipeline_run.report_ready?)
       if background_id
         @report_present = true
@@ -290,10 +292,6 @@ class SamplesController < ApplicationController
         @all_categories = all_categories
         @report_details = report_details(@pipeline_run, current_user.id)
         @ercc_comparison = @pipeline_run.compare_ercc_counts
-      end
-
-      if @pipeline_run.failed?
-        @pipeline_run_retriable = true
       end
     end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -285,14 +285,12 @@ class SamplesController < ApplicationController
     @report_page_params[:scoring_model] = params[:scoring_model] if params[:scoring_model]
 
     # Check if the report table should actually show
-    if @pipeline_run && (((@pipeline_run.adjusted_remaining_reads.to_i > 0 || @pipeline_run.results_finalized?) && !@pipeline_run.failed?) || @pipeline_run.report_ready?)
-      if background_id
-        @report_present = true
-        @report_ts = @pipeline_run.updated_at.to_i
-        @all_categories = all_categories
-        @report_details = report_details(@pipeline_run, current_user.id)
-        @ercc_comparison = @pipeline_run.compare_ercc_counts
-      end
+    if background_id && @pipeline_run && @pipeline_run.report_ready?
+      @report_present = true
+      @report_ts = @pipeline_run.updated_at.to_i
+      @all_categories = all_categories
+      @report_details = report_details(@pipeline_run, current_user.id)
+      @ercc_comparison = @pipeline_run.compare_ercc_counts
     end
 
     tags = %W[sample_id:#{@sample.id} user_id:#{current_user.id}]


### PR DESCRIPTION
- We actually did a good job of migrating data with PipelineRuns -> PipelineRunStages -> OutputStates, so every PipelineRun has non-nil results_finalized, and every successful sample has OutputStates for taxon_counts filled in (see below)
- So the mash of report checks we had here can finally be simplified to report_ready, which checks if the report ready output state is loaded (which is taxon_counts). Basically IFF taxon_counts is loaded, you can show the report table.
- This also fixes the bug where, if you click on a sample while it's running Alignment, you wouldn't see the spinner at all and would actually just get a blank table.
- This is better for people who are keeping the tab open and see the page refresh every 5 minutes and wonder what's going on after host filtering.
- pipeline_run_retriable was no longer used.

#### BEFORE
<img width="1269" alt="screen shot 2018-12-19 at 3 11 06 pm" src="https://user-images.githubusercontent.com/5652739/50254008-409a9000-03a1-11e9-904d-950bf2be4d87.png">

#### AFTER
<img width="1266" alt="screen shot 2018-12-19 at 3 01 49 pm" src="https://user-images.githubusercontent.com/5652739/50254015-47290780-03a1-11e9-881b-3c565943ab30.png">

- You can verify the output states above:

```
irb(main):072:0> PipelineRun.where(results_finalized: nil)
=> #<ActiveRecord::Relation []>
irb(main):073:0>

irb(main):044:0> Sample.all.each do |s|
irb(main):045:1*   pr = s.pipeline_runs[0]
irb(main):046:1>   if pr.results_finalized == PipelineRun::FINALIZED_SUCCESS
irb(main):047:2>     outputs = pr.output_states
irb(main):048:2>     if outputs.find_by(output: "taxon_counts")
irb(main):049:3>       if outputs.find_by(output: "taxon_counts").state != "LOADED"
irb(main):050:4>         puts s.id
irb(main):051:4>       end
irb(main):052:3>     end
irb(main):053:2>   end
irb(main):054:1> end
(returns nothing)
```