### PR TITLE
Fix bugs related to Sample Name casing.

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -15,7 +15,10 @@ import LoadingIcon from "~ui/icons/LoadingIcon";
 import cs from "./sample_upload_flow.scss";
 
 const processMetadataRows = metadataRows =>
-  flow(keyBy("sample_name"), mapValues(omit("sample_name")))(metadataRows);
+  flow(
+    keyBy(row => row.sample_name || row["Sample Name"]),
+    mapValues(omit(["sample_name", "Sample Name"]))
+  )(metadataRows);
 
 class ReviewStep extends React.Component {
   state = {

--- a/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
@@ -1,6 +1,6 @@
 // This modal contains a wizard that allows users to upload metadata to a project.
 import React from "react";
-import { keyBy } from "lodash/fp";
+import { keyBy, flow, mapValues, omit } from "lodash/fp";
 import PropTypes from "prop-types";
 import Wizard from "~ui/containers/Wizard";
 import Modal from "~ui/containers/Modal";
@@ -37,7 +37,10 @@ class MetadataUploadModal extends React.Component {
   handleComplete = () => {
     uploadMetadataForProject(
       this.props.project.id,
-      keyBy("sample_name", this.state.metadata.rows)
+      flow(
+        keyBy(row => row.sample_name || row["Sample Name"]),
+        mapValues(omit(["sample_name", "Sample Name"]))
+      )(this.state.metadata.rows)
     );
     this.props.onClose();
   };

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -62,7 +62,9 @@ module MetadataHelper
              elsif samples_are_new
                HostGenome.find_by(name: "Human").metadata_fields & project.metadata_fields
              else
-               project.metadata_fields
+               # Only use fields from the project that correspond to the host genomes of existing samples.
+               host_genome_ids = Sample.where(id: project.sample_ids).pluck(:host_genome_id).uniq
+               project.metadata_fields.includes(:host_genomes).reject { |field| (field.host_genome_ids & host_genome_ids).empty? }
              end
 
     field_names = ["Sample Name"] + (samples_are_new ? ["Host Genome"] : []) + fields.pluck(:display_name)

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -430,7 +430,7 @@ module SamplesHelper
       end
 
       fields.each do |key, value|
-        next if ["sample_name", "host_genome"].include?(key)
+        next if ["Sample Name", "Host Genome", "sample_name", "host_genome"].include?(key)
 
         saved = sample.metadatum_add_or_update(key, value)
 


### PR DESCRIPTION
Add guard to prevent upload_metadata endpoint from creating custom Sample Name/Host Genome metadata fields.

Remove Sample Name from metadata object before sending to server. (redundant with above, but good practice)

Also only include metadata fields in the metadata template csv that match the host genomes of existing projects.

---

Testing strategy:
Verified that bugs have been fixed and tests pass.