### PR TITLE
Use getSampleMetadataFields on phylo tree.

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -30,7 +30,8 @@ class MetadataTab extends React.Component {
     // Include Sample Info by default so that special cases in SAMPLE_ADDITIONAL_INFO always show
     let nameToFields = { "Sample Info": [] };
     values(this.props.metadataTypes).forEach(field => {
-      const name = field.group + " Info";
+      const name =
+        field.group === null ? "Custom Metadata" : field.group + " Info";
       if (nameToFields.hasOwnProperty(name)) {
         nameToFields[name].push(field.key);
       } else {

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
@@ -57,20 +57,10 @@ class SampleDetailsMode extends React.Component {
       return;
     }
 
-    // Metadata Types currently doesn't change, so only need to fetch it once.
-    let metadata = null;
-    let metadataTypes = null;
-    if (this.state.metadataTypes) {
-      metadata = await getSampleMetadata(
-        this.props.sampleId,
-        this.props.pipelineVersion
-      );
-    } else {
-      [metadata, metadataTypes] = await Promise.all([
-        getSampleMetadata(this.props.sampleId, this.props.pipelineVersion),
-        getSampleMetadataFields(this.props.sampleId)
-      ]);
-    }
+    const [metadata, metadataTypes] = await Promise.all([
+      getSampleMetadata(this.props.sampleId, this.props.pipelineVersion),
+      getSampleMetadataFields(this.props.sampleId)
+    ]);
 
     this.setState({
       metadata: processMetadata(metadata.metadata),

--- a/db/migrate/20190208210837_remove_index_from_metadata_field_name.rb
+++ b/db/migrate/20190208210837_remove_index_from_metadata_field_name.rb
@@ -1,0 +1,5 @@
+class RemoveIndexFromMetadataFieldName < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :metadata_fields, name: "index_metadata_fields_on_name"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -175,7 +175,6 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["group"], name: "index_metadata_fields_on_group"
-    t.index ["name"], name: "index_metadata_fields_on_name"
   end
 
   create_table "metadata_fields_projects", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
Also update metadata fields properly when props change
on SampleDetailsSidebar and PhyloTree.

Show "Custom Metadata" group on sidebar for custom fields. 

Removed index on metadata field name. It was imposing a uniqueness constraint, which we don't want.

![screen shot 2019-02-08 at 2 32 28 pm](https://user-images.githubusercontent.com/837004/52509815-64fb3780-2bae-11e9-8004-bbe1e68aadbf.png)