### PR TITLE
Add access control tests for metadata endpoints.

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -33,7 +33,7 @@ class MetadataController < ApplicationController
     metadata = params[:metadata]
     samples_data = params[:samples]
 
-    projects = current_power.projects
+    projects = current_power.updatable_projects
                             .where(id: samples_data.map { |sample| sample["project_id"] }.uniq)
                             .includes(:metadata_fields).to_a
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,10 +16,9 @@ class ProjectsController < ApplicationController
   READ_ACTIONS = [
     :show, :add_favorite, :remove_favorite, :make_host_gene_counts, :host_gene_counts_status,
     :send_host_gene_counts, :make_project_reports_csv, :project_reports_csv_status,
-    :send_project_reports_csv, :validate_metadata_csv, :upload_metadata,
-    :validate_sample_names
+    :send_project_reports_csv, :validate_sample_names
   ].freeze
-  EDIT_ACTIONS = [:edit, :update, :destroy, :add_user, :all_users, :update_project_visibility].freeze
+  EDIT_ACTIONS = [:edit, :update, :destroy, :add_user, :all_users, :update_project_visibility, :upload_metadata, :validate_metadata_csv].freeze
   OTHER_ACTIONS = [:choose_project, :create, :dimensions, :index, :metadata_fields, :new, :send_project_csv].freeze
 
   # Required for token auth for CLI actions
@@ -416,9 +415,15 @@ class ProjectsController < ApplicationController
   def metadata_fields
     project_ids = (params[:projectIds] || []).map(&:to_i)
 
-    render json: current_power.projects.where(id: project_ids)
-      .includes(metadata_fields: [:host_genomes])
-                              .map(&:metadata_fields).flatten.map(&:field_info)
+    results = if project_ids.length == 1
+                current_power.projects.find(project_ids[0]).metadata_fields.map(&:field_info)
+              else
+                current_power.projects.where(id: project_ids)
+                             .includes(metadata_fields: [:host_genomes])
+                             .map(&:metadata_fields).flatten.uniq.map(&:field_info)
+              end
+
+    render json: results
   end
 
   # TODO: Consider consolidating into a general sample validator

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -406,6 +406,7 @@ class SamplesController < ApplicationController
     samples_to_upload = samples_params || []
     metadata = params[:metadata] || {}
     client = params[:client]
+    errors = []
 
     # Check if the client is up-to-date. "web" is always valid whereas the
     # CLI client should provide a version string to-be-checked against the
@@ -423,18 +424,21 @@ class SamplesController < ApplicationController
 
     samples_to_upload, samples_invalid_projects = samples_to_upload.partition { |sample| editable_project_ids.include?(Integer(sample["project_id"])) }
 
-    errors, samples = upload_samples_with_metadata(samples_to_upload, metadata).values_at("errors", "samples")
-
-    # For each sample with an invalid project ID, add an error.
+    # For invalid projects, don't attempt to upload metadata.
     samples_invalid_projects.each do |sample|
+      metadata.delete(sample["name"])
       errors << SampleUploadErrors.invalid_project_id(sample)
     end
+
+    upload_errors, samples = upload_samples_with_metadata(samples_to_upload, metadata).values_at("errors", "samples")
+
+    errors.concat(upload_errors)
 
     # After creation, if a sample is missing required metadata, destroy it.
     # TODO(mark): Move this logic into a validator in the model in the future.
     # Hard to do right now because this isn't launched yet, and also many existing samples don't have required metadata.
     removed_samples = []
-    samples.each do |sample|
+    samples.includes(host_genome: [:metadata_fields], project: [:metadata_fields], metadata: [:metadata_field]).each do |sample|
       missing_required_metadata_fields = sample.missing_required_metadata_fields
       unless missing_required_metadata_fields.empty?
         errors << SampleUploadErrors.missing_required_metadata(sample, missing_required_metadata_fields.pluck(:name))

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -115,7 +115,7 @@ class Sample < ApplicationRecord
 
   def required_metadata_fields
     # Don't use "where", as this will trigger another SQL query when used inside loops.
-    host_genome.metadata_fields.select { |x| x.is_required == 1 }
+    (host_genome.metadata_fields & project.metadata_fields).select { |x| x.is_required == 1 }
   end
 
   def missing_required_metadata_fields

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -59,7 +59,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     @joe_project = projects(:joe_project)
     get "/samples.json?project_id=#{@joe_project.id}"
     assert_response :success
-    assert JSON.parse(@response.body)["count"] == 3
+    assert JSON.parse(@response.body)["count"] == 4
   end
 
   test 'joe cannot see samples in project one' do
@@ -73,14 +73,14 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     @project = projects(:two)
     get "/samples.json?project_id=#{@project.id}"
     assert_response :success
-    assert JSON.parse(@response.body)["count"] == 1
+    assert JSON.parse(@response.body)["count"] == 2
   end
 
   test 'joe can see samples in public_project' do
     @public_project = projects(:public_project)
     get "/samples.json?project_id=#{@public_project.id}"
     assert_response :success
-    assert JSON.parse(@response.body)["count"] == 3
+    assert JSON.parse(@response.body)["count"] == 4
   end
   # ===== END: /samples/index
 
@@ -89,7 +89,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     @joe_project = projects(:joe_project)
     get "/samples/index_v2.json?projectId=#{@joe_project.id}"
     assert_response :success
-    assert JSON.parse(@response.body)["samples"].count == 3
+    assert JSON.parse(@response.body)["samples"].count == 4
   end
 
   test 'joe cannot see samples in project one with index_v2' do
@@ -103,32 +103,32 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     @project = projects(:two)
     get "/samples/index_v2.json?projectId=#{@project.id}"
     assert_response :success
-    assert JSON.parse(@response.body)["samples"].count == 1
+    assert JSON.parse(@response.body)["samples"].count == 2
   end
 
   test 'joe can see samples in public_project with index_v2' do
     @public_project = projects(:public_project)
     get "/samples/index_v2.json?projectId=#{@public_project.id}"
     assert_response :success
-    assert JSON.parse(@response.body)["samples"].count == 3
+    assert JSON.parse(@response.body)["samples"].count == 4
   end
 
   test 'joe sees samples in its data set with index_v2' do
     get "/samples/index_v2.json?domain=library"
     assert_response :success
-    assert JSON.parse(@response.body)["samples"].count == 3
+    assert JSON.parse(@response.body)["samples"].count == 4
   end
 
   test 'joe sees samples that are public domain with index_v2' do
     get "/samples/index_v2.json?domain=public"
     assert_response :success
-    assert JSON.parse(@response.body)["samples"].count == 4
+    assert JSON.parse(@response.body)["samples"].count == 6
   end
 
   test 'joe sees the samples that he has access to with index_v2' do
     get "/samples/index_v2.json"
     assert_response :success
-    assert JSON.parse(@response.body)["samples"].count == 7
+    assert JSON.parse(@response.body)["samples"].count == 10
   end
   # ===== END: /samples/index_v2
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -4,9 +4,13 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @project = projects(:one)
     @metadata_validation_project = projects(:metadata_validation_project)
+    @joe_project = projects(:joe_project)
+    @public_project = projects(:public_project)
     @deletable_project = projects(:deletable_project)
     @user = users(:one)
     @user_params = { 'user[email]' => @user.email, 'user[password]' => 'password' }
+    @user_nonadmin = users(:joe)
+    @user_nonadmin_params = { 'user[email]' => @user_nonadmin.email, 'user[password]' => 'passwordjoe' }
   end
 
   test 'should get index' do
@@ -79,5 +83,61 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_equal ['Test One', 'Test One_1', 'Test One_1_1'], @response.parsed_body
+  end
+
+  test 'joe can query the metadata fields that belong to a public project' do
+    post user_session_path, params: @user_nonadmin_params
+
+    get metadata_fields_projects_url, params: {
+      projectIds: [@public_project.id]
+    }
+    assert_response :success
+
+    assert_equal ["Nucleotide Type", "Sample Type"], @response.parsed_body.pluck("name")
+  end
+
+  test 'joe can query the metadata fields that belong to a private project he is a part of' do
+    post user_session_path, params: @user_nonadmin_params
+
+    get metadata_fields_projects_url, params: {
+      projectIds: [@joe_project.id]
+    }
+    assert_response :success
+
+    assert_equal ["Nucleotide Type", "Age", "Reported Sex", "Sex", "Sample Type", "Admission Date", "Blood Fed"], @response.parsed_body.pluck("name")
+  end
+
+  test 'joe cannot query the metadata fields that belong to another private project' do
+    post user_session_path, params: @user_nonadmin_params
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      get metadata_fields_projects_url, params: {
+        projectIds: [@metadata_validation_project.id]
+      }
+    end
+  end
+
+  # If multiple samples, merge the fields.
+  test 'joe can query the metadata fields that belong to multiple projects' do
+    post user_session_path, params: @user_nonadmin_params
+
+    get metadata_fields_projects_url, params: {
+      projectIds: [@public_project.id, @joe_project.id]
+    }
+    assert_response :success
+
+    assert_equal ["Nucleotide Type", "Age", "Reported Sex", "Sex", "Sample Type", "Admission Date", "Blood Fed"], @response.parsed_body.pluck("name")
+  end
+
+  # If multiple samples but one is invalid, return fields for the valid ones.
+  test 'joe can query the metadata fields that belong to multiple projects, and invalid projects will be omitted.' do
+    post user_session_path, params: @user_nonadmin_params
+
+    get metadata_fields_projects_url, params: {
+      projectIds: [@public_project.id, @metadata_validation_project.id]
+    }
+    assert_response :success
+
+    assert_equal ["Nucleotide Type", "Sample Type"], @response.parsed_body.pluck("name")
   end
 end

--- a/test/controllers/projects_metadata_upload_test.rb
+++ b/test/controllers/projects_metadata_upload_test.rb
@@ -6,13 +6,17 @@ class ProjectsMetadataUploadTest < ActionDispatch::IntegrationTest
 
   setup do
     @project = projects(:one)
+    @public_project = projects(:public_project)
+    @joe_project = projects(:joe_project)
     @metadata_validation_project = projects(:metadata_validation_project)
     @metadata_validation_sample_human = samples(:metadata_validation_sample_human)
-    @deletable_project = projects(:deletable_project)
+    @joe_project_sample_a = samples(:joe_project_sampleA)
     @user = users(:one)
     @core_field = metadata_fields(:core_field)
     @user_params = { 'user[email]' => @user.email, 'user[password]' => 'password' }
     @host_genome_human = host_genomes(:human)
+    @user_nonadmin = users(:joe)
+    @user_nonadmin_params = { 'user[email]' => @user_nonadmin.email, 'user[password]' => 'passwordjoe' }
   end
 
   test 'metadata upload basic' do
@@ -116,5 +120,56 @@ class ProjectsMetadataUploadTest < ActionDispatch::IntegrationTest
     assert @metadata_validation_project.metadata_fields.pluck(:name).include?("Custom Field 2")
     assert @host_genome_human.metadata_fields.pluck(:name).include?("Custom Field")
     assert @host_genome_human.metadata_fields.pluck(:name).include?("Custom Field 2")
+  end
+
+  test 'joe cannot upload metadata to a public project' do
+    post user_session_path, params: @user_nonadmin_params
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      post upload_metadata_project_url(@public_project), params: {
+        metadata: {
+          'metadata_validation_sample_human' => {
+            'sex' => 'Female',
+            'age' => 100,
+            'admission_date' => '2018-01-01'
+          }
+        }
+      }, as: :json
+    end
+  end
+
+  test 'joe cannot upload metadata to another private project' do
+    post user_session_path, params: @user_nonadmin_params
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      post upload_metadata_project_url(@metadata_validation_project), params: {
+        metadata: {
+          'metadata_validation_sample_human' => {
+            'sex' => 'Female',
+            'age' => 100,
+            'admission_date' => '2018-01-01'
+          }
+        }
+      }, as: :json
+    end
+  end
+
+  test 'joe can upload metadata to a private project he is a member of' do
+    post user_session_path, params: @user_nonadmin_params
+
+    post upload_metadata_project_url(@joe_project), params: {
+      metadata: {
+        'joe_project_sampleA' => {
+          'sex' => 'Female',
+          'age' => 100,
+          'admission_date' => '2018-01-01'
+        }
+      }
+    }, as: :json
+
+    assert_response :success
+
+    assert_equal 0, @response.parsed_body['errors'].length
+    assert_equal 3, Metadatum.where(sample_id: @joe_project_sample_a.id).length
   end
 end

--- a/test/fixtures/metadata.yml
+++ b/test/fixtures/metadata.yml
@@ -13,3 +13,47 @@ sample_human_nucleotide_type:
   string_validated_value: "RNA"
   sample: metadata_validation_sample_human_existing_metadata
   metadata_field: nucleotide_type
+
+# Metadata for private joe project.
+sample_human_private_sex:
+  key: "sex"
+  raw_value: "Male"
+  string_validated_value: "Male"
+  sample: sample_human_existing_metadata_joe_project
+  metadata_field: sex
+
+sample_human_private_sample_type:
+  key: "sample_type"
+  raw_value: "Blood"
+  string_validated_value: "Blood"
+  sample: sample_human_existing_metadata_joe_project
+  metadata_field: sample_type
+
+# Metadata for public project
+sample_human_public_sex:
+  key: "sex"
+  raw_value: "Male"
+  string_validated_value: "Male"
+  sample: sample_human_existing_metadata_public
+  metadata_field: sex
+
+sample_human_public_nucleotide_type:
+  key: "nucleotide_type"
+  raw_value: "RNA"
+  string_validated_value: "RNA"
+  sample: sample_human_existing_metadata_public
+  metadata_field: nucleotide_type
+
+sample_human_expired_sex:
+  key: "sex"
+  raw_value: "Male"
+  string_validated_value: "Male"
+  sample: sample_human_existing_metadata_expired
+  metadata_field: sex
+
+sample_human_expired_age:
+  key: "age"
+  raw_value: "100"
+  number_validated_value: 100
+  sample: sample_human_existing_metadata_expired
+  metadata_field: age

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -5,6 +5,7 @@ one:
 
 two:
   name: Project 2
+  metadata_fields: [age]
 
 deletable_project:
   name: Empty project
@@ -12,10 +13,12 @@ deletable_project:
 public_project:
   name: Public Project
   public_access: 1
+  metadata_fields: [sample_type, nucleotide_type]
 
 joe_project:
   name: Project 3
   users: [joe]
+  metadata_fields: [sample_type, nucleotide_type, age, admission_date, blood_fed, reported_sex, sex]
 
 metadata_validation_project:
   name: Metadata Project

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -12,6 +12,7 @@ expired_sample:
   name: expired_sample
   created_at: '2016-01-31 23:41:59'
   project: two
+  host_genome: human
 
 public_sample:
   name: public_sample
@@ -39,14 +40,17 @@ public_project_sampleA:
 public_project_sampleB:
   name: public_project_sampleB
   project: public_project
+  host_genome: human
 
 joe_project_sampleB:
   name: joe_project_sampleB
   project: joe_project
+  host_genome: human
 
 joe_project_sampleA:
   name: joe_project_sampleA
   project: joe_project
+  host_genome: human
 
 project_one_sampleA:
   name: project_one_sampleA_run
@@ -70,3 +74,19 @@ metadata_validation_sample_human_existing_metadata:
   name: metadata_validation_sample_human_existing_metadata
   project: metadata_validation_project
   host_genome: human
+
+sample_human_existing_metadata_public:
+  name: sample_human_existing_metadata_public
+  project: public_project
+  host_genome: human
+
+sample_human_existing_metadata_joe_project:
+  name: sample_human_existing_metadata_joe_project
+  project: joe_project
+  host_genome: human
+
+sample_human_existing_metadata_expired:
+  name: sample_human_existing_metadata_expired
+  project: two
+  host_genome: human
+  created_at: '2016-01-31 23:41:59'


### PR DESCRIPTION
Also modify 'validate' endpoints to be edit actions, since they are tied to a write action ('upload')

Verified that uploading to new samples and to existing samples still works. Verify that performance via SQL queries was not impacted.

**Added tests**:

bulkUploadWithMetadata

- Test that users can’t upload to private project.
- Test that users can’t upload to public project.
- Test that users can upload to their own project.

getOfficialMetadataFields

- Always the same for all users. No custom metadata is displayed, so no access control tests needed.

getSampleMetadata

- Users can see metadata of their own sample.
- User can see metadata for public sample.
- User can see metadata for expired sample.
- User cannot see metadata of private sample.

getSampleMetadataFields

- Users can see metadata field of their own sample.
- User can see metadata field for public sample.
- User can see metadata field for expired sample.
- User cannot see metadata  field of private sample.
- If multiple samples, just show visible ones.

getProjectMetadataFIelds

- Users can see metadata field of their own project.
- User can see metadata field for public project.
- User cannot see metadata field of private project.
- If multiple project, just show visible ones.

saveSampleMetadata

- Users can save metadata field of their own sample.
- User cannot save to anything else (expired, public, private).

uploadMetadataForProject

- Can upload to own project.
- Cannot upload to public or private project.

validateManualMetadataForProject

- Can validate against own project
- Cannot validate against public or private project.

validateManualMetadataForNewSamples

- Can validate against own project
- Cannot validate against public or private project.

