### PR TITLE
Fix bug where project is invalid for remote samples.

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -128,7 +128,7 @@ module SamplesHelper
   end
 
   def parsed_samples_for_s3_path(s3_path, project_id, host_genome_id)
-    default_attributes = { project_id: project_id,
+    default_attributes = { project_id: project_id.to_i,
                            host_genome_id: host_genome_id,
                            status: 'created' }
     s3_path.chomp!('/')


### PR DESCRIPTION
`project_id` should be an integer. It's currently returned as a string, and then the front-end converts it. This changes it on the back-end.

This function is only used in `bulk_import`, to get files from an S3 bucket.

Tested the existing bulk upload and verified that it still works.