### PR TITLE
Add new visualizations route, controller and active record

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -193,6 +193,11 @@ const bulkUploadWithMetadata = (samples, metadata) =>
     client: "web"
   });
 
+const saveHeatmap = heatmapParams =>
+  postWithCSRF(`/samples/save_heatmap`, {
+    heatmapParams
+  });
+
 const markSampleUploaded = sampleId =>
   putWithCSRF(`/samples/${sampleId}.json`, {
     sample: {
@@ -282,6 +287,7 @@ export {
   bulkUploadRemoteSamples,
   bulkUploadWithMetadata,
   markSampleUploaded,
+  saveHeatmap,
   uploadFileToUrl,
   getTaxonDescriptions,
   getTaxonDistributionForBackground,

--- a/app/assets/src/components/ui/controls/buttons/SaveButton.jsx
+++ b/app/assets/src/components/ui/controls/buttons/SaveButton.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import Icon from "~ui/icons/Icon";
+import SecondaryButton from "./SecondaryButton";
+
+export const SaveButton = props => (
+  <SecondaryButton
+    text="Save"
+    {...props}
+    icon={<Icon size="large" className={"save alternate"} />}
+  />
+);
+
+export default SaveButton;

--- a/app/assets/src/components/ui/controls/buttons/ShareButton.jsx
+++ b/app/assets/src/components/ui/controls/buttons/ShareButton.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import Icon from "~ui/icons/Icon";
+import PrimaryButton from "./PrimaryButton";
+
+const ShareButton = props => (
+  <PrimaryButton
+    text="Share"
+    {...props}
+    icon={<Icon size="large" className={"share alternate"} />}
+  />
+);
+
+export default ShareButton;

--- a/app/assets/src/components/ui/controls/buttons/index.js
+++ b/app/assets/src/components/ui/controls/buttons/index.js
@@ -4,3 +4,5 @@ export { default as PhylogenyButton } from "./PhylogenyButton";
 export { default as PrimaryButton } from "./PrimaryButton";
 export { default as SecondaryButton } from "./SecondaryButton";
 export { default as TransparentButton } from "./TransparentButton";
+export { default as SaveButton } from "./SaveButton";
+export { default as ShareButton } from "./ShareButton";

--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -12,8 +12,7 @@ import DetailsSidebar from "~/components/common/DetailsSidebar";
 import { Divider, NarrowContainer, ViewHeader } from "~/components/layout";
 import SequentialLegendVis from "~/components/visualizations/legends/SequentialLegendVis.jsx";
 import Slider from "~ui/controls/Slider";
-import Icon from "~ui/icons/Icon";
-import { PrimaryButton, SecondaryButton } from "~ui/controls/buttons";
+import { SaveButton, ShareButton } from "~ui/controls/buttons";
 import {
   Dropdown,
   DownloadButtonDropdown,
@@ -721,24 +720,18 @@ class SamplesHeatmapView extends React.Component {
             <ViewHeader.Controls className={cs.controls}>
               <Popup
                 trigger={
-                  <PrimaryButton
-                    text="Share"
+                  <ShareButton
                     onClick={this.onShareClick}
                     className={cs.controlElement}
-                    icon={
-                      <Icon size="large" className={"cloud share alternate"} />
-                    }
                   />
                 }
                 content="A shareable URL has been copied to your clipboard!"
                 on="click"
                 hideOnScroll
               />
-              <SecondaryButton
-                text="Save"
+              <SaveButton
                 onClick={this.onSaveClick}
                 className={cs.controlElement}
-                icon={<Icon size="large" className={"cloud save alternate"} />}
               />
               <DownloadButtonDropdown
                 className={cs.controlElement}

--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -12,7 +12,8 @@ import DetailsSidebar from "~/components/common/DetailsSidebar";
 import { Divider, NarrowContainer, ViewHeader } from "~/components/layout";
 import SequentialLegendVis from "~/components/visualizations/legends/SequentialLegendVis.jsx";
 import Slider from "~ui/controls/Slider";
-import { PrimaryButton } from "~ui/controls/buttons";
+import Icon from "~ui/icons/Icon";
+import { PrimaryButton, SecondaryButton } from "~ui/controls/buttons";
 import {
   Dropdown,
   DownloadButtonDropdown,
@@ -20,7 +21,7 @@ import {
   MultipleNestedDropdown
 } from "~ui/controls/dropdowns";
 import { processMetadata } from "~utils/metadata";
-import { getSampleTaxons, getSampleMetadataFields } from "~/api";
+import { getSampleTaxons, getSampleMetadataFields, saveHeatmap } from "~/api";
 import cs from "./samples_heatmap_view.scss";
 import SamplesHeatmapVis from "./SamplesHeatmapVis";
 
@@ -28,8 +29,12 @@ class SamplesHeatmapView extends React.Component {
   constructor(props) {
     super(props);
 
-    // URL params have precedence
     this.urlParams = this.parseUrlParams();
+    // URL params have precedence
+    this.urlParams = {
+      ...props.savedParamValues,
+      ...this.urlParams
+    };
 
     this.availableOptions = {
       specificityOptions: [
@@ -146,6 +151,11 @@ class SamplesHeatmapView extends React.Component {
 
   onShareClick = () => {
     copy(this.getUrlForCurrentParams());
+  };
+
+  onSaveClick = async () => {
+    // TODO (gdingle): add analytics tracking?
+    await saveHeatmap(this.getUrlParams());
   };
 
   metricToSortField(metric) {
@@ -715,11 +725,20 @@ class SamplesHeatmapView extends React.Component {
                     text="Share"
                     onClick={this.onShareClick}
                     className={cs.controlElement}
+                    icon={
+                      <Icon size="large" className={"cloud share alternate"} />
+                    }
                   />
                 }
                 content="A shareable URL has been copied to your clipboard!"
                 on="click"
                 hideOnScroll
+              />
+              <SecondaryButton
+                text="Save"
+                onClick={this.onSaveClick}
+                className={cs.controlElement}
+                icon={<Icon size="large" className={"cloud save alternate"} />}
               />
               <DownloadButtonDropdown
                 className={cs.controlElement}
@@ -759,7 +778,8 @@ SamplesHeatmapView.propTypes = {
   subcategories: PropTypes.object,
   removedTaxonIds: PropTypes.array,
   taxonLevels: PropTypes.array,
-  thresholdFilters: PropTypes.object
+  thresholdFilters: PropTypes.object,
+  savedParamValues: PropTypes.object
 };
 
 export default SamplesHeatmapView;

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -25,7 +25,7 @@ class SamplesController < ApplicationController
                   :pipeline_runs, :save_metadata, :save_metadata_v2, :raw_results_folder].freeze
 
   OTHER_ACTIONS = [:create, :bulk_new, :bulk_upload, :bulk_upload_with_metadata, :bulk_import, :new, :index, :index_v2, :all, :show_sample_names,
-                   :samples_taxons, :heatmap, :download_heatmap, :cli_user_instructions, :metadata_types_by_host_genome_name, :metadata_fields,
+                   :samples_taxons, :heatmap, :save_heatmap, :download_heatmap, :cli_user_instructions, :metadata_types_by_host_genome_name, :metadata_fields,
                    :samples_going_public, :search_suggestions, :upload].freeze
 
   before_action :authenticate_user!, except: [:create, :update, :bulk_upload, :bulk_upload_with_metadata]

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -4,6 +4,7 @@ class SamplesController < ApplicationController
   include SamplesHelper
   include PipelineOutputsHelper
   include ElasticsearchHelper
+  include HeatmapHelper
 
   ########################################
   # Note to developers:
@@ -486,44 +487,6 @@ class SamplesController < ApplicationController
     MetricUtil.put_metric_now("samples.showed", 1, tags)
   end
 
-  def heatmap
-    @heatmap_data = {
-      taxonLevels: %w[Genus Species],
-      categories: ReportHelper::ALL_CATEGORIES.pluck('name'),
-      subcategories: {
-        Viruses: ["Phage"]
-      },
-      metrics: [
-        { text: "Aggregate Score", value: "NT.aggregatescore" },
-        { text: "NT Z Score", value: "NT.zscore" },
-        { text: "NT rPM", value: "NT.rpm" },
-        { text: "NT r (total reads)", value: "NT.r" },
-        { text: "NR Z Score", value: "NR.zscore" },
-        { text: "NR r (total reads)", value: "NR.r" },
-        { text: "NR rPM", value: "NR.rpm" }
-      ],
-      backgrounds: current_power.backgrounds.map do |background|
-        { name: background.name, value: background.id }
-      end,
-      thresholdFilters: {
-        targets: [
-          { text: "Aggregate Score", value: "NT_aggregatescore" },
-          { text: "NT Z Score", value: "NT_zscore" },
-          { text: "NT rPM", value: "NT_rpm" },
-          { text: "NT r (total reads)", value: "NT_r" },
-          { text: "NT %id", value: "NT_percentidentity" },
-          { text: "NT log(1/e)", value: "NT_neglogevalue" },
-          { text: "NR Z Score", value: "NR_zscore" },
-          { text: "NR r (total reads)", value: "NR_r" },
-          { text: "NR rPM", value: "NR_rpm" },
-          { text: "NR %id", value: "NR_percentidentity" },
-          { text: "R log(1/e)", value: "NR_neglogevalue" }
-        ],
-        operators: [">=", "<="]
-      }
-    }
-  end
-
   def samples_going_public
     ahead = (params[:ahead] || 10).to_i
     behind = params[:behind].to_i
@@ -540,12 +503,6 @@ class SamplesController < ApplicationController
   def samples_taxons
     @sample_taxons_dict = sample_taxons_dict(params)
     render json: @sample_taxons_dict
-  end
-
-  def download_heatmap
-    @sample_taxons_dict = sample_taxons_dict(params)
-    output_csv = generate_heatmap_csv(@sample_taxons_dict)
-    send_data output_csv, filename: 'heatmap.csv'
   end
 
   def report_info
@@ -966,7 +923,12 @@ class SamplesController < ApplicationController
                         else
                           JSON.parse(params[:thresholdFilters] || "[]")
                         end
-    include_phage = (JSON.parse(params[:subcategories]) || {}).fetch("Viruses", []).include?("Phage")
+    subcategories = if params[:subcategories].respond_to?(:to_h)
+                      params[:subcategories].permit!.to_h
+                    else
+                      JSON.parse(params[:subcategories] || "{}")
+                    end
+    include_phage = subcategories.fetch("Viruses", []).include?("Phage")
     read_specificity = params[:readSpecificity] ? params[:readSpecificity].to_i == 1 : false
 
     # TODO: should fail if field is not well formatted and return proper error to client

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -11,6 +11,10 @@ class VisualizationsController < ApplicationController
     id = params[:id]
     if id
       vis = Visualization.find(id)
+      sample_ids = vis.data['sampleIds']
+      if sample_ids != vis.sample_ids
+        raise "Sample IDs do not match: #{sample_ids}, #{vis.sample_ids}"
+      end
       @heatmap_data[:savedParamValues] = vis.data
     end
     # TODO: (gdingle): list view?

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -1,0 +1,18 @@
+class VisualizationsController < ApplicationController
+  include ReportHelper
+  include HeatmapHelper
+
+  def visualization
+    # TODO: (gdingle): dispatch by type
+    # type = params[:type]
+
+    @heatmap_data = heatmap
+
+    id = params[:id]
+    if id
+      vis = Visualization.find(id)
+      @heatmap_data[:savedParamValues] = vis.data
+    end
+    # TODO: (gdingle): list view?
+  end
+end

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -1,0 +1,66 @@
+module HeatmapHelper
+  def heatmap
+    @heatmap_data = {
+      taxonLevels: %w[Genus Species],
+      categories: ReportHelper::ALL_CATEGORIES.pluck('name'),
+      subcategories: {
+        Viruses: ["Phage"]
+      },
+      metrics: [
+        { text: "Aggregate Score", value: "NT.aggregatescore" },
+        { text: "NT Z Score", value: "NT.zscore" },
+        { text: "NT rPM", value: "NT.rpm" },
+        { text: "NT r (total reads)", value: "NT.r" },
+        { text: "NR Z Score", value: "NR.zscore" },
+        { text: "NR r (total reads)", value: "NR.r" },
+        { text: "NR rPM", value: "NR.rpm" }
+      ],
+      backgrounds: current_power.backgrounds.map do |background|
+        { name: background.name, value: background.id }
+      end,
+      thresholdFilters: {
+        targets: [
+          { text: "Aggregate Score", value: "NT_aggregatescore" },
+          { text: "NT Z Score", value: "NT_zscore" },
+          { text: "NT rPM", value: "NT_rpm" },
+          { text: "NT r (total reads)", value: "NT_r" },
+          { text: "NT %id", value: "NT_percentidentity" },
+          { text: "NT log(1/e)", value: "NT_neglogevalue" },
+          { text: "NR Z Score", value: "NR_zscore" },
+          { text: "NR r (total reads)", value: "NR_r" },
+          { text: "NR rPM", value: "NR_rpm" },
+          { text: "NR %id", value: "NR_percentidentity" },
+          { text: "R log(1/e)", value: "NR_neglogevalue" }
+        ],
+        operators: [">=", "<="]
+      }
+    }
+  end
+
+  def download_heatmap
+    @sample_taxons_dict = sample_taxons_dict(params)
+    output_csv = generate_heatmap_csv(@sample_taxons_dict)
+    send_data output_csv, filename: 'heatmap.csv'
+  end
+
+  def save_heatmap
+    @data = params[:heatmapParams]
+    vis = Visualization.create(
+      user: current_user,
+      data: @data
+    )
+    vis.sample_ids = @data[:sampleIds]
+
+    render json: {
+      status: "success",
+      message: "Heatmap saved successfully",
+      data: @data
+    }
+  rescue => err
+    render json: {
+      status: 'failed',
+      message: 'Unable to save heatmap',
+      errors: [err]
+    }
+  end
+end

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -43,6 +43,7 @@ module HeatmapHelper
     send_data output_csv, filename: 'heatmap.csv'
   end
 
+  # TODO: (gdingle): access control
   def save_heatmap
     @data = params[:heatmapParams]
     vis = Visualization.create(
@@ -58,8 +59,8 @@ module HeatmapHelper
     }
   rescue => err
     render json: {
-      status: 'failed',
-      message: 'Unable to save heatmap',
+      status: "failed",
+      message: "Unable to save heatmap",
       errors: [err]
     }
   end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -50,6 +50,7 @@ class Sample < ApplicationRecord
   has_many :input_files, dependent: :destroy
   accepts_nested_attributes_for :input_files
   has_many :metadata, dependent: :destroy
+  has_and_belongs_to_many :visualizations
 
   validate :input_files_checks
   after_create :initiate_input_file_upload

--- a/app/models/visualization.rb
+++ b/app/models/visualization.rb
@@ -1,0 +1,6 @@
+# Represents a Heatmap, phylogeny or other visualization
+class Visualization < ApplicationRecord
+  serialize :data, JSON
+  has_and_belongs_to_many :samples
+  belongs_to :user
+end

--- a/app/views/visualizations/visualization.html.erb
+++ b/app/views/visualizations/visualization.html.erb
@@ -1,0 +1,10 @@
+<div id="SamplesHeatmapView_page">
+</div>
+
+<%= javascript_tag do %>
+  react_component(
+    'SamplesHeatmapView',
+    JSON.parse('<%= raw escape_json(@heatmap_data) %>'),
+    'SamplesHeatmapView_page',
+  );
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
     get :samples_taxons, on: :collection
     get :heatmap, on: :collection
     get :download_heatmap, on: :collection
+    post :save_heatmap, on: :collection
     get :metadata_types_by_host_genome_name, on: :collection
     get :metadata, on: :member
     get :metadata_fields, on: :collection
@@ -85,6 +86,7 @@ Rails.application.routes.draw do
   get 'phylo_trees/:id/download', to: 'phylo_trees#download'
   get 'choose_taxon', to: 'phylo_trees#choose_taxon'
   get 'search_suggestions', to: 'samples#search_suggestions'
+  get 'visualizations/:type(/:id)', to: 'visualizations#visualization'
 
   resources :host_genomes
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]

--- a/db/migrate/20190208233321_create_visualizations.rb
+++ b/db/migrate/20190208233321_create_visualizations.rb
@@ -1,0 +1,19 @@
+class CreateVisualizations < ActiveRecord::Migration[5.1]
+  def change
+    create_table :visualizations do |t|
+      t.references :user, foreign_key: true
+      # Can't use "type" because that is reserved by Rails
+      t.string :visualization_type
+      # TODO: we can use mysql json data type by upgrading to mysql 5.7
+      # t.json :data
+      t.text :data
+
+      t.timestamps
+    end
+
+    create_join_table :visualizations, :samples do |t|
+      t.index [:visualization_id]
+      t.index [:sample_id]
+    end
+  end
+end

--- a/db/migrate/20190208233321_create_visualizations.rb
+++ b/db/migrate/20190208233321_create_visualizations.rb
@@ -1,7 +1,7 @@
 class CreateVisualizations < ActiveRecord::Migration[5.1]
   def change
     create_table :visualizations do |t|
-      t.references :user, foreign_key: true
+      t.references :user
       # Can't use "type" because that is reserved by Rails
       t.string :visualization_type
       # TODO: we can use mysql json data type by upgrading to mysql 5.7

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_116_005_251) do
+ActiveRecord::Schema.define(version: 20_190_208_234_410) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -33,9 +33,6 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
     t.float "depth", limit: 24
     t.bigint "pipeline_run_id"
     t.string "drug_family"
-    t.integer "level"
-    t.float "drug_gene_coverage", limit: 24
-    t.float "drug_gene_depth", limit: 24
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["pipeline_run_id", "allele"], name: "index_amr_counts_on_pipeline_run_id_and_allele", unique: true
@@ -74,7 +71,7 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -105,7 +102,7 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", null: false
+    t.string "name"
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -117,8 +114,8 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
   create_table "host_genomes_metadata_fields", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "host_genome_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields"
-    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes"
+    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields", unique: true
+    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes", unique: true
   end
 
   create_table "input_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -127,7 +124,7 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type", null: false
+    t.string "source_type"
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -146,7 +143,7 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key", null: false, collation: "latin1_swedish_ci"
-    t.integer "data_type", limit: 1, null: false
+    t.integer "data_type"
     t.string "raw_value"
     t.string "string_validated_value"
     t.float "number_validated_value", limit: 24
@@ -180,7 +177,7 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
   create_table "metadata_fields_projects", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "project_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields"
+    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields", unique: true
   end
 
   create_table "output_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -279,7 +276,6 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
     t.string "pipeline_commit"
     t.text "assembled_taxids"
     t.bigint "truncated"
-    t.text "result_status"
     t.integer "results_finalized"
     t.bigint "alignment_config_id"
     t.integer "alert_sent", default: 0
@@ -296,7 +292,7 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1
+    t.integer "public_access", limit: 1, default: 0
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -342,6 +338,13 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
     t.integer "max_input_fragments"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
     t.index ["user_id"], name: "index_samples_on_user_id"
+  end
+
+  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "visualization_id", null: false
+    t.bigint "sample_id", null: false
+    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
+    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
   end
 
   create_table "taxon_byteranges", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -392,12 +395,12 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
   end
 
-  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
-    t.string "title", collation: "utf8mb4_general_ci"
-    t.text "summary", collation: "utf8mb4_general_ci"
-    t.text "description", collation: "utf8mb4_general_ci"
+    t.string "title"
+    t.text "summary", limit: 16_777_215
+    t.text "description", limit: 16_777_215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -487,11 +490,11 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email", default: "", null: false
+    t.string "email"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password", default: "", null: false
+    t.string "encrypted_password"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -508,4 +511,15 @@ ActiveRecord::Schema.define(version: 20_190_116_005_251) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  create_table "visualizations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "user_id"
+    t.string "visualization_type"
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_visualizations_on_user_id"
+  end
+
+  add_foreign_key "visualizations", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,6 +33,9 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.float "depth", limit: 24
     t.bigint "pipeline_run_id"
     t.string "drug_family"
+    t.integer "level"
+    t.float "drug_gene_coverage", limit: 24
+    t.float "drug_gene_depth", limit: 24
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["pipeline_run_id", "allele"], name: "index_amr_counts_on_pipeline_run_id_and_allele", unique: true
@@ -71,7 +74,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -102,7 +105,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -114,8 +117,8 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
   create_table "host_genomes_metadata_fields", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "host_genome_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields", unique: true
-    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes", unique: true
+    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields"
+    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes"
   end
 
   create_table "input_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -124,7 +127,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type"
+    t.string "source_type", null: false
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -143,7 +146,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key", null: false, collation: "latin1_swedish_ci"
-    t.integer "data_type"
+    t.integer "data_type", limit: 1, null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.float "number_validated_value", limit: 24
@@ -177,7 +180,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
   create_table "metadata_fields_projects", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "project_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields", unique: true
+    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields"
   end
 
   create_table "output_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -276,6 +279,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.string "pipeline_commit"
     t.text "assembled_taxids"
     t.bigint "truncated"
+    t.text "result_status"
     t.integer "results_finalized"
     t.bigint "alignment_config_id"
     t.integer "alert_sent", default: 0
@@ -292,7 +296,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1, default: 0
+    t.integer "public_access", limit: 1
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -338,13 +342,6 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.integer "max_input_fragments"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
     t.index ["user_id"], name: "index_samples_on_user_id"
-  end
-
-  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "visualization_id", null: false
-    t.bigint "sample_id", null: false
-    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
-    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
   end
 
   create_table "taxon_byteranges", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -395,12 +392,12 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
   end
 
-  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
-    t.string "title"
-    t.text "summary", limit: 16_777_215
-    t.text "description", limit: 16_777_215
+    t.string "title", collation: "utf8mb4_general_ci"
+    t.text "summary", collation: "utf8mb4_general_ci"
+    t.text "description", collation: "utf8mb4_general_ci"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -490,11 +487,11 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email"
+    t.string "email", default: "", null: false
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password"
+    t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -521,5 +518,10 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.index ["user_id"], name: "index_visualizations_on_user_id"
   end
 
-  add_foreign_key "visualizations", "users"
+  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "visualization_id", null: false
+    t.bigint "sample_id", null: false
+    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
+    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
+  end
 end


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/28797/52679723-cf7fe080-2eea-11e9-8393-1b295bfd2eb7.png)

This adds basic save and view functionality for heatmaps. It moves existing logic from the samples controller to a new helper. In a future PR, I will make the visualization controller handle phylo trees and taxon trees as well. 

And in another PR, I will add the heatmap data to the search index and search results so that the user can actually do something with the saved heatmap.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Go to a heatmap such as http://localhost:3000/samples/heatmap?background=26&dataScaleIdx=0&metric=NT.aggregatescore&readSpecificity=1&sampleIds[]=10399&sampleIds[]=4540&species=1&subcategories=%7B%7D&taxonsPerSample=30&thresholdFilters=%5B%5D
2. Click save
3. Open by visualization page by new ID. For example http://localhost:3000/visualizations/heatmap/3 . 
4. See same viz as in first page. 

# Checklist:

- [ ] I have run through the testing script to make sure current functionality is unchanged
- [x] I have done relevant tests that prove my fix is effective or that my feature works
- [x] I have spent time testing out edge cases for my feature
- [ ] I have updated the test script or pull request template if necessary
- [x] New and existing unit tests pass locally with my changes

