### PR TITLE
Use relevant sample names in Metadata CSV template when possible.

### DIFF
--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -11,6 +11,7 @@ import { getProjectMetadataFields, getAllHostGenomes } from "~/api";
 import cs from "./metadata_upload.scss";
 import MetadataManualInput from "./MetadataManualInput";
 import IssueGroup from "./IssueGroup";
+import { getURLParamString } from "~/helpers/url";
 
 const map = _fp.map.convert({ cap: false });
 
@@ -60,6 +61,17 @@ class MetadataUpload extends React.Component {
     this.props.onMetadataChange({ metadata, wasManual: true });
   };
 
+  getCSVUrl = () => {
+    const params = {
+      ...(this.props.samplesAreNew
+        ? { new_sample_names: map("name", this.props.samples) }
+        : {}),
+      project_id: this.props.project.id
+    };
+
+    return `/metadata/metadata_template_csv?${getURLParamString(params)}`;
+  };
+
   renderTab = () => {
     if (this.state.currentTab === "Manual Input") {
       if (!this.props.samples || !this.state.projectMetadataFields) {
@@ -97,7 +109,7 @@ class MetadataUpload extends React.Component {
             project={this.props.project}
             samplesAreNew={this.props.samplesAreNew}
           />
-          <a className={cs.link} href="/metadata/metadata_template_csv">
+          <a className={cs.link} href={this.getCSVUrl()}>
             Download Metadata CSV Template
           </a>
         </React.Fragment>

--- a/app/assets/src/helpers/url.js
+++ b/app/assets/src/helpers/url.js
@@ -1,5 +1,5 @@
 import QueryString from "query-string";
-import { toPairs, pickBy } from "lodash/fp";
+import { isArray, toPairs, pickBy, isPlainObject } from "lodash/fp";
 import { shortenUrl } from "~/api";
 import copy from "copy-to-clipboard";
 
@@ -24,9 +24,16 @@ export const parseUrlParams = () => {
 };
 
 export const getURLParamString = params => {
-  const filtered = pickBy((v, k) => typeof v !== "object", params);
+  const filtered = pickBy((v, k) => !isPlainObject(v), params);
   return toPairs(filtered)
-    .map(pair => pair.join("="))
+    .map(
+      ([key, value]) =>
+        isArray(value)
+          ? // Convert array parameters correctly.
+            value.map(eachValue => `${key}[]=${eachValue}`)
+          : `${key}=${value}`
+    )
+    .flat()
     .join("&");
 };
 

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -22,7 +22,11 @@ class MetadataController < ApplicationController
   end
 
   def metadata_template_csv
-    send_data metadata_template_csv_helper, filename: 'metadata_template.csv'
+    # The project to pull metadata_fields and existing samples (if applicable) from.
+    project_id = params[:project_id]
+    # The names of new samples that are being created.
+    new_sample_names = params[:new_sample_names]
+    send_data metadata_template_csv_helper(project_id, new_sample_names), filename: 'metadata_template.csv'
   end
 
   def validate_csv_for_new_samples

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -29,11 +29,7 @@ module MetadataHelper
   end
 
   # TODO(mark): Generate more realistic default values.
-  def generate_metadata_default_value(host_genome, field)
-    unless host_genome.metadata_fields.include?(field)
-      return nil
-    end
-
+  def generate_metadata_default_value(field)
     if field.base_type == Metadatum::STRING_TYPE
       if field.options.present?
         options = JSON.parse(field.options)
@@ -52,25 +48,65 @@ module MetadataHelper
     end
   end
 
-  def metadata_template_csv_helper
-    required = MetadataField.where(is_required: true)
-    default = MetadataField.where(is_default: true)
+  def metadata_template_csv_helper(project_id, new_sample_names)
+    samples_are_new = !new_sample_names.nil?
+    project = Project.where(id: project_id)[0]
 
-    fields = (required | default)
+    # If project is nil, use global default and required fields.
+    fields = if project.nil?
+               required = MetadataField.where(is_required: true)
+               default = MetadataField.where(is_default: true)
 
-    field_names = ["sample_name"] + fields.pluck(:display_name)
+               (required | default)
+             # If samples are new, just use Human metadata fields since we default to Human.
+             elsif samples_are_new
+               HostGenome.find_by(name: "Human").metadata_fields & project.metadata_fields
+             else
+               project.metadata_fields
+             end
 
-    host_genomes = HostGenome.all.reject { |x| x.metadata_fields.empty? }
+    field_names = ["Sample Name"] + (samples_are_new ? ["Host Genome"] : []) + fields.pluck(:display_name)
+
+    host_genomes_by_name = HostGenome.all.includes(:metadata_fields).reject { |x| x.metadata_fields.empty? }.index_by(&:name)
+
+    # Assemble sample objects based on params.
+    samples = if samples_are_new
+                # Use new sample names if provided.
+                new_sample_names.map do |sample_name|
+                  {
+                    name: sample_name,
+                    # For now, always default to Human for new samples.
+                    host_genome_name: "Human"
+                  }
+                end
+              elsif project.nil?
+                # If the project is nil, construct a sample for each host genome.
+                host_genomes_by_name.map do |name, _|
+                  {
+                    name: "Example #{name} Sample",
+                    host_genome_name: name
+                  }
+                end
+              else
+                # Use existing samples in the project.
+                Sample.includes(:host_genome).where(id: project.sample_ids).map do |sample|
+                  {
+                    name: sample.name,
+                    host_genome_name: sample.host_genome_name
+                  }
+                end
+              end
 
     CSV.generate(headers: true) do |csv|
       csv << field_names
-      host_genomes.each do |host_genome|
-        default_values = fields.map do |field|
-          generate_metadata_default_value(host_genome, field)
+      samples.each do |sample|
+        values = fields.map do |field|
+          if host_genomes_by_name[sample[:host_genome_name]].metadata_fields.include?(field)
+            generate_metadata_default_value(field)
+          end
         end
 
-        row_name = "Example " + host_genome.name + " Sample"
-        csv << [row_name] + default_values
+        csv << [sample[:name]] + (samples_are_new ? [sample[:host_genome_name]] : []) + values
       end
     end
   end


### PR DESCRIPTION
When uploading new samples, use the names of the new samples.
When uploading to existing samples, use the names of existing samples.

![Screen Shot 2019-03-12 at 6 50 08 PM](https://user-images.githubusercontent.com/837004/54247841-b40ef200-44f7-11e9-868e-d186bd195efa.png)

Verified that we are making peformant queries.

Here is 325 samples from Mosquito project. Endpoint takes about 1 second (most of it seems to be generating the CSV file)
![Screen Shot 2019-03-12 at 6 52 19 PM](https://user-images.githubusercontent.com/837004/54247928-0f40e480-44f8-11e9-82d3-58a80729697a.png)

On other pages such as the CSV upload instructions, we still return example samples based on the host genomes, like before.

![Screen Shot 2019-03-12 at 6 55 22 PM](https://user-images.githubusercontent.com/837004/54248058-7eb6d400-44f8-11e9-9728-59e13b6119cd.png)

----

This relates to stabilization because we need to generate large test files to test our metadata upload and validation, which this PR enables.
