### PR TITLE
[Align Viz] Fix error display blanking out the page

### DIFF
--- a/app/assets/src/components/views/AlignmentViz.jsx
+++ b/app/assets/src/components/views/AlignmentViz.jsx
@@ -42,49 +42,55 @@ class AlignmentViz extends React.Component {
 
   render() {
     const { loading, alignmentData, pipelineRun } = this.state;
-    return loading ? (
-      <div>
-        <h2 className={cs.heading}>
-          Loading alignment data for {this.taxName} ({this.taxLevel}) ...
-        </h2>
-      </div>
-    ) : (
-      <div>
-        <h2 className={cs.heading}>
-          {this.taxName ? this.taxName + " (" + this.taxLevel + ")" : ""}
-          Alignment ({alignmentData.length} unique accessions)
-          {pipelineRun &&
-            pipelineVersionHasAssembly(pipelineRun.pipeline_version) && (
-              <Popup
-                trigger={
-                  <i
-                    className={cx("fa fa-exclamation-circle", cs.warningIcon)}
-                  />
-                }
-                position="bottom left"
-                content={`
+    if (loading) {
+      return (
+        <div>
+          <h2 className={cs.heading}>
+            Loading alignment data for {this.taxName} ({this.taxLevel}) ...
+          </h2>
+        </div>
+      );
+    } else if (Array.isArray(alignmentData)) {
+      return (
+        <div>
+          <h2 className={cs.heading}>
+            {this.taxName ? this.taxName + " (" + this.taxLevel + ")" : ""}
+            Alignment ({alignmentData.length} unique accessions)
+            {pipelineRun &&
+              pipelineVersionHasAssembly(pipelineRun.pipeline_version) && (
+                <Popup
+                  trigger={
+                    <i
+                      className={cx("fa fa-exclamation-circle", cs.warningIcon)}
+                    />
+                  }
+                  position="bottom left"
+                  content={`
                 Only alignments of individual reads are listed. Contig assembly is not currently included.
               `}
-                inverted
-                wide="very"
-                horizontalOffset={4}
-                className={cs.popup}
-              />
-            )}
-        </h2>
-        <div className={cs.accessionViz}>
-          {alignmentData.map(function(item, i) {
-            return (
-              <AccessionViz
-                key={`accession_${i}`}
-                readsPerPage={this.readsPerPage}
-                {...item}
-              />
-            );
-          }, this)}
+                  inverted
+                  wide="very"
+                  horizontalOffset={4}
+                  className={cs.popup}
+                />
+              )}
+          </h2>
+          <div className={cs.accessionViz}>
+            {alignmentData.map(function(item, i) {
+              return (
+                <AccessionViz
+                  key={`accession_${i}`}
+                  readsPerPage={this.readsPerPage}
+                  {...item}
+                />
+              );
+            }, this)}
+          </div>
         </div>
-      </div>
-    );
+      );
+    } else {
+      return <div>{alignmentData.error}</div>;
+    }
   }
 }
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -713,7 +713,7 @@ class SamplesController < ApplicationController
     @taxon_info = params[:taxon_info].split(".")[0]
     @taxid = @taxon_info.split("_")[2].to_i
     if HUMAN_TAX_IDS.include? @taxid.to_i
-      render json: { status: :forbidden, message: "Human taxon ids are not allowed" }
+      render json: { error: "Human taxon ids are not allowed" }
       return
     end
 


### PR DESCRIPTION
- One of those "faster to fix than file" quick fixes
- Someone encountered some align viz pages where the page would just error out and be blank with "alignmentData.map is not a function". Reason is that the controller returns errors like `render json: { error: "alignment file too big" }`. Fix is just to check that the response is an array.