### PR TITLE
[Analytics] Finish adding Segment hooks parallel to Datadog hooks

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -282,7 +282,7 @@ class SamplesController < ApplicationController
         # Send to Datadog and Segment
         tags = %W[client:web type:bulk user_id:#{current_user.id}]
         MetricUtil.put_metric_now("samples.created", @samples.count, tags)
-        Sample.log_upload_batch_analytics(@samples, current_user, "web")
+        MetricUtil.log_upload_batch_analytics(@samples, current_user, "web")
         format.json { render json: { samples: @samples, sample_ids: @samples.pluck(:id) } }
       else
         format.json { render json: { samples: @samples, errors: @errors }, status: :unprocessable_entity }
@@ -799,7 +799,7 @@ class SamplesController < ApplicationController
         tags << "type:single" if client == "web"
         # Send to Datadog and Segment
         MetricUtil.put_metric_now("samples.created", 1, tags)
-        Sample.log_upload_batch_analytics([@sample], current_user, client)
+        MetricUtil.log_upload_batch_analytics([@sample], current_user, client)
 
         format.html { redirect_to @sample, notice: 'Sample was successfully created.' }
         format.json { render :show, status: :created, location: @sample }

--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -84,4 +84,16 @@ class MetricUtil
       SEGMENT_ANALYTICS.track(event: event, user_id: user_id, properties: properties)
     end
   end
+
+  # Log analytics from a batch of new samples from an upload session
+  def self.log_upload_batch_analytics(samples, user, client)
+    # Send off an event for each project and host genome combo
+    samples.group_by { |s| [s.project_id, s.host_genome_id] }.each do |(project_id, host_genome_id), entries|
+      log_analytics_event(
+        ANALYTICS_EVENT_NAMES[:sample_upload_batch_created],
+        user,
+        count: entries.count, project_id: project_id, host_genome_id: host_genome_id, client: client
+      )
+    end
+  end
 end

--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -18,7 +18,10 @@ class MetricUtil
   # non-redundant (e.g. prefer sample_viewed to sample_view_viewed).
   ANALYTICS_EVENT_NAMES = {
     user_created: "user_created",
-    project_created: "project_created"
+    project_created: "project_created",
+    pipeline_run_succeeded: "pipeline_run_succeeded",
+    pipeline_run_failed: "pipeline_run_failed",
+    sample_upload_batch_created: "sample_upload_batch_created"
   }.freeze
 
   def self.put_metric_now(name, value, tags = [], type = "count")

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -764,15 +764,22 @@ class PipelineRun < ApplicationRecord
 
     # Check if run is complete:
     if all_output_states_terminal?
+      run_time = Time.current - created_at
+
       if all_output_states_loaded? && !compiling_stats_failed
         update(results_finalized: FINALIZED_SUCCESS)
 
-        run_time = Time.current - created_at
+        # Send to Datadog and Segment
         tags = ["sample_id:#{sample.id}"]
         MetricUtil.put_metric_now("samples.succeeded.run_time", run_time, tags, "gauge")
+        event = MetricUtil::ANALYTICS_EVENT_NAMES[:pipeline_run_succeeded]
       else
         update(results_finalized: FINALIZED_FAIL)
+        event = MetricUtil::ANALYTICS_EVENT_NAMES[:pipeline_run_failed]
       end
+
+      MetricUtil.log_analytics_event(event, sample.user, pipeline_run_id: id,
+                                                         project_id: sample.project.id, run_time: run_time)
     end
   end
 

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -778,8 +778,11 @@ class PipelineRun < ApplicationRecord
         event = MetricUtil::ANALYTICS_EVENT_NAMES[:pipeline_run_failed]
       end
 
-      MetricUtil.log_analytics_event(event, sample.user, pipeline_run_id: id,
-                                                         project_id: sample.project.id, run_time: run_time)
+      MetricUtil.log_analytics_event(
+        event,
+        sample.user,
+        pipeline_run_id: id, project_id: sample.project.id, run_time: run_time
+      )
     end
   end
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -592,17 +592,4 @@ class Sample < ApplicationRecord
   def metadata_fields_info
     (project.metadata_fields & host_genome.metadata_fields).map(&:field_info)
   end
-
-  # Log analytics from a batch of new samples from an upload session
-  def self.log_upload_batch_analytics(samples, user, client)
-    # Send off an event for each project and host genome combo
-    event = MetricUtil::ANALYTICS_EVENT_NAMES[:sample_upload_batch_created]
-    samples.group_by { |s| [s.project_id, s.host_genome_id] }.each do |(project_id, host_genome_id), entries|
-      MetricUtil.log_analytics_event(
-        event,
-        user,
-        count: entries.count, project_id: project_id, host_genome_id: host_genome_id, client: client
-      )
-    end
-  end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -599,8 +599,9 @@ class Sample < ApplicationRecord
     event = MetricUtil::ANALYTICS_EVENT_NAMES[:sample_upload_batch_created]
     samples.group_by { |s| [s.project_id, s.host_genome_id] }.each do |(project_id, host_genome_id), entries|
       MetricUtil.log_analytics_event(
-        event, user, count: entries.count, project_id: project_id,
-                     host_genome_id: host_genome_id, client: client
+        event,
+        user,
+        count: entries.count, project_id: project_id, host_genome_id: host_genome_id, client: client
       )
     end
   end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -592,4 +592,16 @@ class Sample < ApplicationRecord
   def metadata_fields_info
     (project.metadata_fields & host_genome.metadata_fields).map(&:field_info)
   end
+
+  # Log analytics from a batch of new samples from an upload session
+  def self.log_upload_batch_analytics(samples, user, client)
+    # Send off an event for each project and host genome combo
+    event = MetricUtil::ANALYTICS_EVENT_NAMES[:sample_upload_batch_created]
+    samples.group_by { |s| [s.project_id, s.host_genome_id] }.each do |(project_id, host_genome_id), entries|
+      MetricUtil.log_analytics_event(
+        event, user, count: entries.count, project_id: project_id,
+                     host_genome_id: host_genome_id, client: client
+      )
+    end
+  end
 end


### PR DESCRIPTION
- Soon there will only be one endpoint for uploading "one or more files" (and metadata) so log_upload_batch_analytics will record events for each host/project grouping for some statistics.

![screen shot 2019-02-07 at 1 42 35 pm](https://user-images.githubusercontent.com/5652739/52454062-01fe9780-2aff-11e9-92fd-843289a4dbcb.png)
 
![screen shot 2019-02-07 at 5 17 00 pm](https://user-images.githubusercontent.com/5652739/52454067-04f98800-2aff-11e9-8656-43b26ea3abab.png)

![feb-07-2019 17-21-05](https://user-images.githubusercontent.com/5652739/52454076-07f47880-2aff-11e9-8421-d32cbf062785.gif)