### PR TITLE
[Metadata] Update web for CLI metadata uploads

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -11,7 +11,7 @@ class MetadataController < ApplicationController
 
   def instructions
   end
-
+  
   # TODO(mark): Factor this out into metadata_fields_controller, and add other CRUD endpoints.
   # All users get the same fields.
   def official_metadata_fields

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -43,7 +43,7 @@ class MetadataController < ApplicationController
   rescue => err
     render json: {
       status: "error",
-      issues: err
+      issues: { errors: [err] }
     }, status: :unprocessable_entity
   end
 end

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -11,7 +11,7 @@ class MetadataController < ApplicationController
 
   def instructions
   end
-  
+
   # TODO(mark): Factor this out into metadata_fields_controller, and add other CRUD endpoints.
   # All users get the same fields.
   def official_metadata_fields

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -43,6 +43,7 @@ class MetadataController < ApplicationController
   rescue => err
     render json: {
       status: "error",
+      # Wrapped for consistency with success response
       issues: { errors: [err] }
     }, status: :unprocessable_entity
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -44,7 +44,6 @@ class ProjectsController < ApplicationController
   # GET /projects
   # GET /projects.json
   def index
-    puts "index was called at least"
     respond_to do |format|
       format.html do
         # keep compatibility with old route
@@ -60,8 +59,6 @@ class ProjectsController < ApplicationController
           render json: current_power.updatable_projects
           return
         end
-
-        puts "got up to here at least"
 
         only_library = ActiveModel::Type::Boolean.new.cast(params[:onlyLibrary])
         exclude_library = ActiveModel::Type::Boolean.new.cast(params[:excludeLibrary])
@@ -390,14 +387,12 @@ class ProjectsController < ApplicationController
   end
 
   def set_project
-    puts "why is set_project being called"
     @project = projects_scope.find(params[:id])
     assert_access
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def project_params
-    puts "original params here #{params}"
     result = params.require(:project).permit(:name, :public_access, user_ids: [])
     result[:name] = sanitize(result[:name]) if result[:name]
     result

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -76,6 +76,7 @@ class ProjectsController < ApplicationController
                     else
                       # This check is so that we still return projects without any samples.
                       # Ex: Project listing used by the CLI.
+                      # TODO: Optimize perf if it is an issue.
                       current_power.projects.map { |p| [p, Sample.where(project: p).count] }
                     end
         extended_projects = @projects.map do |project, sample_count|

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -74,13 +74,13 @@ class ProjectsController < ApplicationController
                      current_power.samples
                    end
 
-        if only_library || exclude_library
-          @projects = @samples.group(:project).count
-        else
-          # This check is so that we still return projects without any samples.
-          # Ex: Project listing used by the CLI.
-          @projects = current_power.projects.map {|p| [p, Sample.where(project: p).count] }
-        end
+        @projects = if only_library || exclude_library
+                      @samples.group(:project).count
+                    else
+                      # This check is so that we still return projects without any samples.
+                      # Ex: Project listing used by the CLI.
+                      current_power.projects.map { |p| [p, Sample.where(project: p).count] }
+                    end
         extended_projects = @projects.map do |project, sample_count|
           project.as_json(only: [:id, :name, :created_at, :public_access]).merge(
             number_of_samples: sample_count,

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -74,8 +74,8 @@ class ProjectsController < ApplicationController
         @projects = if only_library || exclude_library
                       @samples.group(:project).count
                     else
-                      # This check is so that we still return projects without any samples.
-                      # Ex: Project listing used by the CLI.
+                      # This check is so that we still return projects without any samples in the
+                      # default case. Ex: Project listing used by the CLI.
                       # TODO: Optimize perf if it is an issue.
                       current_power.projects.map { |p| [p, Sample.where(project: p).count] }
                     end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -922,7 +922,7 @@ class SamplesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def samples_params
-    new_params = params.permit(samples: [:name, :project_id, :project_name, :status, :host_genome_id, :host_genome_name,
+    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name,
                                          input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts]])
     new_params[:samples] if new_params
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -317,10 +317,7 @@ class SamplesController < ApplicationController
     editable_project_names = current_power.updatable_projects.pluck(:name)
 
     # CLI currently supplies project_names
-    samples_to_upload, samples_invalid_projects = samples_to_upload.partition do |sample|
-      sample["project_id"] && editable_project_ids.include?(Integer(sample["project_id"])) || sample["project_name"] && editable_project_names.include?(sample["project_name"])
-    end
-    samples_to_upload = samples_to_upload.map {|s| s.delete("project_name")}
+    samples_to_upload, samples_invalid_projects = samples_to_upload.partition { |sample| editable_project_ids.include?(Integer(sample["project_id"])) }
 
     puts "samples to upload: #{samples_to_upload}"
 
@@ -937,7 +934,7 @@ class SamplesController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def samples_params
     puts "BEFORE: #{params}"
-    new_params = params.permit(samples: [:name, :project_id, :project_name, :status, :host_genome_id,
+    new_params = params.permit(samples: [:name, :project_id, :project_name, :status, :host_genome_id, :host_genome_name,
                                          input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts]])
     if new_params
       puts "foobar it was unwrapped 4:28pm"

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -15,7 +15,7 @@ class SamplesController < ApplicationController
   #                access control should still be checked as neccessary through current_power
   #
   ##########################################
-  skip_before_action :verify_authenticity_token, only: [:create, :update]
+  skip_before_action :verify_authenticity_token, only: [:create, :update, :bulk_upload_with_metadata]
 
   # Read action meant for single samples with set_sample before_action
   READ_ACTIONS = [:show, :report_info, :search_list, :report_csv, :assembly, :show_taxid_fasta, :nonhost_fasta, :unidentified_fasta,
@@ -293,6 +293,9 @@ class SamplesController < ApplicationController
 
   # POST /samples/bulk_upload_with_metadata
   def bulk_upload_with_metadata
+    puts "foobar 12:38pm"
+    puts samples_params
+    puts params[:metadata]
     samples_to_upload = samples_params || []
     metadata = params[:metadata] || {}
     client = params[:client]

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -293,10 +293,6 @@ class SamplesController < ApplicationController
 
   # POST /samples/bulk_upload_with_metadata
   def bulk_upload_with_metadata
-    puts "foobar 12:38pm"
-    puts "samples_params: #{samples_params}"
-    puts "metadata params: #{params[:metadata]}"
-    puts "client: #{params[:client]}"
     samples_to_upload = samples_params || []
     metadata = params[:metadata] || {}
     client = params[:client]
@@ -314,17 +310,10 @@ class SamplesController < ApplicationController
     end
 
     editable_project_ids = current_power.updatable_projects.pluck(:id)
-    editable_project_names = current_power.updatable_projects.pluck(:name)
 
-    # CLI currently supplies project_names
     samples_to_upload, samples_invalid_projects = samples_to_upload.partition { |sample| editable_project_ids.include?(Integer(sample["project_id"])) }
 
-    puts "samples to upload: #{samples_to_upload}"
-
     errors, samples = upload_samples_with_metadata(samples_to_upload, metadata).values_at("errors", "samples")
-
-    puts "samples here:"
-    puts samples
 
     # For each sample with an invalid project ID, add an error.
     samples_invalid_projects.each do |sample|
@@ -772,7 +761,7 @@ class SamplesController < ApplicationController
       project_name = params.delete(:project_name)
       project = Project.find_by(name: project_name)
       unless project
-        project = Project.create(name: project_name, metadata_fields: MetadataField.where(is_default: 1))
+        project = Project.create(name: project_name)
         project.users << current_user if current_user
       end
     end
@@ -933,13 +922,9 @@ class SamplesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def samples_params
-    puts "BEFORE: #{params}"
     new_params = params.permit(samples: [:name, :project_id, :project_name, :status, :host_genome_id, :host_genome_name,
                                          input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts]])
-    if new_params
-      puts "foobar it was unwrapped 4:28pm"
-      new_params[:samples]
-    end
+    new_params[:samples] if new_params
   end
 
   def sample_params

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -761,7 +761,7 @@ class SamplesController < ApplicationController
       project_name = params.delete(:project_name)
       project = Project.find_by(name: project_name)
       unless project
-        project = Project.create(name: project_name)
+        project = Project.create(name: project_name, metadata_fields: MetadataField.where(is_default: 1))
         project.users << current_user if current_user
       end
     end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -31,7 +31,7 @@ class SamplesController < ApplicationController
   before_action :authenticate_user!, except: [:create, :update, :bulk_upload, :bulk_upload_with_metadata]
   acts_as_token_authentication_handler_for User, only: [:create, :update, :bulk_upload, :bulk_upload_with_metadata], fallback: :devise
 
-  before_action :admin_required, only: [:reupload_source, :resync_prod_data_to_staging, :kickoff_pipeline, :retry_pipeline, :pipeline_runs, :upload, :bulk_upload_with_metadata]
+  before_action :admin_required, only: [:reupload_source, :resync_prod_data_to_staging, :kickoff_pipeline, :retry_pipeline, :pipeline_runs]
   before_action :no_demo_user, only: [:create, :bulk_new, :bulk_upload, :bulk_import, :new]
 
   current_power do # Put this here for CLI

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -387,6 +387,7 @@ module SamplesHelper
   # metadata is a hash mapping sample name to hash of fields.
   def upload_metadata_for_samples(samples, metadata)
     errors = []
+    puts "here are all the fields: #{metadata}"
 
     metadata.each do |sample_name, fields|
       sample = samples.find { |s| s.name == sample_name }
@@ -397,7 +398,7 @@ module SamplesHelper
       end
 
       fields.each do |key, value|
-        next if key == "sample_name"
+        next if key == "sample_name" or key == "host_genome"
 
         saved = sample.metadatum_add_or_update(key, value)
 
@@ -413,8 +414,17 @@ module SamplesHelper
     samples = []
     errors = []
     samples_to_upload.each do |sample_attributes|
+      puts "sample attributes look like #{sample_attributes}"
       sample_attributes[:input_files_attributes].reject! { |f| f["source"] == '' }
+      if sample_attributes[:host_genome_name]
+        sample_attributes[:host_genome_id] = HostGenome.find_by(name: sample_attributes[:host_genome_name]).id
+        sample_attributes.delete(:host_genome_name)
+        puts "the id is: #{sample_attributes[:host_genome_id]}"
+        puts "genome was resolved"
+      end
       sample = Sample.new(sample_attributes)
+      puts "sample was newed"
+      puts "host genome: #{sample.host_genome}"
       sample.input_files.each { |f| f.name ||= File.basename(f.source) }
 
       # If s3 upload, set "bulk_mode" to true.

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -398,7 +398,7 @@ module SamplesHelper
       end
 
       fields.each do |key, value|
-        next if key == "sample_name" or key == "host_genome"
+        next if key == "sample_name" || key == "host_genome"
 
         saved = sample.metadatum_add_or_update(key, value)
 

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -387,7 +387,6 @@ module SamplesHelper
   # metadata is a hash mapping sample name to hash of fields.
   def upload_metadata_for_samples(samples, metadata)
     errors = []
-    puts "here are all the fields: #{metadata}"
 
     metadata.each do |sample_name, fields|
       sample = samples.find { |s| s.name == sample_name }
@@ -398,7 +397,7 @@ module SamplesHelper
       end
 
       fields.each do |key, value|
-        next if key == "sample_name" || key == "host_genome"
+        next if ["sample_name", "host_genome"].include?(key)
 
         saved = sample.metadatum_add_or_update(key, value)
 
@@ -414,17 +413,13 @@ module SamplesHelper
     samples = []
     errors = []
     samples_to_upload.each do |sample_attributes|
-      puts "sample attributes look like #{sample_attributes}"
       sample_attributes[:input_files_attributes].reject! { |f| f["source"] == '' }
+
       if sample_attributes[:host_genome_name]
-        sample_attributes[:host_genome_id] = HostGenome.find_by(name: sample_attributes[:host_genome_name]).id
-        sample_attributes.delete(:host_genome_name)
-        puts "the id is: #{sample_attributes[:host_genome_id]}"
-        puts "genome was resolved"
+        name = sample_attributes.delete(:host_genome_name)
+        sample_attributes[:host_genome_id] = HostGenome.find_by(name: name).id
       end
       sample = Sample.new(sample_attributes)
-      puts "sample was newed"
-      puts "host genome: #{sample.host_genome}"
       sample.input_files.each { |f| f.name ||= File.basename(f.source) }
 
       # If s3 upload, set "bulk_mode" to true.

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,6 +14,8 @@ class Project < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   include ReportHelper
 
+  before_create :add_default_metadata_fields
+
   def csv_dir(user_id)
     path = "/app/tmp/report_csvs/#{id}/#{user_id}"
     sanitize_path(path)
@@ -139,5 +141,9 @@ class Project < ApplicationRecord
     samples = Sample.find(sample_ids)
     samples.each(&:destroy)
     super
+  end
+
+  def add_default_metadata_fields
+    self.metadata_fields = MetadataField.where(is_default: 1) unless metadata_fields
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -557,11 +557,11 @@ class Sample < ApplicationRecord
         m.metadata_field = mf
       end
 
-      raise ActiveRecord::RecordNotFound("No matching field for #{key}") unless m.metadata_field
+      raise RecordNotFound("No matching field for #{key}") unless m.metadata_field
       m.key = m.metadata_field.name
     end
     if val.blank?
-      m.destroy
+      m.delete
     else
       m.raw_value = val
       m.save!

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -560,9 +560,7 @@ class Sample < ApplicationRecord
       raise RecordNotFound("No matching field for #{key}") unless m.metadata_field
       m.key = m.metadata_field.name
     end
-    if val.blank?
-      m.delete
-    else
+    if val.present?
       m.raw_value = val
       m.save!
     end

--- a/app/views/metadata/instructions.html.erb
+++ b/app/views/metadata/instructions.html.erb
@@ -1,9 +1,9 @@
 <div id="MetadataInstructions_page">
   <%= javascript_tag do %>
     react_component(
-      'UploadInstructions',
-      { standalone: true, size: "small" },
-      'MetadataInstructions_page'
+    'UploadInstructions',
+    { standalone: true, size: "small" },
+    'MetadataInstructions_page'
     );
   <% end %>
 </div>

--- a/app/views/metadata/instructions.html.erb
+++ b/app/views/metadata/instructions.html.erb
@@ -1,9 +1,9 @@
 <div id="MetadataInstructions_page">
   <%= javascript_tag do %>
     react_component(
-    'UploadInstructions',
-    { standalone: true, size: "small" },
-    'MetadataInstructions_page'
+      'UploadInstructions',
+      { standalone: true, size: "small" },
+      'MetadataInstructions_page'
     );
   <% end %>
 </div>


### PR DESCRIPTION
- Unlock backend /samples/upload endpoints for non-admins (only if called directly)
- Allow CLI to list projects and create new projects (so that the project creation is more explicit and so we don't have to auto-create project names that don't exist)
- Accept host_genome_name from the CLI
- Add default metadata fields to new projects
- Bug fixes for "raise ActiveRecord::RecordNotFound" and "m.destroy" because it didn't seem to work for non-materialized records