### PR TITLE
[S3 Uploads] Wrap s3 cp call in a retry block

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -273,11 +273,12 @@ class Sample < ApplicationRecord
           break
         end
 
+        Rails.logger.error("Try ##{try}: Upload of S3 sample '#{name}' (#{id}) file '#{fastq}' failed with: #{stderr}")
         try += 1
         sleep(10)
       end
 
-      # Log a final stderr after max tries if needed
+      # Record a final stderr after max tries if needed
       unless (status && status.exitstatus.zero?) && (stderr.empty? || stderr.include?(InputFile::S3_CP_PIPE_ERROR))
         stderr_array << stderr
       end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -271,11 +271,11 @@ class Sample < ApplicationRecord
           # errs like HeadObject Forbidden.
           # TODO: Consider refactoring this streaming copy to avoid hacks.
           break
+        else
+          Rails.logger.error("Try ##{try}: Upload of S3 sample '#{name}' (#{id}) file '#{fastq}' failed with: #{stderr}")
+          try += 1
+          sleep(10)
         end
-
-        Rails.logger.error("Try ##{try}: Upload of S3 sample '#{name}' (#{id}) file '#{fastq}' failed with: #{stderr}")
-        try += 1
-        sleep(10)
       end
 
       # Record a final stderr after max tries if needed


### PR DESCRIPTION
- Wrap the s3 cp calls to retry up to 3 times
- Tested in local console ex: Sample.last.initiate_s3_cp