### PR TITLE
Give access to /tmp for resque and monitors in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,9 @@ services:
     volumes:
       - .:/app:ro
       - ./log:/app/log
+      - ./tmp:/app/tmp
+      - ./db:/app/db
+      - ./coverage:/app/coverage
       - ~/.aws:/root/.aws:ro
       - ~/.aws/cli/cache:/root/.aws/cli/cache
     depends_on:
@@ -118,6 +121,8 @@ services:
     volumes:
       - .:/app:ro
       - ./log:/app/log
+      - ./tmp:/app/tmp
+      - ./db:/app/db
       - ~/.aws:/root/.aws:ro
       - ~/.aws/cli/cache:/root/.aws/cli/cache
     depends_on:
@@ -133,6 +138,8 @@ services:
     volumes:
       - .:/app:ro
       - ./log:/app/log
+      - ./tmp:/app/tmp
+      - ./db:/app/db
       - ~/.aws:/root/.aws:ro
       - ~/.aws/cli/cache:/root/.aws/cli/cache
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,8 +104,6 @@ services:
       - .:/app:ro
       - ./log:/app/log
       - ./tmp:/app/tmp
-      - ./db:/app/db
-      - ./coverage:/app/coverage
       - ~/.aws:/root/.aws:ro
       - ~/.aws/cli/cache:/root/.aws/cli/cache
     depends_on:
@@ -122,7 +120,6 @@ services:
       - .:/app:ro
       - ./log:/app/log
       - ./tmp:/app/tmp
-      - ./db:/app/db
       - ~/.aws:/root/.aws:ro
       - ~/.aws/cli/cache:/root/.aws/cli/cache
     depends_on:
@@ -139,7 +136,6 @@ services:
       - .:/app:ro
       - ./log:/app/log
       - ./tmp:/app/tmp
-      - ./db:/app/db
       - ~/.aws:/root/.aws:ro
       - ~/.aws/cli/cache:/root/.aws/cli/cache
     depends_on:


### PR DESCRIPTION
Resque jobs need access to /tmp (e.g. for downloading host gene counts). Monitors might need them too, might as well give access