### PR TITLE
Fix file downloads for invalid pipeline versions being passed (due to NULL values)

### DIFF
--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -1092,10 +1092,11 @@ module ReportHelper
   end
 
   def select_pipeline_run(sample, params)
-    if params[:pipeline_version].blank?
-      sample.pipeline_runs.first
-    else
+    pipeline_version = params[:pipeline_version].to_f
+    if pipeline_version > 0.0
       sample.pipeline_run_by_version(params[:pipeline_version])
+    else
+      sample.pipeline_runs.first
     end
   end
 end


### PR DESCRIPTION
Trying to download non-host FASTAs for old samples (e.g. sample 55) results in an error since the PRs didn't have pipeline versions. Handle non-numeric pipeline versions by just returning the latest pipeline run.