### PR TITLE
Remove data type column from metadata table.

### DIFF
--- a/db/migrate/20190325215059_remote_data_type_from_metadata.rb
+++ b/db/migrate/20190325215059_remote_data_type_from_metadata.rb
@@ -1,0 +1,5 @@
+class RemoteDataTypeFromMetadata < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :metadata, :data_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -146,7 +146,6 @@ ActiveRecord::Schema.define(version: 20_190_321_214_445) do
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key", null: false, collation: "latin1_swedish_ci"
-    t.integer "data_type", limit: 1, null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.float "number_validated_value", limit: 24


### PR DESCRIPTION
It's no longer being used, and is causing rails tests to break
because of "null: false"

Tested:
migration applies successfully.
rails tests still pass.