### PR TITLE
Adding truncation and subsampling options to sample edit page

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -88,7 +88,9 @@ const createSample = (
   preloadResultsPath = "",
   alignmentConfig = "",
   pipelineBranch = "",
-  dagVariables = ""
+  dagVariables = "",
+  maxInputFragments = "",
+  subsample = ""
 ) =>
   new Promise((resolve, reject) => {
     const fileAttributes = Array.from(inputFiles, file => {
@@ -120,7 +122,9 @@ const createSample = (
           s3_preload_result_path: preloadResultsPath,
           alignment_config_name: alignmentConfig,
           pipeline_branch: pipelineBranch,
-          dag_vars: dagVariables
+          dag_vars: dagVariables,
+          max_input_fragments: maxInputFragments,
+          subsample: subSample
         },
         authenticity_token: document.getElementsByName("csrf-token")[0].content
       })

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -124,7 +124,7 @@ const createSample = (
           pipeline_branch: pipelineBranch,
           dag_vars: dagVariables,
           max_input_fragments: maxInputFragments,
-          subsample: subSample
+          subsample: subsample
         },
         authenticity_token: document.getElementsByName("csrf-token")[0].content
       })

--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -64,6 +64,8 @@ class SampleUpload extends React.Component {
       resultPath: this.sample ? this.sample.s3_preload_result_path : "",
       branch: this.sample ? this.sample.pipeline_branch : "",
       dagVars: this.sample ? this.sample.dag_vars : "{}",
+      subsample: this.sample ? this.sample.subsample : "",
+      maxInputFragments: this.sample ? this.sample.max_input_fragments : "",
       alignmentConfigName: this.sample ? this.sample.alignment_config_name : "",
       id: this.sample.id || "",
       inputFiles:
@@ -99,12 +101,13 @@ class SampleUpload extends React.Component {
       selectedResultPath: this.selected.resultPath || "",
       selectedBranch: this.selected.branch || "",
       selectedDagVars: this.selected.dagVars || "{}",
+      selectedMaxInputFragments: this.selected.maxInputFragments || "",
+      selectedSubsample: this.selected.subsample || "",
       id: this.selected.id,
       errors: {},
       adminGenomes,
       sampleName: this.selected.name || "",
       disableProjectSelect: false,
-      omitSubsamplingChecked: false,
       publicChecked: false,
       consentChecked: false,
 
@@ -275,7 +278,9 @@ class SampleUpload extends React.Component {
       this.state.selectedResultPath,
       this.state.selectedAlignmentConfigName,
       this.state.selectedBranch,
-      this.state.selectedDagVars
+      this.state.selectedDagVars,
+      this.state.selectedMaxInputFragments,
+      this.state.selectedSubsample
     )
       .then(response => {
         this.setState({
@@ -317,6 +322,8 @@ class SampleUpload extends React.Component {
           s3_preload_result_path: this.state.selectedResultPath,
           pipeline_branch: this.state.selectedBranch,
           dag_vars: this.state.selectedDagVars,
+          max_input_fragments: this.state.selectedMaxInputFragments,
+          subsample: this.state.selectedSubsample,
           alignment_config_name: this.state.selectedAlignmentConfigName,
           host_genome_id: this.state.selectedHostGenomeId
         },
@@ -475,6 +482,20 @@ class SampleUpload extends React.Component {
   handleDagVarsChange = e => {
     this.setState({
       selectedDagVars: e.target.value
+    });
+    this.clearError();
+  };
+
+  handleSubsampleChange = e => {
+    this.setState({
+      selectedSubsample: e.target.value
+    });
+    this.clearError();
+  };
+
+  handleMaxInputFragmentsChange = e => {
+    this.setState({
+      selectedMaxInputFragments: e.target.value
     });
     this.clearError();
   };
@@ -677,7 +698,9 @@ class SampleUpload extends React.Component {
       this.state.selectedResultPath,
       this.state.selectedAlignmentConfigName,
       this.state.selectedBranch,
-      this.state.selectedDagVars
+      this.state.selectedDagVars,
+      this.state.selectedMaxInputFragments,
+      this.state.selectedSubsample
     )
       .then(response => {
         this.setState({
@@ -1253,6 +1276,45 @@ class SampleUpload extends React.Component {
                             value={this.state.selectedDagVars}
                             placeholder="{}"
                             onChange={this.handleDagVarsChange}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    <div className="field">
+                      <div className="row">
+                        <div className="col no-padding s12">
+                          <div className="field-title">
+                            <div
+                              htmlFor="sampling_options"
+                              className="read-count-label"
+                            >
+                              Truncate input fragments / subsample non-host
+                              reads
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="row input-row">
+                        <div className="col s6">
+                          <input
+                            id="max_input_fragments"
+                            type="text"
+                            className="browser-default"
+                            ref="sampling_options"
+                            value={this.state.selectedMaxInputFragments}
+                            placeholder="max input fragments"
+                            onChange={this.handleMaxInputFragmentsChange}
+                          />
+                        </div>
+                        <div className="col s6">
+                          <input
+                            id="subsample"
+                            type="text"
+                            className="browser-default"
+                            ref="sampling_options"
+                            value={this.state.selectedSubsample}
+                            placeholder="subsample non-host reads"
+                            onChange={this.handleSubsampleChange}
                           />
                         </div>
                       </div>

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -798,7 +798,7 @@ class SamplesController < ApplicationController
                         :s3_star_index_path, :s3_bowtie2_index_path,
                         :host_genome_id, :host_genome_name, :sample_location, :sample_date, :sample_tissue,
                         :sample_template, :sample_library, :sample_sequencer,
-                        :sample_notes, :search,
+                        :sample_notes, :search, :subsample, :max_input_fragments,
                         :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection, :client,
                         input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts]]
     permitted_params.concat([:pipeline_branch, :dag_vars, :s3_preload_result_path, :alignment_config_name, :subsample]) if current_user.admin?

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -29,7 +29,7 @@ class PipelineRun < ApplicationRecord
   accepts_nested_attributes_for :contig_counts
 
   DEFAULT_SUBSAMPLING = 1_000_000 # number of fragments to subsample to, after host filtering
-  MAX_INPUT_FRAGMENTS = 1_000_000_000 # max fragments going into the pipeline
+  DEFAULT_MAX_INPUT_FRAGMENTS = 75_000_000 # max fragments going into the pipeline
   ADAPTER_SEQUENCES = { "single-end" => "s3://idseq-database/adapter_sequences/illumina_TruSeq3-SE.fasta",
                         "paired-end" => "s3://idseq-database/adapter_sequences/illumina_TruSeq3-PE-2_NexteraPE-PE.fasta" }.freeze
 

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -172,7 +172,7 @@ class PipelineRunStage < ApplicationRecord
       file_type: file_type,
       star_genome: sample.s3_star_index_path,
       bowtie2_genome: sample.s3_bowtie2_index_path,
-      max_fragments: PipelineRun::MAX_INPUT_FRAGMENTS,
+      max_fragments: pipeline_run.max_input_fragments,
       max_subsample_frag: pipeline_run.subsample
     }
     attribute_dict[:fastq2] = sample.input_files[1].name if sample.input_files[1]

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -226,7 +226,7 @@ class Sample < ApplicationRecord
     return unless status == STATUS_CREATED
     stderr_array = []
     total_reads_json_path = nil
-    max_lines = 4 * (max_input_fragments ? max_input_fragments : PipelineRun::DEFAULT_MAX_INPUT_FRAGMENTS)
+    max_lines = 4 * (max_input_fragments || PipelineRun::DEFAULT_MAX_INPUT_FRAGMENTS)
     input_files.each do |input_file|
       fastq = input_file.source
       total_reads_json_path = File.join(File.dirname(fastq.to_s), TOTAL_READS_JSON)
@@ -479,8 +479,8 @@ class Sample < ApplicationRecord
 
     pr = PipelineRun.new
     pr.sample = self
-    pr.subsample = subsample ? subsample : PipelineRun::DEFAULT_SUBSAMPLING
-    pr.max_input_fragments = max_input_fragments ? max_input_fragments : PipelineRun::DEFAULT_MAX_INPUT_FRAGMENTS
+    pr.subsample = subsample || PipelineRun::DEFAULT_SUBSAMPLING
+    pr.max_input_fragments = max_input_fragments || PipelineRun::DEFAULT_MAX_INPUT_FRAGMENTS
     pr.pipeline_branch = pipeline_branch.blank? ? "master" : pipeline_branch
     pr.dag_vars = dag_vars if dag_vars
     pr.pipeline_commit = Sample.pipeline_commit(pr.pipeline_branch)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -226,7 +226,7 @@ class Sample < ApplicationRecord
     return unless status == STATUS_CREATED
     stderr_array = []
     total_reads_json_path = nil
-    max_lines = PipelineRun::MAX_INPUT_FRAGMENTS * 4
+    max_lines = 4 * (max_input_fragments ? max_input_fragments : PipelineRun::DEFAULT_MAX_INPUT_FRAGMENTS)
     input_files.each do |input_file|
       fastq = input_file.source
       total_reads_json_path = File.join(File.dirname(fastq.to_s), TOTAL_READS_JSON)
@@ -479,10 +479,8 @@ class Sample < ApplicationRecord
 
     pr = PipelineRun.new
     pr.sample = self
-    pr.subsample = PipelineRun::DEFAULT_SUBSAMPLING # if subsample != 0 ALLWAYS SUBSAMPLE
-    # The subsample field of "sample" is currently used as a simple flag (UI checkbox),
-    # but was made an integer type in case we want to allow users to enter the desired number
-    # of reads to susbample to in the future
+    pr.subsample = subsample ? subsample : PipelineRun::DEFAULT_SUBSAMPLING
+    pr.max_input_fragments = max_input_fragments ? max_input_fragments : PipelineRun::DEFAULT_MAX_INPUT_FRAGMENTS
     pr.pipeline_branch = pipeline_branch.blank? ? "master" : pipeline_branch
     pr.dag_vars = dag_vars if dag_vars
     pr.pipeline_commit = Sample.pipeline_commit(pr.pipeline_branch)

--- a/db/migrate/20190103203930_add_max_input_fragments_to_sample.rb
+++ b/db/migrate/20190103203930_add_max_input_fragments_to_sample.rb
@@ -1,0 +1,6 @@
+class AddMaxInputFragmentsToSample < ActiveRecord::Migration[5.1]
+  def change
+    add_column :samples, :max_input_fragments, :integer
+    add_column :pipeline_runs, :max_input_fragments, :integer
+  end
+end


### PR DESCRIPTION
Added two new fields to sample edit page

<img width="767" alt="screen shot 2019-01-03 at 7 21 59 pm" src="https://user-images.githubusercontent.com/2759121/50672425-e565c180-0f8c-11e9-9c59-bd74fc682fed.png">

These are propagated to Sample and PipelineRun and make their way into the dag file, e.g. below. Tested by editing an existing sample and uploading a new one and looking at states in rails c:

```
{
  "output_dir_s3":
    "s3://idseq-samples-development/samples/63/11744/results",
  "targets": {
    
      "fastqs": ["norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v7__R1.fastq.gz", "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v7__R2.fastq.gz"],
      "star_out": ["unmapped1.fastq", "unmapped2.fastq"],
      "trimmomatic_out": ["trimmomatic1.fastq", "trimmomatic2.fastq"],
      "priceseq_out": ["priceseq1.fa", "priceseq2.fa"],
      "cdhitdup_out": ["dedup1.fa", "dedup2.fa"],
      "lzw_out": ["lzw1.fa", "lzw2.fa"],
      "bowtie2_out": ["bowtie2_1.fa", "bowtie2_2.fa", "bowtie2_merged.fa"],
      "subsampled_out": [
        "subsampled_1.fa",
        "subsampled_2.fa",
        "subsampled_merged.fa"
      ]
      
        ,
        "gsnap_filter_out": [
          "gsnap_filter_1.fa",
          "gsnap_filter_2.fa",
          "gsnap_filter_merged.fa"
        ]
      
    
  },
  "steps": [
    {
      "in": ["fastqs"],
      "out": "star_out",
      "class": "PipelineStepRunStar",
      "module": "idseq_dag.steps.run_star",
      "additional_files": {
        "star_genome": "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/STAR_genome.tar"
      },
      "additional_attributes": { "truncate_fragments_to": 3
                                ,"output_gene_file": "reads_per_gene.star.tab" }
    },
    {
      "in": ["star_out"],
      "out": "trimmomatic_out",
      "class": "PipelineStepRunTrimmomatic",
      "module": "idseq_dag.steps.run_trimmomatic",
      "additional_files": {
        "adapter_fasta": "s3://idseq-database/adapter_sequences/illumina_TruSeq3-PE-2_NexteraPE-PE.fasta"
      },
      "additional_attributes": {}
    },
    {
      "in": [
          "trimmomatic_out"
      ],
      "out": "priceseq_out",
      "class": "PipelineStepRunPriceSeq",
      "module": "idseq_dag.steps.run_priceseq",
      "additional_files": {},
      "additional_attributes": {"file_type": "fastq"}
    },
    {
      "in": ["priceseq_out"],
      "out": "cdhitdup_out",
      "class": "PipelineStepRunCDHitDup",
      "module": "idseq_dag.steps.run_cdhitdup",
      "additional_files": {},
      "additional_attributes": {}
    },
    {
      "in": ["cdhitdup_out"],
      "out": "lzw_out",
      "class": "PipelineStepRunLZW",
      "module": "idseq_dag.steps.run_lzw",
      "additional_files": {},
      "additional_attributes": {
        "thresholds": [0.45, 0.42],
        "threshold_readlength": 150
      }
    },
    {
      "in": ["lzw_out"],
      "out": "bowtie2_out",
      "class": "PipelineStepRunBowtie2",
      "module": "idseq_dag.steps.run_bowtie2",
      "additional_files": {
        "bowtie2_genome": "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/bowtie2_genome.tar"
      },
      "additional_attributes": { "output_sam_file": "bowtie2.sam" }
    },
    {
      "in": ["bowtie2_out"],
      "out": "subsampled_out",
      "class": "PipelineStepRunSubsample",
      "module": "idseq_dag.steps.run_subsample",
      "additional_files": {},
      "additional_attributes": { "max_fragments": 2 }
    }
    
    ,
    {
      "in": ["subsampled_out"],
      "out": "gsnap_filter_out",
      "class": "PipelineStepRunGsnapFilter",
      "module": "idseq_dag.steps.run_gsnap_filter",
      "additional_files": {
        "gsnap_genome": "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar"
      },
      "additional_attributes": { "output_sam_file": "gsnap_filter.sam" }
    }
    
  ],
  "given_targets": {
    "fastqs": {
      "s3_dir": "s3://idseq-samples-development/samples/63/11744/fastqs",
      "count_reads": 1,
      "max_fragments": 3
    }
  }
}



```