### PR TITLE
Fix: Use active record for joins.

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -383,7 +383,7 @@ class Sample < ApplicationRecord
       all
     else
       project_ids = Project.editable(user).select("id").pluck(:id)
-      joins("INNER JOIN projects ON samples.project_id = projects.id")
+      joins(:project)
         .where("(project_id in (?) or
                 projects.public_access = 1 or
                 DATE_ADD(samples.created_at, INTERVAL projects.days_to_keep_sample_private DAY) < ?)",
@@ -416,7 +416,7 @@ class Sample < ApplicationRecord
   end
 
   def self.public_samples
-    joins("INNER JOIN projects ON samples.project_id = projects.id")
+    joins(:project)
       .where("(projects.public_access = 1 or
               DATE_ADD(samples.created_at, INTERVAL projects.days_to_keep_sample_private DAY) < ?)",
              Time.current)


### PR DESCRIPTION
Not using active record might lead to duplicate joins.