### PR TITLE
Check stderr for piped s3 copies

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -255,7 +255,7 @@ class Sample < ApplicationRecord
                   "aws s3 cp #{fastq} - | head -#{max_lines} | aws s3 cp - #{sample_input_s3_path}/#{input_file.name}"
                 end
       _stdout, stderr, status = Open3.capture3(command)
-      stderr_array << stderr unless status.exitstatus.zero?
+      stderr_array << stderr unless status.exitstatus.zero? || stderr.present?
     end
     if total_reads_json_path.present?
       # For samples where we are only given fastas post host filtering, we need to input the total reads (before host filtering) from this file.

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -255,7 +255,7 @@ class Sample < ApplicationRecord
                   "aws s3 cp #{fastq} - | head -#{max_lines} | aws s3 cp - #{sample_input_s3_path}/#{input_file.name}"
                 end
       _stdout, stderr, status = Open3.capture3(command)
-      stderr_array << stderr unless status.exitstatus.zero? || stderr.present?
+      stderr_array << stderr unless status.exitstatus.zero? && stderr.empty?
     end
     if total_reads_json_path.present?
       # For samples where we are only given fastas post host filtering, we need to input the total reads (before host filtering) from this file.


### PR DESCRIPTION
- Problem: A command such as this example could fail on the first part and the subsequent pipes would return success because the statuses are not checked. Was hiding a permissions error.

```
command = "aws s3 cp s3://public/blob/blob_R1.fastq - | head -75000000 | aws s3 cp - s3://staging/samples/63/12402/fastqs/jsheu1"
stdout, stderr, status = Open3.capture3(command)
=> ["", "download failed: s3://public/blob/blob_R1.fastq to - An error occurred (403) when calling the HeadObject operation: Forbidden\n", #<Process::Status: pid 4851 exit 0>]
```

- So we can just check that stderr is empty.
- Alternative seemed to be using `set -o pipefail` (https://unix.stackexchange.com/questions/14270/get-exit-status-of-process-thats-piped-to-another) but there was some variation between bash and sh and that seemed more dangerous.