### PR TITLE
Shorten share URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,9 @@ gem 'activerecord-import'
 # Segment analytics for backend events
 gem 'analytics-ruby', '~> 2.0.0', require: 'segment/analytics'
 
+# Url shortener
+gem 'shortener'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'bundler-audit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -994,6 +994,8 @@ GEM
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
+    shortener (0.8.0)
+      voight_kampff (~> 1.1.2)
     silencer (1.0.1)
     simple_token_authentication (1.15.1)
       actionmailer (>= 3.2.6, < 6)
@@ -1042,6 +1044,8 @@ GEM
     useragent (0.16.10)
     vegas (0.1.11)
       rack (>= 1.0.0)
+    voight_kampff (1.1.3)
+      rack (>= 1.4, < 3.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -1103,6 +1107,7 @@ DEPENDENCIES
   rspec-rails (>= 3.7.2)
   rubocop (= 0.49.1)
   selenium-webdriver
+  shortener
   silencer
   simple_token_authentication (~> 1.15, >= 1.15.1)
   sprockets-es6

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -211,6 +211,8 @@ const saveVisualization = (type, data) =>
     data
   });
 
+const shortenUrl = url => postWithCSRF("/visualizations/shorten_url", { url });
+
 const bulkImportRemoteSamples = ({ projectId, hostGenomeId, bulkPath }) =>
   get("/samples/bulk_import.json", {
     params: {
@@ -322,5 +324,6 @@ export {
   getTaxonDistributionForBackground,
   getSampleTaxons,
   logAnalyticsEvent,
-  validateSampleNames
+  validateSampleNames,
+  shortenUrl
 };

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -4,7 +4,11 @@ import React from "react";
 import cx from "classnames";
 import { get } from "lodash/fp";
 import { logAnalyticsEvent, saveVisualization } from "~/api";
-import { getURLParamString, parseUrlParams } from "~/helpers/url";
+import {
+  getURLParamString,
+  parseUrlParams,
+  copyShortUrlToClipboard
+} from "~/helpers/url";
 import { ANALYTICS_EVENT_NAMES } from "~/api/constants";
 import PropTypes from "~/components/utils/propTypes";
 import { pipelineVersionHasAssembly } from "~/components/utils/sample";
@@ -18,7 +22,6 @@ import DetailsSidebar from "~/components/common/DetailsSidebar";
 import Controls from "./Controls";
 import PipelineVersionSelect from "./PipelineVersionSelect";
 import { SaveButton, ShareButton } from "~ui/controls/buttons";
-import copy from "copy-to-clipboard";
 
 import cs from "./sample_view.scss";
 
@@ -284,9 +287,8 @@ class SampleView extends React.Component {
     return {};
   };
 
-  // TODO (gdingle): refactor with onShareClick in SamplesHeatmapView?
-  onShareClick = () => {
-    copy(window.location.href);
+  onShareClick = async () => {
+    await copyShortUrlToClipboard();
   };
 
   onSaveClick = async () => {

--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -4,7 +4,6 @@ import axios from "axios";
 import queryString from "query-string";
 import { get, set, min, max } from "lodash/fp";
 import DeepEqual from "fast-deep-equal";
-import copy from "copy-to-clipboard";
 import { StickyContainer, Sticky } from "react-sticky";
 import ErrorBoundary from "~/components/ErrorBoundary";
 import DetailsSidebar from "~/components/common/DetailsSidebar";
@@ -12,6 +11,7 @@ import { Divider, NarrowContainer, ViewHeader } from "~/components/layout";
 import SequentialLegendVis from "~/components/visualizations/legends/SequentialLegendVis.jsx";
 import Slider from "~ui/controls/Slider";
 import BasicPopup from "~/components/BasicPopup";
+import { copyShortUrlToClipboard } from "~/helpers/url";
 
 import { SaveButton, ShareButton } from "~ui/controls/buttons";
 import {
@@ -153,8 +153,8 @@ class SamplesHeatmapView extends React.Component {
     return `${url.toString()}?${this.prepareParams()}`;
   }
 
-  onShareClick = () => {
-    copy(this.getUrlForCurrentParams());
+  onShareClick = async () => {
+    await copyShortUrlToClipboard(this.getUrlForCurrentParams());
   };
 
   onSaveClick = async () => {

--- a/app/assets/src/helpers/url.js
+++ b/app/assets/src/helpers/url.js
@@ -1,5 +1,7 @@
 import QueryString from "query-string";
 import { toPairs, pickBy } from "lodash/fp";
+import { shortenUrl } from "~/api";
+import copy from "copy-to-clipboard";
 
 export const resetUrl = () => {
   // remove parameters from url
@@ -26,4 +28,10 @@ export const getURLParamString = params => {
   return toPairs(filtered)
     .map(pair => pair.join("="))
     .join("&");
+};
+
+export const copyShortUrlToClipboard = async url => {
+  url = url || window.location.href;
+  const shortUrl = await shortenUrl(url);
+  copy(window.location.origin + "/" + shortUrl.unique_key);
 };

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -45,4 +45,19 @@ class VisualizationsController < ApplicationController
       # TODO: (gdingle): better error code?
     }, status: :internal_server_error
   end
+
+  def shorten_url
+    short_url = Shortener::ShortenedUrl.generate(params[:url])
+    render json: {
+      status: "success",
+      message: "Url shortened successfully",
+      unique_key: short_url.unique_key
+    }
+  rescue => err
+    render json: {
+      status: "failed",
+      message: "Unable to shorten",
+      errors: [err]
+    }, status: :internal_server_error
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
   get 'visualizations/download_heatmap', to: 'visualizations#download_heatmap'
   post 'visualizations/:type/save', to: 'visualizations#save'
   get 'visualizations/:type(/:id)', to: 'visualizations#visualization'
+  post 'visualizations/shorten_url', to: 'visualizations#shorten_url'
 
   resources :host_genomes
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]
@@ -109,6 +110,9 @@ Rails.application.routes.draw do
   authenticate :user, ->(u) { u.admin? } do
     mount Resque::Server.new, at: "/resque"
   end
+
+  # Un-shorten URLs. This should go second-to-last.
+  get '/:id' => "shortener/shortened_urls#show"
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'home#landing'

--- a/db/migrate/20190220191436_create_shortened_urls_table.rb
+++ b/db/migrate/20190220191436_create_shortened_urls_table.rb
@@ -1,0 +1,34 @@
+class CreateShortenedUrlsTable < ActiveRecord::Migration[4.2]
+  def change
+    create_table :shortened_urls do |t|
+      # we can link this to a user for interesting things
+      t.integer :owner_id
+      t.string :owner_type, limit: 20
+
+      # the real url that we will redirect to
+      t.text :url, null: false, length: 2083
+
+      # the unique key
+      t.string :unique_key, limit: 10, null: false
+
+      # a category to help categorize shortened urls
+      t.string :category
+
+      # how many times the link has been clicked
+      t.integer :use_count, null: false, default: 0
+
+      # valid until date for expirable urls
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+
+    # we will lookup the links in the db by key, urls and owners.
+    # also make sure the unique keys are actually unique
+    add_index :shortened_urls, :unique_key, unique: true
+    # Length 254 because https://stackoverflow.com/questions/1814532/1071-specified-key-was-too-long-max-key-length-is-767-bytes
+    add_index :shortened_urls, :url, length: 254
+    add_index :shortened_urls, [:owner_id, :owner_type]
+    add_index :shortened_urls, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,6 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
-
 ActiveRecord::Schema.define(version: 20_190_220_191_436) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
@@ -33,6 +32,9 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
     t.float "depth", limit: 24
     t.bigint "pipeline_run_id"
     t.string "drug_family"
+    t.integer "level"
+    t.float "drug_gene_coverage", limit: 24
+    t.float "drug_gene_depth", limit: 24
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["pipeline_run_id", "allele"], name: "index_amr_counts_on_pipeline_run_id_and_allele", unique: true
@@ -71,7 +73,7 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -102,7 +104,7 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -114,8 +116,8 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
   create_table "host_genomes_metadata_fields", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "host_genome_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields", unique: true
-    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes", unique: true
+    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields"
+    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes"
   end
 
   create_table "input_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -124,7 +126,7 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type"
+    t.string "source_type", null: false
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -143,7 +145,7 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key", null: false, collation: "latin1_swedish_ci"
-    t.integer "data_type"
+    t.integer "data_type", limit: 1, null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.float "number_validated_value", limit: 24
@@ -177,7 +179,7 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
   create_table "metadata_fields_projects", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "project_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields", unique: true
+    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields"
   end
 
   create_table "output_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -276,6 +278,7 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
     t.string "pipeline_commit"
     t.text "assembled_taxids"
     t.bigint "truncated"
+    t.text "result_status"
     t.integer "results_finalized"
     t.bigint "alignment_config_id"
     t.integer "alert_sent", default: 0
@@ -292,7 +295,7 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1, default: 0
+    t.integer "public_access", limit: 1
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -338,13 +341,6 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
     t.integer "max_input_fragments"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
     t.index ["user_id"], name: "index_samples_on_user_id"
-  end
-
-  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "visualization_id", null: false
-    t.bigint "sample_id", null: false
-    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
-    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
   end
 
   create_table "shortened_urls", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -411,12 +407,12 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
   end
 
-  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
-    t.string "title"
-    t.text "summary", limit: 16_777_215
-    t.text "description", limit: 16_777_215
+    t.string "title", collation: "utf8mb4_general_ci"
+    t.text "summary", collation: "utf8mb4_general_ci"
+    t.text "description", collation: "utf8mb4_general_ci"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -506,11 +502,11 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email"
+    t.string "email", default: "", null: false
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password"
+    t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -537,5 +533,10 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
     t.index ["user_id"], name: "index_visualizations_on_user_id"
   end
 
-  add_foreign_key "visualizations", "users"
+  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "visualization_id", null: false
+    t.bigint "sample_id", null: false
+    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
+    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_208_234_410) do
+ActiveRecord::Schema.define(version: 20_190_220_191_436) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -33,9 +33,6 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.float "depth", limit: 24
     t.bigint "pipeline_run_id"
     t.string "drug_family"
-    t.integer "level"
-    t.float "drug_gene_coverage", limit: 24
-    t.float "drug_gene_depth", limit: 24
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["pipeline_run_id", "allele"], name: "index_amr_counts_on_pipeline_run_id_and_allele", unique: true
@@ -74,7 +71,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -105,7 +102,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", null: false
+    t.string "name"
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -117,8 +114,8 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
   create_table "host_genomes_metadata_fields", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "host_genome_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields"
-    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes"
+    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields", unique: true
+    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes", unique: true
   end
 
   create_table "input_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -127,7 +124,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type", null: false
+    t.string "source_type"
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -146,7 +143,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key", null: false, collation: "latin1_swedish_ci"
-    t.integer "data_type", limit: 1, null: false
+    t.integer "data_type"
     t.string "raw_value"
     t.string "string_validated_value"
     t.float "number_validated_value", limit: 24
@@ -180,7 +177,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
   create_table "metadata_fields_projects", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "project_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields"
+    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields", unique: true
   end
 
   create_table "output_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -279,7 +276,6 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.string "pipeline_commit"
     t.text "assembled_taxids"
     t.bigint "truncated"
-    t.text "result_status"
     t.integer "results_finalized"
     t.bigint "alignment_config_id"
     t.integer "alert_sent", default: 0
@@ -296,7 +292,7 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1
+    t.integer "public_access", limit: 1, default: 0
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -342,6 +338,29 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.integer "max_input_fragments"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
     t.index ["user_id"], name: "index_samples_on_user_id"
+  end
+
+  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "visualization_id", null: false
+    t.bigint "sample_id", null: false
+    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
+    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
+  end
+
+  create_table "shortened_urls", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer "owner_id"
+    t.string "owner_type", limit: 20
+    t.text "url", null: false
+    t.string "unique_key", limit: 10, null: false
+    t.string "category"
+    t.integer "use_count", default: 0, null: false
+    t.datetime "expires_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["category"], name: "index_shortened_urls_on_category"
+    t.index ["owner_id", "owner_type"], name: "index_shortened_urls_on_owner_id_and_owner_type"
+    t.index ["unique_key"], name: "index_shortened_urls_on_unique_key", unique: true
+    t.index ["url"], name: "index_shortened_urls_on_url", length: { url: 254 }
   end
 
   create_table "taxon_byteranges", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -392,12 +411,12 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
   end
 
-  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
-    t.string "title", collation: "utf8mb4_general_ci"
-    t.text "summary", collation: "utf8mb4_general_ci"
-    t.text "description", collation: "utf8mb4_general_ci"
+    t.string "title"
+    t.text "summary", limit: 16_777_215
+    t.text "description", limit: 16_777_215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -487,11 +506,11 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email", default: "", null: false
+    t.string "email"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password", default: "", null: false
+    t.string "encrypted_password"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -518,10 +537,5 @@ ActiveRecord::Schema.define(version: 20_190_208_234_410) do
     t.index ["user_id"], name: "index_visualizations_on_user_id"
   end
 
-  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "visualization_id", null: false
-    t.bigint "sample_id", null: false
-    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
-    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
-  end
+  add_foreign_key "visualizations", "users"
 end


### PR DESCRIPTION
# Description

This shortens the long URLs on the visualization pages. 

![image](https://user-images.githubusercontent.com/28797/53121410-09636f00-3509-11e9-9b16-14ba730f6463.png)

Most of the work is handled by the `shortener` gem. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. open a heatmap / report page
2. customize
3. hit share
5. paste the short url into a new tab
6. see the same vis state

## Impacted Areas in Application
List general components of the application that this PR will affect:

Which pages?

- [ ] Login Screen
- [ ] Single Upload Page
- [ ] Batch Upload Page
- [ ] All Projects Page
- [ ] Sample Details Page
- [X] Report Page

