### PR TITLE
Protect metadata visualization for metadata fields for which there is not know type.

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -224,9 +224,11 @@ class SamplesHeatmapVis extends React.Component {
   }
 
   getSelectedMetadata() {
-    return Array.from(this.state.selectedMetadata).map(metadatum => {
-      return { value: metadatum, label: this.metadataTypes[metadatum].name };
-    });
+    return Array.from(this.state.selectedMetadata)
+      .filter(metadatum => !!this.metadataTypes[metadatum])
+      .map(metadatum => {
+        return { value: metadatum, label: this.metadataTypes[metadatum].name };
+      });
   }
 
   getAvailableMetadataOptions() {


### PR DESCRIPTION
This is just a safeguard to avoid heatmap from crashing.
This should not happen in normal opearation. 