### PR TITLE
Fix bugs with DetailsSidebar.

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -680,7 +680,8 @@ class SamplesHeatmapView extends React.Component {
     if (this.state.sidebarMode === "sampleDetails") {
       return {
         sampleId: this.state.selectedSampleId,
-        onMetadataUpdate: this.handleMetadataUpdate
+        onMetadataUpdate: this.handleMetadataUpdate,
+        showReportLink: true
       };
     }
     return {};

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeListView.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeListView.jsx
@@ -25,7 +25,9 @@ class PhyloTreeListView extends React.Component {
       phyloTreeMap: fromPairs(props.phyloTrees.map(tree => [tree.id, tree])),
       sidebarMode: null,
       sidebarVisible: false,
-      sidebarConfig: null
+      sidebarConfig: null,
+      selectedSampleId: null,
+      selectedPipelineRunId: null
     };
   }
 
@@ -55,14 +57,14 @@ class PhyloTreeListView extends React.Component {
     });
   };
 
-  handleMetadataUpdate = (key, newValue, pipelineRunId) => {
+  handleMetadataUpdate = (key, newValue) => {
     // Update the metadata stored locally.
     this.setState({
       phyloTreeMap: set(
         [
           this.state.selectedPhyloTreeId,
           "sampleDetailsByNodeName",
-          pipelineRunId,
+          this.state.selectedPipelineRunId,
           "metadata",
           key
         ],
@@ -132,10 +134,11 @@ class PhyloTreeListView extends React.Component {
     } else {
       this.setState({
         selectedSampleId: sampleId,
+        selectedPipelineRunId: pipelineRunId,
         sidebarConfig: {
           sampleId,
-          pipelineRunId,
-          onMetadataUpdate: this.handleMetadataUpdate
+          onMetadataUpdate: this.handleMetadataUpdate,
+          showReportLink: true
         },
         sidebarMode: "sampleDetails",
         sidebarVisible: true

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeVis.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeVis.jsx
@@ -42,7 +42,6 @@ class PhyloTreeVis extends React.Component {
       // If we made the sidebar visibility depend on sampleId !== null,
       // there would be a visual flicker when sampleId is set to null as the sidebar closes.
       selectedSampleId: null,
-      selectedPipelineRunId: null,
       sidebarVisible: false,
       sampleMetadataTypesByHostGenomeName: null,
       allMetadataTypes: [],
@@ -140,16 +139,6 @@ class PhyloTreeVis extends React.Component {
     this.setState({
       sidebarVisible: false
     });
-  };
-
-  handleMetadataUpdate = (key, newValue) => {
-    if (this.props.onMetadataUpdate) {
-      this.props.onMetadataUpdate(
-        key,
-        newValue,
-        this.state.selectedPipelineRunId
-      );
-    }
   };
 
   handleMetadataTypeChange = (selectedMetadataType, name) => {


### PR DESCRIPTION
Report link now shows up for heatmap and phylo tree sample detail sidebars.

Metadata now properly updates without page reload on phylo tree.

![screen shot 2019-02-04 at 3 18 16 pm](https://user-images.githubusercontent.com/837004/52243926-2acd2580-2890-11e9-8e4d-aabfa22e901c.png)
