### PR TITLE
Update S3 location of resist gene db file.

### DIFF
--- a/app/lib/dags/experimental.json.erb
+++ b/app/lib/dags/experimental.json.erb
@@ -29,7 +29,7 @@
       "out": "srst2_out",
       "class": "PipelineStepRunSRST2",
       "module": "idseq_dag.steps.run_srst2",
-      "additional_files": {"resist_gene_db": "s3://idseq-database/test/AMR/ARGannot_r2.fasta"},
+      "additional_files": {"resist_gene_db": "s3://idseq-database/amr/ARGannot_r2.fasta"},
       "additional_attributes": {
         "min_cov": 0,
         "n_threads": 16,


### PR DESCRIPTION
We recently cleaned up the `idseq-database` s3 bucket.