### PR TITLE
Improve phylo_trees#index performance

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -304,11 +304,12 @@ module SamplesHelper
 
   def metadata_multiget(sample_ids)
     metadata = Metadatum.where(sample_id: sample_ids)
+    validated_value_map = Metadatum.validated_value_multiget(metadata)
 
     metadata_by_sample_id = {}
     metadata.each do |metadatum|
       metadata_by_sample_id[metadatum.sample_id] ||= {}
-      metadata_by_sample_id[metadatum.sample_id][metadatum.key.to_sym] = metadatum.validated_value
+      metadata_by_sample_id[metadatum.sample_id][metadatum.key.to_sym] = validated_value_map[metadatum.id]
     end
 
     metadata_by_sample_id
@@ -325,7 +326,7 @@ module SamplesHelper
   end
 
   def format_samples_basic(samples)
-    metadata_by_sample_id = metadata_multiget(samples.map(&:id))
+    metadata_by_sample_id = metadata_multiget(samples.pluck(:id))
     return samples.map do |sample|
       {
         name: sample.name,

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -235,6 +235,21 @@ class Metadatum < ApplicationRecord
     ""
   end
 
+  def self.validated_value_multiget(metadata)
+    metadata_fields = MetadataField.where(id: metadata.pluck(:metadata_field_id)).index_by(&:id)
+    validated_values = {}
+    metadata.each do |md|
+      mdf = metadata_fields[md.metadata_field_id]
+      if mdf
+        base = convert_type_to_string(mdf.base_type)
+        validated_values[md.id] = md["#{base}_validated_value"]
+      else
+        validated_values[md.id] = ""
+      end
+    end
+    validated_values
+  end
+
   def self.convert_type_to_string(type)
     if type == STRING_TYPE
       return "string"

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -219,38 +219,6 @@ class PhyloTree < ApplicationRecord
     ").index_by { |entry| entry["phylo_tree_id"] }
   end
 
-  def self.sample_details_by_tree_id
-    query_results = ActiveRecord::Base.connection.select_all("
-      select phylo_tree_id, pipeline_run_id, ncbi_metadata, sample_id, samples.*, projects.name as project_name
-      from phylo_trees, phylo_trees_pipeline_runs, pipeline_runs, samples
-      inner join projects on samples.project_id = projects.id
-      where phylo_trees.id = phylo_trees_pipeline_runs.phylo_tree_id and
-            phylo_trees_pipeline_runs.pipeline_run_id = pipeline_runs.id and
-            pipeline_runs.sample_id = samples.id
-      order by phylo_tree_id
-    ").to_a
-    indexed_results = {}
-    metadata_by_sample_id = metadata_multiget(query_results.pluck("sample_id").uniq)
-
-    query_results.each do |entry|
-      tree_id = entry["phylo_tree_id"]
-      pipeline_run_id = entry["pipeline_run_id"]
-      tree_node_name = pipeline_run_id.to_s
-      entry["metadata"] = metadata_by_sample_id[entry["sample_id"]]
-      indexed_results[tree_id] ||= {}
-      indexed_results[tree_id][tree_node_name] = entry
-    end
-    # Add NCBI metadata
-    query_results.index_by { |entry| entry["phylo_tree_id"] }.each do |tree_id, tree_data|
-      ncbi_metadata = JSON.parse(tree_data["ncbi_metadata"] || "{}")
-      ncbi_metadata.each do |node_id, node_metadata|
-        node_metadata["name"] ||= node_metadata["accession"]
-        indexed_results[tree_id][node_id] = node_metadata
-      end
-    end
-    indexed_results
-  end
-
   def sample_names_by_run_ids
     query_results = ActiveRecord::Base.connection.select_all("
       select pipeline_runs.id, samples.name


### PR DESCRIPTION
# Description
- This PR fixes performance regressions due to inefficient `TaxonLineage` and `MetadataField` queries. 
- A follow-up PR should fix performance problems due to the fact that all metadata for all phylo_trees are being loaded, just to display the tree list. We should have separate `index` and `show` actions, where `index` just gets tree names and such, whereas `show` gets all the info for a single tree, only if the user actually visits that tree.
- A review of the performance of all metadata-related actions across the entire app will be necessary in the future, since a number of inefficient queries have crept in.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

## Before
Excerpts from `log/development.log` of 1 single `phylo_trees#index` action:
<img width="1238" alt="screen shot 2019-02-27 at 2 32 52 pm" src="https://user-images.githubusercontent.com/16944816/53527804-c96a3200-3a9c-11e9-98b2-bf70538a994f.png">
...
<img width="1227" alt="screen shot 2019-02-27 at 2 33 01 pm" src="https://user-images.githubusercontent.com/16944816/53527825-d2f39a00-3a9c-11e9-9c58-7519ce235b35.png">
...
<img width="1239" alt="screen shot 2019-02-27 at 2 33 24 pm" src="https://user-images.githubusercontent.com/16944816/53527834-d9821180-3a9c-11e9-9acc-8bb909166afa.png">
...

## After
only O(1) query per table (`log/development.log`)
<img width="1132" alt="screen shot 2019-02-27 at 2 28 26 pm" src="https://user-images.githubusercontent.com/16944816/53527877-ef8fd200-3a9c-11e9-91a8-f6dab2a823da.png">
