### PR TITLE
Fixes edge-case bug when multiple metadata fields have same name.

### DIFF
--- a/app/assets/src/components/common/MetadataCSVUpload.jsx
+++ b/app/assets/src/components/common/MetadataCSVUpload.jsx
@@ -2,7 +2,7 @@
 // Sends uploaded to server for validation and displays errors and warnings.
 import React from "react";
 import cx from "classnames";
-import { map, pickBy, zipObject, isNull } from "lodash/fp";
+import { filter, map, zip, fromPairs, isNull } from "lodash/fp";
 import CSVUpload from "~ui/controls/CSVUpload";
 import {
   validateMetadataCSVForProject,
@@ -18,7 +18,13 @@ const processCSVMetadata = csv => {
     headers,
     rows: map(
       // Remove empty values, and convert rows from array of strings to object.
-      row => pickBy(value => value !== "", zipObject(headers, row)),
+      // It's possible to have two different MetadataFields with the same name, but for different host genomes.
+      // In this case, only one of the two fields will have a value for any given sample
+      // (since only one of them will the sample's host genome).
+      // There is a risk if you naively zipObject that you will overwrite the actual value with an empty value
+      // (from the other metadata field with the same name), since precedence is based on the order.
+      // The below code makes sure this case is handled correctly by filtering before converting to an object.
+      row => fromPairs(filter(pair => pair[1] !== "", zip(headers, row))),
       rows
     )
   };

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -574,7 +574,7 @@ class Sample < ApplicationRecord
       raise RecordNotFound("No matching field for #{key}") unless m.metadata_field
       m.key = m.metadata_field.name
     end
-    if val.present?
+    if val.present? && m.raw_value != val
       m.raw_value = val
       m.save!
     end


### PR DESCRIPTION
Also don't make sql insert call if metadata value didn't change.

Verified that uploading still works, and bug is fixed.

----

This fixes an edge case that results from complexity in our metadata framework.

**Explanation of the weird edge case:**
Let's take the MetadataField `Host Genus Species`, which is a global default field that only applies to the Mosquitoes Host Genome.

If a user tries to upload Host Genus Species for a human, our system will not find a matching MetadataField (since Human != Mosquito), so it will create a custom human MetadataField for that project.

Now this project has two MetadataFields both called `Host Genus Species` (the default one for mosquitoes and the custom one for humans), which is the edge case that this fix addresses.