### PR TITLE
Fix styling issue with landing header.

### DIFF
--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -84,13 +84,7 @@ class Landing extends React.Component {
               </span>
             </a>
           </div>
-          <div className="sign-in">
-            <TransparentButton
-              text="Sign In"
-              onClick={signInLink}
-              disabled={!this.props.browserInfo.supported}
-            />
-          </div>
+          <div className="fill" />
           <div className="hiring-ad">
             {"Join our team! We're hiring "}
             <a href="https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1342063">
@@ -102,7 +96,15 @@ class Landing extends React.Component {
             </a>
             !
           </div>
-          {this.props.browserInfo.supported || (
+          {this.props.browserInfo.supported ? (
+            <div className="sign-in">
+              <TransparentButton
+                text="Sign In"
+                onClick={signInLink}
+                disabled={!this.props.browserInfo.supported}
+              />
+            </div>
+          ) : (
             <div className="alert-browser-support">
               {this.props.browserInfo.browser} is not currently supported.
               Please sign in from a different browser.

--- a/app/assets/src/styles/views/landing.scss
+++ b/app/assets/src/styles/views/landing.scss
@@ -1,7 +1,6 @@
 @import "../themes/colors";
 
 .sign-in {
-  float: right;
   margin-top: 0.4rem;
   margin-right: 0.75rem;
 }
@@ -10,7 +9,6 @@
   @media screen and (max-width: 768px) {
     display: none;
   }
-  float: right;
   margin-top: 1.1rem;
   margin-right: 0.9rem;
   color: white;
@@ -21,12 +19,9 @@
 }
 
 .alert-browser-support {
-  color: $light-grey;
-  float: right;
+  color: $medium-grey;
   margin-right: 0.75rem;
-  position: relative;
-  top: 50%;
-  transform: translateY(-50%);
+  margin-top: 15px;
 
   .browser-name {
     font-weight: 700;


### PR DESCRIPTION
Before:
![screen shot 2019-01-02 at 10 27 00 am](https://user-images.githubusercontent.com/837004/50605980-f6bda980-0e78-11e9-9c75-57548ada7653.png)


After:
![screen shot 2019-01-02 at 10 21 45 am](https://user-images.githubusercontent.com/837004/50605963-e3124300-0e78-11e9-94c9-e05266a53c13.png)

Before, we would gray out the button and show the "no browser" message to the left. I think we then added the "Join us" message without realizing it that it gets in between the button and the "no browser" message, and makes it look cluttered. I removed the button, and just show the "no browser" message.
![screen shot 2019-01-02 at 10 20 20 am](https://user-images.githubusercontent.com/837004/50605961-e1487f80-0e78-11e9-89ce-f191dcef1fc8.png)
