### PR TITLE
Fix bug with Name Type where the default wasn't shown in dropdown.

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -147,7 +147,7 @@ class PipelineSampleReport extends React.Component {
             return category in this.categoryChildParent;
           })
         : [],
-      name_type: cached_name_type ? cached_name_type : "Scientific Name",
+      name_type: cached_name_type ? cached_name_type : "Scientific name",
       rendering: false,
       loading: true,
       activeThresholds: savedThresholdFilters,


### PR DESCRIPTION
The reason is Scientific name was mis-capitalized.

In `NameTypeFilter`:
```
const NAME_TYPE_OPTIONS = [
  { text: "Scientific", value: "Scientific name" },
  { text: "Common", value: "Common name" }
```
