### PR TITLE
Guard against javascript errors on phylo tree page.

### DIFF
--- a/app/assets/src/components/views/phylo_tree/PhyloTreeListView.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeListView.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fromPairs, set } from "lodash/fp";
+import { fromPairs, set, find } from "lodash/fp";
 import Divider from "../../layout/Divider";
 import QueryString from "query-string";
 import PhyloTreeVis from "./PhyloTreeVis";
@@ -26,11 +26,15 @@ class PhyloTreeListView extends React.Component {
   }
 
   getDefaultSelectedTreeId(urlParams, phyloTrees = []) {
-    return (
-      urlParams.treeId ||
-      parseInt(window.sessionStorage.getItem("treeId")) ||
-      (phyloTrees[0] || {}).id
-    );
+    const selectedId =
+      urlParams.treeId || parseInt(window.sessionStorage.getItem("treeId"));
+
+    // If the selected tree doesn't exist, default to the first one.
+    if (!selectedId || !find({ id: selectedId }, phyloTrees)) {
+      return (phyloTrees[0] || {}).id;
+    }
+
+    return selectedId;
   }
 
   resetUrl() {
@@ -91,9 +95,10 @@ class PhyloTreeListView extends React.Component {
   render() {
     if (!this.state.selectedPhyloTreeId) {
       return (
-        <p className={cs.noTreeBanner}>
-          No trees yet. You can create trees from the report page.
-        </p>
+        <div className={cs.noTreeBanner}>
+          No phylogenetic trees were found. You can create trees from the report
+          page.
+        </div>
       );
     }
 

--- a/app/assets/src/components/views/phylo_tree/phylo_tree_list_view.scss
+++ b/app/assets/src/components/views/phylo_tree/phylo_tree_list_view.scss
@@ -6,8 +6,10 @@
     margin-top: 40px;
     margin-bottom: 40px;
   }
+}
 
-  .noTreeBanner {
-    padding: 20px;
-  }
+.noTreeBanner {
+  margin-top: 50px;
+  text-align: center;
+  color: $medium-grey;
 }


### PR DESCRIPTION
If the treeId that is stored in windowStorage (or passed through the URL params) isn't found in the phylo tree array, the page would previously crash.