### PR TITLE
Add default_for_new_host_genome metadata field.

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -14,6 +14,7 @@ class MetadataController < ApplicationController
   def instructions
   end
 
+  # TODO(mark): Factor this out into metadata_fields_controller, and add other CRUD endpoints.
   # All users get the same fields.
   def official_metadata_fields
     render json: official_metadata_fields_helper

--- a/app/models/host_genome.rb
+++ b/app/models/host_genome.rb
@@ -2,7 +2,16 @@ class HostGenome < ApplicationRecord
   has_many :samples
   has_and_belongs_to_many :metadata_fields
 
+  before_create :add_default_metadata_fields
+
   def default_background
     Background.find(default_background_id) if default_background_id
+  end
+
+  def add_default_metadata_fields
+    # Cat Genome was created in migrations before MetadataField table, so need to check this for the test db migrations.
+    if MetadataField.table_exists?
+      self.metadata_fields = MetadataField.where(default_for_new_host_genome: 1)
+    end
   end
 end

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -83,6 +83,9 @@ class MetadataField < ApplicationRecord
   # "default". Then they can add and subtract from their set of meta-fields from there.
   # create_join_table :projects, :metadata_fields
 
+  # Whether this metadata field should be added automatically to new host genomes.
+  # t.integer :default_for_new_host_genome, limit: 1, default: 0
+
   # Important attributes for the frontend
   def field_info
     {
@@ -94,7 +97,8 @@ class MetadataField < ApplicationRecord
       host_genome_ids: host_genome_ids,
       description: description,
       is_required: is_required,
-      examples: examples && JSON.parse(examples)
+      examples: examples && JSON.parse(examples),
+      default_for_new_host_genome: default_for_new_host_genome
     }
   end
 

--- a/db/migrate/20190220211036_add_new_host_genome_default_to_metadata_fields.rb
+++ b/db/migrate/20190220211036_add_new_host_genome_default_to_metadata_fields.rb
@@ -1,0 +1,35 @@
+class AddNewHostGenomeDefaultToMetadataFields < ActiveRecord::Migration[5.1]
+  DEFAULTS = [
+    "collection_date",
+    "collection_location",
+    "nucleotide_type",
+    "sample_type",
+    "water_control",
+    "isolate",
+    "host_genus_species",
+    "host_sex",
+    "infection_class",
+    "known_organism",
+    "detection_method",
+    "library_prep",
+    "sequencer",
+    "rna_dna_input",
+    # The following fields are important for most species, but might not apply to ALL.
+    "host_age", # For some hosts like ticks, host_life_stage might be more relevant.
+    "diseases_and_conditions" # Might not apply to disease vectors such as mosquitoes and ticks.
+  ].freeze
+
+  def up
+    add_column :metadata_fields, :default_for_new_host_genome, :integer, limit: 1, default: 0
+    DEFAULTS.each do |key|
+      field = MetadataField.find_by(name: key)
+      if field
+        field.update(default_for_new_host_genome: 1)
+      end
+    end
+  end
+
+  def down
+    remove_column :metadata_fields, :default_for_new_host_genome
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,6 +174,7 @@ ActiveRecord::Schema.define(version: 20_190_220_191_436) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "examples"
+    t.integer "default_for_new_host_genome", limit: 1, default: 0
     t.index ["group"], name: "index_metadata_fields_on_group"
   end
 


### PR DESCRIPTION
Auto-add default metadata fields when a new host genome is created.

Tested with `rake db:migrate` and `rake db:rollback` and by creating a new HostGenome and verifying that it has the default fields.
