### PR TITLE
Fix bug with pipeline run loading order

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -88,8 +88,8 @@ class ProjectsController < ApplicationController
           end
           (locations_by_project_id[s.project_id] ||= Set.new) << s.sample_location if s.sample_location
           unless s.pipeline_runs.empty?
-            total_reads += s.pipeline_runs[0].total_reads || 0
-            adjusted_remaining_reads += s.pipeline_runs[0].adjusted_remaining_reads || 0
+            total_reads += s.first_pipeline_run.total_reads || 0
+            adjusted_remaining_reads += s.first_pipeline_run.adjusted_remaining_reads || 0
           end
         end
         extended_projects = projects.includes(:users).map do |project|

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -797,7 +797,7 @@ class SamplesController < ApplicationController
     can_edit = current_power.updatable_samples.include?(@sample)
     @exposed_raw_results_url = can_edit ? raw_results_folder_sample_url(@sample) : nil
     can_see_stage1_results = can_edit
-    @file_list = @sample.pipeline_runs.first.outputs_by_step(can_see_stage1_results)
+    @file_list = @sample.first_pipeline_run.outputs_by_step(can_see_stage1_results)
     @file_path = "#{@sample.sample_path}/results/"
     respond_to do |format|
       format.html do

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -113,7 +113,7 @@ module SamplesHelper
     if sample.status == Sample::STATUS_CREATED
       'uploading'
     elsif sample.status == Sample::STATUS_CHECKED
-      pipeline_run = sample.pipeline_runs.first
+      pipeline_run = sample.first_pipeline_run
       return '' unless pipeline_run
       if pipeline_run.job_status == PipelineRun::STATUS_CHECKED
         return 'complete'
@@ -265,7 +265,7 @@ module SamplesHelper
 
   def sample_derived_data(sample, job_stats_hash)
     output_data = {}
-    pipeline_run = sample.pipeline_runs.first
+    pipeline_run = sample.first_pipeline_run
     summary_stats = job_stats_hash.present? ? get_summary_stats(job_stats_hash, pipeline_run) : nil
     output_data[:pipeline_run] = pipeline_run
     output_data[:host_genome_name] = sample.host_genome ? sample.host_genome.name : nil

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -279,7 +279,7 @@ module ReportHelper
   end
 
   def fetch_top_taxons(samples, background_id, categories, read_specificity = false, include_phage = false)
-    pipeline_run_ids = samples.map { |s| s.pipeline_runs.first ? s.pipeline_runs.first.id : nil }.compact
+    pipeline_run_ids = samples.map { |s| s.first_pipeline_run ? s.first_pipeline_run.id : nil }.compact
 
     categories_clause = ""
     if categories.present?
@@ -372,7 +372,7 @@ module ReportHelper
   end
 
   def fetch_samples_taxons_counts(samples, taxon_ids, parent_ids, background_id)
-    pipeline_run_ids = samples.map { |s| s.pipeline_runs.first ? s.pipeline_runs.first.id : nil }.compact
+    pipeline_run_ids = samples.map { |s| s.first_pipeline_run ? s.first_pipeline_run.id : nil }.compact
     parent_ids = parent_ids.to_a
     parent_ids_clause = parent_ids.empty? ? "" : " OR taxon_counts.tax_id in (#{parent_ids.join(',')}) "
 
@@ -1068,7 +1068,7 @@ module ReportHelper
     if pipeline_version > 0.0
       sample.pipeline_run_by_version(params[:pipeline_version])
     else
-      sample.pipeline_runs.first
+      sample.first_pipeline_run
     end
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -215,7 +215,7 @@ class Sample < ApplicationRecord
   end
 
   def results_folder_files
-    pr = pipeline_runs.first
+    pr = first_pipeline_run
     return list_outputs(sample_output_s3_path) unless pr
     file_list = []
     if pr.pipeline_version.to_f >= 2.0
@@ -336,21 +336,21 @@ class Sample < ApplicationRecord
   end
 
   def sample_alignment_output_s3_path
-    pr = pipeline_runs.first
+    pr = first_pipeline_run
     return pr.alignment_output_s3_path
   rescue
     return sample_output_s3_path
   end
 
   def sample_host_filter_output_s3_path
-    pr = pipeline_runs.first
+    pr = first_pipeline_run
     return pr.host_filter_output_s3_path
   rescue
     return sample_output_s3_path
   end
 
   def subsample_suffix
-    pr = pipeline_runs.first
+    pr = first_pipeline_run
     pr.subsample_suffix
   end
 
@@ -415,7 +415,7 @@ class Sample < ApplicationRecord
 
   def check_status
     return unless [STATUS_UPLOADED, STATUS_RERUN, STATUS_RETRY_PR].include?(status)
-    pr = pipeline_runs.first
+    pr = first_pipeline_run
     transient_status = status
     self.status = STATUS_CHECKED
 
@@ -713,5 +713,11 @@ class Sample < ApplicationRecord
   # Get field info for fields that are appropriate for both the project and the host genome
   def metadata_fields_info
     (project.metadata_fields & host_genome.metadata_fields).map(&:field_info)
+  end
+
+  # Explicit getter because we had issues with ":pipeline_runs, -> { order(created_at: :desc) }"
+  # not being applied with the non-admin path in self.viewable.
+  def first_pipeline_run
+    pipeline_runs.order(created_at: :desc).first
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -716,7 +716,7 @@ class Sample < ApplicationRecord
   end
 
   # Explicit getter because we had issues with ":pipeline_runs, -> { order(created_at: :desc) }"
-  # not being applied with the non-admin path in self.viewable.
+  # not being applied with the non-admin path in self.viewable when combined with an 'includes'.
   def first_pipeline_run
     pipeline_runs.order(created_at: :desc).first
   end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -48,7 +48,7 @@
             <% end %>
           </td>
           <td>
-            <% pipeline_run = sample.pipeline_runs.first %>
+            <% pipeline_run = sample.first_pipeline_run %>
             <% pipeline_run_submitted = 'N/A' %>
             <% pipeline_job_id = 'N/A' %>
             <% if pipeline_run %>

--- a/lib/tasks/download_amr_for_project.rake
+++ b/lib/tasks/download_amr_for_project.rake
@@ -4,7 +4,7 @@ task :download_amr_for_project, [:project_id, :output_s3_path] => :environment d
   samples = Sample.where(project_id: args[:project_id])
   s3_output_path = args[:output_s3_path]
   samples.each do |s|
-    pr = s.pipeline_runs.first
+    pr = s.first_pipeline_run
     if pr
       dest_dir = "#{s3_output_path}/#{s.name.tr(' ', '-')}-SRST2"
       puts "mkdir -p #{dest_dir}; aws s3 cp #{pr.expt_output_s3_path}/ #{dest_dir}/ --recursive"

--- a/lib/tasks/download_non_host_reads_for_project.rake
+++ b/lib/tasks/download_non_host_reads_for_project.rake
@@ -4,7 +4,7 @@ task :download_non_host_reads_for_project, [:project_id, :output_s3_path] => :en
   samples = Sample.where(project_id: args[:project_id])
   s3_output_path = args[:output_s3_path]
   samples.each do |s|
-    pr = s.pipeline_runs.first
+    pr = s.first_pipeline_run
     if pr && pr.pipeline_run_stages[1] && pr.pipeline_run_stages[1].dag_json
       alignment_json = JSON.parse(pr.pipeline_run_stages[1].dag_json)
       host_filter_out = alignment_json["targets"]["host_filter_out"]

--- a/lib/tasks/fix_result_loading.rake
+++ b/lib/tasks/fix_result_loading.rake
@@ -5,7 +5,7 @@ require 'open3'
 task fix_result_loading: :environment do
   Sample.all.each do |sample|
     puts sample.id
-    pr = sample.pipeline_runs.first
+    pr = sample.first_pipeline_run
     if pr
       pr.check_job_status
       pr.save

--- a/lib/tasks/genus_aggregation.rake
+++ b/lib/tasks/genus_aggregation.rake
@@ -1,6 +1,6 @@
 task genus_aggregation: :environment do
   Sample.all.each do |s|
-    pr = s.pipeline_runs.first
+    pr = s.first_pipeline_run
     next unless pr
     ActiveRecord::Base.transaction do
       TaxonCount.connection.execute(


### PR DESCRIPTION
### Problem
- Non-admins were seeing samples stats from the oldest pipeline run instead of the newest pipeline run
- Example loading pipeline run versions:
```
# Admin
web_1                      | FOOBAR 11:30am prs:
web_1                      | 683
web_1                      | 623
web_1                      | 470
web_1                      | 92
web_1                      | 85
web_1                      | FOOBAR 11:30am pr:
web_1                      | 683

# Non-admin
web_1                      | FOOBAR 11:30am prs:
web_1                      | 85
web_1                      | 92
web_1                      | 470
web_1                      | 623
web_1                      | 683
web_1                      | FOOBAR 11:30am pr:
web_1                      | 85
```

### Cause
- In SamplesHelper#format_samples, we added a `samples.includes(:pipeline_runs, :host_genome, :project, :input_files, :user)`. In Sample.rb we have `has_many :pipeline_runs, -> { order(created_at: :desc) }` and also in sample.viewable a `joins(:project)`. So the combination of all of these seemed to create a new scope that didn't have the ordering applied. Removing the `includes` fixed the issue, and setting the `viewable` to `all` would also fix the issue.

### Solution
- To be safe we decided to do a first_pipeline_run instead of pipeline_runs.first for all the places it was used. I did a code search for uses of pipeline_runs.each and map and didn't find other important ordering dependent calls to change.

### Test
- With the changes you end up with the right ordering in responses
```
# Admin
web_1                      | FOOBAR 11:44am prs:
web_1                      | 683
web_1                      | 623
web_1                      | 470
web_1                      | 92
web_1                      | 85
web_1                      | FOOBAR 11:44am pr:
web_1                      | 683

# Non-admin
web_1                      | FOOBAR 11:44am prs:
web_1                      | 683
web_1                      | 623
web_1                      | 470
web_1                      | 92
web_1                      | 85
web_1                      | FOOBAR 11:44am pr:
web_1                      | 683
```