### PR TITLE
[Taxon Byteranges] Fix getter functions for fasta downloads

### DIFF
--- a/app/helpers/pipeline_outputs_helper.rb
+++ b/app/helpers/pipeline_outputs_helper.rb
@@ -146,7 +146,8 @@ module PipelineOutputsHelper
     uri_parts = uri.split("/", 4)
     bucket = uri_parts[2]
     key = uri_parts[3]
-    # Take the last taxon_byterange in case there are duplicate records (not supposed to happen)
+    # Take the last matching taxon_byterange in case there are duplicate records due to a previous
+    # bug (see IDSEQ-881)
     taxon_location = pipeline_run.taxon_byteranges.where(taxid: taxid, hit_type: hit_type).last if pipeline_run
     return '' if taxon_location.nil?
     resp = Client.get_object(bucket: bucket, key: key, range: "bytes=#{taxon_location.first_byte}-#{taxon_location.last_byte}")

--- a/app/helpers/pipeline_outputs_helper.rb
+++ b/app/helpers/pipeline_outputs_helper.rb
@@ -146,7 +146,8 @@ module PipelineOutputsHelper
     uri_parts = uri.split("/", 4)
     bucket = uri_parts[2]
     key = uri_parts[3]
-    taxon_location = pipeline_run.taxon_byteranges.find_by(taxid: taxid, hit_type: hit_type) if pipeline_run
+    # Take the last taxon_byterange in case there are duplicate records (not supposed to happen)
+    taxon_location = pipeline_run.taxon_byteranges.where(taxid: taxid, hit_type: hit_type).last if pipeline_run
     return '' if taxon_location.nil?
     resp = Client.get_object(bucket: bucket, key: key, range: "bytes=#{taxon_location.first_byte}-#{taxon_location.last_byte}")
     resp.body.read

--- a/app/jobs/result_monitor_loader.rb
+++ b/app/jobs/result_monitor_loader.rb
@@ -3,12 +3,8 @@ class ResultMonitorLoader
   @queue = :q03_pipeline_run
 
   def self.perform(pipeline_run_id, output)
-    Rails.logger.info("Loading #{output} for pipeline run #{pipeline_run_id}")
     pr = PipelineRun.find(pipeline_run_id)
-
-    # Just return if version is not yet set (likely a run just starting)
-    return if pr.pipeline_version.blank?
-
+    Rails.logger.info("Loading #{output} for pipeline run #{pipeline_run_id} (v#{pr.pipeline_version})")
     output_state = pr.output_states.find_by(output: output)
     begin
       output_state.update(state: PipelineRun::STATUS_LOADING)

--- a/app/jobs/result_monitor_loader.rb
+++ b/app/jobs/result_monitor_loader.rb
@@ -5,6 +5,10 @@ class ResultMonitorLoader
   def self.perform(pipeline_run_id, output)
     Rails.logger.info("Loading #{output} for pipeline run #{pipeline_run_id}")
     pr = PipelineRun.find(pipeline_run_id)
+
+    # Just return if version is not yet set (likely a run just starting)
+    return if pr.pipeline_version.blank?
+
     output_state = pr.output_states.find_by(output: output)
     begin
       output_state.update(state: PipelineRun::STATUS_LOADING)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -652,26 +652,15 @@ class PipelineRun < ApplicationRecord
   end
 
   def s3_file_for(output)
-    # Just return if version is not yet set (likely a run just starting)
-    return if pipeline_version.blank?
-
     case output
     when "ercc_counts"
       "#{host_filter_output_s3_path}/#{ERCC_OUTPUT_NAME}"
     when "amr_counts"
       "#{expt_output_s3_path}/#{AMR_FULL_RESULTS_NAME}"
     when "taxon_counts"
-      if pipeline_version.to_f >= ASSEMBLY_PIPELINE_VERSION
-        "#{postprocess_output_s3_path}/#{REFINED_TAXON_COUNTS_JSON_NAME}"
-      else
-        "#{alignment_output_s3_path}/#{taxon_counts_json_name}"
-      end
+      "#{postprocess_output_s3_path}/#{REFINED_TAXON_COUNTS_JSON_NAME}"
     when "taxon_byteranges"
-      if pipeline_version.to_f >= ASSEMBLY_PIPELINE_VERSION
-        "#{postprocess_output_s3_path}/#{REFINED_TAXID_BYTERANGE_JSON_NAME}"
-      else
-        "#{postprocess_output_s3_path}/#{TAXID_BYTERANGE_JSON_NAME}"
-      end
+      "#{postprocess_output_s3_path}/#{REFINED_TAXID_BYTERANGE_JSON_NAME}"
     when "contigs"
       "#{postprocess_output_s3_path}/#{ASSEMBLED_STATS_NAME}"
     when "contig_counts"

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -652,6 +652,10 @@ class PipelineRun < ApplicationRecord
   end
 
   def s3_file_for(output)
+    # This function assumes that pipeline_version has been set and is assembly-enabled (>=3.1) for
+    # taxon_counts/taxon_byteranges/contigs/contig_counts.
+    LogUtil.log_err_and_airbrake("s3_file_for was called without a pipeline_version for PR #{id}")
+
     case output
     when "ercc_counts"
       "#{host_filter_output_s3_path}/#{ERCC_OUTPUT_NAME}"

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -652,19 +652,22 @@ class PipelineRun < ApplicationRecord
   end
 
   def s3_file_for(output)
+    # Just return if version is not yet set (likely a run just starting)
+    return if pipeline_version.blank?
+
     case output
     when "ercc_counts"
       "#{host_filter_output_s3_path}/#{ERCC_OUTPUT_NAME}"
     when "amr_counts"
       "#{expt_output_s3_path}/#{AMR_FULL_RESULTS_NAME}"
     when "taxon_counts"
-      if pipeline_version && pipeline_version.to_f >= ASSEMBLY_PIPELINE_VERSION
+      if pipeline_version.to_f >= ASSEMBLY_PIPELINE_VERSION
         "#{postprocess_output_s3_path}/#{REFINED_TAXON_COUNTS_JSON_NAME}"
       else
         "#{alignment_output_s3_path}/#{taxon_counts_json_name}"
       end
     when "taxon_byteranges"
-      if pipeline_version && pipeline_version.to_f >= ASSEMBLY_PIPELINE_VERSION
+      if pipeline_version.to_f >= ASSEMBLY_PIPELINE_VERSION
         "#{postprocess_output_s3_path}/#{REFINED_TAXID_BYTERANGE_JSON_NAME}"
       else
         "#{postprocess_output_s3_path}/#{TAXID_BYTERANGE_JSON_NAME}"

--- a/bin/shell
+++ b/bin/shell
@@ -21,7 +21,7 @@ service = "idseq-#{env}-web"
 resp = ecs_client.describe_services(cluster: env, services: [service])
 service = resp.services.first
 
-task = ecs_client.list_tasks(cluster: env, service_name: "idseq-#{env}-web").task_arns[7]
+task = ecs_client.list_tasks(cluster: env, service_name: "idseq-#{env}-web").task_arns.first
 
 tasks = ecs_client.describe_tasks(cluster: env, tasks: [task])
 instances = ecs_client.describe_container_instances(cluster: env,
@@ -30,7 +30,5 @@ instances = ecs_client.describe_container_instances(cluster: env,
 resp = ec2_client.describe_instances(instance_ids: [instances.container_instances[0].ec2_instance_id])
 
 private_ip = resp.reservations.first.instances.first.private_ip_address
-
-puts private_ip
 
 exec %(ssh -t #{private_ip} "sudo docker exec -it \\`sudo docker ps | grep ecs-idseq-#{env}-web | head -1 | awk '{print \\$NF}'\\` bin/entrypoint.sh #{command} ")

--- a/bin/shell
+++ b/bin/shell
@@ -21,7 +21,7 @@ service = "idseq-#{env}-web"
 resp = ecs_client.describe_services(cluster: env, services: [service])
 service = resp.services.first
 
-task = ecs_client.list_tasks(cluster: env, service_name: "idseq-#{env}-web").task_arns.first
+task = ecs_client.list_tasks(cluster: env, service_name: "idseq-#{env}-web").task_arns[7]
 
 tasks = ecs_client.describe_tasks(cluster: env, tasks: [task])
 instances = ecs_client.describe_container_instances(cluster: env,
@@ -30,5 +30,7 @@ instances = ecs_client.describe_container_instances(cluster: env,
 resp = ec2_client.describe_instances(instance_ids: [instances.container_instances[0].ec2_instance_id])
 
 private_ip = resp.reservations.first.instances.first.private_ip_address
+
+puts private_ip
 
 exec %(ssh -t #{private_ip} "sudo docker exec -it \\`sudo docker ps | grep ecs-idseq-#{env}-web | head -1 | awk '{print \\$NF}'\\` bin/entrypoint.sh #{command} ")


### PR DESCRIPTION
- Going to put up another PR later with more fixes but this is the safest
- First change is changing a `pipeline_run.taxon_byteranges.find_by(taxid: taxid, hit_type: hit_type)` to `pipeline_run.taxon_byteranges.where(taxid: taxid, hit_type: hit_type).last` because it appears we had pipeline runs inserting byteranges from the previous run and then the correct one being inserted later. This enables a "quick fix" by calling db_load_byteranges on all the pipeline runs again and then fetching the last correct one. Then we will clean up all the duplicates (saving the last one) and correct the unique index on (pipeline_run_id, taxid, hit_type) since there's a unique index (pipeline_run_id, taxid, hit_type, tax_level) that's useless.
- Second is fixing an assumption in s3_file_for that was saying `if pipeline_version and assembly-enabled, load the new path; else load this old file` so the old file was being loaded when pipeline_version was not yet set in a new pipeline run. Add a log line in ResultMonitorLoader for pipeline version. Migrate s3_file_for to just use the new assembly paths to deprecate running < 3.1.
- Will need some more test jobs in staging.

### How to reproduce
- Go to a sample on this broken list: https://jira.czi.team/browse/IDSEQ-881
- Go to the console and run pipeline_run.db_load_byteranges
- Call `pipeline_run.taxon_byteranges.where(taxid: taxid, hit_type: hit_type)` and notice that the last entry is the correct one. Example: `=> #<ActiveRecord::AssociationRelation [#<TaxonByterange id: 132270753, taxid: 12059, first_byte: 10670019, last_byte: 10900167, created_at: nil, updated_at: nil, hit_type: "NT", tax_level: nil, pipeline_run_id: 23682>, #<TaxonByterange id: 134558333, taxid: 12059, first_byte: 4675807, last_byte: 4839836, created_at: nil, updated_at: nil, hit_type: "NT", tax_level: nil, pipeline_run_id: 23682>]>`
- Grabbing the last byterange will result in a valid fasta download (or deleting all but the last one)