### PR TITLE
Fix accordion yet again

### DIFF
--- a/app/assets/src/components/layout/Accordion.jsx
+++ b/app/assets/src/components/layout/Accordion.jsx
@@ -4,23 +4,19 @@ import cx from "classnames";
 import cs from "./accordion.scss";
 
 class Accordion extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      open: this.props.open
-    };
-  }
+  state = {};
 
   onToggle = () => {
     this.setState({
-      open: !this.state.open
+      open: !this.state.open,
+      wasToggled: true
     });
   };
 
   render() {
     const { header, children, toggleable, className } = this.props;
 
-    const open = this.state.open;
+    const open = this.state.wasToggled ? this.state.open : this.props.open;
 
     return (
       <div className={cx(cs.accordion, className)}>


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/28797/54320299-b5005c00-45a9-11e9-9512-e8db9db9059f.png)

Embarrassing! This fixes the accordion yet again, and was a lesson in React. I think the biggest lesson was not to make components again that can have the same behavior be both controlled either by props or by internal state.  It is too hard to think about. 

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Try accordion on sample details sidebar
2. try accordion on DD sidebar
