### PR TITLE
Restrict phylo tree taxons to those present in selected project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'airbrake', '~> 8.3.2'
+gem 'airbrake', '~> 7.0'
 gem 'airbrake-ruby'
 gem 'aws-sdk-ecs'
 gem 'aws-sdk-resources'

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1343,6 +1343,7 @@ class RenderMarkup extends React.Component {
               serverSearchAction="choose_taxon"
               serverSearchActionArgs={{
                 // TODO (gdingle): change backend to support filter by sample_id
+                args: "species,genus",
                 project_id: parent.projectId
               }}
               onResultSelect={parent.searchSelectedTaxon}

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1340,6 +1340,7 @@ class RenderMarkup extends React.Component {
             <SearchBox
               rounded
               levelLabel
+              // TODO (gdingle): add filter?
               serverSearchAction="choose_taxon"
               onResultSelect={parent.searchSelectedTaxon}
               placeholder="Taxon name"

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1340,7 +1340,6 @@ class RenderMarkup extends React.Component {
             <SearchBox
               rounded
               levelLabel
-              // TODO (gdingle): add filter?
               serverSearchAction="choose_taxon"
               onResultSelect={parent.searchSelectedTaxon}
               placeholder="Taxon name"

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1341,6 +1341,10 @@ class RenderMarkup extends React.Component {
               rounded
               levelLabel
               serverSearchAction="choose_taxon"
+              serverSearchActionArgs={{
+                // TODO (gdingle): change backend to support filter by sample_id
+                project_id: parent.projectId
+              }}
               onResultSelect={parent.searchSelectedTaxon}
               placeholder="Taxon name"
             />

--- a/app/assets/src/components/ui/controls/SearchBox.jsx
+++ b/app/assets/src/components/ui/controls/SearchBox.jsx
@@ -129,7 +129,7 @@ SearchBox.propTypes = {
   // If serverSearchAction is provided, query matching will happen on the server side (use for large data).
   clientSearchSource: PropTypes.array,
   serverSearchAction: PropTypes.string,
-  serverSearchActionArgs: PropTypes.string,
+  serverSearchActionArgs: PropTypes.object,
   rounded: PropTypes.bool,
   category: PropTypes.bool,
   levelLabel: PropTypes.bool,

--- a/app/assets/src/components/ui/controls/SearchBox.jsx
+++ b/app/assets/src/components/ui/controls/SearchBox.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import cx from "classnames";
-import cs from "./search_box.scss";
+import PropTypes from "prop-types";
 import { Search } from "semantic-ui-react";
 import { escapeRegExp, debounce } from "lodash";
-import PropTypes from "prop-types";
+
+import cs from "./search_box.scss";
 import { get } from "../../../api";
+import { getURLParamString } from "~/helpers/url";
 
 class SearchBox extends React.Component {
   constructor(props) {
@@ -70,10 +72,9 @@ class SearchBox extends React.Component {
         const isMatch = result => re.test(result.title);
         searchResults = this.props.clientSearchSource.filter(isMatch);
       } else if (this.props.serverSearchAction) {
-        // TODO: (gdingle): pass in project filter here... append to CSV?
         let url = `/${this.props.serverSearchAction}?query=${this.state.value}`;
         if (this.props.serverSearchActionArgs) {
-          url += `&args=${this.props.serverSearchActionArgs}`;
+          url += `&${getURLParamString(this.props.serverSearchActionArgs)}`;
         }
         searchResults = await get(url);
         if (this.props.levelLabel) {

--- a/app/assets/src/components/ui/controls/SearchBox.jsx
+++ b/app/assets/src/components/ui/controls/SearchBox.jsx
@@ -70,6 +70,7 @@ class SearchBox extends React.Component {
         const isMatch = result => re.test(result.title);
         searchResults = this.props.clientSearchSource.filter(isMatch);
       } else if (this.props.serverSearchAction) {
+        // TODO: (gdingle): pass in project filter here... append to CSV?
         let url = `/${this.props.serverSearchAction}?query=${this.state.value}`;
         if (this.props.serverSearchActionArgs) {
           url += `&args=${this.props.serverSearchActionArgs}`;

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -139,6 +139,7 @@ class PhyloTreeCreation extends React.Component {
   }
 
   loadProjectSearchContext() {
+    // TODO (gdingle): add filter
     axios
       .get("/choose_project.json")
       .then(response => this.handleProjectSearchContextResponse(response))

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -139,7 +139,6 @@ class PhyloTreeCreation extends React.Component {
   }
 
   loadProjectSearchContext() {
-    // TODO (gdingle): add filter
     axios
       .get("/choose_project.json")
       .then(response => this.handleProjectSearchContextResponse(response))

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -461,7 +461,10 @@ class PhyloTreeCreation extends React.Component {
             <div className="wizard__page-2__searchbar__container">
               <SearchBox
                 serverSearchAction="choose_taxon"
-                serverSearchActionArgs="species,genus"
+                serverSearchActionArgs={{
+                  args: "species,genus",
+                  project_id: this.state.projectId
+                }}
                 onResultSelect={this.handleSelectTaxon}
                 initialValue={this.state.taxonName}
                 placeholder="Taxon name"

--- a/app/assets/src/helpers/url.js
+++ b/app/assets/src/helpers/url.js
@@ -5,7 +5,8 @@ import {
   isArray,
   toPairs,
   pickBy,
-  isPlainObject
+  isPlainObject,
+  isUndefined
 } from "lodash/fp";
 import { shortenUrl } from "~/api";
 import copy from "copy-to-clipboard";
@@ -32,7 +33,10 @@ export const parseUrlParams = () => {
 
 export const getURLParamString = params => {
   // Use isPlainObject to remove objects, but keep arrays.
-  const filtered = pickBy((v, k) => !isPlainObject(v), params);
+  const filtered = pickBy(
+    (v, k) => !isPlainObject(v) && !isUndefined(v),
+    params
+  );
   return toPairs(filtered)
     .map(
       ([key, value]) =>

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -85,6 +85,7 @@ class PhyloTreesController < ApplicationController
 
   def choose_taxon
     taxon_search_args = [params[:query]]
+    # TODO: (gdingle): pass in project filter here
     taxon_search_args << params[:args].split(",") if params[:args].present?
     taxon_list = taxon_search(*taxon_search_args)
     render json: JSON.dump(taxon_list)

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -85,8 +85,8 @@ class PhyloTreesController < ApplicationController
 
   def choose_taxon
     taxon_search_args = [params[:query]]
-    # TODO: (gdingle): pass in project filter here
     taxon_search_args << params[:args].split(",") if params[:args].present?
+    taxon_search_args << params[:project_id]
     taxon_list = taxon_search(*taxon_search_args)
     render json: JSON.dump(taxon_list)
   end

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -45,7 +45,6 @@ module ElasticsearchHelper
 
   # Took 250ms in local testing on real data
   def filter_by_project(matching_taxa, project_id)
-    # TODO: (gdingle): do we want both species and genus? only genus appears to be returned by TaxonCount
     project_tax_ids = Set.new(TaxonCount
       .joins(pipeline_run: { sample: :project })
       .where(samples: { project_id: project_id })

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -46,12 +46,12 @@ module ElasticsearchHelper
   # Took 250ms in local testing on real data
   def filter_by_project(matching_taxa, project_id)
     project_tax_ids = Set.new(TaxonCount
-      .joins(pipeline_run: { sample: :project })
+      .joins(pipeline_run: :sample)
       .where(samples: { project_id: project_id })
       .where(tax_id: [matching_taxa.map { |taxa| taxa["taxid"] }])
       .where("tax_id > 0") # negative numbers mean unknown... see TaxonLineage
       .where(count_type: ["NT", "NR"])
-      .where("count > ?", ReportHelper::MINIMUM_READ_THRESHOLD)
+      .where("count > 0")
       .distinct()
       .pluck(:tax_id))
 

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -51,7 +51,7 @@ module ElasticsearchHelper
       .where(tax_id: [matching_taxa.map { |taxa| taxa["taxid"] }])
       .where("tax_id > 0") # negative numbers mean unknown... see TaxonLineage
       .where(count_type: ["NT", "NR"])
-      .where("count > #{ReportHelper::MINIMUM_READ_THRESHOLD}")
+      .where("count > ?", ReportHelper::MINIMUM_READ_THRESHOLD)
       .distinct()
       .pluck(:tax_id))
 

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -19,9 +19,11 @@ module ElasticsearchHelper
     return {} if Rails.env == "test"
     prefix = sanitize(prefix)
     matching_taxa = {}
+
     tax_levels.each do |level|
       # TODO: (gdingle): pass in project filter here
       search_params = { query: { query_string: { query: "#{prefix}*", fields: ["#{level}_name"] } } }
+      # TODO: (gdingle): query taxon counts and see how expensive?
       TaxonLineage.__elasticsearch__.search(search_params).records.each do |record|
         name = record["#{level}_name"]
         taxid = record["#{level}_taxid"]
@@ -33,10 +35,23 @@ module ElasticsearchHelper
         }
       end
     end
-    matching_taxa.values
+    filter_by_project(matching_taxa.values)
   end
 
   private
+
+  def filter_by_project(matching_taxa, project_id)
+    # taxon_counts.pipeline_run_id -> pipeline_runs->sample_id -> samples.project_id
+    project_id = 70 # medical detectives
+    tax_ids = TaxonCount
+              .joins(:pipeline_run)
+              .joins(:sample)
+              .joins(:project)
+              .where(project: project_id)
+              .pluck(:taxid)
+    tax_ids = Set[tax_ids]
+    matching_taxa.filter { |_taxa| tax_ids.includes?(taxid) }
+  end
 
   def sanitize(prefix)
     # Add \\ to escape special characters. Four \ to escape the backslashes.

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -20,6 +20,7 @@ module ElasticsearchHelper
     prefix = sanitize(prefix)
     matching_taxa = {}
     tax_levels.each do |level|
+      # TODO: (gdingle): pass in project filter here
       search_params = { query: { query_string: { query: "#{prefix}*", fields: ["#{level}_name"] } } }
       TaxonLineage.__elasticsearch__.search(search_params).records.each do |record|
         name = record["#{level}_name"]

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -52,9 +52,6 @@ if ENV['AIRBRAKE_PROJECT_ID'] && ENV['AIRBRAKE_PROJECT_KEY']
     # Alternatively, you can integrate with Rails' filter_parameters.
     # Read more: https://goo.gl/gqQ1xS
     # c.blacklist_keys = Rails.application.config.filter_parameters
-
-    # For Performance Dashboard
-    c.performance_stats = true
   end
 
   # A filter that collects request body information. Enable it if you are sure you


### PR DESCRIPTION
# Description

This fixes the problem of trees on organisms that have no samples. 

![image](https://user-images.githubusercontent.com/28797/54465372-06d6ec80-4738-11e9-8390-45543962db6a.png)

Perf was a concern so I made sure it was fast enough for a big project ("medical detectives") at ~250ms.

Note: I'm not sure if the SQL query *exactly* defines what we want. Please advise.


# Test and Reproduce

1. Try endpoint with and without project_id, see different set
http://localhost:3000/choose_taxon?query=rub&args=species,genus
http://localhost:3000/choose_taxon?query=rub&args=species,genus&project_id=70

2. Try autocomplete with project, see results

3. Try autocomplete without project, see results
