### PR TITLE
Use dockerhub image instead for elasticsearch.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ x-honeycomb-variables: &honeycomb-variables
 version: '3.4'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.1
+    image: elasticsearch:6.6.2
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,8 @@ x-honeycomb-variables: &honeycomb-variables
 version: '3.4'
 services:
   elasticsearch:
-    image: elasticsearch:6.6.2
+    image: elasticsearch:6.4.3
+
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true


### PR DESCRIPTION
* Unblocks travis
* Only affects dev environment
* Reduce the likelihood of problems (since we load almost everything from dockerhub)
* AWS suggests upgrading ElasticSearch to 6.4
TODO: Upgrade ElasticSearch in staging (and later prod) to 6.4