### PR TITLE
Fix improper parsing of url params.

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -6,6 +6,7 @@ import { Label, Menu, Icon, Popup } from "semantic-ui-react";
 import { numberWithCommas } from "../helpers/strings";
 import { getTaxonName, getGeneraContainingTags } from "../helpers/taxon";
 import ThresholdMap from "./utils/ThresholdMap";
+import { omit } from "lodash/fp";
 import {
   computeThresholdedTaxons,
   isTaxonIncluded,
@@ -188,7 +189,11 @@ class PipelineSampleReport extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     // Set the state in the URL
-    this.props.refreshPage(this.state, false);
+    // Omit contigTaxidList and taxonomy_details, which are large arrays that shouldn't be put into the URL.
+    this.props.refreshPage(
+      omit(["contigTaxidList", "taxonomy_details"], this.state),
+      false
+    );
   }
 
   // fetchReportData loads the actual report information with another call to

--- a/app/assets/src/helpers/url.js
+++ b/app/assets/src/helpers/url.js
@@ -1,5 +1,12 @@
 import QueryString from "query-string";
-import { isArray, toPairs, pickBy, isPlainObject } from "lodash/fp";
+import {
+  filter,
+  isObject,
+  isArray,
+  toPairs,
+  pickBy,
+  isPlainObject
+} from "lodash/fp";
 import { shortenUrl } from "~/api";
 import copy from "copy-to-clipboard";
 
@@ -24,13 +31,18 @@ export const parseUrlParams = () => {
 };
 
 export const getURLParamString = params => {
+  // Use isPlainObject to remove objects, but keep arrays.
   const filtered = pickBy((v, k) => !isPlainObject(v), params);
   return toPairs(filtered)
     .map(
       ([key, value]) =>
         isArray(value)
           ? // Convert array parameters correctly.
-            value.map(eachValue => `${key}[]=${eachValue}`)
+            // Filter out objects and nested arrays within the array.
+            // We only parse one level deep for now.
+            filter(val => !isObject(val), value).map(
+              eachValue => `${key}[]=${eachValue}`
+            )
           : `${key}=${value}`
     )
     .flat()


### PR DESCRIPTION
Recent changes to getURLParamString didn't take arrays of objects into account.
This broke the report page.
