### PR TITLE
Fix backend perf of report table

### DIFF
--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -957,8 +957,11 @@ module ReportHelper
 
     # Compute all species aggregate scores.  These are used in filtering.
     compute_species_aggregate_scores!(rows, tax_2d, params[:scoring_model])
+    t2 = wall_clock_ms
+
     # Compute all genus aggregate scores.  These are used only in sorting.
     compute_genera_aggregate_scores!(rows, tax_2d)
+    t3 = wall_clock_ms
 
     # Total number of rows for view level, before application of filters.
     rows_total = tax_2d.length
@@ -981,7 +984,8 @@ module ReportHelper
     end
 
     t5 = wall_clock_ms
-    Rails.logger.info "Data processing took #{t5 - t1} seconds (#{t5 - t0} with I/O)."
+    Rails.logger.info "Data processing took #{(t5 - t1).round(2)}s (#{(t5 - t0).round(2)}s with I/O)."
+    Rails.logger.info "Agg scoring took #{(t2 - t1).round(2)}s,  #{(t3 - t2).round(2)}s."
 
     [rows_passing_filters, rows_total, rows]
   end


### PR DESCRIPTION
# Description

After a few hours of investigation with help from @jshoe , I concluded that 
1) `report_info` endpoint was the critical endpoint for the report table, taking up to 16s 
2) `fill_lineage_details` method was wasting the most time in `report_info`

I made a couple of changes to `fill_lineage_details` method to make `report_info` 2x faster (in local dev). 

1) avoiding active record and `as_json` by using `pluck` (6s)
2) using `Set` instead of array includes in inner loop (2s)

NOTE: 8s is still pretty slow for a webpage. For next steps, I recommend 

1) use gem OJ for faster json serialization (should get us 30% faster serialization across the whole app, see https://medium.com/infosimples/performance-comparison-for-json-generation-in-ruby-cc2cce55cf0b)
2) pre-compute `fill_lineage_details` on every pipeline run success
3) use gem 'fast_jsonapi' for even faster serialization of schematized json responses

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. try `report_info` endpoint for a very large sample such as id 10399 (14270 total rows)
2. see that TTL is reduced by 50% from ~16s to ~8s
3. see same report table
