### PR TITLE
Phylo tree job monitor doesn't work properly if the dag_version isn't set

### DIFF
--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -102,6 +102,7 @@ class PhyloTree < ApplicationRecord
     return if throttle && rand >= 0.1 # if throttling, do time-consuming aegea checks only 10% of the time
     job_status, self.job_log_id, _job_hash, self.job_description = job_info(job_id, id)
     required_outputs = select_outputs("required")
+    update_pipeline_version(self, :dag_version, dag_version_file) if job_status == "SUCCEEDED" && dag_version.blank?
     if job_status == PipelineRunStage::STATUS_FAILED ||
        (job_status == "SUCCEEDED" && !required_outputs.all? { |ro| exists_in_s3?(s3_outputs[ro]["s3_path"]) })
       self.status = STATUS_FAILED


### PR DESCRIPTION
Ran into a weird case where phylo tree creation said it failed but it's because the job monitor couldn't find the s3 files because dag_version == nil. This should fix it (though open to suggestions if there's an earlier spot this should happen)