### PR TITLE
[S3 Uploads] Replace commands with Open3.pipeline for granular status checking

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -275,8 +275,8 @@ class Sample < ApplicationRecord
       stderr = err_read.read
 
       # Ignore proc_download and proc_unzip status because they will always throw exit 1 and
-      # SIGPIPE 13 'pipe broken' unless the entire file was headed. But we still want to see stderrs
-      # like HeadObject Forbidden.
+      # SIGPIPE 13 'pipe broken' unless the entire file was headed. Ignore pipe error in stderr but
+      # we still want to see errs like HeadObject Forbidden.
       unless to_check.all? { |p| p && p.exitstatus && p.exitstatus.zero? } && (stderr.empty? || stderr.include?(InputFile::S3_CP_PIPE_ERROR))
         stderr_array << stderr
       end


### PR DESCRIPTION
- Commands do the same actions as before but using Open3.pipeline instead of Open3.capture3.

### How I tested
- Tested in my local console and called ex Sample.last.initiate_s3_cp while setting the input_files.sources to both fq and fq.gz files.
- Happy path: Verified that the commands worked and the files appeared completely in the development bucket.
- Sad path: Verified that the same error behavior was handled

### Example of what the procs look like with the broken pipe warning
```
irb(main):315:0> err_read, err_write = IO.pipe
=> [#<IO:fd 74>, #<IO:fd 75>]
irb(main):316:0> proc_download, proc_unzip, proc_head, proc_zip, proc_upload = Open3.pipeline(
irb(main):317:1*     ["aws", "s3", "cp", fastq, "-"],
irb(main):318:1*     "gzip -dc",
irb(main):319:1*     ["head", "-n", max_lines.to_s],
irb(main):320:1*     "gzip -c",
irb(main):321:1*     ["aws", "s3", "cp", "-", "s3://dst/object"],
irb(main):322:1*     :err => err_write
irb(main):323:1> )
=> [#<Process::Status: pid 1522 exit 1>, #<Process::Status: pid 1524 SIGPIPE (signal 13)>, #<Process::Status: pid 1526 exit 0>, #<Process::Status: pid 1528 exit 0>, #<Process::Status: pid 1530 exit 0>]
irb(main):324:0> err_write.close
=> nil
irb(main):325:0> stderr = err_read.read
=> "download failed: s3://bucket/object to - [Errno 32] Broken pipe\n"
```

### Example of the warnings we'll still get
`[2019-03-21T00:22:30] ERROR Rails : Failed to upload S3 sample 'afewafdasfweafaewf' (12541): download failed: s3://test/bucket/here.fq.gz to - An error occurred (403) when calling the HeadObject operation: Forbidden`