### PR TITLE
Remove required star and other style tweaks.

### DIFF
--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -53,27 +53,8 @@ class MetadataManualInput extends React.Component {
       hostGenomes,
       headers: {
         "Sample Name": "Sample Name",
-        ...(samplesAreNew
-          ? {
-              "Host Genome": (
-                <div>
-                  Host Genome<span className={cs.requiredStar}>*</span>
-                </div>
-              )
-            }
-          : {}),
-        ...mapValues(
-          field =>
-            samplesAreNew && field.is_required ? (
-              <div>
-                {field.name}
-                <span className={cs.requiredStar}>*</span>
-              </div>
-            ) : (
-              field.name
-            ),
-          keyBy("key", projectMetadataFields)
-        )
+        ...(samplesAreNew ? { "Host Genome": "Host Genome" } : {}),
+        ...mapValues("name", keyBy("key", projectMetadataFields))
       }
     });
 
@@ -316,9 +297,6 @@ class MetadataManualInput extends React.Component {
   render() {
     return (
       <div className={cx(cs.metadataManualInput, this.props.className)}>
-        {this.props.samplesAreNew && (
-          <div className={cs.requiredMessage}>* = Required Field</div>
-        )}
         <div className={cs.tableContainer}>
           <div className={cs.tableScrollWrapper}>
             <DataTable

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -1,17 +1,17 @@
 import React from "react";
 import cx from "classnames";
+import _fp, { filter, keyBy, concat } from "lodash/fp";
 
 import MetadataCSVUpload from "~/components/common/MetadataCSVUpload";
 import PropTypes from "~/components/utils/propTypes";
 import AlertIcon from "~ui/icons/AlertIcon";
 import Tabs from "~/components/ui/controls/Tabs";
+import { getProjectMetadataFields, getAllHostGenomes } from "~/api";
 
 import cs from "./metadata_upload.scss";
 import MetadataManualInput from "./MetadataManualInput";
 import IssueGroup from "./IssueGroup";
-import { getProjectMetadataFields, getAllHostGenomes } from "~/api";
 
-import _fp, { filter, keyBy } from "lodash/fp";
 const map = _fp.map.convert({ cap: false });
 
 class MetadataUpload extends React.Component {
@@ -181,9 +181,9 @@ class MetadataUpload extends React.Component {
       currentTab,
       showInfo
     } = this.state;
-    const requiredFields = map(
-      "name",
-      filter(["is_required", 1], projectMetadataFields)
+    const requiredFields = concat(
+      "Host Genome",
+      map("name", filter(["is_required", 1], projectMetadataFields))
     );
     return (
       <div className={cx(cs.metadataUpload, this.props.className)}>
@@ -193,10 +193,14 @@ class MetadataUpload extends React.Component {
               View Metadata Dictionary
             </a>
           </span>
-          {` | `}
-          <span className={cs.link} onClick={this.toggleInfo}>
-            {showInfo ? "Hide" : "Show"} Required Fields and Host Genomes
-          </span>
+          {this.props.samplesAreNew && (
+            <React.Fragment>
+              {` | `}
+              <span className={cs.link} onClick={this.toggleInfo}>
+                {showInfo ? "Hide" : "Show"} Required Fields and Host Genomes
+              </span>
+            </React.Fragment>
+          )}
         </div>
         {this.state.showInfo && (
           <div className={cs.info}>

--- a/app/assets/src/components/ui/controls/BulkSampleUploadTable.jsx
+++ b/app/assets/src/components/ui/controls/BulkSampleUploadTable.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
-import DataTable from "../../visualizations/table/DataTable";
+import cx from "classnames";
 import { isEmpty, concat, size, sortBy } from "lodash/fp";
+
 import RemoveIcon from "~/components/ui/icons/RemoveIcon";
 import LoadingIcon from "~/components/ui/icons/LoadingIcon";
 import CheckmarkIcon from "~/components/ui/icons/CheckmarkIcon";
 import BasicPopup from "~/components/BasicPopup";
+import DataTable from "../../visualizations/table/DataTable";
+
 import cs from "./bulk_sample_upload_table.scss";
 
 // BulkSampleUploadTable is a table showing Sample Names and Files for local
@@ -82,7 +85,7 @@ class BulkSampleUploadTable extends React.Component {
     const sortedEntries = sortBy("sampleName", entries);
 
     return (
-      <div className={cs.bulkSampleUploadTable}>
+      <div className={cx(cs.bulkSampleUploadTable, this.props.className)}>
         {this.props.showCount && (
           <div className={cs.detectedMsg}>
             <span className={cs.count}>
@@ -123,7 +126,8 @@ BulkSampleUploadTable.propTypes = {
   fileNamesToProgress: PropTypes.objectOf(PropTypes.number),
   onRemoved: PropTypes.func,
   hideProgressColumn: PropTypes.bool,
-  showCount: PropTypes.bool
+  showCount: PropTypes.bool,
+  className: PropTypes.string
 };
 
 export default BulkSampleUploadTable;

--- a/app/assets/src/components/ui/controls/bulk_sample_upload_table.scss
+++ b/app/assets/src/components/ui/controls/bulk_sample_upload_table.scss
@@ -51,7 +51,6 @@
       &__data {
         &.column-sampleName {
           font-weight: 600;
-          padding-left: 5px;
         }
 
         &.column-files {

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -159,7 +159,7 @@ class ReviewStep extends React.Component {
                 </div>
               </div>
               <div className={cs.existingSamples}>
-                {this.props.project.number_of_samples} existing samples in
+                {this.props.project.number_of_samples || 0} existing samples in
                 project
               </div>
             </div>

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -389,6 +389,7 @@ class UploadSampleStep extends React.Component {
             onRemoved={this.handleSampleRemoved}
             hideProgressColumn
             showCount={this.state.currentTab === REMOTE_UPLOAD_TAB}
+            className={cs.uploadTable}
           />
         </div>
         <div className={cs.mainControls}>

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -95,6 +95,10 @@
       margin-right: 10px;
     }
   }
+
+  .uploadTable {
+    margin-top: 30px;
+  }
 }
 
 .localFilePicker {

--- a/app/assets/src/components/views/metadata/MetadataDictionary.jsx
+++ b/app/assets/src/components/views/metadata/MetadataDictionary.jsx
@@ -119,6 +119,8 @@ class MetadataDictionary extends React.Component {
       }))
     );
 
+  getColumnWidth = column => (column === "name" ? 250 : "");
+
   render() {
     const fieldGroupsToDisplay = this.getFieldGroups();
     return (
@@ -147,6 +149,7 @@ class MetadataDictionary extends React.Component {
                   data={fieldGroup.fields}
                   headers={dictionaryHeaders}
                   columns={["name", "description", "examples"]}
+                  getColumnWidth={this.getColumnWidth}
                 />
               </div>
             ),

--- a/app/assets/src/styles/ui/containers/wizard.scss
+++ b/app/assets/src/styles/ui/containers/wizard.scss
@@ -19,7 +19,7 @@
 
   &__header {
     display: block;
-    margin-bottom: 10px;
+    margin-bottom: 5px;
     width: 100%;
 
     &__title {

--- a/app/assets/src/styles/visualizations/table/data_table.scss
+++ b/app/assets/src/styles/visualizations/table/data_table.scss
@@ -55,8 +55,8 @@
   }
 
   &__header {
-    @include font-header-xs;
-    color: $medium-grey;
+    @include font-header-s;
+    color: $black;
 
     &.column-reserved-selectable {
       width: 30px;


### PR DESCRIPTION
Make sample name column in metadata dictionary smaller.

Make the header in data table black instead of grey.

----

No more star here.
![Screen Shot 2019-03-11 at 1 24 20 PM](https://user-images.githubusercontent.com/837004/54155266-01f4fe80-4401-11e9-93dc-bbcc851f5ffe.png)

Star is still on the metadata dictionary. Sample name column narrower, headers now black.

![Screen Shot 2019-03-11 at 1 23 35 PM](https://user-images.githubusercontent.com/837004/54155227-ebe73e00-4400-11e9-9ff4-6feb3634daf7.png)
