### PR TITLE
[Metadata] Move metadata dictionary line up + Fix typo 'converage'

### DIFF
--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -65,10 +65,6 @@ class MetadataUpload extends React.Component {
             >
               See Instructions
             </span>
-            <span> | </span>
-            <a href="/metadata/dictionary" className={cs.link} target="_blank">
-              See Metadata Dictionary
-            </a>
           </div>
           <MetadataCSVUpload
             className={cs.metadataCSVUpload}

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -132,6 +132,9 @@ class MetadataUpload extends React.Component {
   render() {
     return (
       <div className={cx(cs.metadataUpload, this.props.className)}>
+        <a href="/metadata/dictionary" className={cs.link} target="_blank">
+          See Metadata Dictionary
+        </a>
         <Tabs
           className={cs.tabs}
           tabs={["Manual Input", "CSV Upload"]}

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -78,6 +78,15 @@ class UploadMetadataStep extends React.Component {
         <div className={cx(this.state.showInstructions && cs.hide)}>
           <div>
             <div className={cs.title}>Upload Metadata</div>
+            <div className={cs.dictionary}>
+              <a
+                href="/metadata/dictionary"
+                className={cs.link}
+                target="_blank"
+              >
+                See Metadata Dictionary
+              </a>
+            </div>
           </div>
           <MetadataUpload
             onShowCSVInstructions={() => this.setShowInstructions(true)}

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -138,6 +138,10 @@
     margin-bottom: 8px;
   }
 
+  .dictionary {
+    margin-top: 20px;
+  }
+
   .link {
     // Overwrite <a> inherit rule in header.scss
     color: $primary-light !important;

--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -32,7 +32,7 @@ module PipelineRunsHelper
         "taxid_locator_out" => "Sort preliminary annotated FASTA by Taxonomy IDs and store the byte range of each Taxonomy ID in a JSON.",
         "alignment_viz_out" => "Record number of unique accessions matched.",
         "assembly_out" => "Assemble non-host reads using SPAdes.",
-        "coverage_out" => "Calculate converage statistics for assembled contigs",
+        "coverage_out" => "Calculate coverage statistics for assembled contigs",
         "gsnap_accessions_out" => "Generate FASTA of candidate references matched during GSNAP / NT alignment.",
         "rapsearch2_accessions_out" => "Generate FASTA of candidate references matched during RAPSearch2 / NR alignment.",
         "refined_gsnap_out" => "BLAST assembled contigs against candidate references from NT; reassign corresponding reads to the matched taxon.",


### PR DESCRIPTION
- So that they can see "See Metadata Dictionary" in both tabs for metadata uploading
![screen shot 2019-03-05 at 3 23 26 pm](https://user-images.githubusercontent.com/5652739/53844539-db474b80-3f5a-11e9-81f6-e7c09320d12b.png)

- Also s/converage/coverage