### PR TITLE
Enforce required metadata in sample bulk upload endpoint.

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -26,7 +26,7 @@ class MetadataController < ApplicationController
       )
     end
 
-    issues = validate_metadata_csv_for_samples(samples, metadata)
+    issues = validate_metadata_csv_for_samples(samples, metadata, true)
 
     render json: {
       status: "success",

--- a/app/lib/constants/errors.rb
+++ b/app/lib/constants/errors.rb
@@ -24,6 +24,10 @@ module MetadataValidationErrors
     "#{invalid_name} does not match any samples in this project (row #{row_index})"
   end
 
+  def self.missing_required_metadata(missing_metadata_fields, row_index)
+    "Sample is missing required metadata: #{missing_metadata_fields.join(', ')}. (row #{row_index})"
+  end
+
   def self.invalid_key_for_host_genome(key, host_genome)
     "#{key} is not a supported metadata type for host genome #{host_genome}"
   end
@@ -60,5 +64,9 @@ end
 module SampleUploadErrors
   def self.invalid_project_id(sample)
     "Could not save sample #{sample['name']}. Invalid project id."
+  end
+
+  def self.missing_required_metadata(sample, missing_metadata_fields)
+    "Could not save sample #{sample['name']}. Missing required metadata: #{missing_metadata_fields.join(', ')}"
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -4,7 +4,6 @@ require 'tempfile'
 require 'aws-sdk'
 require 'elasticsearch/model'
 # TODO(mark): Move to an initializer. Make sure this works with Rails auto-reloading.
-require 'constants/errors'
 
 class Sample < ApplicationRecord
   if ELASTICSEARCH_ON
@@ -110,6 +109,14 @@ class Sample < ApplicationRecord
         errors.add(:input_files, "have identical read 1 source and read 2 source")
       end
     end
+  end
+
+  def required_metadata_fields
+    host_genome.metadata_fields.where(is_required: 1).pluck(:name)
+  end
+
+  def missing_required_metadata_fields
+    required_metadata_fields - metadata.map(&:metadata_field).pluck(:name)
   end
 
   def set_presigned_url_for_local_upload

--- a/test/controllers/metadata_validate_new_samples_test.rb
+++ b/test/controllers/metadata_validate_new_samples_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'constants/errors'
 
 # Tests MetadataController validate_csv_for_new_samples endpoint
 class MetadataValudateNewSamplesTest < ActionDispatch::IntegrationTest
@@ -71,10 +72,10 @@ class MetadataValudateNewSamplesTest < ActionDispatch::IntegrationTest
 
     post validate_csv_for_new_samples_metadata_url, params: {
       metadata: {
-        headers: ['sample_name', 'sample_type', 'blood_fed'],
+        headers: ['sample_name', 'sample_type', 'nucleotide_type', 'blood_fed'],
         rows: [
-          ['Test Sample', 'Whole Blood', 'Blood Fed'],
-          ['Test Sample 2', 'Whole Blood', 'Blood Fed']
+          ['Test Sample', 'Whole Blood', '', 'Blood Fed'],
+          ['Test Sample 2', 'Whole Blood', 'DNA', 'Blood Fed']
         ]
       },
       samples: [
@@ -94,6 +95,38 @@ class MetadataValudateNewSamplesTest < ActionDispatch::IntegrationTest
     assert_equal 1, @response.parsed_body['issues']['errors'].length
     # Error should throw if metadata type is not supported for the sample's host genome.
     assert_match "#{MetadataValidationErrors.invalid_key_for_host_genome('blood_fed', 'Human')} (row 2)", @response.parsed_body['issues']['errors'][0]
+
+    assert_equal 0, @response.parsed_body['issues']['warnings'].length
+  end
+
+  test 'metadata validate required fields' do
+    post user_session_path, params: @user_params
+
+    post validate_csv_for_new_samples_metadata_url, params: {
+      metadata: {
+        headers: ['sample_name', 'sample_type', 'nucleotide_type'],
+        rows: [
+          ['Test Sample', 'Whole Blood', 'DNA'],
+          ['Test Sample 2', 'Whole Blood', '']
+        ]
+      },
+      samples: [
+        {
+          name: "Test Sample",
+          host_genome_id: @human_host_genome.id
+        },
+        {
+          name: "Test Sample 2",
+          host_genome_id: @human_host_genome.id
+        }
+      ]
+    }, as: :json
+
+    assert_response :success
+
+    assert_equal 1, @response.parsed_body['issues']['errors'].length
+    # Error should throw if row is missing required metadata.
+    assert_match MetadataValidationErrors.missing_required_metadata(['nucleotide_type'], 2), @response.parsed_body['issues']['errors'][0]
 
     assert_equal 0, @response.parsed_body['issues']['warnings'].length
   end

--- a/test/controllers/projects_metadata_validate_test.rb
+++ b/test/controllers/projects_metadata_validate_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'constants/errors'
 
 # Tests ProjectsController validate_metadata_csv endpoint
 class ProjectsMetadataValidateTest < ActionDispatch::IntegrationTest

--- a/test/controllers/samples_bulk_upload_test.rb
+++ b/test/controllers/samples_bulk_upload_test.rb
@@ -18,11 +18,15 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01'
+          'admission_date' => '2018-01-01',
+          'sample_type' => 'blood',
+          'nucleotide_type' => 'DNA'
         },
         "RR004_water_2_S23B" => {
           'sex' => 'Male',
-          'age' => 50
+          'age' => 50,
+          'sample_type' => 'CSF',
+          'nucleotide_type' => 'RNA'
         }
       },
       samples: [
@@ -68,15 +72,14 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     }, as: :json
 
     assert_response :success
-
     assert_equal 0, @response.parsed_body["errors"].length
 
     assert_equal 1, Sample.where(name: "RR004_water_2_S23A").length
     sample_id = Sample.where(name: "RR004_water_2_S23A").first.id
-    assert_equal 3, Metadatum.where(sample_id: sample_id).length
+    assert_equal 5, Metadatum.where(sample_id: sample_id).length
     assert_equal 1, Sample.where(name: "RR004_water_2_S23B").length
     sample_id = Sample.where(name: "RR004_water_2_S23B").first.id
-    assert_equal 2, Metadatum.where(sample_id: sample_id).length
+    assert_equal 4, Metadatum.where(sample_id: sample_id).length
   end
 
   test 'bulk upload basic local' do
@@ -88,11 +91,15 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01'
+          'admission_date' => '2018-01-01',
+          'sample_type' => 'blood',
+          'nucleotide_type' => 'DNA'
         },
         "RR004_water_2_S23B" => {
           'sex' => 'Male',
-          'age' => 50
+          'age' => 50,
+          'sample_type' => 'CSF',
+          'nucleotide_type' => 'RNA'
         }
       },
       samples: [
@@ -136,15 +143,14 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     }, as: :json
 
     assert_response :success
-
     assert_equal 0, @response.parsed_body["errors"].length
 
     assert_equal 1, Sample.where(name: "RR004_water_2_S23A").length
     sample_id = Sample.where(name: "RR004_water_2_S23A").first.id
-    assert_equal 3, Metadatum.where(sample_id: sample_id).length
+    assert_equal 5, Metadatum.where(sample_id: sample_id).length
     assert_equal 1, Sample.where(name: "RR004_water_2_S23B").length
     sample_id = Sample.where(name: "RR004_water_2_S23B").first.id
-    assert_equal 2, Metadatum.where(sample_id: sample_id).length
+    assert_equal 4, Metadatum.where(sample_id: sample_id).length
   end
 
   test 'bulk upload old client' do
@@ -156,7 +162,9 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01'
+          'admission_date' => '2018-01-01',
+          'sample_type' => 'blood',
+          'nucleotide_type' => 'DNA'
         }
       },
       samples: [
@@ -182,11 +190,54 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     }, as: :json
 
     assert_response :success
-
     assert_equal "upgrade_required", @response.parsed_body["status"]
   end
 
   test 'bulk upload new client' do
+    post user_session_path, params: @user_params
+
+    post bulk_upload_with_metadata_samples_url, params: {
+      client: "0.5.0",
+      metadata: {
+        "RR004_water_2_S23A" => {
+          'sex' => 'Female',
+          'age' => 100,
+          'admission_date' => '2018-01-01',
+          'sample_type' => 'blood',
+          'nucleotide_type' => 'DNA'
+        }
+      },
+      samples: [
+        {
+          host_genome_id: @host_genome_human.id,
+          input_files_attributes: [
+            {
+              parts: "RR004_water_2_S23A_R1_001.fastq",
+              source: "RR004_water_2_S23A_R1_001.fastq",
+              source_type: "local"
+            },
+            {
+              parts: "RR004_water_2_S23A_R2_001.fastq",
+              source: "RR004_water_2_S23A_R2_001.fastq",
+              source_type: "local"
+            }
+          ],
+          name: "RR004_water_2_S23A",
+          project_id: String(@metadata_validation_project.id),
+          status: "created"
+        }
+      ]
+    }, as: :json
+
+    assert_response :success
+    assert_equal 0, @response.parsed_body["errors"].length
+
+    assert_equal 1, Sample.where(name: "RR004_water_2_S23A").length
+    sample_id = Sample.where(name: "RR004_water_2_S23A").first.id
+    assert_equal 5, Metadatum.where(sample_id: sample_id).length
+  end
+
+  test 'bulk upload missing required metadata' do
     post user_session_path, params: @user_params
 
     post bulk_upload_with_metadata_samples_url, params: {
@@ -221,10 +272,13 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     }, as: :json
 
     assert_response :success
+    assert_equal 1, @response.parsed_body["errors"].length
+    assert_equal SampleUploadErrors.missing_required_metadata(
+      { "name" => "RR004_water_2_S23A" },
+      ["nucleotide_type", "sample_type"]
+    ), @response.parsed_body["errors"][0]
 
-    assert_equal 1, Sample.where(name: "RR004_water_2_S23A").length
-    sample_id = Sample.where(name: "RR004_water_2_S23A").first.id
-    assert_equal 3, Metadatum.where(sample_id: sample_id).length
+    assert_equal 0, Sample.where(name: "RR004_water_2_S23A").length
   end
 
   # TODO(mark): Test for sample with invalid project id.

--- a/test/fixtures/host_genomes.yml
+++ b/test/fixtures/host_genomes.yml
@@ -3,7 +3,7 @@ one:
 
 two:
   name: Human
-  metadata_fields: [sample_type, sex, age, admission_date]
+  metadata_fields: [sample_type, sex, age, admission_date, nucleotide_type]
 
 human:
   name: Human

--- a/test/fixtures/metadata_fields.yml
+++ b/test/fixtures/metadata_fields.yml
@@ -3,6 +3,16 @@ sample_type:
   display_name: "Sample Type"
   base_type: 0
   host_genomes: [human]
+  is_required: 1
+
+nucleotide_type:
+  name: "nucleotide_type"
+  display_name: "Nucleotide Type"
+  base_type: 0
+  host_genomes: [human]
+  is_required: 1
+  force_options: 1
+  options: "[\"DNA\", \"RNA\"]"
 
 sex:
   name: "sex"

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -20,4 +20,4 @@ joe_project:
 metadata_validation_project:
   name: Metadata Project
   users: [one]
-
+  metadata_fields: [sample_type, nucleotide_type]


### PR DESCRIPTION
![screen shot 2019-02-11 at 5 34 35 pm](https://user-images.githubusercontent.com/837004/52605497-f6271400-2e23-11e9-9de2-feeaec0e9e02.png)

Also enforce required metadata in validation endpoint.

Test strategy:
Wrote Rails tests.
Verified that error correctly throws during sample upload flow.
Verified that error does NOT throw when uploading metadata to existing samples.