### PR TITLE
[Report Page] Fix lineage loading for the taxon tree

### DIFF
--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -182,7 +182,7 @@ class TaxonLineage < ApplicationRecord
     # Use pluck because it saved 5s on 10k rows in testing
     # lineage_by_taxid[x.taxid] = x.as_json
     TaxonLineage.where(taxid: tax_ids).where("#{lineage_version} BETWEEN version_start AND version_end").each do |x|
-      # Extra fields for levels of _taxid and _name are used in the phylo tree
+      # Extra fields for levels of _taxid and _name are used in the taxon tree
       lineage_by_taxid[x.taxid] = x.as_json
     end
     t1 = Time.now.to_f

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -182,6 +182,7 @@ class TaxonLineage < ApplicationRecord
     # Use pluck because it saved 5s on 10k rows in testing
     # lineage_by_taxid[x.taxid] = x.as_json
     TaxonLineage.where(taxid: tax_ids).where("#{lineage_version} BETWEEN version_start AND version_end").each do |x|
+      # Extra fields for levels of _taxid and _name are used in the phylo tree
       lineage_by_taxid[x.taxid] = x.as_json
     end
     t1 = Time.now.to_f

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -181,11 +181,8 @@ class TaxonLineage < ApplicationRecord
 
     # Use pluck because it saved 5s on 10k rows in testing
     # lineage_by_taxid[x.taxid] = x.as_json
-    TaxonLineage
-      .where(taxid: tax_ids).where("#{lineage_version} BETWEEN version_start AND version_end")
-      .pluck(:taxid, :species_taxid, :genus_taxid, :family_taxid)
-      .each do |arr|
-      lineage_by_taxid[arr[0]] = { taxid: arr[0], species_taxid: arr[1], genus_taxid: arr[2], family_taxid: arr[3] }
+    TaxonLineage.where(taxid: tax_ids).where("#{lineage_version} BETWEEN version_start AND version_end").each do |x|
+      lineage_by_taxid[x.taxid] = x.as_json
     end
     t1 = Time.now.to_f
     Rails.logger.info "fetch_lineage_by_taxid took #{(t1 - t0).round(2)}s"

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -179,8 +179,6 @@ class TaxonLineage < ApplicationRecord
     lineage_version = PipelineRun.find(pipeline_run_id).alignment_config.lineage_version
     lineage_by_taxid = {}
 
-    # Use pluck because it saved 5s on 10k rows in testing
-    # lineage_by_taxid[x.taxid] = x.as_json
     TaxonLineage.where(taxid: tax_ids).where("#{lineage_version} BETWEEN version_start AND version_end").each do |x|
       # Extra fields for levels of _taxid and _name are used in the taxon tree
       lineage_by_taxid[x.taxid] = x.as_json

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -179,7 +179,7 @@ class TaxonLineage < ApplicationRecord
     lineage_version = PipelineRun.find(pipeline_run_id).alignment_config.lineage_version
     lineage_by_taxid = {}
 
-    TaxonLineage.where(taxid: tax_ids).where("#{lineage_version} BETWEEN version_start AND version_end").each do |x|
+    TaxonLineage.where(taxid: tax_ids).where("? BETWEEN version_start AND version_end", lineage_version).each do |x|
       # Extra fields for levels of _taxid and _name are used in the taxon tree
       lineage_by_taxid[x.taxid] = x.as_json
     end


### PR DESCRIPTION
- Taxon lineage was missing fields for all the _taxid and _name levels so the taxon tree on the report page was broken
- This reverts to the as_json call it had before since it seems like we do need all the fields to be used ex: 
```
web_1                      | {"id"=>5224343, "taxid"=>261302, "superkingdom_taxid"=>2, "phylum_taxid"=>1224, "class_taxid"=>28216, "order_taxid"=>80840, "family_taxid"=>119060, "genus_taxid"=>1822464, "species_taxid"=>261302, "created_at"=>nil, "updated_at"=>nil, "superkingdom_name"=>"Bacteria", "phylum_name"=>"Proteobacteria", "class_name"=>"Betaproteobacteria", "order_name"=>"Burkholderiales", "family_name"=>"Burkholderiaceae", "genus_name"=>"Paraburkholderia", "species_name"=>"Paraburkholderia phytofirmans", "superkingdom_common_name"=>"eubacteria", "phylum_common_name"=>"", "class_common_name"=>"", "order_common_name"=>"", "family_common_name"=>"", "genus_common_name"=>"", "species_common_name"=>"", "started_at"=>Fri, 31 Dec 1999 16:00:00 PST -08:00, "ended_at"=>Tue, 31 Dec 2999 16:00:00 PST -08:00, "kingdom_taxid"=>-650, "kingdom_name"=>"", "kingdom_common_name"=>"", "tax_name"=>"Paraburkholderia phytofirmans", "version_start"=>0, "version_end"=>3}
```
- I tried using Oj https://github.com/ohler55/oj but that would've only helped us if we needed to replace "to_json". This case as_json is interpreting the ActiveRecord object as json.
- Will probably slow down perf again until someone has time to optimize it (e.g. by splitting the report page and the taxon tree into separate endpoints)

### Before and After
![Screen Shot 2019-03-26 at 4 30 28 PM](https://user-images.githubusercontent.com/5652739/55040410-6f9a5080-4fe5-11e9-958a-312ec170253e.png)
