### PR TITLE
Download phylo tree and taxon tree as SVG or PNG

### DIFF
--- a/app/assets/src/components/views/SampleView/Controls.jsx
+++ b/app/assets/src/components/views/SampleView/Controls.jsx
@@ -1,4 +1,6 @@
 import React from "react";
+import SvgSaver from "svgsaver";
+
 import PropTypes from "~/components/utils/propTypes";
 import { deleteSample } from "~/api";
 import DownloadButtonDropdown from "~/components/ui/controls/dropdowns/DownloadButtonDropdown";
@@ -39,6 +41,14 @@ class Controls extends React.Component {
     if (option === "download_csv") {
       this.downloadCSV();
       return;
+    } else if (option == "taxon_svg") {
+      // TODO (gdingle): filename per tree?
+      new SvgSaver().asSvg(this.getNode(), "taxon_tree.svg");
+      return;
+    } else if (option == "taxon_png") {
+      // TODO (gdingle): filename per tree?
+      new SvgSaver().asPng(this.getNode(), "taxon_tree.png");
+      return;
     }
     const linkInfo = getLinkInfoForDownloadOption(
       option,
@@ -50,6 +60,11 @@ class Controls extends React.Component {
     }
   };
 
+  // TODO (gdingle): should we pass in a reference with React somehow?
+  getNode() {
+    return document.getElementsByClassName("taxon-tree-vis")[0];
+  }
+
   render() {
     const { reportPresent, pipelineRun, canEdit } = this.props;
 
@@ -59,7 +74,9 @@ class Controls extends React.Component {
           text: "Download Report Table (.csv)",
           value: "download_csv"
         },
-        ...getDownloadDropdownOptions(pipelineRun)
+        ...getDownloadDropdownOptions(pipelineRun),
+        { text: "Download Taxon Tree as SVG", value: "taxon_svg" },
+        { text: "Download Taxon Tree as PNG", value: "taxon_png" }
       ];
 
       return (

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
@@ -17,7 +17,6 @@ class PhyloTreeDownloadButton extends React.Component {
     ];
     this.download = this.download.bind(this);
     this.svgSaver = new SvgSaver();
-    this.node = document.getElementsByClassName("phylo-tree-vis")[0];
   }
 
   download(option) {
@@ -28,16 +27,20 @@ class PhyloTreeDownloadButton extends React.Component {
       return;
     } else if (option == "svg") {
       // TODO (gdingle): filename per tree?
-      this.svgSaver.asSvg(this.node, "phylo_tree.svg");
+      this.svgSaver.asSvg(this.getNode(), "phylo_tree.svg");
       return;
     } else if (option == "png") {
       // TODO (gdingle): filename per tree?
-      this.svgSaver.asPng(this.node, "phylo_tree.png");
+      this.svgSaver.asPng(this.getNode(), "phylo_tree.png");
       return;
     } else {
       // eslint-disable-next-line no-console
       console.error("Bad download option: " + option);
     }
+  }
+
+  getNode() {
+    return document.getElementsByClassName("phylo-tree-vis")[0];
   }
 
   render() {

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
@@ -1,28 +1,46 @@
 import React from "react";
 import PropTypes from "prop-types";
 import DownloadButtonDropdown from "../../ui/controls/dropdowns/DownloadButtonDropdown";
+import SvgSaver from "svgsaver";
 
 class PhyloTreeDownloadButton extends React.Component {
   constructor(props) {
     super(props);
 
-    this.allOptions = [
+    this.dataOptions = [
       { text: "VCF", value: "vcf" },
       { text: "SNP annotations", value: "snp_annotations" }
     ];
+    this.imageOptions = [
+      { text: "SVG", value: "svg" },
+      { text: "PNG", value: "png" }
+    ];
     this.download = this.download.bind(this);
+    this.svgSaver = new SvgSaver();
   }
 
   download(option) {
-    location.href = `/phylo_trees/${
-      this.props.tree.id
-    }/download?output=${option}`;
+    if (this.dataOptions.map(o => o.value).includes(option)) {
+      location.href = `/phylo_trees/${
+        this.props.tree.id
+      }/download?output=${option}`;
+      return;
+    } else if (this.imageOptions.map(o => o.value).includes(option)) {
+      const elem = document.getElementsByClassName("phylo-tree-vis")[0];
+      // TODO (gdingle): custom filename
+      this.svgSaver.asSvg(elem, "phylo_tree.svg");
+      return;
+    } else {
+      // eslint-disable-next-line no-console
+      console.error("Bad download option: " + option);
+    }
   }
 
   render() {
-    let readyOptions = this.allOptions.filter(
+    let readyOptions = this.dataOptions.filter(
       opt => !!this.props.tree[opt.value]
     );
+    readyOptions = readyOptions.concat(this.imageOptions);
     return (
       <DownloadButtonDropdown
         options={readyOptions}

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import DownloadButtonDropdown from "../../ui/controls/dropdowns/DownloadButtonDropdown";
 import SvgSaver from "svgsaver";
+
+import DownloadButtonDropdown from "../../ui/controls/dropdowns/DownloadButtonDropdown";
 
 class PhyloTreeDownloadButton extends React.Component {
   constructor(props) {

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
@@ -36,7 +36,7 @@ class PhyloTreeDownloadButton extends React.Component {
       return;
     } else {
       // eslint-disable-next-line no-console
-      console.error("Bad download option: " + option);
+      console.error(`Bad download option: ${option}`);
     }
   }
 

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
@@ -39,6 +39,7 @@ class PhyloTreeDownloadButton extends React.Component {
     }
   }
 
+  // TODO (gdingle): should we pass in a reference with React somehow?
   getNode() {
     return document.getElementsByClassName("phylo-tree-vis")[0];
   }

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
@@ -17,6 +17,7 @@ class PhyloTreeDownloadButton extends React.Component {
     ];
     this.download = this.download.bind(this);
     this.svgSaver = new SvgSaver();
+    this.node = document.getElementsByClassName("phylo-tree-vis")[0];
   }
 
   download(option) {
@@ -25,10 +26,13 @@ class PhyloTreeDownloadButton extends React.Component {
         this.props.tree.id
       }/download?output=${option}`;
       return;
-    } else if (this.imageOptions.map(o => o.value).includes(option)) {
-      const elem = document.getElementsByClassName("phylo-tree-vis")[0];
-      // TODO (gdingle): custom filename
-      this.svgSaver.asSvg(elem, "phylo_tree.svg");
+    } else if (option == "svg") {
+      // TODO (gdingle): filename per tree?
+      this.svgSaver.asSvg(this.node, "phylo_tree.svg");
+      return;
+    } else if (option == "png") {
+      // TODO (gdingle): filename per tree?
+      this.svgSaver.asPng(this.node, "phylo_tree.png");
       return;
     } else {
       // eslint-disable-next-line no-console

--- a/app/assets/src/components/visualizations/TidyTree.js
+++ b/app/assets/src/components/visualizations/TidyTree.js
@@ -57,7 +57,7 @@ export default class TidyTree {
         `background-color: ${this.options.svgBackgroundColor}`
       );
 
-    this.pathContainer = this.svgq
+    this.pathContainer = this.svg
       .append("g")
       .attr(
         "transform",

--- a/app/assets/src/components/visualizations/TidyTree.js
+++ b/app/assets/src/components/visualizations/TidyTree.js
@@ -26,7 +26,8 @@ export default class TidyTree {
         smallerFont: 8,
         largerFont: 12,
         onCollapsedStateChange: () => {},
-        collapsed: new Set()
+        collapsed: new Set(),
+        svgBackgroundColor: "white"
       },
       options || {}
     );
@@ -48,9 +49,15 @@ export default class TidyTree {
       .append("svg")
       .attr("class", "tidy-tree")
       .attr("width", this.options.width)
-      .attr("height", this.options.height);
+      .attr("height", this.options.height)
+      .attr(
+        "style",
+        // Not standard but it works for downloads and svgsaver. See
+        // https://stackoverflow.com/questions/11293026/default-background-color-of-svg-root-element
+        `background-color: ${this.options.svgBackgroundColor}`
+      );
 
-    this.pathContainer = this.svg
+    this.pathContainer = this.svgq
       .append("g")
       .attr(
         "transform",

--- a/app/assets/src/components/visualizations/dendrogram/Dendogram.js
+++ b/app/assets/src/components/visualizations/dendrogram/Dendogram.js
@@ -51,7 +51,9 @@ export default class Dendogram {
         onNodeClick: null,
         onNodeHover: null,
         tooltipContainer: null,
-        scaleLabel: null
+        scaleLabel: null,
+        // This is needed for downloading PNG and SVG on solid background
+        backgroundColor: "white"
       },
       options || {}
     );
@@ -88,6 +90,12 @@ export default class Dendogram {
       .attr(
         "height",
         this.minTreeSize.height + this.margins.top + this.margins.bottom
+      )
+      .attr(
+        "style",
+        // Not standard but it works for downloads and svgsaver. See
+        // https://stackoverflow.com/questions/11293026/default-background-color-of-svg-root-element
+        "background-color: " + this.options.backgroundColor
       );
 
     this.viz = this.svg

--- a/app/assets/src/components/visualizations/dendrogram/Dendogram.js
+++ b/app/assets/src/components/visualizations/dendrogram/Dendogram.js
@@ -53,7 +53,7 @@ export default class Dendogram {
         tooltipContainer: null,
         scaleLabel: null,
         // This is needed for downloading PNG and SVG on solid background
-        backgroundColor: "white"
+        svgBackgroundColor: "white"
       },
       options || {}
     );
@@ -95,7 +95,7 @@ export default class Dendogram {
         "style",
         // Not standard but it works for downloads and svgsaver. See
         // https://stackoverflow.com/questions/11293026/default-background-color-of-svg-root-element
-        "background-color: " + this.options.backgroundColor
+        `background-color: ${this.options.svgBackgroundColor}`
       );
 
     this.viz = this.svg


### PR DESCRIPTION
# Description

This functionality did not exist, so I added it. It behaves the same way as for heatmaps.

![image](https://user-images.githubusercontent.com/28797/54227756-d71cb000-44bd-11e9-93d4-65ed91f2642c.png)

![image](https://user-images.githubusercontent.com/28797/54231659-26ff7500-44c6-11e9-9f69-fb3322fcb5d1.png)

# Test and Reproduce
1. Click PNG
2. See download
3. Open file, see good PNG with white background
4. Repeat steps for other download options and other tree