### PR TITLE
[S3 Uploads] Wrap s3 copy in retries

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -250,35 +250,49 @@ class Sample < ApplicationRecord
       fastq = input_file.source
       total_reads_json_path = File.join(File.dirname(fastq.to_s), TOTAL_READS_JSON)
 
-      # Run the piped commands and save stderr
-      err_read, err_write = IO.pipe
-      if fastq =~ /\.gz/
-        _proc_download, _proc_unzip, proc_head, proc_zip, proc_upload = Open3.pipeline(
-          ["aws", "s3", "cp", fastq, "-"],
-          "gzip -dc",
-          ["head", "-n", max_lines.to_s],
-          "gzip -c",
-          ["aws", "s3", "cp", "-", "#{sample_input_s3_path}/#{input_file.name}"],
-          err: err_write
-        )
-        to_check = [proc_head, proc_zip, proc_upload]
-      else
-        _proc_download, proc_head, proc_upload = Open3.pipeline(
-          ["aws", "s3", "cp", fastq, "-"],
-          ["head", "-n", max_lines.to_s],
-          ["aws", "s3", "cp", "-", "#{sample_input_s3_path}/#{input_file.name}"],
-          err: err_write
-        )
-        to_check = [proc_head, proc_upload]
-      end
-      err_write.close
-      stderr = err_read.read
+      # Retry s3 cp up to 3 times
+      max_tries = 3
+      try = 0
+      while try < max_tries
+        # Run the piped commands and save stderr
+        err_read, err_write = IO.pipe
+        if fastq =~ /\.gz/
+          _proc_download, _proc_unzip, proc_head, proc_zip, proc_upload = Open3.pipeline(
+            ["aws", "s3", "cp", fastq, "-"],
+            "gzip -dc",
+            ["head", "-n", max_lines.to_s],
+            "gzip -c",
+            ["aws", "s3", "cp", "-", "#{sample_input_s3_path}/#{input_file.name}"],
+            err: err_write
+          )
+          to_check = [proc_head, proc_zip, proc_upload]
+        else
+          _proc_download, proc_head, proc_upload = Open3.pipeline(
+            ["aws", "s3", "cp", fastq, "-"],
+            ["head", "-n", max_lines.to_s],
+            ["aws", "s3", "cp", "-", "#{sample_input_s3_path}/#{input_file.name}"],
+            err: err_write
+          )
+          to_check = [proc_head, proc_upload]
+        end
+        err_write.close
+        stderr = err_read.read
 
-      # Ignore proc_download and proc_unzip status because they will always throw exit 1 and
-      # SIGPIPE 13 'pipe broken' unless the entire file was headed. Ignore pipe error in stderr but
-      # we still want to see errs like HeadObject Forbidden.
-      unless to_check.all? { |p| p && p.exitstatus && p.exitstatus.zero? } && (stderr.empty? || stderr.include?(InputFile::S3_CP_PIPE_ERROR))
-        stderr_array << stderr
+        # Ignore proc_download and proc_unzip status because they will always throw exit 1 and
+        # SIGPIPE 13 'pipe broken' unless the entire file was headed. Ignore pipe error in stderr but
+        # we still want to see errs like HeadObject Forbidden.
+        if to_check.all? { |p| p && p.exitstatus && p.exitstatus.zero? } && (stderr.empty? || stderr.include?(InputFile::S3_CP_PIPE_ERROR))
+          # Success
+          break
+        else
+          # Try again
+          Rails.logger.error("Try ##{try}: Upload of S3 sample '#{name}' (#{id}) file '#{fastq}' failed with: #{stderr}")
+          try += 1
+
+          # Record final stderr if exceeding max tries
+          stderr_array << stderr if try == max_tries
+          sleep(10)
+        end
       end
     end
 
@@ -296,10 +310,8 @@ class Sample < ApplicationRecord
       _stdout, stderr, status = Open3.capture3("aws", "s3", "cp", s3_preload_result_path.to_s, sample_output_s3_path.to_s, "--recursive")
       stderr_array << stderr unless status.exitstatus.zero?
     end
-    unless stderr_array.empty?
-      LogUtil.log_err_and_airbrake("Failed to upload S3 sample '#{name}' (#{id}): #{stderr_array[0]}")
-      raise stderr_array[0]
-    end
+
+    raise stderr_array.join(" ") unless stderr_array.empty?
 
     self.status = STATUS_UPLOADED
     save # this triggers pipeline command


### PR DESCRIPTION
- Simple retries around the s3 cp commands
- Also removes a redundant Airbrake below because the same line was being posted twice
- Tested in local console by setting input_files.source to S3 paths and calling sample.initiate_s3_cp

### Sad path
```
[2019-03-21T19:56:39] ERROR Rails : Try #0: Upload of S3 sample 'afewafdasfweafaewf' (12541) file 's3://test/bucket/here.fq.gz' failed with: download failed: s3://test/bucket/here.fq.gz to - An error occurred (403) when calling the HeadObject operation: Forbidden

gzip: stdin: unexpected end of file

[2019-03-21T19:56:50] ERROR Rails : Try #1: Upload of S3 sample 'afewafdasfweafaewf' (12541) file 's3://test/bucket/here.fq.gz' failed with: download failed: s3://test/bucket/here.fq.gz to - An error occurred (403) when calling the HeadObject operation: Forbidden

gzip: stdin: unexpected end of file

[2019-03-21T19:57:02] ERROR Rails : Try #2: Upload of S3 sample 'afewafdasfweafaewf' (12541) file 's3://test/bucket/here.fq.gz' failed with: download failed: s3://test/bucket/here.fq.gz to - An error occurred (403) when calling the HeadObject operation: Forbidden

gzip: stdin: unexpected end of file

[2019-03-21T19:57:17] ERROR Rails : Failed to upload S3 sample 'afewafdasfweafaewf' (12541): download failed: s3://test/bucket/here.fq.gz to - An error occurred (403) when calling the HeadObject operation: Forbidden

gzip: stdin: unexpected end of file
```

### Happy path
```
[2019-03-21T19:58:10] DEBUG ActiveRecord::Base :   Sample Load (0.7ms)  SELECT  `samples`.* FROM `samples` ORDER BY `samples`.`id` DESC LIMIT 1
[2019-03-21T19:58:10] DEBUG ActiveRecord::Base :   InputFile Load (0.7ms)  SELECT `input_files`.* FROM `input_files` WHERE `input_files`.`sample_id` = 12541
[2019-03-21T19:58:10] DEBUG ActiveRecord::Base : Query Trace:
      app/models/sample.rb:249:in `initiate_s3_cp'
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base :    (0.6ms)  BEGIN
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base :   Project Load (2.7ms)  SELECT  `projects`.* FROM `projects` WHERE `projects`.`id` = 278 LIMIT 1
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base : Query Trace:
      app/models/sample.rb:317:in `initiate_s3_cp'
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base :   Sample Exists (2.9ms)  SELECT  1 AS one FROM `samples` WHERE `samples`.`name` = BINARY 'afewafdasfweafaewf' AND (`samples`.`id` != 12541) AND `samples`.`project_id` = 278 LIMIT 1
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base : Query Trace:
      app/models/sample.rb:317:in `initiate_s3_cp'
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base :   HostGenome Load (1.9ms)  SELECT  `host_genomes`.* FROM `host_genomes` WHERE `host_genomes`.`id` = 1 LIMIT 1
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base : Query Trace:
      app/models/sample.rb:382:in `check_host_genome'
      app/models/sample.rb:317:in `initiate_s3_cp'
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base :   PipelineRun Load (2.5ms)  SELECT  `pipeline_runs`.* FROM `pipeline_runs` WHERE `pipeline_runs`.`sample_id` = 12541 ORDER BY `pipeline_runs`.`created_at` DESC LIMIT 1
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base : Query Trace:
      app/models/sample.rb:418:in `check_status'
      app/models/sample.rb:317:in `initiate_s3_cp'
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base :   PipelineRun Exists (5.7ms)  SELECT  1 AS one FROM `pipeline_runs` WHERE `pipeline_runs`.`sample_id` = 12541 AND (job_status != 'FAILED' OR job_status IS NULL) AND `pipeline_runs`.`finalized` = 0 LIMIT 1
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base : Query Trace:
      app/models/sample.rb:557:in `kickoff_pipeline'
      app/models/sample.rb:425:in `check_status'
      app/models/sample.rb:317:in `initiate_s3_cp'
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base :   SQL (0.8ms)  UPDATE `samples` SET `status` = 'checked', `updated_at` = '2019-03-21 19:58:15' WHERE `samples`.`id` = 12541
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base : Query Trace:
      app/models/sample.rb:317:in `initiate_s3_cp'
[2019-03-21T19:58:15] DEBUG ActiveRecord::Base :    (2.4ms)  COMMIT
=> true
```