### PR TITLE
Update more styles.

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -34,7 +34,7 @@
   }
 
   :global(.item) {
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 400;
     letter-spacing: 0.4px;
     height: 30px;
@@ -43,6 +43,7 @@
     /* Overwrite semantic ui */
     padding-left: 14px !important;
     padding-right: 14px !important;
+    color: black !important;
   }
 
   .menu {

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -370,34 +370,6 @@ input[type="number"] {
   }
 }
 
-.report-action-buttons {
-  .ui.labeled.icon.button > .icon {
-    // Actual icon in the button
-    background-color: transparent;
-    font-size: 1.3em;
-    margin-left: 0.4em !important;
-  }
-  .download-btn {
-    // The whole button
-    color: $primary-light;
-    background-color: $white;
-    padding-left: 5em !important;
-    border: 1px solid $primary-light;
-    border-radius: 50px;
-    &:hover {
-      background-color: $primary-light;
-      color: $white;
-    }
-    width: 162px;
-    height: 38px;
-  }
-  .ui.dropdown .text {
-    // The text in the button
-    font-size: 1.2em;
-    padding: 0.05em;
-  }
-}
-
 .s3.download-area {
   padding-left: 5rem;
   margin-top: 25px;

--- a/app/assets/src/styles/samples.scss
+++ b/app/assets/src/styles/samples.scss
@@ -666,16 +666,6 @@ input[type="button"] {
           margin-top: 0.3em;
           padding: 3px 0.05em 0.05em;
         }
-        .download-btn {
-          // The whole button
-          width: 162px;
-          height: 38px;
-          color: $primary-light;
-          background-color: transparent;
-          padding: 9px 9px 9px 5em;
-          min-height: 39px !important;
-          border: 1px solid $primary-light !important;
-        }
         .download-reports {
           color: $primary-light;
         }

--- a/app/assets/src/styles/ui/controls/dropdowns/threshold_filter_dropdown.scss
+++ b/app/assets/src/styles/ui/controls/dropdowns/threshold_filter_dropdown.scss
@@ -129,7 +129,7 @@
             border: 1px solid $light-grey;
             box-shadow: none;
             box-sizing: border-box;
-            height: 38px;
+            height: 34px;
             padding: 10px;
 
             &:focus {

--- a/app/assets/src/styles/ui/controls/input.scss
+++ b/app/assets/src/styles/ui/controls/input.scss
@@ -3,7 +3,8 @@
 .idseq-ui.input {
   input[type="text"],
   input[type="number"] {
-    height: 38px;
+    height: 34px;
+    font-size: 13px;
     border-radius: 4px;
     box-sizing: border-box;
     border: 1px solid $light-grey;

--- a/app/assets/src/styles/ui/controls/slider.scss
+++ b/app/assets/src/styles/ui/controls/slider.scss
@@ -7,7 +7,7 @@
   font-weight: 400;
   font-style: normal;
   font-stretch: normal;
-  height: 38px;
+  height: 34px;
   text-align: center;
 
   .label-title {


### PR DESCRIPTION
Change some inputs to height 34px that were missed the first time.
Change the font-size back to 13px.
Change the dropdown item color to pure black (semantic ui has 0.87 opacity)

<img width="667" alt="screen shot 2018-12-20 at 4 34 48 pm" src="https://user-images.githubusercontent.com/837004/50318322-34800280-0475-11e9-8a22-a7df5ce2084b.png">
