### PR TITLE
[Data Discovery] Change to Avg. total reads per sample and Avg. non-host reads

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -1,6 +1,15 @@
 import React from "react";
 import cx from "classnames";
-import { countBy, flatten, map, sortBy, sum, sumBy, uniqBy, meanBy } from "lodash/fp";
+import {
+  countBy,
+  flatten,
+  map,
+  sortBy,
+  sum,
+  sumBy,
+  uniqBy,
+  meanBy
+} from "lodash/fp";
 import moment from "moment";
 
 import PropTypes from "~/components/utils/propTypes";
@@ -37,8 +46,6 @@ export default class DiscoverySidebar extends React.Component {
       if (!samples || !samples.length) {
         return prevState;
       }
-      console.log("total reads:", sumBy("totalReads", samples));
-      console.log("count:", samples.length);
       return {
         stats: {
           numSamples: samples.length,
@@ -72,7 +79,8 @@ export default class DiscoverySidebar extends React.Component {
           numSamples: sumBy("number_of_samples", projects),
           numProjects: projects.length,
           avgTotalReads: Math.round(meanBy("total_reads", projects)) || "",
-          avgNonHostReads: Math.round(meanBy("adjusted_remaining_reads", projects)) || ""
+          avgNonHostReads:
+            Math.round(meanBy("adjusted_remaining_reads", projects)) || ""
         },
         metadata: {
           host: countBy(null, hosts),
@@ -194,7 +202,6 @@ export default class DiscoverySidebar extends React.Component {
     // This represents the unique dataset loaded and will force a refresh of the
     // Accordions when it changes.
     const dataKey = this.state.stats.avgTotalReads;
-    console.log("data key: ", dataKey);
     return (
       <div className={cx(this.props.className, cs.sidebar)}>
         <div className={cs.metadataContainer}>

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -50,8 +50,14 @@ export default class DiscoverySidebar extends React.Component {
         stats: {
           numSamples: samples.length,
           numProjects: uniqBy("project_id", samples).length,
-          avgTotalReads: Math.round(meanBy("totalReads", samples)) || "",
-          avgNonHostReads: Math.round(meanBy("nonHostReads", samples)) || ""
+          avgTotalReads: DiscoverySidebar.meanByAndFormat(
+            samples,
+            "totalReads"
+          ),
+          avgNonHostReads: DiscoverySidebar.meanByAndFormat(
+            samples,
+            "nonHostReads"
+          )
         },
         metadata: {
           host: countBy("hostGenome", samples),
@@ -78,9 +84,14 @@ export default class DiscoverySidebar extends React.Component {
         stats: {
           numSamples: sumBy("number_of_samples", projects),
           numProjects: projects.length,
-          avgTotalReads: Math.round(meanBy("total_reads", projects)) || "",
-          avgNonHostReads:
-            Math.round(meanBy("adjusted_remaining_reads", projects)) || ""
+          avgTotalReads: DiscoverySidebar.meanByAndFormat(
+            projects,
+            "total_reads"
+          ),
+          avgNonHostReads: DiscoverySidebar.meanByAndFormat(
+            projects,
+            "adjusted_remaining_reads"
+          )
         },
         metadata: {
           host: countBy(null, hosts),
@@ -98,6 +109,10 @@ export default class DiscoverySidebar extends React.Component {
 
   static formatDate(createdAt) {
     return moment(createdAt).format("YYYY-MM-DD");
+  }
+
+  static meanByAndFormat(data, field) {
+    return (Math.round(meanBy(field, data)) || "").toLocaleString();
   }
 
   static selectSampleData(newSamples) {

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -246,7 +246,7 @@ export default class DiscoverySidebar extends React.Component {
                 <dt>
                   <strong>Avg. reads per sample</strong>
                 </dt>
-                <dd>{this.state.stats.avgTotalReads.toLocaleString()}</dd>
+                <dd>{this.state.stats.avgTotalReads}</dd>
               </dl>
             </div>
             <div className={cs.hasBackground}>
@@ -257,7 +257,7 @@ export default class DiscoverySidebar extends React.Component {
                     <br />reads per sample
                   </strong>
                 </dt>
-                <dd>{this.state.stats.avgNonHostReads.toLocaleString()}</dd>
+                <dd>{this.state.stats.avgNonHostReads}</dd>
               </dl>
             </div>
           </Accordion>

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -43,7 +43,7 @@ class ProjectsView extends React.Component {
       {
         dataKey: "number_of_samples",
         width: 140,
-        label: "No. Of Samples"
+        label: "No. of Samples"
       }
     ];
   }


### PR DESCRIPTION
- I noticed halfway through that formatNumber() was doing the averaging but I decided to change it a little so that the average stats can get set with the rest of 'stats'..
- Tested with console.log statements and double-checking the values