### PR TITLE
[Gems] Fix potential conflicts with Bundler 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.5
 
 # Install apt based dependencies required to run Rails as
 # well as RubyGems. As the Ruby image itself is based on a

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'bcrypt', '~> 3.1.7'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2', '>= 4.2.2'
 gem 'consul', '>= 0.13.1'
-gem 'devise', '4.3.0'
+gem 'devise', '4.4.0'
 gem "health_check", ">= 2.7.0"
 gem 'honeycomb-rails', '>= 0.8.1'
 gem 'mailgun_rails', '>= 0.9.0'

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'bcrypt', '~> 3.1.7'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2', '>= 4.2.2'
 gem 'consul', '>= 0.13.1'
-gem 'devise', '4.4.0'
+gem 'devise', '>= 4.6.0'
 gem "health_check", ">= 2.7.0"
 gem 'honeycomb-rails', '>= 0.8.1'
 gem 'mailgun_rails', '>= 0.9.0'
@@ -73,6 +73,9 @@ gem 'analytics-ruby', '~> 2.0.0', require: 'segment/analytics'
 
 # Url shortener
 gem 'shortener'
+
+# Explicit load to avoid an "unable to load" warning
+gem 'http-2'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -792,7 +792,7 @@ GEM
       thor (~> 0.19.4)
       tins (~> 1.6)
     crass (1.0.4)
-    devise (4.3.0)
+    devise (4.4.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.2)
@@ -1092,7 +1092,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2, >= 4.2.2)
   consul (>= 0.13.1)
   coveralls
-  devise (= 4.3.0)
+  devise (= 4.4.0)
   elasticsearch-model
   flamegraph
   health_check (>= 2.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -792,10 +792,10 @@ GEM
       thor (~> 0.19.4)
       tins (~> 1.6)
     crass (1.0.4)
-    devise (4.4.0)
+    devise (4.6.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 5.2)
+      railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
@@ -835,6 +835,7 @@ GEM
     honeycomb-rails (0.8.1)
       libhoney (>= 1.9)
       rails (>= 3.0.0)
+    http-2 (0.10.1)
     http (4.1.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -1092,11 +1093,12 @@ DEPENDENCIES
   coffee-rails (~> 4.2, >= 4.2.2)
   consul (>= 0.13.1)
   coveralls
-  devise (= 4.4.0)
+  devise (>= 4.6.0)
   elasticsearch-model
   flamegraph
   health_check (>= 2.7.0)
   honeycomb-rails (>= 0.8.1)
+  http-2
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   logging-rails


### PR DESCRIPTION
- Mark and I had some tricky issues building the Docker image with Bundler 2, which was introduced yesterday. Changing to Ruby 2.5 base solved it perhaps because Bundler 2 has references to requiring RubyGems 2.5.
- Of note, Travis CI / Tiago / Greg didn't seem to experience this issue.
- Changing to Ruby 2.5 required bumping Devise to 4.4 because of a bug in 4.3 that would throw a syntax error with Ruby 2.5. Just went to 4.6 due to security warning.
- Now we tested with the new image and it is working for us as well.