### PR TITLE
Make heatmap readSpecificity persist in URL

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -74,7 +74,10 @@ class SamplesHeatmapView extends React.Component {
         thresholdFilters: this.urlParams.thresholdFilters || [],
         dataScaleIdx: parseAndCheckInt(this.urlParams.dataScaleIdx, 0),
         taxonsPerSample: parseAndCheckInt(this.urlParams.taxonsPerSample, 30),
-        readSpecificity: this.availableOptions.specificityOptions[1].value
+        readSpecificity: parseAndCheckInt(
+          this.urlParams.readSpecificity,
+          this.availableOptions.specificityOptions[1].value
+        )
       },
       loading: false,
       sampleIds: this.urlParams.sampleIds || this.props.sampleIds,


### PR DESCRIPTION
# Description

This one param was not working for saved URLs such as 

https://idseq.net/samples/heatmap?background=26&dataScaleIdx=0&metric=NT.aggregatescore&readSpecificity=0&sampleIds[]=12301&sampleIds[]=12302&species=1&subcategories=%7B%7D&taxonsPerSample=30&thresholdFilters=%5B%5D

as you would expect from the UI. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Checklist:

- [X] I have run through the testing script to make sure current functionality is unchanged
- [X] I have done relevant tests that prove my fix is effective or that my feature works
- [X] I have spent time testing out edge cases for my feature
- [X] I have updated the test script or pull request template if necessary
- [X] New and existing unit tests pass locally with my changes

