### PR TITLE
[Logging] Fix Honeycomb logging + Fix health_check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'coffee-rails', '~> 4.2', '>= 4.2.2'
 gem 'consul', '>= 0.13.1'
 gem 'devise', '4.3.0'
 gem "health_check", ">= 2.7.0"
-gem 'honeycomb-rails', '0.4.1'
+gem 'honeycomb-rails', '>= 0.8.1'
 gem 'mailgun_rails', '>= 0.9.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -822,8 +822,8 @@ GEM
     hashie (3.6.0)
     health_check (3.0.0)
       railties (>= 5.0)
-    honeycomb-rails (0.4.1)
-      libhoney (>= 1.3.2)
+    honeycomb-rails (0.8.1)
+      libhoney (>= 1.9)
       rails (>= 3.0.0)
     http (3.3.0)
       addressable (~> 2.3)
@@ -1085,7 +1085,7 @@ DEPENDENCIES
   elasticsearch-model
   flamegraph
   health_check (>= 2.7.0)
-  honeycomb-rails (= 0.4.1)
+  honeycomb-rails (>= 0.8.1)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   logging-rails

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,10 +1,9 @@
-
 if ENV["IDSEQ_HONEYCOMB_WRITE_KEY"] && ENV["IDSEQ_HONEYCOMB_DATA_SET"] && ENV["IDSEQ_HONEYCOMB_DB_DATA_SET"]
   HoneycombRails.configure do |conf|
     conf.writekey = ENV["IDSEQ_HONEYCOMB_WRITE_KEY"]
     conf.dataset = ENV["IDSEQ_HONEYCOMB_DATA_SET"]
     conf.db_dataset = ENV["IDSEQ_HONEYCOMB_DB_DATA_SET"]
-    conf.sample_rate = proc do |payload|
+    conf.sample_rate = proc do |_, payload|
       case payload[:controller]
       when 'HealthCheck::HealthCheckController'
         60

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,8 +113,11 @@ Rails.application.routes.draw do
     mount Resque::Server.new, at: "/resque"
   end
 
+  # See health_check gem
+  get 'health_check' => "health_check/health_check#index"
+
   # Un-shorten URLs. This should go second-to-last.
-  get '/:id' => "shortener/shortened_urls#show"
+  # get '/:id' => "shortener/shortened_urls#show"
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'home#landing'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,7 @@ Rails.application.routes.draw do
   get 'health_check' => "health_check/health_check#index"
 
   # Un-shorten URLs. This should go second-to-last.
-  # get '/:id' => "shortener/shortened_urls#show"
+  get '/:id' => "shortener/shortened_urls#show"
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'home#landing'


### PR DESCRIPTION
- The gem libhoney was updated from 1.4.1->1.11.0 in #1882 which seemed to trigger a bug in Honeycomb's libraries. Error was "Libhoney::Client: no dataset configured, disabling sending events" even though I verified that the env variables were being loaded properly.
- Honeycomb has their wrapper gem "honeycomb-rails", which wasn't updated with libhoney. Updating it seemed to fix the issue here.
- honeycomb-rails was also deprecated in Dec 2018 but we can't adopt the successor beeline-ruby (https://github.com/honeycombio/beeline-ruby) because it doesn't have the params db_dataset and the new sample_rate doesn't seem to accept a proc, likely because it's new.
- Other change is fixing the /health_check route.

#### Logging showing when the issue started
![screen shot 2019-02-26 at 10 26 17 am](https://user-images.githubusercontent.com/5652739/53447582-45477a00-39ca-11e9-9a12-ae284f542669.png)

#### Proof it works now (Honeycomb UI)
![screen shot 2019-02-26 at 12 48 19 pm](https://user-images.githubusercontent.com/5652739/53447598-4bd5f180-39ca-11e9-896e-697bef6ae8c5.png)
