### PR TITLE
Update in-app CLI instructions with metadata links

### DIFF
--- a/app/assets/src/components/views/CliUserInstructions.jsx
+++ b/app/assets/src/components/views/CliUserInstructions.jsx
@@ -9,11 +9,11 @@ class CliUserInstructions extends React.Component {
   render() {
     const singleUploadCmd = `idseq -e='${this.props.email}' -t='${
       this.props.authToken
-    }' -p='Your Project Name' -s='Your Sample Name' --r1=your_sample_R1.fastq.gz --r2=your_sample_R2.fastq.gz --host-genome-name='Human'`;
+    }' -p='Your Project Name' -s='Your Sample Name' --r1=your_sample_R1.fastq.gz --r2=your_sample_R2.fastq.gz`;
 
     const bulkUploadCmd = `idseq -e='${this.props.email}' -t='${
       this.props.authToken
-    }' -p='Your Project Name' --bulk=. --host-genome-name='Human'`;
+    }' -p='Your Project Name' --bulk=.`;
 
     const genomesList = `'${this.props.hostGenomes.join("', '")}'`;
 
@@ -87,11 +87,7 @@ class CliUserInstructions extends React.Component {
               your_sample_R1
             </span>.fastq.gz --r2=<span className={cs.codeToEdit}>
               your_sample_R2
-            </span>.fastq.gz --host-genome-name='<span
-              className={cs.codeToEdit}
-            >
-              Human
-            </span>'
+            </span>.fastq.gz
           </p>
         </div>
         <div className={cs.instructionMediumMarginTop}>
@@ -202,8 +198,7 @@ class CliUserInstructions extends React.Component {
             </span>' \
             <br /> --bulk=<span className={cs.codeToEdit}>
               /path/to/your/folder
-            </span>{" "}
-            --host-genome-name='<span className={cs.codeToEdit}>Human</span>'
+            </span>
           </p>
         </div>
         <div className={cs.instructionMediumMarginTop}>

--- a/app/assets/src/components/views/CliUserInstructions.jsx
+++ b/app/assets/src/components/views/CliUserInstructions.jsx
@@ -3,6 +3,7 @@ import { Form, TextArea } from "semantic-ui-react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import cs from "./cli_user_instructions.scss";
+import { openUrlInNewTab } from "~utils/links";
 
 class CliUserInstructions extends React.Component {
   render() {
@@ -107,6 +108,47 @@ class CliUserInstructions extends React.Component {
           {
             "- Supported file types: .fastq/.fq/.fasta/.fa or .fastq.gz/.fq.gz/.fasta.gz/.fa.gz"
           }
+        </p>
+        <p>
+          - You will be prompted to upload metadata in a CSV file with your
+          samples. This is also where you will specify the Host Genome.
+        </p>
+        <p>
+          <div className={cs.firstIndent}>
+            {"- "}
+            <span
+              onClick={() =>
+                openUrlInNewTab("https://idseq.net/metadata/instructions")
+              }
+              className={cs.link}
+            >
+              Metadata Instructions
+            </span>
+          </div>
+          <div className={cs.firstIndent}>
+            {"- "}
+            <span
+              onClick={() =>
+                openUrlInNewTab("https://idseq.net/metadata/dictionary")
+              }
+              className={cs.link}
+            >
+              Metadata Dictionary
+            </span>
+          </div>
+          <div className={cs.firstIndent}>
+            {"- "}
+            <span
+              onClick={() =>
+                openUrlInNewTab(
+                  "https://idseq.net/metadata/metadata_template_csv"
+                )
+              }
+              className={cs.link}
+            >
+              Metadata CSV Template
+            </span>
+          </div>
         </p>
         <p>{`- Supported host genome values: ${genomesList}`}</p>
         <p>

--- a/app/assets/src/components/views/CliUserInstructions.jsx
+++ b/app/assets/src/components/views/CliUserInstructions.jsx
@@ -19,6 +19,7 @@ class CliUserInstructions extends React.Component {
 
     return (
       <div className={cs.instructionContainer}>
+        <div className={cs.title}>Command Line Interface Instructions</div>
         <p className={cs.instructionHeading}>
           {
             "(1) Install and configure the Amazon Web Services Command Line Interface (AWS CLI): "

--- a/app/assets/src/components/views/cli_user_instructions.scss
+++ b/app/assets/src/components/views/cli_user_instructions.scss
@@ -2,6 +2,11 @@
 @import "~styles/themes/colors";
 
 .instructionContainer {
+  .title {
+    font-size: 25px;
+    margin-bottom: 50px;
+  }
+
   margin: 5%;
 }
 

--- a/app/assets/src/components/views/cli_user_instructions.scss
+++ b/app/assets/src/components/views/cli_user_instructions.scss
@@ -15,6 +15,11 @@
   margin-top: 1rem;
 }
 
+.firstIndent {
+  margin-left: 20px;
+  margin-bottom: 5px;
+}
+
 .codeBullet {
   width: fit-content;
   background-color: $primary-lightest;
@@ -62,4 +67,9 @@
       color: $primary-light !important;
     }
   }
+}
+
+.link {
+  color: $primary-light;
+  cursor: pointer;
 }


### PR DESCRIPTION
- Residual task to bring the web instructions up-to-date with the updated CLI. Host genome moves to the CSV template file.
- The old CLI versions have not been expired so they will still hit the old endpoints and work. But anyone new who goes to idseq-cli will get the new version.
- Users who view the current instructions but are using the old CLI version will still be able to use the instructions but just won't be prompted for metadata (until we force the switch). They'll still be prompted to type in the host genome name.
- Also adds a title asked for by Design.

![Screen Shot 2019-03-12 at 12 36 58 PM](https://user-images.githubusercontent.com/5652739/54230394-8f992280-44c3-11e9-9f6b-c3dcbe7a2d81.png)

### How to test
- Go to http://localhost:3000/cli_user_instructions
- Go to https://github.com/chanzuckerberg/idseq-cli and follow the instructions