### PR TITLE
Increase default volume size to 1TB

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -20,7 +20,7 @@ class Sample < ApplicationRecord
   ASSEMBLY_DIR = 'assembly'.freeze
 
   # TODO: Make all these params configurable without code change
-  DEFAULT_STORAGE_IN_GB = 500
+  DEFAULT_STORAGE_IN_GB = 1000
   DEFAULT_MEMORY_IN_MB = 120_000 # sorry, hacky
   HIMEM_IN_MB = 240_000
 


### PR DESCRIPTION
- To improve IOPS performance and make it less likely to run out of disk space in sequence fetching in postprocessing. You get double the IOPS on these:
![screen shot 2019-01-17 at 1 50 45 pm](https://user-images.githubusercontent.com/5652739/51351162-edc6fd80-1a5e-11e9-90e9-c24f53e2ce31.png)

- We tried this change in July and went back to 500GB because there were some machine "hanging" issues that we attributed to the disk not unmounting after finishing its task. But many things have changed since then as well

- Reran about 20 samples by submitting to Batch directly and on staging (https://staging.idseq.net/home?project_id=70) and didn't encounter hanging so hoping it is OK.
- Ex in Batch:
![screen shot 2019-01-17 at 1 49 40 pm](https://user-images.githubusercontent.com/5652739/51351098-c5d79a00-1a5e-11e9-99d6-6059842a7b6a.png)
