### PR TITLE
Fix bug with arrow dropdown font size.

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -23,7 +23,6 @@
   &.arrowOutsideTrigger {
     display: flex;
     align-items: center;
-    font-size: 20px;
 
     i:global(.dropdown) {
       margin-left: 0;


### PR DESCRIPTION
This was the bug:
![Screen Shot 2019-03-12 at 12 36 23 PM](https://user-images.githubusercontent.com/837004/54230543-d7b84500-44c3-11e9-9bb8-f8ae4414bb81.png)
