### PR TITLE
When user uploads additional files, merge them instead of overwriting.

### DIFF
--- a/app/assets/src/components/ui/controls/BulkSampleUploadTable.jsx
+++ b/app/assets/src/components/ui/controls/BulkSampleUploadTable.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import DataTable from "../../visualizations/table/DataTable";
-import { isEmpty, concat, size } from "lodash/fp";
+import { isEmpty, concat, size, sortBy } from "lodash/fp";
 import RemoveIcon from "~/components/ui/icons/RemoveIcon";
 import LoadingIcon from "~/components/ui/icons/LoadingIcon";
 import CheckmarkIcon from "~/components/ui/icons/CheckmarkIcon";
@@ -61,9 +61,12 @@ class BulkSampleUploadTable extends React.Component {
         }
       }
 
+      // Sort the file list by name.
+      const sortedFiles = sortBy(file => file.name || file.source, files);
+
       const filesList = (
         <div>
-          {files.map(f => <div key={f.source}>{f.name || f.source}</div>)}
+          {sortedFiles.map(f => <div key={f.source}>{f.name || f.source}</div>)}
         </div>
       );
 
@@ -75,6 +78,8 @@ class BulkSampleUploadTable extends React.Component {
       };
       entries.push(entry);
     }
+
+    const sortedEntries = sortBy("sampleName", entries);
 
     return (
       <div className={cs.bulkSampleUploadTable}>
@@ -103,7 +108,7 @@ class BulkSampleUploadTable extends React.Component {
             "files",
             "removeIcon"
           ])}
-          data={entries}
+          data={sortedEntries}
         />
       </div>
     );

--- a/app/assets/src/components/utils/propTypes.js
+++ b/app/assets/src/components/utils/propTypes.js
@@ -45,7 +45,7 @@ const BackgroundData = PropTypes.shape({
 
 // TODO(mark): Expand signature as more fields of Sample are used in the app.
 const Sample = PropTypes.shape({
-  id: PropTypes.number.isRequired,
+  id: PropTypes.number,
   name: PropTypes.string,
   host_genome_id: PropTypes.number
 });

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -85,7 +85,7 @@ class UploadMetadataStep extends React.Component {
             project={this.props.project}
             onMetadataChange={this.handleMetadataChange}
             samplesAreNew
-            issues={this.state.wasManual && this.state.issues}
+            issues={this.state.wasManual ? this.state.issues : null}
           />
           <div className={cs.mainControls}>
             <PrimaryButton


### PR DESCRIPTION
Also fix bug with sampleNamesToFile map.
If a project changes and the sample names are validated and changed, the sampleNamesToFile
wasn't updating its name before.

Also fix some additional propType issues.

Here, we add four files and then change the project (notice the sample names update at the very end) 
![merge_sample_inputs](https://user-images.githubusercontent.com/837004/53529306-0afcdc00-3aa1-11e9-84ba-03a03de7051a.gif)

