### PR TITLE
Fix sample edit page and small UI changes

### DIFF
--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -39,6 +39,8 @@ class SampleUpload extends React.Component {
     );
     this.toggleNewProjectInput = this.toggleNewProjectInput.bind(this);
     this.projects = props.projects || [];
+    // Needed to fill in this.selected.project used on the sample /edit page.
+    this.project = props.projectInfo || "";
     const urlParams = parseUrlParams();
     resetUrl();
 
@@ -1180,7 +1182,7 @@ class SampleUpload extends React.Component {
                               htmlFor="alignment_config_name"
                               className="read-count-label"
                             >
-                              Alignment Config Name. i.e. 2018-02-15
+                              Alignment Config Name. i.e. 2018-12-01
                             </div>
                           </div>
                         </div>
@@ -1193,7 +1195,7 @@ class SampleUpload extends React.Component {
                             className="browser-default"
                             ref="alignment_config_name"
                             value={this.state.selectedAlignmentConfigName}
-                            placeholder="2018-02-15"
+                            placeholder="2018-12-01"
                             onChange={this.handleAlignmentConfigNameChange}
                           />
                         </div>

--- a/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
+++ b/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
@@ -80,7 +80,7 @@ export default class ReportTable extends React.Component {
                 <span className="table-arrow hidden">
                   <i className="fa fa-angle-down" onClick={collapseTable} />
                 </span>
-                Taxonomy
+                Taxon
               </th>
               {renderColumnHeader(
                 "Score",


### PR DESCRIPTION
- Sample edit page was broken-ish ex: https://idseq.net/samples/14048/edit because this.project was moved to urlParams (so the project wouldn't get filled in)

![screen shot 2019-01-17 at 1 18 32 pm](https://user-images.githubusercontent.com/5652739/51349493-68d9e500-1a5a-11e9-984d-74eeace6e705.png)

- Update Alignment Config Name example (doesn't really have any effect except reminds us of the latest one for now)

- Taxonomy -> Taxon on the report page header