### PR TITLE
[Metadata] Fix current_power for CLI

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -5,6 +5,9 @@ class MetadataController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:validate_csv_for_new_samples]
   before_action :authenticate_user!, except: [:validate_csv_for_new_samples]
   acts_as_token_authentication_handler_for User, only: [:validate_csv_for_new_samples], fallback: :devise
+  current_power do # Needed for CLI
+    Power.new(current_user)
+  end
 
   def dictionary
   end


### PR DESCRIPTION
- Left this off the other PR accidentally. Without it you still get `undefined method `admin?' for nil:NilClass` because current_power is not set properly in the control flow apparently.