### PR TITLE
Reduce redundant queries when rendering heatmap.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -415,7 +415,9 @@ class ProjectsController < ApplicationController
   def metadata_fields
     project_ids = (params[:projectIds] || []).map(&:to_i)
 
-    render json: current_power.projects.where(id: project_ids).map(&:metadata_fields).flatten.map(&:field_info)
+    render json: current_power.projects.where(id: project_ids)
+      .includes(metadata_fields: [:host_genomes])
+                              .map(&:metadata_fields).flatten.map(&:field_info)
   end
 
   # TODO: Consider consolidating into a general sample validator

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -511,8 +511,8 @@ class SamplesController < ApplicationController
       project_ids = samples.distinct.pluck(:project_id)
       host_genome_ids = samples.distinct.pluck(:host_genome_id)
 
-      project_fields = Project.where(id: project_ids).map(&:metadata_fields)
-      host_genome_fields = HostGenome.where(id: host_genome_ids).map(&:metadata_fields)
+      project_fields = Project.where(id: project_ids).includes(metadata_fields: [:host_genomes]).map(&:metadata_fields)
+      host_genome_fields = HostGenome.where(id: host_genome_ids).includes(metadata_fields: [:host_genomes]).map(&:metadata_fields)
       results = (project_fields.flatten & host_genome_fields.flatten).map(&:field_info)
     end
 

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -77,7 +77,7 @@ module HeatmapHelper
     # TODO: should fail if field is not well formatted and return proper error to client
     sort_by = params[:sortBy] || ReportHelper::DEFAULT_TAXON_SORT_PARAM
     species_selected = params[:species] == "1" # Otherwise genus selected
-    samples = current_power.samples.where(id: sample_ids).includes([:pipeline_runs, :metadata])
+    samples = current_power.samples.where(id: sample_ids).includes([:host_genome, :pipeline_runs, metadata: [:metadata_field]])
     return {} if samples.empty?
 
     first_sample = samples.first


### PR DESCRIPTION
Reduces time to render 130 samples on dev by about 35 seconds.

Also make metadata_fields endpoint more efficient.
