### PR TITLE
Fix bugs in metadata upload flow.

### DIFF
--- a/app/assets/src/components/common/ProjectCreationForm.jsx
+++ b/app/assets/src/components/common/ProjectCreationForm.jsx
@@ -34,9 +34,13 @@ class ProjectCreationForm extends React.Component {
 
       this.props.onCreate(newProject);
     } catch (e) {
-      if (e === "Duplicate name") {
+      if (e[0] === "Name has already been taken") {
         this.setState({
           error: "Project name is already taken."
+        });
+      } else {
+        this.setState({
+          error: "There was an error creating your project."
         });
       }
     }

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -78,15 +78,6 @@ class UploadMetadataStep extends React.Component {
         <div className={cx(this.state.showInstructions && cs.hide)}>
           <div>
             <div className={cs.title}>Upload Metadata</div>
-            <div className={cs.dictionary}>
-              <a
-                href="/metadata/dictionary"
-                className={cs.link}
-                target="_blank"
-              >
-                See Metadata Dictionary
-              </a>
-            </div>
           </div>
           <MetadataUpload
             onShowCSVInstructions={() => this.setShowInstructions(true)}

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -138,16 +138,6 @@
     margin-bottom: 8px;
   }
 
-  .dictionary {
-    margin-top: 20px;
-  }
-
-  .link {
-    // Overwrite <a> inherit rule in header.scss
-    color: $primary-light !important;
-    cursor: pointer;
-  }
-
   .mainControls {
     margin-top: 60px;
 


### PR DESCRIPTION
Fix bug where project creation with duplicate name silently fails.
Fix bug with duplicate "metadata dictionary" link.
Properly validate sample names and add project_id to sample after new project
is created.
Disable button while sample validation is happening.

Tested manually that the bugs have all been fixed, and sample creation still works.