### PR TITLE
Return month-only dates in CSV template.

### DIFF
--- a/app/assets/src/components/views/metadata/MetadataDictionary.jsx
+++ b/app/assets/src/components/views/metadata/MetadataDictionary.jsx
@@ -7,7 +7,6 @@ import _fp, {
   partition,
   first,
   get,
-  union,
   compact
 } from "lodash/fp";
 import NarrowContainer from "~/components/layout/NarrowContainer";
@@ -27,9 +26,9 @@ const dictionaryHeaders = {
 };
 
 const getExamplesForHostGenome = (field, hostGenomeId) =>
-  compact(
-    union(get("all", field.examples), get(hostGenomeId, field.examples))
-  ).join(", ") || "--";
+  compact(get(hostGenomeId, field.examples) || get("all", field.examples)).join(
+    ", "
+  ) || "--";
 
 class MetadataDictionary extends React.Component {
   state = {

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -29,7 +29,7 @@ module MetadataHelper
   end
 
   # TODO(mark): Generate more realistic default values.
-  def generate_metadata_default_value(field)
+  def generate_metadata_default_value(field, host_genome_name)
     if field.base_type == Metadatum::STRING_TYPE
       if field.options.present?
         options = JSON.parse(field.options)
@@ -44,7 +44,7 @@ module MetadataHelper
     end
 
     if field.base_type == Metadatum::DATE_TYPE
-      return String(Time.zone.today)
+      return Time.zone.today.strftime(host_genome_name == "Human" ? "%Y-%m" : "%Y-%m-%d")
     end
   end
 
@@ -102,7 +102,7 @@ module MetadataHelper
       samples.each do |sample|
         values = fields.map do |field|
           if host_genomes_by_name[sample[:host_genome_name]].metadata_fields.include?(field)
-            generate_metadata_default_value(field)
+            generate_metadata_default_value(field, sample[:host_genome_name])
           end
         end
 


### PR DESCRIPTION
Since we ask for year and month, we should return this in the CSV template.

Also change how examples are handled on metadata dictionary. Treat "all" as the default,
instead of appending "all" to all host genomes.
This makes it easier to specify certain examples for Humans (2019-01-01), and other examples for all other host genomes (2019-01)