### PR TITLE
Ensure Heatmap doesn't crash when metric data is missing.

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -328,7 +328,7 @@ class SamplesHeatmapView extends React.Component {
     if (
       this.state.loading ||
       !this.state.data ||
-      Object.values(this.state.data).every(e => !e.length) ||
+      !(this.state.data[this.state.selectedOptions.metric] || []).length ||
       !this.state.metadataTypes
     ) {
       return <div className={cs.noDataMsg}>No data to render</div>;


### PR DESCRIPTION
This guards against a hypothetical crash where `this.state.data` has data for some metrics but not all.

Previously, if any metric had data, we would try to render the heatmap even if the currently selected metric had no data, causing a crash.
Now, we only render the heatmap if the currently selected metric has data. (using the same condition from line 311 which renders the legend)