### PR TITLE
[Upload Flow] Start SampleUploadFlowHeader and add additional details

### DIFF
--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -279,7 +279,6 @@ class MetadataManualInput extends React.Component {
             )
           ) {
             return (
-<<<<<<< HEAD
               <div>
                 <MetadataInput
                   key={column}
@@ -293,18 +292,6 @@ class MetadataManualInput extends React.Component {
                 />
                 {this.renderApplyToAll(sample, column)}
               </div>
-=======
-              <MetadataInput
-                key={column}
-                className={cs.input}
-                value={this.getMetadataValue(sample, column)}
-                metadataType={this.props.projectMetadataFields[column]}
-                onChange={(key, value) =>
-                  this.updateMetadataField(key, value, sample)
-                }
-                withinModal={this.props.withinModal}
-              />
->>>>>>> Fix bug
             );
           }
           return (

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -40,12 +40,8 @@ class MetadataManualInput extends React.Component {
     }
   };
 
-  componentDidUpdate() {
-    const { projectMetadataFields, hostGenomes } = this.props;
-    // Only update if fields not set already
-    if (this.state.projectMetadataFields && this.state.hostGenomes.length > 0) {
-      return;
-    }
+  componentDidMount() {
+    const { projectMetadataFields, hostGenomes, samplesAreNew } = this.props;
 
     this.setState({
       projectMetadataFields: projectMetadataFields,
@@ -57,7 +53,7 @@ class MetadataManualInput extends React.Component {
       hostGenomes,
       headers: {
         "Sample Name": "Sample Name",
-        ...(this.props.samplesAreNew
+        ...(samplesAreNew
           ? {
               "Host Genome": (
                 <div>
@@ -68,7 +64,7 @@ class MetadataManualInput extends React.Component {
           : {}),
         ...mapValues(
           field =>
-            this.props.samplesAreNew && field.is_required ? (
+            samplesAreNew && field.is_required ? (
               <div>
                 {field.name}
                 <span className={cs.requiredStar}>*</span>
@@ -169,16 +165,14 @@ class MetadataManualInput extends React.Component {
   getHostGenomeOptions = () =>
     sortBy(
       "text",
-      this.state.hostGenomes.map(hostGenome => ({
+      this.props.hostGenomes.map(hostGenome => ({
         text: hostGenome.name,
         value: hostGenome.id
       }))
     );
 
   renderColumnSelector = () => {
-    const { projectMetadataFields, selectedFieldNames } = this.state;
-
-    const options = values(projectMetadataFields).map(field => ({
+    const options = values(this.props.projectMetadataFields).map(field => ({
       value: field.key,
       text: field.name
     }));
@@ -195,7 +189,7 @@ class MetadataManualInput extends React.Component {
         onChange={this.handleColumnChange}
         options={options}
         trigger={<PlusIcon className={cs.plusIcon} />}
-        value={selectedFieldNames}
+        value={this.state.selectedFieldNames}
         className={cs.columnPicker}
       />
     );
@@ -206,7 +200,7 @@ class MetadataManualInput extends React.Component {
     this.updateMetadataField(
       "Host Genome",
       // Convert the id to a name.
-      find(["id", hostGenomeId], this.state.hostGenomes).name,
+      find(["id", hostGenomeId], this.props.hostGenomes).name,
       sample
     );
   };
@@ -256,7 +250,7 @@ class MetadataManualInput extends React.Component {
                 "id",
                 find(
                   ["name", this.getMetadataValue(sample, "Host Genome")],
-                  this.state.hostGenomes
+                  this.props.hostGenomes
                 )
               )
             : sample.host_genome_id;
@@ -281,10 +275,11 @@ class MetadataManualInput extends React.Component {
           if (
             includes(
               sampleHostGenomeId,
-              this.state.projectMetadataFields[column].host_genome_ids
+              this.props.projectMetadataFields[column].host_genome_ids
             )
           ) {
             return (
+<<<<<<< HEAD
               <div>
                 <MetadataInput
                   key={column}
@@ -298,6 +293,18 @@ class MetadataManualInput extends React.Component {
                 />
                 {this.renderApplyToAll(sample, column)}
               </div>
+=======
+              <MetadataInput
+                key={column}
+                className={cs.input}
+                value={this.getMetadataValue(sample, column)}
+                metadataType={this.props.projectMetadataFields[column]}
+                onChange={(key, value) =>
+                  this.updateMetadataField(key, value, sample)
+                }
+                withinModal={this.props.withinModal}
+              />
+>>>>>>> Fix bug
             );
           }
           return (
@@ -311,10 +318,6 @@ class MetadataManualInput extends React.Component {
   };
 
   render() {
-    if (!this.props.samples || !this.state.projectMetadataFields) {
-      return <div className={cs.loadingMsg}>Loading...</div>;
-    }
-
     return (
       <div className={cx(cs.metadataManualInput, this.props.className)}>
         {this.props.samplesAreNew && (

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -77,8 +77,17 @@ class MetadataManualInput extends React.Component {
       }
     });
 
-    // Default to the first host genome (Human)
-    this.props.samples.map(sample => this.updateHostGenome(1, sample));
+    // Set all to Human by default
+    const newHeaders = union(["Host Genome"], this.state.headersToEdit);
+    let newFields = this.state.metadataFieldsToEdit;
+    this.props.samples.map(sample => {
+      newFields = set([sample.name, "Host Genome"], "Human", newFields);
+    });
+    this.setState({
+      headersToEdit: newHeaders,
+      metadataFieldsToEdit: newFields
+    });
+    this.onMetadataChange(newHeaders, newFields);
   }
 
   getManualInputColumns = () => {

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -18,7 +18,6 @@ import MultipleDropdown from "~ui/controls/dropdowns/MultipleDropdown";
 import DataTable from "~/components/visualizations/table/DataTable";
 import PropTypes from "~/components/utils/propTypes";
 import { Dropdown } from "~ui/controls/dropdowns";
-import { getProjectMetadataFields, getAllHostGenomes } from "~/api";
 import PlusIcon from "~ui/icons/PlusIcon";
 
 import cs from "./metadata_manual_input.scss";
@@ -41,14 +40,15 @@ class MetadataManualInput extends React.Component {
     }
   };
 
-  async componentDidMount() {
-    const [projectMetadataFields, hostGenomes] = await Promise.all([
-      getProjectMetadataFields(this.props.project.id),
-      getAllHostGenomes()
-    ]);
+  componentDidUpdate() {
+    const { projectMetadataFields, hostGenomes } = this.props;
+    // Only update if fields not set already
+    if (this.state.projectMetadataFields && this.state.hostGenomes.length > 0) {
+      return;
+    }
 
     this.setState({
-      projectMetadataFields: keyBy("key", projectMetadataFields),
+      projectMetadataFields: projectMetadataFields,
       // Default to the required fields.
       selectedFieldNames: map(
         "key",
@@ -343,7 +343,9 @@ MetadataManualInput.propTypes = {
   className: PropTypes.string,
   onMetadataChange: PropTypes.func.isRequired,
   samplesAreNew: PropTypes.bool,
-  withinModal: PropTypes.bool
+  withinModal: PropTypes.bool,
+  projectMetadataFields: PropTypes.object,
+  hostGenomes: PropTypes.array
 };
 
 export default MetadataManualInput;

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -77,10 +77,10 @@ class MetadataManualInput extends React.Component {
       }
     });
 
-    // Set all to Human by default
+    // Set all to Human by default. Can't use updateHostGenome/updateMetadataField for bulk update.
     const newHeaders = union(["Host Genome"], this.state.headersToEdit);
     let newFields = this.state.metadataFieldsToEdit;
-    this.props.samples.map(sample => {
+    this.props.samples.forEach(sample => {
       newFields = set([sample.name, "Host Genome"], "Human", newFields);
     });
     this.setState({

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -30,9 +30,6 @@ class MetadataUpload extends React.Component {
       getProjectMetadataFields(this.props.project.id),
       getAllHostGenomes()
     ]);
-
-    console.log("fetched!");
-
     this.setState({
       projectMetadataFields: keyBy("key", projectMetadataFields),
       hostGenomes

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -22,7 +22,8 @@ class MetadataUpload extends React.Component {
       warnings: []
     },
     projectMetadataFields: null,
-    hostGenomes: []
+    hostGenomes: [],
+    showInfo: false
   };
 
   async componentDidMount() {
@@ -58,6 +59,12 @@ class MetadataUpload extends React.Component {
   // This happens when Continue is clicked in the parent component.
   onMetadataChangeManual = ({ metadata }) => {
     this.props.onMetadataChange({ metadata, wasManual: true });
+  };
+
+  toggleInfo = () => {
+    this.setState({
+      showInfo: !this.state.showInfo
+    });
   };
 
   renderTab = () => {
@@ -168,26 +175,41 @@ class MetadataUpload extends React.Component {
   };
 
   render() {
-    const { hostGenomes, projectMetadataFields, currentTab } = this.state;
+    const {
+      hostGenomes,
+      projectMetadataFields,
+      currentTab,
+      showInfo
+    } = this.state;
     const requiredFields = map(
       "name",
       filter(["is_required", 1], projectMetadataFields)
     );
     return (
       <div className={cx(cs.metadataUpload, this.props.className)}>
-        <div className={cs.details}>
-          <span className={cs.label}>{`Required fields: `}</span>
-          {requiredFields && requiredFields.join(", ")}
+        <div>
+          <span>
+            <a href="/metadata/dictionary" className={cs.link} target="_blank">
+              See Metadata Dictionary
+            </a>
+          </span>
+          {` | `}
+          <span className={cs.link} onClick={this.toggleInfo}>
+            {showInfo ? "Hide" : "See"} Required Fields and Host Genomes
+          </span>
         </div>
-        {currentTab === "CSV Upload" && (
-          <div className={cs.details}>
-            <span className={cs.label}>{`Host genomes: `}</span>
-            {hostGenomes && hostGenomes.map(h => h.name).join(", ")}
+        {this.state.showInfo && (
+          <div className={cs.info}>
+            <div className={cs.details}>
+              <span className={cs.label}>{`Required fields: `}</span>
+              {requiredFields && requiredFields.join(", ")}
+            </div>
+            <div className={cs.details}>
+              <span className={cs.label}>{`Host genomes: `}</span>
+              {hostGenomes && hostGenomes.map(h => h.name).join(", ")}
+            </div>
           </div>
         )}
-        <a href="/metadata/dictionary" className={cs.link} target="_blank">
-          See Metadata Dictionary
-        </a>
         <Tabs
           className={cs.tabs}
           tabs={["Manual Input", "CSV Upload"]}

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -176,16 +176,15 @@ class MetadataUpload extends React.Component {
     return (
       <div className={cx(cs.metadataUpload, this.props.className)}>
         <div className={cs.details}>
-          Add metadata details to use in analyzing your data.
-        </div>
-        <div className={cs.details}>
-          <span className={cs.label}>{`Host Genome Options: `}</span>
-          {hostGenomes && hostGenomes.map(h => h.name).join(", ")}
-        </div>
-        <div className={cs.details}>
-          <span className={cs.label}>{`Required Fields: `}</span>
+          <span className={cs.label}>{`Required fields: `}</span>
           {requiredFields && requiredFields.join(", ")}
         </div>
+        {currentTab === "CSV Upload" && (
+          <div className={cs.details}>
+            <span className={cs.label}>{`Host genomes: `}</span>
+            {hostGenomes && hostGenomes.map(h => h.name).join(", ")}
+          </div>
+        )}
         <a href="/metadata/dictionary" className={cs.link} target="_blank">
           See Metadata Dictionary
         </a>

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -31,6 +31,8 @@ class MetadataUpload extends React.Component {
       getAllHostGenomes()
     ]);
 
+    console.log("fetched!");
+
     this.setState({
       projectMetadataFields: keyBy("key", projectMetadataFields),
       hostGenomes
@@ -63,17 +65,21 @@ class MetadataUpload extends React.Component {
 
   renderTab = () => {
     if (this.state.currentTab === "Manual Input") {
-      return (
-        <MetadataManualInput
-          project={this.props.project}
-          samples={this.props.samples}
-          samplesAreNew={this.props.samplesAreNew}
-          onMetadataChange={this.onMetadataChangeManual}
-          withinModal={this.props.withinModal}
-          projectMetadataFields={this.state.projectMetadataFields}
-          hostGenomes={this.state.hostGenomes}
-        />
-      );
+      if (!this.props.samples || !this.state.projectMetadataFields) {
+        return <div className={cs.loadingMsg}>Loading...</div>;
+      } else {
+        return (
+          <MetadataManualInput
+            project={this.props.project}
+            samples={this.props.samples}
+            samplesAreNew={this.props.samplesAreNew}
+            onMetadataChange={this.onMetadataChangeManual}
+            withinModal={this.props.withinModal}
+            projectMetadataFields={this.state.projectMetadataFields}
+            hostGenomes={this.state.hostGenomes}
+          />
+        );
+      }
     }
 
     if (this.state.currentTab === "CSV Upload") {

--- a/app/assets/src/components/common/metadata_upload.scss
+++ b/app/assets/src/components/common/metadata_upload.scss
@@ -32,6 +32,13 @@
       font-weight: 600;
     }
   }
+
+  .info {
+    background-color: $off-white;
+    padding: 20px 20px 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
 }
 
 .issues {

--- a/app/assets/src/components/common/metadata_upload.scss
+++ b/app/assets/src/components/common/metadata_upload.scss
@@ -24,6 +24,14 @@
     @include font-body-s;
     margin-top: 10px;
   }
+
+  .details {
+    margin-bottom: 10px;
+
+    .label {
+      font-weight: 600;
+    }
+  }
 }
 
 .issues {

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -41,7 +41,9 @@ class BareDropdown extends React.Component {
       {
         filterString
       },
-      () => onFilterChange(filterString)
+      () => {
+        onFilterChange && onFilterChange(filterString);
+      }
     );
   };
 

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -89,12 +89,14 @@ class ReviewStep extends React.Component {
   render() {
     return (
       <div className={cs.reviewStep}>
-        <DataTable
-          className={cs.metadataTable}
-          columns={this.props.metadata.headers}
-          data={this.props.metadata.rows}
-          columnWidth={120}
-        />
+        <div className={cs.tallBody}>
+          <DataTable
+            className={cs.metadataTable}
+            columns={this.props.metadata.headers}
+            data={this.props.metadata.rows}
+            columnWidth={120}
+          />
+        </div>
         {this.state.submitState === "review" && (
           <TermsAgreement
             checked={this.state.consentChecked}

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -89,7 +89,6 @@ class ReviewStep extends React.Component {
   render() {
     return (
       <div className={cs.reviewStep}>
-        <div className={cs.title}>Review</div>
         <DataTable
           className={cs.metadataTable}
           columns={this.props.metadata.headers}

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -3,11 +3,11 @@ import cx from "classnames";
 import { get, without, flow, omit, set, find } from "lodash/fp";
 import UploadSampleStep from "./UploadSampleStep";
 import NarrowContainer from "~/components/layout/NarrowContainer";
-import Divider from "~/components/layout/Divider";
 import PropTypes from "~/components/utils/propTypes";
 import UploadMetadataStep from "./UploadMetadataStep";
 import ReviewStep from "./ReviewStep";
 import cs from "./sample_upload_flow.scss";
+import SampleUploadFlowHeader from "./SampleUploadFlowHeader";
 
 class SampleUploadFlow extends React.Component {
   state = {
@@ -76,40 +76,6 @@ class SampleUploadFlow extends React.Component {
     }));
   };
 
-  renderHeader = () => {
-    switch (this.state.currentStep) {
-      case "uploadSamples":
-        return (
-          <div className={cs.header}>
-            <div className={cs.title}>Upload Samples</div>
-            <div className={cs.subtitle}>
-              Rather use our command-line interface?
-              <a
-                href="/cli_user_instructions"
-                target="_blank"
-                className={cs.link}
-              >
-                Instructions here.
-              </a>
-            </div>
-            <div className={cs.subtitle}>
-              Need help?
-              <a className={cs.link} href="mailto:help@idseq.com">
-                Message us.
-              </a>
-            </div>
-            <div className={cs.border} />
-          </div>
-        );
-      case "uploadMetadata":
-        return <div />;
-      case "review":
-        return <div />;
-      default:
-        return <div />;
-    }
-  };
-
   renderStep = () => {
     switch (this.state.currentStep) {
       case "uploadSamples":
@@ -140,7 +106,7 @@ class SampleUploadFlow extends React.Component {
   render() {
     return (
       <div>
-        {this.renderHeader()}
+        <SampleUploadFlowHeader currentStep={this.state.currentStep} />
         <NarrowContainer
           className={cx(
             cs.sampleUploadFlow,

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -3,6 +3,7 @@ import cx from "classnames";
 import { get, without, flow, omit, set, find } from "lodash/fp";
 import UploadSampleStep from "./UploadSampleStep";
 import NarrowContainer from "~/components/layout/NarrowContainer";
+import Divider from "~/components/layout/Divider";
 import PropTypes from "~/components/utils/propTypes";
 import UploadMetadataStep from "./UploadMetadataStep";
 import ReviewStep from "./ReviewStep";
@@ -75,6 +76,40 @@ class SampleUploadFlow extends React.Component {
     }));
   };
 
+  renderHeader = () => {
+    switch (this.state.currentStep) {
+      case "uploadSamples":
+        return (
+          <div className={cs.header}>
+            <div className={cs.title}>Upload Samples</div>
+            <div className={cs.subtitle}>
+              Rather use our command-line interface?
+              <a
+                href="/cli_user_instructions"
+                target="_blank"
+                className={cs.link}
+              >
+                Instructions here.
+              </a>
+            </div>
+            <div className={cs.subtitle}>
+              Need help?
+              <a className={cs.link} href="mailto:help@idseq.com">
+                Message us.
+              </a>
+            </div>
+            <div className={cs.border} />
+          </div>
+        );
+      case "uploadMetadata":
+        return <div />;
+      case "review":
+        return <div />;
+      default:
+        return <div />;
+    }
+  };
+
   renderStep = () => {
     switch (this.state.currentStep) {
       case "uploadSamples":
@@ -104,14 +139,17 @@ class SampleUploadFlow extends React.Component {
 
   render() {
     return (
-      <NarrowContainer
-        className={cx(
-          cs.sampleUploadFlow,
-          this.state.currentStep === "uploadSamples" && cs.narrow
-        )}
-      >
-        <div className={cs.inner}>{this.renderStep()}</div>
-      </NarrowContainer>
+      <div>
+        {this.renderHeader()}
+        <NarrowContainer
+          className={cx(
+            cs.sampleUploadFlow,
+            this.state.currentStep === "uploadSamples" && cs.narrow
+          )}
+        >
+          <div className={cs.inner}>{this.renderStep()}</div>
+        </NarrowContainer>
+      </div>
     );
   }
 }

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
@@ -23,12 +23,6 @@ class SampleUploadFlowHeader extends React.Component {
               </a>
             </div>
           )}
-          <div className={cs.subtitle}>
-            Need help?
-            <a className={cs.link} href="mailto:help@idseq.com">
-              Message us.
-            </a>
-          </div>
           <div className={cs.border} />
         </div>
       </NarrowContainer>

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
@@ -1,34 +1,37 @@
 import React from "react";
 import PropTypes from "~/components/utils/propTypes";
 import cs from "./sample_upload_flow.scss";
+import NarrowContainer from "~/components/layout/NarrowContainer";
 import { startCase } from "lodash/fp";
 
 class SampleUploadFlowHeader extends React.Component {
   render() {
     const { currentStep } = this.props;
     return (
-      <div className={cs.header}>
-        <div className={cs.title}>{startCase(currentStep)}</div>
-        {currentStep === "uploadSamples" && (
+      <NarrowContainer>
+        <div className={cs.header}>
+          <div className={cs.title}>{startCase(currentStep)}</div>
+          {currentStep === "uploadSamples" && (
+            <div className={cs.subtitle}>
+              Rather use our command-line interface?
+              <a
+                href="/cli_user_instructions"
+                target="_blank"
+                className={cs.link}
+              >
+                Instructions here.
+              </a>
+            </div>
+          )}
           <div className={cs.subtitle}>
-            Rather use our command-line interface?
-            <a
-              href="/cli_user_instructions"
-              target="_blank"
-              className={cs.link}
-            >
-              Instructions here.
+            Need help?
+            <a className={cs.link} href="mailto:help@idseq.com">
+              Message us.
             </a>
           </div>
-        )}
-        <div className={cs.subtitle}>
-          Need help?
-          <a className={cs.link} href="mailto:help@idseq.com">
-            Message us.
-          </a>
+          <div className={cs.border} />
         </div>
-        <div className={cs.border} />
-      </div>
+      </NarrowContainer>
     );
   }
 }

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "~/components/utils/propTypes";
+import cs from "./sample_upload_flow.scss";
+import { startCase } from "lodash/fp";
+
+class SampleUploadFlowHeader extends React.Component {
+  render() {
+    const { currentStep } = this.props;
+    return (
+      <div className={cs.header}>
+        <div className={cs.title}>{startCase(currentStep)}</div>
+        {currentStep === "uploadSamples" && (
+          <div className={cs.subtitle}>
+            Rather use our command-line interface?
+            <a
+              href="/cli_user_instructions"
+              target="_blank"
+              className={cs.link}
+            >
+              Instructions here.
+            </a>
+          </div>
+        )}
+        <div className={cs.subtitle}>
+          Need help?
+          <a className={cs.link} href="mailto:help@idseq.com">
+            Message us.
+          </a>
+        </div>
+        <div className={cs.border} />
+      </div>
+    );
+  }
+}
+
+SampleUploadFlowHeader.propTypes = {
+  currentStep: PropTypes.string.isRequired
+};
+
+export default SampleUploadFlowHeader;

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -84,9 +84,6 @@ class UploadMetadataStep extends React.Component {
               onMetadataChange={this.handleMetadataChange}
               samplesAreNew
               issues={this.state.wasManual ? this.state.issues : null}
-              handleRequiredMetadataFields={
-                this.props.handleRequiredMetadataFields
-              }
             />
           </div>
           <div className={cs.mainControls}>
@@ -118,8 +115,7 @@ UploadMetadataStep.propTypes = {
   project: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string
-  }),
-  handleRequiredMetadataFields: PropTypes.func
+  })
 };
 
 export default UploadMetadataStep;

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -76,9 +76,6 @@ class UploadMetadataStep extends React.Component {
           <Instructions onClose={() => this.setShowInstructions(false)} />
         </div>
         <div className={cx(this.state.showInstructions && cs.hide)}>
-          <div>
-            <div className={cs.title}>Upload Metadata</div>
-          </div>
           <MetadataUpload
             onShowCSVInstructions={() => this.setShowInstructions(true)}
             samples={this.props.samples}
@@ -86,6 +83,9 @@ class UploadMetadataStep extends React.Component {
             onMetadataChange={this.handleMetadataChange}
             samplesAreNew
             issues={this.state.wasManual ? this.state.issues : null}
+            handleRequiredMetadataFields={
+              this.props.handleRequiredMetadataFields
+            }
           />
           <div className={cs.mainControls}>
             <PrimaryButton
@@ -116,7 +116,8 @@ UploadMetadataStep.propTypes = {
   project: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string
-  })
+  }),
+  handleRequiredMetadataFields: PropTypes.func
 };
 
 export default UploadMetadataStep;

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -76,17 +76,19 @@ class UploadMetadataStep extends React.Component {
           <Instructions onClose={() => this.setShowInstructions(false)} />
         </div>
         <div className={cx(this.state.showInstructions && cs.hide)}>
-          <MetadataUpload
-            onShowCSVInstructions={() => this.setShowInstructions(true)}
-            samples={this.props.samples}
-            project={this.props.project}
-            onMetadataChange={this.handleMetadataChange}
-            samplesAreNew
-            issues={this.state.wasManual ? this.state.issues : null}
-            handleRequiredMetadataFields={
-              this.props.handleRequiredMetadataFields
-            }
-          />
+          <div className={cs.tallBody}>
+            <MetadataUpload
+              onShowCSVInstructions={() => this.setShowInstructions(true)}
+              samples={this.props.samples}
+              project={this.props.project}
+              onMetadataChange={this.handleMetadataChange}
+              samplesAreNew
+              issues={this.state.wasManual ? this.state.issues : null}
+              handleRequiredMetadataFields={
+                this.props.handleRequiredMetadataFields
+              }
+            />
+          </div>
           <div className={cs.mainControls}>
             <PrimaryButton
               text="Continue"

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -349,46 +349,48 @@ class UploadSampleStep extends React.Component {
   render() {
     return (
       <div className={cs.uploadSampleStep}>
-        <div className={cs.projectSelect}>
-          <div className={cs.label}>Project</div>
-          <ProjectSelect
-            projects={this.state.projects}
-            value={get("id", this.state.selectedProject)}
-            onChange={this.handleProjectChange}
-            disabled={this.state.createProjectOpen}
+        <div className={cs.tallBody}>
+          <div className={cs.projectSelect}>
+            <div className={cs.label}>Project</div>
+            <ProjectSelect
+              projects={this.state.projects}
+              value={get("id", this.state.selectedProject)}
+              onChange={this.handleProjectChange}
+              disabled={this.state.createProjectOpen}
+            />
+            {this.state.createProjectOpen ? (
+              <div className={cs.projectCreationContainer}>
+                <ProjectCreationForm
+                  onCancel={this.closeCreateProject}
+                  onCreate={this.handleProjectCreate}
+                />
+              </div>
+            ) : (
+              <div
+                className={cs.createProjectButton}
+                onClick={this.openCreateProject}
+              >
+                + Create Project
+              </div>
+            )}
+          </div>
+          <div className={cs.fileUpload}>
+            <div className={cs.title}>Upload Files</div>
+            <Tabs
+              className={cs.tabs}
+              tabs={[LOCAL_UPLOAD_TAB, REMOTE_UPLOAD_TAB]}
+              value={this.state.currentTab}
+              onChange={this.handleTabChange}
+            />
+            {this.renderTab()}
+          </div>
+          <BulkSampleUploadTable
+            sampleNamesToFiles={this.getSampleNamesToFiles()}
+            onRemoved={this.handleSampleRemoved}
+            hideProgressColumn
+            showCount={this.state.currentTab === REMOTE_UPLOAD_TAB}
           />
-          {this.state.createProjectOpen ? (
-            <div className={cs.projectCreationContainer}>
-              <ProjectCreationForm
-                onCancel={this.closeCreateProject}
-                onCreate={this.handleProjectCreate}
-              />
-            </div>
-          ) : (
-            <div
-              className={cs.createProjectButton}
-              onClick={this.openCreateProject}
-            >
-              + Create Project
-            </div>
-          )}
         </div>
-        <div className={cs.fileUpload}>
-          <div className={cs.title}>Upload Files</div>
-          <Tabs
-            className={cs.tabs}
-            tabs={[LOCAL_UPLOAD_TAB, REMOTE_UPLOAD_TAB]}
-            value={this.state.currentTab}
-            onChange={this.handleTabChange}
-          />
-          {this.renderTab()}
-        </div>
-        <BulkSampleUploadTable
-          sampleNamesToFiles={this.getSampleNamesToFiles()}
-          onRemoved={this.handleSampleRemoved}
-          hideProgressColumn
-          showCount={this.state.currentTab === REMOTE_UPLOAD_TAB}
-        />
         <div className={cs.mainControls}>
           <PrimaryButton
             text="Continue"

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -349,19 +349,6 @@ class UploadSampleStep extends React.Component {
   render() {
     return (
       <div className={cs.uploadSampleStep}>
-        <div className={cs.header}>
-          <div className={cs.title}>Upload Samples</div>
-          <div className={cs.subtitle}>
-            Rather use our command-line interface?
-            <a
-              href="/cli_user_instructions"
-              target="_blank"
-              className={cs.cliLink}
-            >
-              Instructions here.
-            </a>
-          </div>
-        </div>
         <div className={cs.projectSelect}>
           <div className={cs.label}>Project</div>
           <ProjectSelect

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -30,7 +30,7 @@
 
   .title {
     @include font-header-xxl;
-    margin-bottom: 15px;
+    margin-bottom: 5px;
   }
 
   .subtitle {
@@ -49,7 +49,7 @@
     position: absolute;
     left: 0;
     right: 0;
-    margin-top: 20px;
+    margin-top: 15px;
     background-color: $lightest-grey;
   }
 }

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -25,8 +25,8 @@
 }
 
 .header {
-  margin: 20px auto 40px 130px;
-  width: 85%;
+  margin: 20px auto 40px;
+  width: 91%;
 
   .title {
     @include font-header-xxl;

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -24,26 +24,38 @@
   }
 }
 
-.uploadSampleStep {
-  .header {
-    margin-bottom: 40px;
+.header {
+  margin-left: 200px;
+  margin-top: 20px;
+  margin-bottom: 40px;
 
-    .title {
-      @include font-header-xxl;
-    }
-
-    .subtitle {
-      margin-top: 5px;
-    }
-
-    .cliLink {
-      // Overwrite <a> inherit rule in header.scss
-      color: $primary-light !important;
-      cursor: pointer;
-      margin-left: 5px;
-    }
+  .title {
+    @include font-header-xxl;
+    margin-bottom: 10px;
   }
 
+  .subtitle {
+    margin-top: 5px;
+  }
+
+  .link {
+    // Overwrite <a> inherit rule in header.scss
+    color: $primary-light !important;
+    cursor: pointer;
+    margin-left: 5px;
+  }
+
+  .border {
+    height: 4px;
+    position: absolute;
+    left: 0;
+    right: 0;
+    margin-top: 20px;
+    background-color: $lightest-grey;
+  }
+}
+
+.uploadSampleStep {
   .projectSelect {
     margin-bottom: 30px;
 

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -25,7 +25,7 @@
 }
 
 .header {
-  margin: 20px auto 40px;
+  margin: 20px auto 40px 130px;
   width: 85%;
 
   .title {
@@ -169,6 +169,10 @@
       }
     }
   }
+}
+
+.tallBody {
+  min-height: 600px;
 }
 
 .uploadMetadataStep {

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -25,13 +25,12 @@
 }
 
 .header {
-  margin-left: 200px;
-  margin-top: 20px;
-  margin-bottom: 40px;
+  margin: 20px auto 40px;
+  width: 85%;
 
   .title {
     @include font-header-xxl;
-    margin-bottom: 10px;
+    margin-bottom: 15px;
   }
 
   .subtitle {

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -70,7 +70,7 @@ class ProjectsController < ApplicationController
         host_genome_names_by_project_id = {}
         tissues_by_project_id = {}
         samples.includes(:host_genome).each do |s|
-          (host_genome_names_by_project_id[s.project_id] ||= Set.new) << s.host_genome.name if s.host_genome.name
+          (host_genome_names_by_project_id[s.project_id] ||= Set.new) << s.host_genome.name if s.host_genome && s.host_genome.name
           # TODO: sample_tissue column is deprecated, retrieve sample_type from Metadatum model instead
           (tissues_by_project_id[s.project_id] ||= Set.new) << s.sample_tissue if s.sample_tissue
         end


### PR DESCRIPTION
- This PR moves the current upload flow titles to Headers and adds some additional details like a help link.
- Going to put these up as they're ready. NEXT UP: the tab selectors and footer.
- One big change is moving getProjectMetadataFields and getAllHostGenomes up a level to MetadataUpload so that it can be called once and use those fields for host genomes and required fields listing + MetadataManualInput. So MetadataManualInput is no longer async.
- Also moves the title details for each page to SampleUploadFlowHeader

![screen shot 2019-03-07 at 10 17 47 pm](https://user-images.githubusercontent.com/5652739/54011348-10a09480-4127-11e9-8a1a-6fe1288652f7.png)
![screen shot 2019-03-07 at 10 18 00 pm](https://user-images.githubusercontent.com/5652739/54011355-14ccb200-4127-11e9-87bb-d625a129c0cf.png)
![screen shot 2019-03-07 at 10 18 20 pm](https://user-images.githubusercontent.com/5652739/54011358-18f8cf80-4127-11e9-94f7-c8321d6f652a.png)
![screen shot 2019-03-07 at 10 18 30 pm](https://user-images.githubusercontent.com/5652739/54011361-1bf3c000-4127-11e9-9ca1-018f2545901d.png)
![screen shot 2019-03-07 at 10 19 06 pm](https://user-images.githubusercontent.com/5652739/54011363-1e561a00-4127-11e9-86e9-526d2046c286.png)
