### PR TITLE
Add PNG download and white background for heatmaps

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -690,7 +690,12 @@ class SamplesHeatmapView extends React.Component {
   handleDownloadClick = fileType => {
     switch (fileType) {
       case "svg":
+        // TODO (gdingle): pass in filename per sample?
         this.heatmapVis.download();
+        break;
+      case "png":
+        // TODO (gdingle): pass in filename per sample?
+        this.heatmapVis.downloadAsPng();
         break;
       case "csv":
         this.downloadCurrentViewDataURL();
@@ -717,7 +722,8 @@ class SamplesHeatmapView extends React.Component {
   render() {
     let downloadOptions = [
       { text: "Download CSV", value: "csv" },
-      { text: "Download SVG", value: "svg" }
+      { text: "Download SVG", value: "svg" },
+      { text: "Download PNG", value: "png" }
     ];
 
     return (

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -125,6 +125,10 @@ class SamplesHeatmapVis extends React.Component {
     this.heatmap.download();
   }
 
+  downloadAsPng() {
+    this.heatmap.downloadAsPng();
+  }
+
   getTooltipData(node) {
     let sampleId = this.props.sampleIds[node.columnIndex];
     let taxonId = this.props.taxonIds[node.rowIndex];

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -56,7 +56,9 @@ export default class Heatmap {
         columnMetadata: [],
         metadataColorScale: new CategoricalColormap(),
         enableColumnMetadata: false,
-        iconPath: "/assets/icons"
+        iconPath: "/assets/icons",
+        // This is needed for downloading PNG and SVG on solid background
+        backgroundColor: "white"
       },
       options
     );
@@ -204,7 +206,10 @@ export default class Heatmap {
       .append("svg")
       .attr("class", cs.heatmap)
       .attr("id", "visualization")
-      .attr("xmlns", "http://www.w3.org/2000/svg");
+      .attr("xmlns", "http://www.w3.org/2000/svg")
+      // Not standard but it works for downloads and svgsaver. See:
+      // https://stackoverflow.com/questions/11293026/default-background-color-of-svg-root-element
+      .attr("style", "background-color: " + this.options.backgroundColor);
 
     this.g = this.svg.append("g");
     this.gRowLabels = this.g.append("g").attr("class", cs.rowLabels);
@@ -491,6 +496,10 @@ export default class Heatmap {
 
   download(filename) {
     this.svgSaver.asSvg(this.svg.node(), filename || "heatmap.svg");
+  }
+
+  downloadAsPng(filename) {
+    this.svgSaver.asPng(this.svg.node(), filename || "heatmap.png");
   }
 
   removeRow = row => {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -58,7 +58,7 @@ export default class Heatmap {
         enableColumnMetadata: false,
         iconPath: "/assets/icons",
         // This is needed for downloading PNG and SVG on solid background
-        backgroundColor: "white"
+        svgBackgroundColor: "white"
       },
       options
     );
@@ -209,7 +209,7 @@ export default class Heatmap {
       .attr("xmlns", "http://www.w3.org/2000/svg")
       // Not standard but it works for downloads and svgsaver. See:
       // https://stackoverflow.com/questions/11293026/default-background-color-of-svg-root-element
-      .attr("style", "background-color: " + this.options.backgroundColor);
+      .attr("style", `background-color: ${this.options.svgBackgroundColor}`);
 
     this.g = this.svg.append("g");
     this.gRowLabels = this.g.append("g").attr("class", cs.rowLabels);


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/28797/54224830-915ce900-44b7-11e9-9448-0e5873cff6dc.png)

As title. I learned that PNG is supported by the existing lib, but not jpg, which I think is fine. 

Also, I think I fixed the root cause of the SVG "compatibility" issues. Before they were downloaded with a transparent background which may appear as gray in some applications. I changed the background to white for the heatmap globally which I think is appropriate. If we ever want to change the page color background, it will be obvious what to do. 

# Test and Reproduce

1. click "download png"
2. see download
3. open download and see good png on white background
4. repeat for svg download