### PR TITLE
Persist visualization params of sample report page in URL

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -1,6 +1,6 @@
 // TODO(mark): Split this file up as more API methods get added.
 import axios from "axios";
-import { toPairs } from "lodash/fp";
+import { toPairs, pickBy } from "lodash/fp";
 import { cleanFilePath } from "~utils/sample";
 
 const postWithCSRF = async (url, params) => {
@@ -49,10 +49,12 @@ const deleteWithCSRF = url =>
     }
   });
 
-const getURLParamString = params =>
-  toPairs(params)
+const getURLParamString = params => {
+  const filtered = pickBy((v, k) => typeof v !== "object", params);
+  return toPairs(filtered)
     .map(pair => pair.join("="))
     .join("&");
+};
 
 const getSampleMetadata = (id, pipelineVersion) => {
   return get(

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -34,6 +34,7 @@ import LoadingLabel from "./ui/labels/LoadingLabel";
 import HoverActions from "./views/report/ReportTable/HoverActions";
 import { getSampleReportInfo, getSummaryContigCounts } from "~/api";
 import { pipelineVersionHasAssembly } from "./utils/sample";
+import queryString from "query-string";
 
 const DEFAULT_MIN_CONTIG_SIZE = 4;
 const HUMAN_TAX_IDS = [9605, 9606];
@@ -163,6 +164,12 @@ class PipelineSampleReport extends React.Component {
       minContigSize: cachedMinContigSize || DEFAULT_MIN_CONTIG_SIZE
     };
 
+    this.state = {
+      ...this.state,
+      // Override from the URL
+      ...this.parseUrlParams()
+    };
+
     this.expandAll = false;
     this.expandedGenera = [];
     this.thresholded_taxons = [];
@@ -179,6 +186,26 @@ class PipelineSampleReport extends React.Component {
 
   componentDidMount() {
     this.scrollDown();
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    // Set the state in the URL
+    this.props.refreshPage(this.state, false);
+  }
+
+  // See also parseUrlParams in SamplesHeatmapView
+  parseUrlParams() {
+    let urlParams = queryString.parse(location.search, {
+      arrayFormat: "bracket"
+    });
+    for (var key in urlParams) {
+      try {
+        urlParams[key] = JSON.parse(urlParams[key]);
+      } catch (e) {
+        // pass
+      }
+    }
+    return urlParams;
   }
 
   fetchSearchList = () => {
@@ -652,6 +679,7 @@ class PipelineSampleReport extends React.Component {
         }
       },
       () => {
+        // TODO (gdingle): do we really want to reload the page here?
         this.props.refreshPage({ background_id: backgroundId });
       }
     );

--- a/app/assets/src/components/views/SampleView/Controls.jsx
+++ b/app/assets/src/components/views/SampleView/Controls.jsx
@@ -85,7 +85,7 @@ Controls.propTypes = {
   reportDetails: PropTypes.ReportDetails,
   reportPageParams: PropTypes.shape({
     pipeline_version: PropTypes.string,
-    background_id: PropTypes.string
+    background_id: PropTypes.number
   }),
   canEdit: PropTypes.bool
 };

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -66,19 +66,30 @@ class SampleView extends React.Component {
     return "gsnap filter on human/chimp genome was not run.";
   };
 
-  refreshPage = overrideUrlParams => {
+  refreshPage = (overrideUrlParams, reload = true) => {
     const newParams = Object.assign(
       {},
       this.props.reportPageParams,
       overrideUrlParams
     );
-    window.location =
+    const url =
       location.protocol +
       "//" +
       location.host +
       location.pathname +
       "?" +
       getURLParamString(newParams);
+    if (reload) {
+      window.location = url;
+    } else {
+      try {
+        history.pushState(window.history.state, document.title, url);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        window.location = url;
+      }
+    }
   };
 
   handleTabChange = tab => {
@@ -134,6 +145,7 @@ class SampleView extends React.Component {
   };
 
   handlePipelineVersionSelect = version => {
+    // TODO (gdingle): do we really want to reload the page here?
     this.refreshPage({ pipeline_version: version });
   };
 

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeListView.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeListView.jsx
@@ -6,7 +6,7 @@ import PhyloTreeDownloadButton from "./PhyloTreeDownloadButton";
 import NarrowContainer from "~/components/layout/NarrowContainer";
 import DetailsSidebar from "~/components/common/DetailsSidebar";
 import PropTypes from "prop-types";
-import { resetUrl, parseUrlParams } from "~/helpers/url";
+import { parseUrlParams } from "~/helpers/url";
 import ViewHeader from "../../layout/ViewHeader/ViewHeader";
 import cs from "./phylo_tree_list_view.scss";
 
@@ -15,7 +15,6 @@ class PhyloTreeListView extends React.Component {
     super(props);
 
     let urlParams = this.parseUrlParams();
-    resetUrl();
 
     this.state = {
       selectedPhyloTreeId: this.getDefaultSelectedTreeId(

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -34,7 +34,8 @@ class PhyloTreesController < ApplicationController
 
   def index
     @project = []
-    @phylo_trees = current_power.phylo_trees
+    # Common use case is looking for the most recently created phylo tree
+    @phylo_trees = current_power.phylo_trees.order(updated_at: :desc)
     @taxon = {}
 
     taxid = params[:taxId]

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -94,6 +94,7 @@ module ReportHelper
   end
 
   def decode_sort_by(sort_by)
+    return nil unless sort_by
     parts = sort_by.split "_"
     return nil unless parts.length == 3
     direction = parts[0]
@@ -999,7 +1000,7 @@ module ReportHelper
     rows_passing_filters = rows.length
 
     # Compute sort key and sort.
-    sort_by = decode_sort_by(params[:sort_by] || DEFAULT_SORT_PARAM)
+    sort_by = decode_sort_by(params[:sort_by]) || decode_sort_by(DEFAULT_SORT_PARAM)
     rows.each do |tax_info|
       tax_info[:sort_key] = sort_key(tax_2d, tax_info, sort_by)
     end


### PR DESCRIPTION
# Description

This adds URL state to the report page, same as the heatmap page, so that a user can go back to the same state. In a future PR, I plan to add a save button which which will save the state defined here to the database, again, same as the heatmap page. 

For example: http://localhost:3000/samples/12303?pipeline_version=3.3&background_id=26&search_taxon_id=0&searchKey=&rows_passing_filters=80&rows_total=104&pagesRendered=1&sort_by=nt_aggregatescore&name_type=Scientific%20name&rendering=false&loading=false&countType=NT&readSpecificity=1&treeMetric=aggregatescore&phyloTreeModalOpen=true&minContigSize=8&view=tree

![image](https://user-images.githubusercontent.com/28797/52677189-d0f8db00-2ee1-11e9-96e6-0ff34f71509d.png)

The state covers all the controls above the visualization. It does not cover the controls inside the SVG.

There was existing code to persist `pipeline_version` in the URL. I did not touch this, but I wonder why not `history.pushState` to avoid the full page load?

Along the way, I tweaked the phylo tree page so that the ID in the URL persists. For example, http://localhost:3000/phylo_trees/index?treeId=115 . I have no idea why `resetUrl()` was there. I did not see anything break when I removed it. Please advise. 

I also change the phylo tree list to be ordered by most recent first. This was to help me in testing. I'm not sure why there was no order before.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Open a page such as  http://localhost:3000/samples/12303?pipeline_version=3.3&background_id=26&search_taxon_id=0&searchKey=&rows_passing_filters=80&rows_total=104&pagesRendered=1&sort_by=nt_aggregatescore&name_type=Scientific%20name&rendering=false&loading=false&countType=NT&readSpecificity=1&treeMetric=aggregatescore&phyloTreeModalOpen=true&minContigSize=8&view=tree
2. See non-default values loaded
3. Change all controls
4. See URL update accordingly

# Checklist:

- [X] I have run through the testing script to make sure current functionality is unchanged
- [X] I have done relevant tests that prove my fix is effective or that my feature works
- [X] I have spent time testing out edge cases for my feature
- [X] I have updated the test script or pull request template if necessary
- [X] New and existing unit tests pass locally with my changes

