### PR TITLE
Fix checking the checkbox when opening samples

### DIFF
--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -687,6 +687,7 @@ class Samples extends React.Component {
   }
 
   viewSample(id, currentEvent) {
+    currentEvent.stopPropagation();
     openUrl(`/samples/${id}`, currentEvent);
   }
 
@@ -791,6 +792,9 @@ class Samples extends React.Component {
       .length === 0;
 
   selectSample(e) {
+    console.log("time is 2:17pm");
+    e.stopPropagation();
+
     let sampleId = parseInt(e.target.getAttribute("data-sample-id"));
 
     const sampleList = e.target.checked
@@ -1359,6 +1363,7 @@ function PipelineOutputCards({
   parent
 }) {
   let dbSample = sample.db_sample;
+  console.log("time is 2:06pm");
   return (
     <a className="col s12 no-padding sample-feed" key={i}>
       <div>
@@ -1371,6 +1376,10 @@ function PipelineOutputCards({
                 sample_name_info={sample_name_info}
                 i={i}
                 parent={parent}
+                onClick={e => {
+                  e.stopPropagation();
+                  console.log("hhi 2:04pm");
+                }}
               />
               <SampleDetailedColumns
                 dbSample={dbSample}

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -687,7 +687,6 @@ class Samples extends React.Component {
   }
 
   viewSample(id, currentEvent) {
-    console.log("I am in viewSample");
     openUrl(`/samples/${id}`, currentEvent);
   }
 
@@ -792,15 +791,8 @@ class Samples extends React.Component {
       .length === 0;
 
   selectSample(e) {
-    console.log("this was the click", e);
-    console.log(e.target);
-    console.log(e.target.getAttribute("data-sample-id"));
-    console.log("I am in selectSample. time is 3:57pm");
-
     let sampleId = parseInt(e.target.getAttribute("data-sample-id"));
 
-    console.log(e.target.getAttribute("data-checked") === "false");
-    console.log(e.target.getAttribute("data-checked") === "false");
     const sampleList =
       e.target.getAttribute("data-checked") === "false"
         ? union(this.state.selectedSampleIds, [+sampleId])
@@ -1368,7 +1360,6 @@ function PipelineOutputCards({
   parent
 }) {
   let dbSample = sample.db_sample;
-  console.log("I am in PipelineOutputCards. time is 2:06pm");
   return (
     <a className="col s12 no-padding sample-feed" key={i}>
       <div>
@@ -1869,6 +1860,8 @@ function SampleCardCheckboxes({
   i,
   parent
 }) {
+  const checked =
+    parent.state.selectedSampleIds.indexOf(sample.db_sample.id) >= 0;
   return (
     <li className="check-box-container">
       {parent.state.displaySelectSamples ? (
@@ -1876,19 +1869,15 @@ function SampleCardCheckboxes({
           <input
             type="checkbox"
             id={i}
-            key={`sample_${sample.db_sample.id}`}
             onClick={parent.selectSample}
+            key={`sample_${sample.db_sample.id}`}
             data-sample-id={sample.db_sample.id}
             className="filled-in checkbox"
-            checked={
-              parent.state.selectedSampleIds.indexOf(sample.db_sample.id) >= 0
-            }
+            checked={checked}
             disabled={report_ready != 1}
           />{" "}
           <label
-            data-checked={
-              parent.state.selectedSampleIds.indexOf(sample.db_sample.id) >= 0
-            }
+            data-checked={checked}
             onClick={parent.selectSample}
             data-sample-id={sample.db_sample.id}
           >

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -688,6 +688,7 @@ class Samples extends React.Component {
 
   viewSample(id, currentEvent) {
     currentEvent.stopPropagation();
+    console.log("I am in viewSample");
     openUrl(`/samples/${id}`, currentEvent);
   }
 

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -687,7 +687,6 @@ class Samples extends React.Component {
   }
 
   viewSample(id, currentEvent) {
-    currentEvent.stopPropagation();
     console.log("I am in viewSample");
     openUrl(`/samples/${id}`, currentEvent);
   }
@@ -793,14 +792,19 @@ class Samples extends React.Component {
       .length === 0;
 
   selectSample(e) {
-    console.log("time is 2:17pm");
-    e.stopPropagation();
+    console.log("this was the click", e);
+    console.log(e.target);
+    console.log(e.target.getAttribute("data-sample-id"));
+    console.log("I am in selectSample. time is 3:57pm");
 
     let sampleId = parseInt(e.target.getAttribute("data-sample-id"));
 
-    const sampleList = e.target.checked
-      ? union(this.state.selectedSampleIds, [+sampleId])
-      : difference(this.state.selectedSampleIds, [+sampleId]);
+    console.log(e.target.getAttribute("data-checked") === "false");
+    console.log(e.target.getAttribute("data-checked") === "false");
+    const sampleList =
+      e.target.getAttribute("data-checked") === "false"
+        ? union(this.state.selectedSampleIds, [+sampleId])
+        : difference(this.state.selectedSampleIds, [+sampleId]);
 
     // update the state with the new array of options
     this.setState({
@@ -1364,7 +1368,7 @@ function PipelineOutputCards({
   parent
 }) {
   let dbSample = sample.db_sample;
-  console.log("time is 2:06pm");
+  console.log("I am in PipelineOutputCards. time is 2:06pm");
   return (
     <a className="col s12 no-padding sample-feed" key={i}>
       <div>
@@ -1377,10 +1381,6 @@ function PipelineOutputCards({
                 sample_name_info={sample_name_info}
                 i={i}
                 parent={parent}
-                onClick={e => {
-                  e.stopPropagation();
-                  console.log("hhi 2:04pm");
-                }}
               />
               <SampleDetailedColumns
                 dbSample={dbSample}
@@ -1876,8 +1876,8 @@ function SampleCardCheckboxes({
           <input
             type="checkbox"
             id={i}
-            onClick={parent.selectSample}
             key={`sample_${sample.db_sample.id}`}
+            onClick={parent.selectSample}
             data-sample-id={sample.db_sample.id}
             className="filled-in checkbox"
             checked={
@@ -1885,7 +1885,15 @@ function SampleCardCheckboxes({
             }
             disabled={report_ready != 1}
           />{" "}
-          <label htmlFor={i}>{sample_name_info}</label>
+          <label
+            data-checked={
+              parent.state.selectedSampleIds.indexOf(sample.db_sample.id) >= 0
+            }
+            onClick={parent.selectSample}
+            data-sample-id={sample.db_sample.id}
+          >
+            {sample_name_info}
+          </label>
         </div>
       ) : (
         sample_name_info

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1869,19 +1869,17 @@ function SampleCardCheckboxes({
           <input
             type="checkbox"
             id={i}
-            onClick={parent.selectSample}
             key={`sample_${sample.db_sample.id}`}
-            data-sample-id={sample.db_sample.id}
             className="filled-in checkbox"
             checked={checked}
             disabled={report_ready != 1}
-          />{" "}
+          />
           <label
             data-checked={checked}
             onClick={parent.selectSample}
             data-sample-id={sample.db_sample.id}
           >
-            {sample_name_info}
+            <div onClick={e => e.stopPropagation()}>{sample_name_info}</div>
           </label>
         </div>
       ) : (

--- a/app/assets/src/components/utils/links.js
+++ b/app/assets/src/components/utils/links.js
@@ -1,9 +1,6 @@
 const openUrl = (link, currentEvent) => {
   // currentEvent is optional and it is used to consider
   // modifiers like CMD and CTRL key to open urls in new tabs
-  console.log("I am in openURL. stopping the click");
-  currentEvent.stopPropagation();
-  return;
   let openInNewTab = false;
 
   // metakey is CMD in mac

--- a/app/assets/src/components/utils/links.js
+++ b/app/assets/src/components/utils/links.js
@@ -1,6 +1,9 @@
 const openUrl = (link, currentEvent) => {
   // currentEvent is optional and it is used to consider
   // modifiers like CMD and CTRL key to open urls in new tabs
+  console.log("I am in openURL. stopping the click");
+  currentEvent.stopPropagation();
+  return;
   let openInNewTab = false;
 
   // metakey is CMD in mac


### PR DESCRIPTION
- This is kind of hacky to work within the existing code, but basically before the htmlFor in <label> would bind the "sample name zone" to the checkbox and count that as a click. So it made it weird to open up lots of samples with SHIFT+CLICK and such because they'd also get checked. And when you open a sample it'll get checked too.
- This basically removes the htmlFor and adds data-checked/onClick/data-sample-id to the label. The label is/was basically resting on top of the checkbox in alignment so it'll get the click.

### NOW

![jan-02-2019 10-30-10](https://user-images.githubusercontent.com/5652739/50606560-063df200-0e7b-11e9-9abc-81614e976cf0.gif)
