### PR TITLE
Add basic option to projects index endpoint.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -205,10 +205,11 @@ const getProjectDimensions = ({ domain }) =>
 
 const getSamplesV1 = params => get("/samples.json", { params });
 
-const getProjects = ({ domain, filters } = {}) =>
+const getProjects = ({ domain, filters, basic } = {}) =>
   get("/projects.json", {
     params: {
       domain,
+      basic,
       ...filters
     }
   });

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -55,7 +55,8 @@ class UploadSampleStep extends React.Component {
 
   async componentDidMount() {
     const projects = await getProjects({
-      domain: "updatable"
+      domain: "updatable",
+      basic: true
     });
 
     this.setState({

--- a/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
@@ -20,7 +20,7 @@ class MetadataUploadModal extends React.Component {
   async componentDidMount() {
     const projectSamples = await getSamplesV1({
       project_id: this.props.project.id,
-      basic_only: true
+      basic: true
     });
 
     this.setState({

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -64,7 +64,8 @@ class SamplesController < ApplicationController
     samples_query = params[:ids].split(',') if params[:ids].present?
     sort = params[:sort_by]
     # Return only some basic props for samples.
-    basic_only = ActiveModel::Type::Boolean.new.cast(params[:basic_only])
+    # TODO(mark): Make "basic" the default. This involves refactoring all the callers of this endpoint.
+    basic = ActiveModel::Type::Boolean.new.cast(params[:basic])
 
     results = current_power.samples
 
@@ -98,11 +99,11 @@ class SamplesController < ApplicationController
 
     @samples = sort_by(results, sort).paginate(page: page, per_page: params[:per_page] || PAGE_SIZE).includes([:user, :host_genome, :pipeline_runs, :input_files])
     @samples_count = results.size
-    @samples_formatted = basic_only ? format_samples_basic(@samples) : format_samples(@samples)
+    @samples_formatted = basic ? format_samples_basic(@samples) : format_samples(@samples)
 
     @ready_sample_ids = get_ready_sample_ids(results)
 
-    if basic_only
+    if basic
       render json: @samples_formatted
     # Send more information with the first page.
     elsif !page || page == '1'


### PR DESCRIPTION
The projects index endpoint was taking 30s or more to load. The basic version takes about 200ms.

Tested that admin and non-admin can fetch projects in the new upload flow and samples in the upload modal properly.