### PR TITLE
[Uploads] Fix disappearing error on bulk uploads

### DIFF
--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -160,9 +160,7 @@ class BulkUploadImport extends React.Component {
     e.preventDefault();
     $("html, body")
       .stop()
-      .animate({ scrollTop: 0 }, 200, "swing", () => {
-        this.clearError();
-      });
+      .animate({ scrollTop: 0 }, 200, "swing");
     if (!this.isUploadFormInvalid()) {
       this.setState({
         submitting: true


### PR DESCRIPTION
- Not sure how this code was before but it seems like the submit is clicked and THEN the error is cleared. I think we can remove this call to clearError. (You would think this.isUploadFormInvalid errs but it only checks that a sample was selected..)
- We'll get a fresh upload flow soon that will handle errors more cleanly.

#### Before
![feb-13-2019 12-57-32](https://user-images.githubusercontent.com/5652739/52743665-61d9c000-2f8f-11e9-9880-3f38006a0955.gif)

#### After
![screen shot 2019-02-13 at 12 56 46 pm](https://user-images.githubusercontent.com/5652739/52743700-7ae27100-2f8f-11e9-8bc0-c2b78b94ca62.png)
