### PR TITLE
Apply new styles to ui components and refactor BareDropdown.

### DIFF
--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -930,7 +930,7 @@ class Samples extends React.Component {
         {search_field}
         <div className="filter-container">
           <MultipleDropdown
-            label="Hosts: "
+            label="Hosts:"
             disabled={this.state.hostGenomes.length == 0}
             options={this.state.hostGenomes.map(host => {
               return { text: host.name, value: host.id };
@@ -942,7 +942,7 @@ class Samples extends React.Component {
         </div>
         <div className="filter-container">
           <MultipleDropdown
-            label="Sample Types: "
+            label="Sample Types:"
             disabled={this.state.tissueTypes.length == 0}
             options={this.state.tissueTypes.map(tissue => {
               return { text: tissue, value: tissue };

--- a/app/assets/src/components/layout/ViewHeader/Controls.jsx
+++ b/app/assets/src/components/layout/ViewHeader/Controls.jsx
@@ -1,15 +1,21 @@
 import React from "react";
 import PropTypes from "prop-types";
+import cx from "classnames";
 import cs from "./view_header.scss";
 
 class ViewHeaderControls extends React.Component {
   render() {
-    return <div className={cs.controls}>{this.props.children}</div>;
+    return (
+      <div className={cx(cs.controls, this.props.className)}>
+        {this.props.children}
+      </div>
+    );
   }
 }
 
 ViewHeaderControls.propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
+  className: PropTypes.string
 };
 
 ViewHeaderControls.CLASS_NAME = "ViewHeaderControls";

--- a/app/assets/src/components/layout/ViewHeader/Title.jsx
+++ b/app/assets/src/components/layout/ViewHeader/Title.jsx
@@ -68,21 +68,20 @@ class Title extends React.Component {
         options,
         option => String(option.id) !== String(id)
       );
+
+      const items = filteredOptions.map(option => (
+        <BareDropdown.Item onClick={option.onClick} key={option.id}>
+          {option.label}
+        </BareDropdown.Item>
+      ));
+
       return (
         <BareDropdown
           trigger={sampleName}
           className={cs.sampleDropdown}
           floating
-          scrolling
-        >
-          <BareDropdown.Menu>
-            {filteredOptions.map(option => (
-              <BareDropdown.Item onClick={option.onClick} key={option.id}>
-                {option.label}
-              </BareDropdown.Item>
-            ))}
-          </BareDropdown.Menu>
-        </BareDropdown>
+          items={items}
+        />
       );
     } else {
       return sampleName;

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -1,31 +1,72 @@
 // This component allows you to easily add a dropdown of options to any trigger element
 // Wraps around Semantic UI Dropdown
+
 import React from "react";
 import cx from "classnames";
+import { omit } from "lodash/fp";
 import { forbidExtraProps } from "airbnb-prop-types";
 import { Dropdown as BaseDropdown } from "semantic-ui-react";
 import PropTypes from "prop-types";
 import cs from "./bare_dropdown.scss";
 
 class BareDropdown extends React.Component {
+  // If the user provides us options instead of items, we will render them like this.
+  renderItemsDefault = () => {
+    return this.props.options.map(option => (
+      <BaseDropdown.Item
+        key={option.value}
+        onClick={() => this.props.onChange(option.value)}
+        active={this.props.value === option.value}
+      >
+        {option.text}
+      </BaseDropdown.Item>
+    ));
+  };
+
   render() {
     const {
       arrowInsideTrigger,
       className,
       hideArrow,
+      menuLabel,
       ...otherProps
     } = this.props;
 
+    const dropdownClassName = cx(
+      cs.bareDropdown,
+      arrowInsideTrigger ? cs.arrowInsideTrigger : cs.arrowOutsideTrigger,
+      className,
+      hideArrow && cs.hideArrow
+    );
+
+    // Allows you the flexibility to put stuff OTHER than a menu of options in the dropdown.
+    if (!this.props.options && !this.props.items) {
+      return <BaseDropdown {...otherProps} className={dropdownClassName} />;
+    }
+
+    if (this.props.options && this.props.items) {
+      throw new Error(
+        "Only one of options or items should be provided to <BareDropdown>"
+      );
+    }
+
+    // If options are provided, render them as dropdown items the default way.
+    const items = this.props.items || this.renderItemsDefault();
+
+    const baseDropdownProps = omit(
+      ["options", "value", "onChange", "items"],
+      otherProps
+    );
+
     return (
-      <BaseDropdown
-        {...otherProps}
-        className={cx(
-          cs.bareDropdown,
-          arrowInsideTrigger ? cs.arrowInsideTrigger : cs.arrowOutsideTrigger,
-          className,
-          hideArrow && cs.hideArrow
-        )}
-      />
+      <BaseDropdown {...baseDropdownProps} className={dropdownClassName}>
+        <BaseDropdown.Menu className={cs.menu}>
+          {menuLabel && <div className={cs.menuLabel}>{menuLabel}</div>}
+          <BaseDropdown.Menu scrolling className={cs.innerMenu}>
+            {items}
+          </BaseDropdown.Menu>
+        </BaseDropdown.Menu>
+      </BaseDropdown>
     );
   }
 }
@@ -38,18 +79,19 @@ BareDropdown.propTypes = forbidExtraProps({
       text: PropTypes.string
     })
   ),
+  items: PropTypes.arrayOf(PropTypes.node),
   value: PropTypes.any,
   onChange: PropTypes.func,
   children: PropTypes.node,
   className: PropTypes.string,
   floating: PropTypes.bool,
-  scrolling: PropTypes.bool,
   hideArrow: PropTypes.bool,
   disabled: PropTypes.bool,
   selectOnBlur: PropTypes.bool,
   fluid: PropTypes.bool,
   placeholder: PropTypes.string,
-  arrowInsideTrigger: PropTypes.bool // whether the arrow should be displayed outside the trigger or inside it.
+  arrowInsideTrigger: PropTypes.bool, // whether the arrow should be displayed outside the trigger or inside it.
+  menuLabel: PropTypes.string
 });
 
 BareDropdown.Header = BaseDropdown.Header;

--- a/app/assets/src/components/ui/controls/dropdowns/ButtonDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/ButtonDropdown.jsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import cx from "classnames";
 
+/* TODO(mark): Refactor ButtonDropdown to use BareDropdown */
 class ButtonDropdown extends React.Component {
   constructor(props) {
     super(props);

--- a/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
@@ -22,9 +22,9 @@ class Dropdown extends React.Component {
     }
   }
 
-  handleOnChange = (e, d) => {
-    this.setState({ value: d.value });
-    this.props.onChange(d.value, this.labels[d.value]);
+  handleOnChange = value => {
+    this.setState({ value });
+    this.props.onChange(value, this.labels[value]);
   };
 
   renderTrigger = () => {

--- a/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
@@ -48,7 +48,6 @@ class Dropdown extends React.Component {
         className={cs.dropdown}
         arrowInsideTrigger
         placeholder={this.props.placeholder}
-        scrolling={this.props.scrolling}
         disabled={this.props.disabled}
         fluid={this.props.fluid}
         options={this.props.options}
@@ -65,7 +64,6 @@ class Dropdown extends React.Component {
 Dropdown.propTypes = {
   placeholder: PropTypes.string,
   disabled: PropTypes.bool,
-  scrolling: PropTypes.bool,
   fluid: PropTypes.bool,
   rounded: PropTypes.bool,
   label: PropTypes.string,

--- a/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx
@@ -83,9 +83,8 @@ class MultipleDropdown extends React.Component {
         {...otherProps}
         arrowInsideTrigger
         trigger={this.renderText()}
-      >
-        <BareDropdown.Menu>{this.renderMenuItems()}</BareDropdown.Menu>
-      </BareDropdown>
+        items={this.renderMenuItems()}
+      />
     );
   }
 }

--- a/app/assets/src/components/ui/controls/dropdowns/MultipleNestedDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/MultipleNestedDropdown.jsx
@@ -256,9 +256,8 @@ class MultipleNestedDropdown extends React.Component {
         arrowInsideTrigger
         {...otherProps}
         trigger={this.renderLabel()}
-      >
-        <BareDropdown.Menu>{this.renderItems()}</BareDropdown.Menu>
-      </BareDropdown>
+        items={this.renderItems()}
+      />
     );
   }
 }

--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -10,7 +10,7 @@
       padding: 0;
       position: absolute;
       right: 10px;
-      top: 6px;
+      top: 5px;
       line-height: 24px;
       pointer-events: none;
       font-size: 20px;
@@ -34,9 +34,38 @@
   }
 
   :global(.item) {
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 400;
     letter-spacing: 0.4px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+  }
+
+  .menu {
+    min-width: 100%;
+    padding: 6px 0;
+  }
+
+  .menuLabel {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.4px;
+    margin-bottom: 10px;
+    margin-top: 8px;
+    padding: 0 16px;
+  }
+
+  .innerMenu {
+    /* Override semantic-ui */
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    border-top: none !important;
+
+    &::-webkit-scrollbar {
+      width: 6px;
+      border-radius: 3px;
+    }
   }
 
   i:global(.dropdown) {

--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -40,6 +40,9 @@
     height: 30px;
     display: flex;
     align-items: center;
+    /* Overwrite semantic ui */
+    padding-left: 14px !important;
+    padding-right: 14px !important;
   }
 
   .menu {
@@ -53,7 +56,7 @@
     letter-spacing: 0.4px;
     margin-bottom: 10px;
     margin-top: 8px;
-    padding: 0 16px;
+    padding: 0 14px;
   }
 
   .innerMenu {
@@ -62,9 +65,14 @@
     border-radius: 0 !important;
     border-top: none !important;
 
+    // TODO(mark): Move this to a global CSS file.
     &::-webkit-scrollbar {
-      width: 6px;
+      width: 8px;
       border-radius: 3px;
+    }
+
+    &::-webkit-scrollbar-track {
+      display: none;
     }
   }
 

--- a/app/assets/src/components/ui/controls/dropdowns/common/dropdown_trigger.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/common/dropdown_trigger.scss
@@ -9,7 +9,7 @@
   letter-spacing: 0.4px;
   height: 34px;
   line-height: 24px;
-  padding: 4px 26px 4px 16px;
+  padding: 4px 26px 4px 14px;
   font-size: 13px;
 
   &.rounded {

--- a/app/assets/src/components/ui/controls/dropdowns/common/dropdown_trigger.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/common/dropdown_trigger.scss
@@ -7,9 +7,9 @@
   background-color: $white;
   color: $black;
   letter-spacing: 0.4px;
-  height: 38px;
+  height: 34px;
   line-height: 24px;
-  padding: 6px 26px 6px 16px;
+  padding: 4px 26px 4px 16px;
   font-size: 13px;
 
   &.rounded {
@@ -34,6 +34,6 @@
 
   .label {
     font-weight: 600;
-    margin-right: 1px;
+    margin-right: 5px;
   }
 }

--- a/app/assets/src/components/ui/controls/dropdowns/multiple_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/multiple_dropdown.scss
@@ -4,11 +4,7 @@
 :global(.ui):global(.dropdown).multipleDropdown {
   :global(.item) {
     /* override semantic-ui */
-    padding: 6px 10px !important;
-  }
-
-  .dropdownLabel {
-    margin-left: 6px;
+    padding: 6px 14px 6px 10px !important;
   }
 
   &:global(.active) {

--- a/app/assets/src/components/ui/controls/dropdowns/multiple_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/multiple_dropdown.scss
@@ -4,7 +4,7 @@
 :global(.ui):global(.dropdown).multipleDropdown {
   :global(.item) {
     /* override semantic-ui */
-    padding: 6px 14px 6px 10px !important;
+    padding: 6px 14px 6px 9px !important;
   }
 
   &:global(.active) {

--- a/app/assets/src/components/ui/controls/dropdowns/multiple_nested_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/multiple_nested_dropdown.scss
@@ -4,11 +4,7 @@
 :global(.ui):global(.dropdown).multipleNestedDropdown {
   :global(.item) {
     /* override semantic-ui */
-    padding: 6px 10px !important;
-  }
-
-  .dropdownLabel {
-    margin-left: 6px;
+    padding: 6px 14px 6px 10px !important;
   }
 
   &:global(.active) {

--- a/app/assets/src/components/ui/controls/dropdowns/multiple_nested_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/multiple_nested_dropdown.scss
@@ -4,7 +4,7 @@
 :global(.ui):global(.dropdown).multipleNestedDropdown {
   :global(.item) {
     /* override semantic-ui */
-    padding: 6px 14px 6px 10px !important;
+    padding: 6px 14px 6px 9px !important;
   }
 
   &:global(.active) {

--- a/app/assets/src/components/views/PlaygroundControls.jsx
+++ b/app/assets/src/components/views/PlaygroundControls.jsx
@@ -2,6 +2,7 @@ import CompareButton from "../ui/controls/buttons/CompareButton";
 import DownloadButton from "../ui/controls/buttons/DownloadButton";
 import Dropdown from "../ui/controls/dropdowns/Dropdown";
 import ButtonDropdown from "../ui/controls/dropdowns/ButtonDropdown";
+import BetaLabel from "../ui/labels/BetaLabel";
 import DownloadButtonDropdown from "../ui/controls/dropdowns/DownloadButtonDropdown";
 import MultipleDropdown from "../ui/controls/dropdowns/MultipleDropdown";
 import ThresholdFilterDropdown from "../ui/controls/dropdowns/ThresholdFilterDropdown";
@@ -52,6 +53,12 @@ class PlaygroundControls extends React.Component {
                 key={1}
                 text="Submit"
                 disabled
+                onClick={() => this.setState({ event: "PrimaryButton:Click" })}
+              />,
+              <PrimaryButton
+                key={1}
+                label={<BetaLabel />}
+                text="Submit"
                 onClick={() => this.setState({ event: "PrimaryButton:Click" })}
               />
             ]}
@@ -177,7 +184,7 @@ class PlaygroundControls extends React.Component {
           />
           <ComponentCard
             title="Download Dropdown Button"
-            width={3}
+            width={4}
             components={[
               <DownloadButtonDropdown
                 key={0}
@@ -278,6 +285,22 @@ class PlaygroundControls extends React.Component {
             ]}
           />
           <ComponentCard
+            title="Multiple Tree Dropdown"
+            width={4}
+            components={[
+              <MultipleNestedDropdown
+                key={0}
+                fluid
+                rounded
+                options={this.dropdownOptions}
+                label="Options: "
+                onChange={(a, b) => {
+                  this.setState({ event: "MultipleDropdown:Change" });
+                }}
+              />
+            ]}
+          />
+          <ComponentCard
             title="Slider"
             width={4}
             components={[
@@ -324,22 +347,6 @@ class PlaygroundControls extends React.Component {
                 label="Checkbox"
                 onChange={() => this.setState({ event: "Checkbox:Change" })}
                 value={1}
-              />
-            ]}
-          />
-          <ComponentCard
-            title="Multiple Tree Dropdown"
-            width={4}
-            components={[
-              <MultipleNestedDropdown
-                key={0}
-                fluid
-                rounded
-                options={this.dropdownOptions}
-                label="Options: "
-                onChange={(a, b) => {
-                  this.setState({ event: "MultipleDropdown:Change" });
-                }}
               />
             ]}
           />

--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -385,7 +385,7 @@ class SamplesHeatmapView extends React.Component {
         options={this.state.availableOptions.metrics}
         onChange={this.onMetricChange}
         value={this.state.selectedOptions.metric}
-        label="Metric: "
+        label="Metric:"
         disabled={!this.state.data}
       />
     );
@@ -429,7 +429,7 @@ class SamplesHeatmapView extends React.Component {
         options={this.state.availableOptions.taxonLevels}
         value={this.state.selectedOptions.species}
         onChange={this.onTaxonLevelChange}
-        label="Taxon Level: "
+        label="Taxon Level:"
         disabled={!this.state.data}
       />
     );
@@ -459,7 +459,7 @@ class SamplesHeatmapView extends React.Component {
         value={this.state.selectedOptions.dataScaleIdx}
         onChange={this.onDataScaleChange}
         options={options}
-        label="Scale: "
+        label="Scale:"
         disabled={!this.state.data}
       />
     );
@@ -538,7 +538,7 @@ class SamplesHeatmapView extends React.Component {
         options={options}
         onChange={this.onBackgroundChanged}
         value={this.state.selectedOptions.background}
-        label="Background: "
+        label="Background:"
         disabled={!this.state.data}
       />
     );
@@ -554,7 +554,7 @@ class SamplesHeatmapView extends React.Component {
   renderTaxonsPerSampleSlider() {
     return (
       <Slider
-        label="Taxa per Sample: "
+        label="Taxa per Sample:"
         min={this.state.availableOptions.taxonsPerSample.min}
         max={this.state.availableOptions.taxonsPerSample.max}
         value={this.state.selectedOptions.taxonsPerSample}
@@ -582,7 +582,7 @@ class SamplesHeatmapView extends React.Component {
         rounded
         options={this.availableOptions.specificityOptions}
         value={this.state.selectedOptions.readSpecificity}
-        label="Read Specificity: "
+        label="Read Specificity:"
         onChange={this.onSpecificityChange}
       />
     );
@@ -649,7 +649,7 @@ class SamplesHeatmapView extends React.Component {
                 } Samples`}
               />
             </ViewHeader.Content>
-            <ViewHeader.Controls>
+            <ViewHeader.Controls className={cs.controls}>
               <Popup
                 trigger={
                   <PrimaryButton

--- a/app/assets/src/components/views/compare/samples_heatmap_view.scss
+++ b/app/assets/src/components/views/compare/samples_heatmap_view.scss
@@ -5,8 +5,12 @@
     margin-top: 40px;
     margin-bottom: 40px;
 
-    .controlElement {
-      margin-left: 10px;
+    .controls {
+      display: flex;
+
+      .controlElement {
+        margin-left: 10px;
+      }
     }
   }
 

--- a/app/assets/src/components/views/report/SampleDetailsSidebar/MetadataTab.jsx
+++ b/app/assets/src/components/views/report/SampleDetailsSidebar/MetadataTab.jsx
@@ -79,7 +79,6 @@ class MetadataTab extends React.Component {
         <Dropdown
           fluid
           floating
-          scrolling
           options={options}
           onChange={val => onMetadataChange(metadataType.key, val, true)}
           value={metadata[metadataType.key]}

--- a/app/assets/src/components/views/report/filters/BackgroundModelFilter.jsx
+++ b/app/assets/src/components/views/report/filters/BackgroundModelFilter.jsx
@@ -19,7 +19,7 @@ const BackgroundModelFilter = ({ allBackgrounds, value, onChange }) => {
       options={backgroundOptions}
       value={value}
       disabled={disabled}
-      label="Background: "
+      label="Background:"
       onChange={onChange}
       rounded
     />

--- a/app/assets/src/components/views/report/filters/CategoryFilter.jsx
+++ b/app/assets/src/components/views/report/filters/CategoryFilter.jsx
@@ -42,7 +42,7 @@ const CategoryFilter = ({
       selectedOptions={selectedCategories}
       selectedSuboptions={selectedSuboptions}
       rounded
-      label="Categories: "
+      label="Categories:"
       onChange={onChange}
     />
   );

--- a/app/assets/src/components/views/report/filters/MetricPicker.jsx
+++ b/app/assets/src/components/views/report/filters/MetricPicker.jsx
@@ -8,7 +8,7 @@ const MetricPicker = ({ value, onChange, options }) => {
     <Dropdown
       options={options}
       value={value}
-      label="Tree Metric: "
+      label="Tree Metric:"
       onChange={onChange}
       rounded
     />

--- a/app/assets/src/components/views/report/filters/MinContigSizeFilter.jsx
+++ b/app/assets/src/components/views/report/filters/MinContigSizeFilter.jsx
@@ -71,7 +71,7 @@ class MinContigSizeFilter extends React.Component {
         trigger={
           <DropdownTrigger
             className={cs.dropdownTrigger}
-            label="Min Contig Size: "
+            label="Min Contig Size:"
             value={this.state.value}
             rounded
           />

--- a/app/assets/src/components/views/report/filters/NameTypeFilter.jsx
+++ b/app/assets/src/components/views/report/filters/NameTypeFilter.jsx
@@ -13,7 +13,7 @@ const NameTypeFilter = ({ value, onChange }) => {
     <Dropdown
       options={NAME_TYPE_OPTIONS}
       value={value}
-      label="Name Type: "
+      label="Name Type:"
       onChange={onChange}
       rounded
     />

--- a/app/assets/src/components/views/report/filters/SpecificityFilter.jsx
+++ b/app/assets/src/components/views/report/filters/SpecificityFilter.jsx
@@ -13,7 +13,7 @@ const SpecificityFilter = ({ value, onChange }) => {
     <Dropdown
       options={SPECIFICITY_OPTIONS}
       value={value}
-      label="Read Specificity: "
+      label="Read Specificity:"
       onChange={onChange}
       rounded
     />

--- a/app/assets/src/components/views/report/filters/min_contig_size_filter.scss
+++ b/app/assets/src/components/views/report/filters/min_contig_size_filter.scss
@@ -23,5 +23,7 @@
   .label {
     font-weight: 600;
     margin-right: 3px;
+    font-size: 13px;
+    letter-spacing: 0.4px;
   }
 }

--- a/app/assets/src/components/views/samples/PipelineStatusFilter.jsx
+++ b/app/assets/src/components/views/samples/PipelineStatusFilter.jsx
@@ -34,24 +34,24 @@ class PipelineStatusFilter extends React.Component {
       />
     );
 
+    const items = STATUS_OPTIONS.map(option => (
+      <BareDropdown.Item
+        key={option.name}
+        onClick={() => onStatusFilterSelect(option.name)}
+        className={cs.option}
+      >
+        <span className={cs[option.class]}>{option.name}</span>
+      </BareDropdown.Item>
+    ));
+
     return (
-      <BareDropdown trigger={trigger} floating scrolling hideArrow>
-        <BareDropdown.Menu>
-          <BareDropdown.Header
-            content="Filter Pipeline Status"
-            className={cs.header}
-          />
-          {STATUS_OPTIONS.map(option => (
-            <BareDropdown.Item
-              key={option.name}
-              onClick={() => onStatusFilterSelect(option.name)}
-              className={cs.option}
-            >
-              <span className={cs[option.class]}>{option.name}</span>
-            </BareDropdown.Item>
-          ))}
-        </BareDropdown.Menu>
-      </BareDropdown>
+      <BareDropdown
+        trigger={trigger}
+        floating
+        hideArrow
+        items={items}
+        menuLabel="Filter Pipeline Status"
+      />
     );
   }
 }

--- a/app/assets/src/components/views/samples/TableColumnHeader.jsx
+++ b/app/assets/src/components/views/samples/TableColumnHeader.jsx
@@ -29,20 +29,19 @@ class TableColumnHeader extends React.Component {
       return trigger;
     }
 
+    const options = columnOptions.map(option => ({
+      value: option,
+      text: columnMap[option].display_name
+    }));
+
     return (
-      <BareDropdown trigger={trigger} floating scrolling>
-        <BareDropdown.Menu>
-          <BareDropdown.Header content="Switch Columns" className={cs.header} />
-          {columnOptions.map(option => (
-            <BareDropdown.Item
-              key={columnMap[option].display_name}
-              onClick={() => onColumnOptionSelect(option)}
-            >
-              {columnMap[option].display_name}
-            </BareDropdown.Item>
-          ))}
-        </BareDropdown.Menu>
-      </BareDropdown>
+      <BareDropdown
+        trigger={trigger}
+        floating
+        onChange={onColumnOptionSelect}
+        options={options}
+        menuLabel="Switch Columns"
+      />
     );
   }
 }

--- a/app/assets/src/components/views/samples/table_column_header.scss
+++ b/app/assets/src/components/views/samples/table_column_header.scss
@@ -3,8 +3,3 @@
 .tableColumnHeader {
   margin-right: 5px;
 }
-
-.header {
-  // overwrite semantic-ui.
-  color: $light-grey !important;
-}

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -311,10 +311,10 @@ input[type="number"] {
             input {
               width: 100%;
               border: 1px solid $light-grey;
-              padding: 6px 35px 6px 10px;
+              padding: 6px 29px 6px 16px;
               position: relative;
               margin: 0;
-              height: 24px !important;
+              height: 20px !important;
               border-radius: 19px;
             }
             i {

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -311,7 +311,7 @@ input[type="number"] {
             input {
               width: 100%;
               border: 1px solid $light-grey;
-              padding: 6px 29px 6px 16px;
+              padding: 6px 31px 6px 14px;
               position: relative;
               margin: 0;
               height: 20px !important;

--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -388,8 +388,8 @@ $break-large: 1070px;
         position: relative;
         margin-left: 10px;
         font-size: 18px;
-        top: 0.6em;
-        color: $dark-grey;
+        top: 7px;
+        color: $medium-grey;
       }
     }
 
@@ -403,8 +403,8 @@ $break-large: 1070px;
       border: solid 1px $light-grey;
       padding-left: 32px;
       position: relative;
-      top: -1.2em;
-      height: 38px;
+      top: -18px;
+      height: 34px;
       &::placeholder {
         color: $medium-grey;
         font-family: $font-family-default;

--- a/app/assets/src/styles/ui/controls/buttons/button.scss
+++ b/app/assets/src/styles/ui/controls/buttons/button.scss
@@ -9,7 +9,7 @@
   height: 34px;
   letter-spacing: 0.4px;
   min-width: 120px;
-  padding: 4px 16px;
+  padding: 4px 14px;
   vertical-align: middle;
 
   &.rectangular {
@@ -24,7 +24,7 @@
     i.icon,
     svg {
       height: 24px;
-      margin-right: 10px;
+      margin-right: 8px;
       vertical-align: middle;
     }
 

--- a/app/assets/src/styles/ui/controls/buttons/button.scss
+++ b/app/assets/src/styles/ui/controls/buttons/button.scss
@@ -6,10 +6,10 @@
   font-weight: 400;
   font-style: normal;
   font-stretch: normal;
-  height: 38px;
+  height: 34px;
   letter-spacing: 0.4px;
   min-width: 120px;
-  padding: 6px 16px;
+  padding: 4px 16px;
   vertical-align: middle;
 
   &.rectangular {

--- a/app/assets/src/styles/ui/controls/dropdowns/button_dropdown.scss
+++ b/app/assets/src/styles/ui/controls/dropdowns/button_dropdown.scss
@@ -13,7 +13,7 @@
 
   .idseq-ui.ui.button {
     margin: 0;
-    padding: 3px 31px 3px 16px;
+    padding: 2px 31px 4px 14px;
   }
 
   & > i.icon {
@@ -21,7 +21,7 @@
     padding: 0;
     position: absolute;
     right: 10px;
-    top: 5px;
+    top: 4px;
     line-height: 24px;
     pointer-events: none;
     font-size: 20px;

--- a/app/assets/src/styles/ui/controls/dropdowns/button_dropdown.scss
+++ b/app/assets/src/styles/ui/controls/dropdowns/button_dropdown.scss
@@ -1,5 +1,6 @@
 @import "../../../themes/colors";
 
+// TODO(mark): Redundant with bare_dropdown.scss. Refactor.
 .idseq-ui.ui.dropdown.button.button-dropdown {
   padding: 0;
   border-radius: 19px;
@@ -12,7 +13,7 @@
 
   .idseq-ui.ui.button {
     margin: 0;
-    padding: 6px 31px 6px 16px;
+    padding: 3px 31px 3px 16px;
   }
 
   & > i.icon {
@@ -20,7 +21,7 @@
     padding: 0;
     position: absolute;
     right: 10px;
-    top: 6px;
+    top: 5px;
     line-height: 24px;
     pointer-events: none;
     font-size: 20px;
@@ -31,9 +32,18 @@
     }
   }
 
+  .menu {
+    padding: 6px 0;
+  }
+
   .item {
-    background-color: $white;
+    font-size: 12px;
     font-weight: 400;
+    letter-spacing: 0.4px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    background-color: $white;
 
     &:hover {
       /* Override semantic UI */

--- a/app/assets/src/styles/ui/controls/dropdowns/threshold_filter_dropdown.scss
+++ b/app/assets/src/styles/ui/controls/dropdowns/threshold_filter_dropdown.scss
@@ -9,7 +9,7 @@
   letter-spacing: 0.4px;
   height: 34px;
   line-height: 24px;
-  padding: 4px 16px;
+  padding: 4px 14px;
   position: relative;
   width: 100%;
   font-family: $font-family-default;

--- a/app/assets/src/styles/ui/controls/dropdowns/threshold_filter_dropdown.scss
+++ b/app/assets/src/styles/ui/controls/dropdowns/threshold_filter_dropdown.scss
@@ -1,14 +1,15 @@
 @import "../../../themes/colors";
 @import "../../../themes/typography";
 
+// TODO(mark): Redundant with threshld_filter_dropdown.scss. Refactor.
 .idseq-ui.ui.dropdown.threshold {
   border: 1px solid $light-grey;
   border-radius: 19px;
   color: $black;
   letter-spacing: 0.4px;
-  height: 38px;
+  height: 34px;
   line-height: 24px;
-  padding: 6px 16px;
+  padding: 4px 16px;
   position: relative;
   width: 100%;
   font-family: $font-family-default;
@@ -36,8 +37,7 @@
   .label-container-title {
     float: left;
     font-weight: 600;
-    vertical-align: middle;
-    margin-right: 10px;
+    margin-right: 5px;
   }
 
   .label-container-count.ui.label {


### PR DESCRIPTION
Major style changes are reducing the font size in the dropdown menus
and reducing the height of buttons and triggers.

We also make all dropdowns scrollable by default, and add some styling to
the scrollbars. Dropdowns also take up 100% width by default now.

In order to make styling more consistent, we refactor BareDropdown to
render the Dropdown Items manually in nested Dropdown Menus. (that's
the only way to get a scrollbar inside the Menu)

We also add the ability to specify a menu label in BareDropdown.

We also refactor several components usage of BareDropdown so they
can receive the new styling.

Before:

<img width="1267" alt="screen shot 2018-12-19 at 7 54 28 pm" src="https://user-images.githubusercontent.com/837004/50262829-ee209a00-03c7-11e9-8e95-a5848b7adba2.png">

After:

<img width="1270" alt="screen shot 2018-12-19 at 7 54 20 pm" src="https://user-images.githubusercontent.com/837004/50262834-f24cb780-03c7-11e9-8d1b-e0bdfde580ec.png">

<img width="1206" alt="screen shot 2018-12-19 at 7 56 16 pm" src="https://user-images.githubusercontent.com/837004/50262899-2fb14500-03c8-11e9-8071-b21ff580936e.png">

<img width="1234" alt="screen shot 2018-12-19 at 7 57 12 pm" src="https://user-images.githubusercontent.com/837004/50262926-51aac780-03c8-11e9-9663-3e47ca62e348.png">

<img width="806" alt="screen shot 2018-12-19 at 7 55 59 pm" src="https://user-images.githubusercontent.com/837004/50262902-32139f00-03c8-11e9-9b58-722f913051fc.png">

Threshold Filter isn't changed. Is currently still using semantic-ui-dropdown without our styling...

<img width="807" alt="screen shot 2018-12-20 at 11 45 36 am" src="https://user-images.githubusercontent.com/837004/50307298-dd663780-044c-11e9-944e-ee50679ff9bf.png">

<img width="622" alt="screen shot 2018-12-20 at 11 45 39 am" src="https://user-images.githubusercontent.com/837004/50307307-e3f4af00-044c-11e9-9335-5e6276e714c2.png">
