### PR TITLE
Fix perf of report table render

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -159,7 +159,8 @@ class PipelineSampleReport extends React.Component {
       treeMetric: cachedTreeMetric || this.treeMetrics[0].value,
       phyloTreeModalOpen: true,
       contigTaxidList: [],
-      minContigSize: cachedMinContigSize || DEFAULT_MIN_CONTIG_SIZE
+      minContigSize: cachedMinContigSize || DEFAULT_MIN_CONTIG_SIZE,
+      hoverRowId: null
     };
 
     this.state = {
@@ -840,7 +841,8 @@ class PipelineSampleReport extends React.Component {
           />
         )}
         {tax_info.pathogenTag && <PathogenLabel type={tax_info.pathogenTag} />}
-        {this.displayHoverActions(tax_info, report_details)}
+        {this.isRowHovered(tax_info) &&
+          this.displayHoverActions(tax_info, report_details)}
       </span>
     );
     let taxonDescription;
@@ -876,6 +878,20 @@ class PipelineSampleReport extends React.Component {
       );
     }
     return taxonDescription;
+  };
+
+  // Use JS events for hover state to so we can avoid rendering many hidden
+  // elements which was taking >500ms.
+  isRowHovered = taxInfo => {
+    return this.state.hoverRowId === taxInfo.tax_id;
+  };
+
+  handleMouseEnter = taxID => {
+    this.setState({ hoverRowId: taxID });
+  };
+
+  handleMouseLeave = () => {
+    this.setState({ hoverRowId: null });
   };
 
   renderNumber = (
@@ -1412,6 +1428,8 @@ class RenderMarkup extends React.Component {
           parent.props.reportPageParams.pipeline_version
         )}
         onTaxonClick={parent.props.onTaxonClick}
+        handleMouseEnter={parent.handleMouseEnter}
+        handleMouseLeave={parent.handleMouseLeave}
       />
     );
   }

--- a/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
+++ b/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
@@ -4,67 +4,79 @@ import { get } from "lodash/fp";
 // TODO(mark): Use alias instead, to avoid dots.
 import PropTypes from "../../../utils/propTypes";
 
-const DetailCells = ({
-  taxons,
-  taxonRowRefs,
-  renderName,
-  renderNumber,
-  showConcordance,
-  getRowClass,
-  onTaxonClick,
-  reportDetails,
-  backgroundData,
-  showAssemblyColumns
-}) => {
-  return taxons.map(taxInfo => (
-    <tr
-      key={taxInfo.tax_id}
-      id={`taxon-${taxInfo.tax_id}`}
-      ref={elm => {
-        taxonRowRefs[taxInfo.tax_id] = elm;
-      }}
-      className={getRowClass(taxInfo)}
-    >
-      <td>
-        {renderName(taxInfo, reportDetails, backgroundData, onTaxonClick)}
-      </td>
-      {renderNumber(
-        taxInfo.NT.aggregatescore,
-        null,
-        0,
-        true,
-        undefined,
-        taxInfo.topScoring == 1,
-        "score-column"
-      )}
-      {renderNumber(taxInfo.NT.zscore, taxInfo.NR.zscore, 1)}
-      {renderNumber(taxInfo.NT.rpm, taxInfo.NR.rpm, 1)}
-      {renderNumber(taxInfo.NT.r, taxInfo.NR.r, 0)}
-      {showAssemblyColumns &&
-        renderNumber(
-          get("summaryContigCounts.NT.contigs", taxInfo) || 0,
-          get("summaryContigCounts.NR.contigs", taxInfo) || 0,
-          0
+export default class DetailCells extends React.Component {
+  render() {
+    const {
+      taxons,
+      taxonRowRefs,
+      renderName,
+      renderNumber,
+      showConcordance,
+      getRowClass,
+      onTaxonClick,
+      reportDetails,
+      backgroundData,
+      showAssemblyColumns,
+      handleMouseEnter,
+      handleMouseLeave
+    } = this.props;
+
+    return taxons.map(taxInfo => (
+      <tr
+        key={taxInfo.tax_id}
+        id={`taxon-${taxInfo.tax_id}`}
+        ref={elm => {
+          taxonRowRefs[taxInfo.tax_id] = elm;
+        }}
+        className={getRowClass(taxInfo)}
+        onMouseEnter={() => handleMouseEnter(taxInfo.tax_id)}
+        onMouseLeave={() => handleMouseLeave(taxInfo.tax_id)}
+      >
+        <td>
+          {renderName(taxInfo, reportDetails, backgroundData, onTaxonClick)}
+        </td>
+        {renderNumber(
+          taxInfo.NT.aggregatescore,
+          null,
+          0,
+          true,
+          undefined,
+          taxInfo.topScoring == 1,
+          "score-column"
         )}
-      {showAssemblyColumns &&
-        renderNumber(
-          get("summaryContigCounts.NT.contigreads", taxInfo) || 0,
-          get("summaryContigCounts.NR.contigreads", taxInfo) || 0,
-          0
+        {renderNumber(taxInfo.NT.zscore, taxInfo.NR.zscore, 1)}
+        {renderNumber(taxInfo.NT.rpm, taxInfo.NR.rpm, 1)}
+        {renderNumber(taxInfo.NT.r, taxInfo.NR.r, 0)}
+        {showAssemblyColumns &&
+          renderNumber(
+            get("summaryContigCounts.NT.contigs", taxInfo) || 0,
+            get("summaryContigCounts.NR.contigs", taxInfo) || 0,
+            0
+          )}
+        {showAssemblyColumns &&
+          renderNumber(
+            get("summaryContigCounts.NT.contigreads", taxInfo) || 0,
+            get("summaryContigCounts.NR.contigreads", taxInfo) || 0,
+            0
+          )}
+        {renderNumber(
+          taxInfo.NT.percentidentity,
+          taxInfo.NR.percentidentity,
+          1
         )}
-      {renderNumber(taxInfo.NT.percentidentity, taxInfo.NR.percentidentity, 1)}
-      {renderNumber(taxInfo.NT.neglogevalue, taxInfo.NR.neglogevalue, 0)}
-      {renderNumber(
-        taxInfo.NT.percentconcordant,
-        taxInfo.NR.percentconcordant,
-        1,
-        undefined,
-        showConcordance
-      )}
-      <td className="last-col" />
-    </tr>
-  ));
-};
+        {renderNumber(taxInfo.NT.neglogevalue, taxInfo.NR.neglogevalue, 0)}
+        {renderNumber(
+          taxInfo.NT.percentconcordant,
+          taxInfo.NR.percentconcordant,
+          1,
+          undefined,
+          showConcordance
+        )}
+        <td className="last-col" />
+      </tr>
+    ));
+  }
+}
 
 DetailCells.propTypes = {
   taxons: PropTypes.arrayOf(PropTypes.Taxon).isRequired,
@@ -76,7 +88,7 @@ DetailCells.propTypes = {
   getRowClass: PropTypes.func.isRequired,
   reportDetails: PropTypes.ReportDetails,
   backgroundData: PropTypes.BackgroundData,
-  showAssemblyColumns: PropTypes.bool
+  showAssemblyColumns: PropTypes.bool,
+  handleMouseEnter: PropTypes.func,
+  handleMouseLeave: PropTypes.func
 };
-
-export default DetailCells;

--- a/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
+++ b/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
@@ -82,17 +82,13 @@ class HoverActions extends React.Component {
           data-tax-id={taxId}
           onClick={hoverAction.handleClick}
           className={cx("fa", hoverAction.icon, cs.actionDot)}
-          aria-hidden="true"
           {...hoverAction.extraProps}
         />
       );
       tooltipMessage = hoverAction.message;
     } else {
       trigger = (
-        <i
-          className={cx("fa", hoverAction.icon, cs.actionDot, cs.disabled)}
-          aria-hidden="true"
-        />
+        <i className={cx("fa", hoverAction.icon, cs.actionDot, cs.disabled)} />
       );
       tooltipMessage = hoverAction.disabledMessage;
     }

--- a/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
+++ b/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
@@ -144,6 +144,8 @@ export default class ReportTable extends React.Component {
               reportDetails={reportDetails}
               backgroundData={backgroundData}
               showAssemblyColumns={showAssemblyColumns}
+              handleMouseEnter={this.props.handleMouseEnter}
+              handleMouseLeave={this.props.handleMouseLeave}
             />
           </tbody>
         </table>
@@ -167,5 +169,7 @@ ReportTable.propTypes = {
   countType: PropTypes.string.isRequired,
   setCountType: PropTypes.func.isRequired,
   showAssemblyColumns: PropTypes.bool,
-  onTaxonClick: PropTypes.func
+  onTaxonClick: PropTypes.func,
+  handleMouseEnter: PropTypes.func,
+  handleMouseLeave: PropTypes.func
 };

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -62,12 +62,10 @@ input[type="number"] {
     font-weight: normal !important;
   }
 
+  // NOTE: Show/hide on hover is now handled by JS for perf. See isRowHovered in
+  // PipelineSampleReport.
   tr:hover {
     .hover-wrapper {
-      .link-tag {
-        visibility: visible;
-      }
-
       span.taxon-sidebar-link {
         color: $primary-light;
       }
@@ -360,12 +358,10 @@ input[type="number"] {
   cursor: pointer;
   &:hover {
     .link-tag {
-      visibility: visible;
       color: $primary-light;
     }
   }
   .link-tag {
-    visibility: hidden;
     padding-left: 10px;
   }
 }


### PR DESCRIPTION
# Description

See https://jira.czi.team/projects/IDSEQ/issues/IDSEQ-723.

This reduces render time by 2/3 (or 300ms) in my testing by eliminating rendering of hidden elements. The showing is now handled by JS. 

This might also fix large tables not rendering at all. Please point me to a good example. @MarkAZhang 

![image](https://user-images.githubusercontent.com/28797/54315854-829c3200-459c-11e9-8640-53e5c404010c.png)


# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Using chrome dev tools, record time switching views in report page
2. See time decrease 300ms before and after

1. hover over row
2. see links appear as before