### PR TITLE
Restrict date metadata to month-only in front end and back end.

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -2,9 +2,11 @@ import React from "react";
 import { mapValues, filter, includes } from "lodash";
 // TODO(mark): Refactor all calls to lodash/fp.
 import { set, values } from "lodash/fp";
+
 import PropTypes from "~/components/utils/propTypes";
 import Input from "~/components/ui/controls/Input";
 import MetadataInput from "~/components/common/MetadataInput";
+
 import MetadataSection from "./MetadataSection";
 import { SAMPLE_ADDITIONAL_INFO } from "./constants";
 import cs from "./sample_details_mode.scss";
@@ -38,7 +40,7 @@ class MetadataTab extends React.Component {
       }
     });
 
-    // Format as [{name: "Sample Info", keys: ["sample_type"], {name: "Host Info", keys: ["age"]}]
+    // Format as [{name: "Sample Info", keys: ["sample_type"]}, {name: "Host Info", keys: ["age"]}]
     return Object.entries(nameToFields).map(entry => {
       return { name: entry[0], keys: entry[1].sort() };
     });
@@ -79,16 +81,28 @@ class MetadataTab extends React.Component {
   };
 
   renderInput = metadataType => {
-    const { metadata, onMetadataChange, onMetadataSave } = this.props;
+    const {
+      metadata,
+      onMetadataChange,
+      onMetadataSave,
+      metadataErrors,
+      additionalInfo
+    } = this.props;
 
     return (
-      <MetadataInput
-        className={cs.input}
-        value={metadata[metadataType.key]}
-        metadataType={metadataType}
-        onChange={onMetadataChange}
-        onSave={onMetadataSave}
-      />
+      <div className={cs.inputWrapper}>
+        <MetadataInput
+          className={cs.metadataInput}
+          value={metadata[metadataType.key]}
+          metadataType={metadataType}
+          onChange={onMetadataChange}
+          onSave={onMetadataSave}
+          isHuman={additionalInfo.host_genome_name === "Human"}
+        />
+        {metadataErrors[metadataType.key] && (
+          <div className={cs.error}>{metadataErrors[metadataType.key]}</div>
+        )}
+      </div>
     );
   };
 
@@ -150,7 +164,7 @@ class MetadataTab extends React.Component {
                 onBlur={() => onMetadataSave("name")}
                 value={additionalInfo.name}
                 type="text"
-                className={cs.input}
+                className={cs.sampleNameInput}
               />
             </div>
           )}
@@ -204,7 +218,8 @@ MetadataTab.propTypes = {
     upload_date: PropTypes.string,
     host_genome_name: PropTypes.string,
     editable: PropTypes.bool
-  }).isRequired
+  }).isRequired,
+  metadataErrors: PropTypes.objectOf(PropTypes.string)
 };
 
 export default MetadataTab;

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/sample_details_mode.scss
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/sample_details_mode.scss
@@ -1,4 +1,5 @@
 @import "~styles/typography";
+@import "~styles/themes/typography";
 @import "~styles/themes/colors";
 
 .content {
@@ -38,9 +39,20 @@
     margin-left: 10px;
   }
 
-  .input {
+  .inputWrapper,
+  .sampleNameInput {
     flex: 1 1 0;
     min-width: 0;
+
+    .metadataInput {
+      width: 100%;
+    }
+
+    .error {
+      @include font-body-xxs;
+      color: $error;
+      margin-top: 5px;
+    }
   }
 
   .metadataValue {

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/utils.js
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/utils.js
@@ -57,7 +57,7 @@ export const processPipelineInfo = additionalInfo => {
     pipelineInfo.compressionRatio = compressionRatio;
     pipelineInfo.lastProcessedAt = moment(
       summaryStats.last_processed_at
-    ).format("MM/DD/YYYY");
+    ).format("YYYY-MM-DD");
   }
 
   return pipelineInfo;
@@ -66,5 +66,5 @@ export const processPipelineInfo = additionalInfo => {
 // Format the upload date.
 export const processAdditionalInfo = additionalInfo => ({
   ...additionalInfo,
-  upload_date: moment(additionalInfo.upload_date).format("MM/DD/YYYY")
+  upload_date: moment(additionalInfo.upload_date).format("YYYY-MM-DD")
 });

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -4,11 +4,17 @@ import { isArray } from "lodash";
 
 import Input from "~/components/ui/controls/Input";
 import Dropdown from "~/components/ui/controls/dropdowns/Dropdown";
-import DateInput from "~/components/ui/controls/DateInput";
 
 class MetadataInput extends React.Component {
   render() {
-    const { value, onChange, onSave, metadataType, className } = this.props;
+    const {
+      value,
+      onChange,
+      onSave,
+      metadataType,
+      className,
+      isHuman
+    } = this.props;
 
     if (isArray(metadataType.options)) {
       const options = metadataType.options.map(option => ({
@@ -29,10 +35,13 @@ class MetadataInput extends React.Component {
       );
     } else if (metadataType.dataType == "date") {
       return (
-        <DateInput
+        <Input
           className={className}
-          onChange={val => onChange(metadataType.key, val, true)}
+          onChange={val => onChange(metadataType.key, val)}
+          onBlur={() => onSave && onSave(metadataType.key)}
           value={value}
+          placeholder={isHuman ? "YYYY-MM" : "YYYY-MM-DD"}
+          type="text"
         />
       );
     } else {
@@ -61,7 +70,8 @@ MetadataInput.propTypes = {
   // This is useful for the text input, where the parent wants to save onBlur, not onChange.
   onChange: PropTypes.func.isRequired,
   onSave: PropTypes.func,
-  withinModal: PropTypes.bool
+  withinModal: PropTypes.bool,
+  isHuman: PropTypes.bool
 };
 
 export default MetadataInput;

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -282,6 +282,7 @@ class MetadataManualInput extends React.Component {
                     this.updateMetadataField(key, value, sample)
                   }
                   withinModal={this.props.withinModal}
+                  isHuman={sampleHostGenomeId === 1}
                 />
                 {this.renderApplyToAll(sample, column)}
               </div>

--- a/app/assets/src/components/utils/metadata.js
+++ b/app/assets/src/components/utils/metadata.js
@@ -5,7 +5,10 @@ export const processMetadata = metadata => {
   let newMetadata = keyBy("key", metadata);
 
   newMetadata = mapValues(
-    val => val[`${val.base_type}_validated_value`],
+    val =>
+      val.base_type === "date"
+        ? val.raw_value
+        : val[`${val.base_type}_validated_value`],
     newMetadata
   );
   return newMetadata;

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -529,18 +529,16 @@ class SamplesController < ApplicationController
 
   # POST /samples/1/save_metadata_v2
   def save_metadata_v2
-    saved = @sample.metadatum_add_or_update(params[:field], params[:value])
-    if saved
+    result = @sample.metadatum_add_or_update(params[:field], params[:value])
+    if result[:status] == "ok"
       render json: {
         status: "success",
         message: "Saved successfully"
       }
     else
-      error_messages = @sample ? @sample.errors.full_messages : []
       render json: {
         status: 'failed',
-        message: 'Unable to update sample',
-        errors: error_messages
+        message: result[:error]
       }
     end
   end

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -259,7 +259,7 @@ module MetadataHelper
 
         if val_errors[:raw_value].present?
           # Create a custom error group if it hasn't already been done.
-          error_key = error_aggregator.create_raw_value_error_group_for_metadata_field(val_field, col_index + 1)
+          error_key = error_aggregator.create_raw_value_error_group_for_metadata_field(val_field, col_index + 1, sample.host_genome_name == "Human")
           error_aggregator.add_error(error_key, [index + 1, sample.name, value])
         end
 
@@ -270,7 +270,7 @@ module MetadataHelper
         existing_m = sample.get_existing_metadatum(field.to_s)
 
         # We currently compare the raw_value because val is also a raw string, so we compare equivalent things.
-        if existing_m && !existing_m.raw_value.nil? && existing_m.raw_value != value
+        if existing_m && val_errors.empty? && !existing_m.raw_value.nil? && existing_m.raw_value != value
           warning_aggregator.add_error(:value_already_exists, [index + 1, sample.name, field, existing_m.raw_value, value])
         end
       end

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -90,10 +90,8 @@ class Metadatum < ApplicationRecord
   end
 
   def check_and_set_date_type
-    # TODO(mark): Reject dates with a day if host genome is human.
-    # We are actually blocked on having a good FRONT-END date picker for MetadataInput,
-    # since semantic-ui-calendar-react is missing a month + year picker.
-    self.date_validated_value = parse_date(raw_value)
+    # Only allow day in the date if host genome is not Human.
+    self.date_validated_value = parse_date(raw_value, sample.host_genome_name != "Human")
   rescue ArgumentError
     errors.add(:raw_value, MetadataValidationErrors::INVALID_DATE)
   end

--- a/test/controllers/projects_metadata_upload_test.rb
+++ b/test/controllers/projects_metadata_upload_test.rb
@@ -27,7 +27,7 @@ class ProjectsMetadataUploadTest < ActionDispatch::IntegrationTest
         'metadata_validation_sample_human' => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01'
+          'admission_date' => '2018-01'
         }
       }
     }, as: :json
@@ -48,7 +48,7 @@ class ProjectsMetadataUploadTest < ActionDispatch::IntegrationTest
           'foobar' => {
             'sex' => 'Female',
             'age' => 100,
-            'admission_date' => '2018-01-01'
+            'admission_date' => '2018-01'
           }
         }
       }, as: :json
@@ -98,7 +98,7 @@ class ProjectsMetadataUploadTest < ActionDispatch::IntegrationTest
         'metadata_validation_sample_human' => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01',
+          'admission_date' => '2018-01',
           'Example Core Field' => 'Value',
           'Custom Field' => 'Value',
           'Custom Field 2' => 'Value'
@@ -131,7 +131,7 @@ class ProjectsMetadataUploadTest < ActionDispatch::IntegrationTest
           'metadata_validation_sample_human' => {
             'sex' => 'Female',
             'age' => 100,
-            'admission_date' => '2018-01-01'
+            'admission_date' => '2018-01'
           }
         }
       }, as: :json
@@ -147,7 +147,7 @@ class ProjectsMetadataUploadTest < ActionDispatch::IntegrationTest
           'metadata_validation_sample_human' => {
             'sex' => 'Female',
             'age' => 100,
-            'admission_date' => '2018-01-01'
+            'admission_date' => '2018-01'
           }
         }
       }, as: :json
@@ -162,7 +162,7 @@ class ProjectsMetadataUploadTest < ActionDispatch::IntegrationTest
         'joe_project_sampleA' => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01'
+          'admission_date' => '2018-01'
         }
       }
     }, as: :json

--- a/test/controllers/samples_bulk_upload_test.rb
+++ b/test/controllers/samples_bulk_upload_test.rb
@@ -25,7 +25,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01',
+          'admission_date' => '2018-01',
           'sample_type' => 'blood',
           'nucleotide_type' => 'DNA'
         },
@@ -98,7 +98,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01',
+          'admission_date' => '2018-01',
           'sample_type' => 'blood',
           'nucleotide_type' => 'DNA'
         },
@@ -170,7 +170,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
         "RR004_water_2_S23A" => {
           'Sex' => 'Female',
           'Age' => 100,
-          'Admission Date' => '2018-01-01',
+          'Admission Date' => '2018-01',
           'Sample Type' => 'blood',
           'Nucleotide Type' => 'DNA'
         }
@@ -215,7 +215,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01',
+          'admission_date' => '2018-01',
           'sample_type' => 'blood',
           'nucleotide_type' => 'DNA'
         }
@@ -255,7 +255,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01',
+          'admission_date' => '2018-01',
           'sample_type' => 'blood',
           'nucleotide_type' => 'DNA'
         }
@@ -299,7 +299,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
           'age' => 100,
-          'admission_date' => '2018-01-01'
+          'admission_date' => '2018-01'
         }
       },
       samples: [

--- a/test/fixtures/host_genomes.yml
+++ b/test/fixtures/host_genomes.yml
@@ -3,15 +3,15 @@ one:
 
 two:
   name: Human
-  metadata_fields: [sample_type, sex, age, admission_date, nucleotide_type]
+  metadata_fields: [collection_date, sample_type, sex, age, admission_date, nucleotide_type]
 
 human:
   name: Human
-  metadata_fields: [sample_type, sex, age, admission_date, nucleotide_type, core_field]
+  metadata_fields: [collection_date, sample_type, sex, age, admission_date, nucleotide_type, core_field]
 
 mosquito:
   name: Mosquito
-  metadata_fields: [sample_type, sex, reported_sex, blood_fed]
+  metadata_fields: [collection_date, sample_type, sex, reported_sex, blood_fed]
 
 tick:
   name: Tick

--- a/test/fixtures/metadata_fields.yml
+++ b/test/fixtures/metadata_fields.yml
@@ -12,6 +12,11 @@ nucleotide_type:
   force_options: 1
   options: "[\"DNA\", \"RNA\"]"
 
+collection_date:
+  name: "collection_date"
+  display_name: "Collection Date"
+  base_type: 2
+
 sex:
   name: "sex"
   display_name: "Sex"

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -23,4 +23,4 @@ joe_project:
 metadata_validation_project:
   name: Metadata Project
   users: [one]
-  metadata_fields: [sample_type, nucleotide_type, age, admission_date, blood_fed, reported_sex, sex]
+  metadata_fields: [sample_type, nucleotide_type, collection_date, age, admission_date, blood_fed, reported_sex, sex]


### PR DESCRIPTION
Also fix some small bugs around error passing. For example:
* If a metadata value fails validation, don't also show the "overwriting previous value" warning.
* Properly pass the underlying validation error to the front-end (instead of saying "failed to save value")

Error now shows up in front-end.
![Screen Shot 2019-03-25 at 1 07 57 PM](https://user-images.githubusercontent.com/837004/54958287-74da9b00-4f12-11e9-9167-e64859c95dcf.png)

![Screen Shot 2019-03-25 at 1 09 15 PM](https://user-images.githubusercontent.com/837004/54958300-7e640300-4f12-11e9-8fce-8923e6718414.png)

Placeholder text distinguishes human samples:
![Screen Shot 2019-03-25 at 1 07 42 PM](https://user-images.githubusercontent.com/837004/54958314-8b80f200-4f12-11e9-8acc-6c3de2b8343c.png)
