### PR TITLE
Improve performance of bulk metadata upload with activerecord-import.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -403,7 +403,7 @@ class ProjectsController < ApplicationController
   def upload_metadata
     metadata = params[:metadata]
 
-    project_samples = current_power.project_samples(@project)
+    project_samples = current_power.project_samples(@project).includes(host_genome: [:metadata_fields], metadata: :metadata_field)
 
     errors = upload_metadata_for_samples(project_samples.to_a, metadata)
     render json: {


### PR DESCRIPTION
Also remove duplicate SQL queries.

Performance improvement of about 50x. (it was really bad before)

Uploading full metadata for 14 samples went from 12 seconds to 200ms.

---

Verified that integration tests pass, and metadata uploading still works on existing and new samples. Verified that Rails model validation is still being done with activerecord-import (for example, submitting "Test" for "Host Sex" correctly errors)