### PR TITLE
 Persist heatmap selected rows and cols to URL

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -102,6 +102,9 @@ class SamplesHeatmapView extends React.Component {
       this.urlParams.removedTaxonIds || this.props.removedTaxonIds || []
     );
     this.lastRequestToken = null;
+    this.selectedMetadata = this.urlParams.selectedMetadata || [
+      "collection_location"
+    ];
   }
 
   componentDidMount() {
@@ -295,9 +298,29 @@ class SamplesHeatmapView extends React.Component {
     );
   }
 
+  afterSelectedMetadataChange = selectedMetadata => {
+    this.selectedMetadata = selectedMetadata;
+    this.persistToUrl();
+  };
+
   handleRemoveTaxon = taxonName => {
     let taxonId = this.state.taxonDetails[taxonName].id;
     this.removedTaxonIds.add(taxonId);
+    // Need to change URL explicitly because removing does not AJAX
+    this.persistToUrl();
+  };
+
+  persistToUrl = () => {
+    try {
+      history.pushState(
+        window.history.state,
+        document.title,
+        this.getUrlForCurrentParams()
+      );
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    }
   };
 
   closeSidebar = () => {
@@ -410,6 +433,8 @@ class SamplesHeatmapView extends React.Component {
           onRemoveTaxon={this.handleRemoveTaxon}
           onSampleLabelClick={this.handleSampleLabelClick}
           onTaxonLabelClick={this.handleTaxonLabelClick}
+          afterSelectedMetadataChange={this.afterSelectedMetadataChange}
+          defaultMetadata={this.selectedMetadata}
         />
       </ErrorBoundary>
     );
@@ -536,7 +561,8 @@ class SamplesHeatmapView extends React.Component {
     return Object.assign(
       {
         sampleIds: this.state.sampleIds,
-        removedTaxonIds: Array.from(this.removedTaxonIds)
+        removedTaxonIds: Array.from(this.removedTaxonIds),
+        selectedMetadata: Array.from(this.selectedMetadata)
       },
       this.state.selectedOptions
     );

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -164,6 +164,7 @@ class SamplesHeatmapVis extends React.Component {
   }
 
   handleCellClick = (cell, currentEvent) => {
+    // TODO (gdingle): highlight the corresponding row on the sample report page
     openUrl(`/samples/${this.props.sampleIds[cell.columnIndex]}`, currentEvent);
   };
 
@@ -179,14 +180,11 @@ class SamplesHeatmapVis extends React.Component {
         selectedMetadata.has(metadatum)
       )
     );
-    this.setState(
-      {
-        selectedMetadata: new Set([...intersection, ...selectedMetadata])
-      },
-      () => {
-        this.heatmap.updateColumnMetadata(this.getSelectedMetadata());
-      }
-    );
+    selectedMetadata = new Set([...intersection, ...selectedMetadata]);
+    this.setState({ selectedMetadata }, () => {
+      this.heatmap.updateColumnMetadata(this.getSelectedMetadata());
+    });
+    this.props.afterSelectedMetadataChange(selectedMetadata);
   };
 
   renderColumnMetadataSelector() {
@@ -311,7 +309,8 @@ SamplesHeatmapVis.propTypes = {
   sampleIds: PropTypes.array,
   scale: PropTypes.string,
   taxonDetails: PropTypes.object,
-  taxonIds: PropTypes.array
+  taxonIds: PropTypes.array,
+  afterSelectedMetadataChange: PropTypes.func
 };
 
 export default SamplesHeatmapVis;


### PR DESCRIPTION
# Description

This makes the X out and metadata selection persist in heatmaps.

![image](https://user-images.githubusercontent.com/28797/53059415-95bf5480-346b-11e9-81c5-5d6a36438d1c.png)

For example:
http://localhost:3000/visualizations/heatmap/31?background=26&dataScaleIdx=0&metric=NT.aggregatescore&readSpecificity=1&removedTaxonIds[]=139&removedTaxonIds[]=2055263&sampleIds[]=10399&sampleIds[]=4540&selectedMetadata[]=collection_location&selectedMetadata[]=antibiotic_administered&selectedMetadata[]=collection_date&species=1&subcategories=%7B%7D&taxonsPerSample=30&thresholdFilters=%5B%5D

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. open a heatmap
2. select custom metadata
3. reload page, see metadata
4. X out some rows
5. reload page, see rows still hidden

