### PR TITLE
[Uploads] Add another catch-all Airbrake line to initiate_s3_cp

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -272,12 +272,14 @@ class Sample < ApplicationRecord
       stderr_array << stderr unless status.exitstatus.zero?
     end
     unless stderr_array.empty?
-      LogUtil.log_err_and_airbrake("Failed to upload sample #{id} with error #{stderr_array[0]}")
+      LogUtil.log_err_and_airbrake("Failed to upload S3 sample #{name} (#{id}): #{stderr_array[0]}")
       raise stderr_array[0]
     end
 
     self.status = STATUS_UPLOADED
     save # this triggers pipeline command
+  rescue => e
+    LogUtil.log_err_and_airbrake("Failed to upload S3 sample #{name} (#{id}): #{e}")
   end
 
   def sample_input_s3_path

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -272,14 +272,14 @@ class Sample < ApplicationRecord
       stderr_array << stderr unless status.exitstatus.zero?
     end
     unless stderr_array.empty?
-      LogUtil.log_err_and_airbrake("Failed to upload S3 sample #{name} (#{id}): #{stderr_array[0]}")
+      LogUtil.log_err_and_airbrake("Failed to upload S3 sample '#{name}' (#{id}): #{stderr_array[0]}")
       raise stderr_array[0]
     end
 
     self.status = STATUS_UPLOADED
     save # this triggers pipeline command
   rescue => e
-    LogUtil.log_err_and_airbrake("Failed to upload S3 sample #{name} (#{id}): #{e}")
+    LogUtil.log_err_and_airbrake("Failed to upload S3 sample '#{name}' (#{id}): #{e}")
   end
 
   def sample_input_s3_path


### PR DESCRIPTION
- Even though we do the `aws s3 cp` in Open3.capture3, it appears that a broken pipe still manages to trigger a RuntimeError. So add a catch-all rescue in initiate_s3_cp so that we always log an error.
- You can view some of these errs in Resque: https://idseq.net/resque/failed?start=6280 Ex: `download failed: s3://...fastq.gz to - [Errno 32] Broken pipe` especially for 5GB+ files