### PR TITLE
Save taxon collapse state

### DIFF
--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -57,7 +57,8 @@ class TaxonTreeVis extends React.Component {
         onNodeHover: this.handleNodeHover,
         onNodeLabelClick: this.handleNodeLabelClick,
         onCreatedTree: this.fillNodeValues,
-        tooltipContainer: this.treeTooltip
+        tooltipContainer: this.treeTooltip,
+        persistCollapsedInUrl: true
       }
     );
     this.treeVis.update();
@@ -85,19 +86,13 @@ class TaxonTreeVis extends React.Component {
     }
   }
 
-  static createNode() {
-    return {
-      children: [],
-      collapsed: false
-    };
-  }
-
   handleNodeHover(node) {
     this.setState({ nodeHover: node });
   }
 
   handleNodeLabelClick(node) {
     if (!node.data.modalData) {
+      // TODO (gdingle): we should show a "no description" instead of no-op
       this.props.onTaxonClick(null);
       return;
     }

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -58,10 +58,45 @@ class TaxonTreeVis extends React.Component {
         onNodeLabelClick: this.handleNodeLabelClick,
         onCreatedTree: this.fillNodeValues,
         tooltipContainer: this.treeTooltip,
-        persistCollapsedInUrl: true
+        onCollapsedStateChange: this.persistCollapsedInUrl,
+        collapsed: this.getCollapsedInUrl() || new Set()
       }
     );
     this.treeVis.update();
+  }
+
+  persistCollapsedInUrl(node) {
+    function hasAllChildrenCollapsed(node) {
+      return !!(!node.children && node.collapsedChildren);
+    }
+    try {
+      const href = new URL(window.location.href);
+      if (hasAllChildrenCollapsed(node)) {
+        href.searchParams.set(node.id, "c"); // 'c'ollapsed
+      } else {
+        href.searchParams.delete(node.id);
+      }
+      history.pushState(window.history.state, document.title, href);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    }
+  }
+
+  getCollapsedInUrl() {
+    try {
+      const href = new URL(window.location.href);
+      const collapsed = [];
+      href.searchParams.forEach((v, k) => {
+        if (v === "c") {
+          collapsed.push(k);
+        }
+      });
+      return new Set(collapsed);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    }
   }
 
   componentDidUpdate() {

--- a/app/assets/src/components/visualizations/TidyTree.js
+++ b/app/assets/src/components/visualizations/TidyTree.js
@@ -24,7 +24,8 @@ export default class TidyTree {
         useCommonName: false,
         minNonCollapsableChildren: 2,
         smallerFont: 8,
-        largerFont: 12
+        largerFont: 12,
+        persistCollapsedInUrl: false
       },
       options || {}
     );
@@ -68,7 +69,11 @@ export default class TidyTree {
   setOptions(options) {
     Object.assign(this.options, options);
 
-    if (options.attribute || options.collapseThreshold) {
+    if (
+      options.attribute ||
+      options.collapseThreshold ||
+      options.persistCollapsedInUrl
+    ) {
       this.sortAndScaleTree();
     }
 
@@ -121,7 +126,10 @@ export default class TidyTree {
       .domain(this.range)
       .range([0, 1]);
     this.root.eachAfter(d => {
-      if (
+      if (this.options.persistCollapsedInUrl && this.isCollapsedInUrl(d)) {
+        d.collapsedChildren = d.children;
+        d.children = null;
+      } else if (
         !d.data.highlight &&
         collapsedScale(d.data.values[this.options.attribute]) <
           this.options.collapseThreshold
@@ -171,6 +179,31 @@ export default class TidyTree {
     });
   }
 
+  persistCollapsedInUrl(node) {
+    try {
+      const href = new URL(window.location.href);
+      if (this.hasAllChildrenCollapsed(node)) {
+        href.searchParams.set(node.id, "c"); // 'c'ollapsed
+      } else {
+        href.searchParams.delete(node.id);
+      }
+      history.pushState(window.history.state, document.title, href);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    }
+  }
+
+  isCollapsedInUrl(node) {
+    try {
+      const href = new URL(window.location.href);
+      return href.searchParams.get(node.id) == "c"; // 'c'ollapsed
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    }
+  }
+
   toggleCollapseNode(node) {
     let updatedNode = node;
 
@@ -209,6 +242,9 @@ export default class TidyTree {
         y0: node.y
       })
     );
+    if (this.options.persistCollapsedInUrl) {
+      this.persistCollapsedInUrl(node);
+    }
   }
 
   expandCollapsedWithFewChildren(node) {


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/28797/53056458-2132e880-3460-11e9-96ba-ec5279b634ba.png)

This adds the collapsed state of the taxon viz to the URL so that the same-looking viz will re-appear on share or save. 

For example:
http://localhost:3000/samples/12302?pipeline_version=3.3&background_id=26&10239_-650=c&2_-650=c&view=tree

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. open a taxon viz
2. click on a node to collapse it
3. see the update of the url 
4. reload the page
5. see the same viz
6. un-collapse the node
7. reload and see the same viz
## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?

- [ ] Login Screen
- [ ] Single Upload Page
- [ ] Batch Upload Page
- [ ] All Projects Page
- [ ] Sample Details Page
- [x] Report Page
