### PR TITLE
[Analytics] Only load Segment for logged in users

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,5 +1,6 @@
 <% if Rails.env == 'prod' %>
 <!-- Global site tag (gtag.js) - Google Analytics -->
+<!-- Consider removing Google Analytics, see IDSEQ-841. -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-83494302-3"></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/app/views/layouts/_segment_analytics.html.erb
+++ b/app/views/layouts/_segment_analytics.html.erb
@@ -1,5 +1,5 @@
-<!-- Global site tags for Segment analytics-->
-<% if ENV["SEGMENT_JS_ID"] %>
+<% if ENV["SEGMENT_JS_ID"] && current_user %>
+  <!-- Global site tags for Segment analytics-->
   <script>
     // Snippet from https://segment.com/docs/sources/website/analytics.js/quickstart/
     // Segment ID is designed to be public: https://community.segment.com/t/m26sng/writekey-accessible-by-anyone

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <!-- Consider removing Google Analytics, see IDSEQ-841. -->
     <%= render "layouts/google_analytics" %>
     <%= render "layouts/segment_analytics" %>
     <title>IDseq</title>


### PR DESCRIPTION
- This just loads Segment for our logged in users to "protect" the writekey a little more.
- Reasons: We're seeing "spammy hits" from Catchpoint from shared-infra which adds thousands to our "Monthly Tracked Users" quotas. And from other potential sources on the open web.
- Not really worth keeping it on the landing page / logged-in is good enough.

![screen shot 2019-02-25 at 4 49 20 pm](https://user-images.githubusercontent.com/5652739/53379169-5be3c780-391d-11e9-900a-7d4a2a20a3c4.png)
