### PR TITLE
Fix multiple back arrows needed to go back from a report

### DIFF
--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -89,7 +89,7 @@ class SampleView extends React.Component {
       window.location = url;
     } else {
       try {
-        history.pushState(window.history.state, document.title, url);
+        history.replaceState(window.history.state, document.title, url);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error(e);


### PR DESCRIPTION
- Problem was that right now going back to the samples/project from a report page would take 3 presses of the back arrow because history.pushState gets called. This will probably seem buggy to the users when browsing.
- Seems like we can just safely replace with replaceState

![Mar-22-2019 14-43-58](https://user-images.githubusercontent.com/5652739/54854693-fdf29780-4cb0-11e9-887a-e939ca15d86d.gif)
