### PR TITLE
Turn on metadata upload to existing samples for all users.

### DIFF
--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1709,10 +1709,7 @@ class BackgroundModal extends React.Component {
 }
 
 function ProjectHeaderMenu({ proj, proj_users_count, parent }) {
-  const showUploadMenu =
-    (parent.admin !== 0 ||
-      parent.allowedFeatures.includes("project_metadata_upload")) &&
-    (proj && parent.canEditProject(proj.id));
+  const showUploadMenu = proj && parent.canEditProject(proj.id);
 
   const currentTimestamp = moment();
   const nextPublicSampleTimestamp = min(
@@ -1762,7 +1759,6 @@ function ProjectHeaderMenu({ proj, proj_users_count, parent }) {
           </div>
         )}
 
-      {/* TODO(mark): Change admin to canEditProject when launch */}
       {showUploadMenu && (
         <div className={cs.projectMenuItem}>
           <ProjectUploadMenu project={proj} />

--- a/app/assets/src/components/views/samples/MetadataUploadModal/UploadPage.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/UploadPage.jsx
@@ -46,7 +46,7 @@ class UploadPage extends React.Component {
             See Instructions
           </span>
           <span> | </span>
-          <a href="/metadata/dictionary" className={cs.link}>
+          <a href="/metadata/dictionary" className={cs.link} target="_blank">
             See Metadata Dictionary
           </a>
         </div>

--- a/app/controllers/host_genomes_controller.rb
+++ b/app/controllers/host_genomes_controller.rb
@@ -1,6 +1,6 @@
 class HostGenomesController < ApplicationController
   before_action :set_host_genome, only: [:show, :edit, :update, :destroy]
-  before_action :admin_required
+  before_action :admin_required, except: [:index]
 
   # GET /host_genomes
   # GET /host_genomes.json

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -6,8 +6,6 @@ class MetadataController < ApplicationController
   before_action :authenticate_user!, except: [:validate_csv_for_new_samples]
   acts_as_token_authentication_handler_for User, only: [:validate_csv_for_new_samples], fallback: :devise
 
-  before_action :admin_required
-
   def dictionary
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -40,11 +40,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   # Host Genomes
 
-  test 'host genome -non admin shouldnt get index' do
-    get host_genomes_url
-    assert_redirected_to root_url
-  end
-
   test 'host genome -non admin shouldnt get new' do
     get new_host_genome_url
     assert_redirected_to root_url


### PR DESCRIPTION
This flips on this "Upload" Menu:
![screen shot 2019-02-22 at 1 51 51 pm](https://user-images.githubusercontent.com/837004/53273532-1dde6d80-36a9-11e9-9f22-cdbd4ce8767a.png)

The following screenshots are from a non-admin user:
![screen shot 2019-02-22 at 1 51 58 pm](https://user-images.githubusercontent.com/837004/53273542-2040c780-36a9-11e9-9b1b-ec2f1096ce88.png)

![screen shot 2019-02-22 at 1 52 02 pm](https://user-images.githubusercontent.com/837004/53273544-220a8b00-36a9-11e9-8b1d-41bbd22143ad.png)

![screen shot 2019-02-22 at 1 52 23 pm](https://user-images.githubusercontent.com/837004/53273546-23d44e80-36a9-11e9-8ba6-f08f0cd2b246.png)
