### PR TITLE
Fix perf regression from fixing pipeline run ordering

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -99,7 +99,8 @@ class ProjectsController < ApplicationController
         locations_by_project_id = {}
         total_reads = 0
         adjusted_remaining_reads = 0
-        samples.includes(:host_genome, :user, :pipeline_runs).order('pipeline_runs.created_at DESC').each do |s|
+        top_pipeline_run_by_sample_id = top_pipeline_runs_multiget(samples.pluck(:id))
+        samples.includes(:host_genome, :user).each do |s|
           (host_genome_names_by_project_id[s.project_id] ||= Set.new) << s.host_genome.name if s.host_genome && s.host_genome.name
           # TODO: sample_tissue column is deprecated, retrieve sample_type from Metadatum model instead
           (tissues_by_project_id[s.project_id] ||= Set.new) << s.sample_tissue if s.sample_tissue
@@ -109,11 +110,10 @@ class ProjectsController < ApplicationController
             owner_by_project_id[s.project_id] = s.user ? s.user.name : nil
           end
           (locations_by_project_id[s.project_id] ||= Set.new) << s.sample_location if s.sample_location
-          unless s.pipeline_runs.empty?
-            # Note, using sample.first_pipeline_run would generate a mass of queries to order. The
-            # order('pipeline_runs.created_at DESC') above handles this sort.
-            total_reads += s.pipeline_runs.first.total_reads || 0
-            adjusted_remaining_reads += s.pipeline_runs.first.adjusted_remaining_reads || 0
+          if top_pipeline_run_by_sample_id.key?(s.id)
+            pipeline_run = top_pipeline_run_by_sample_id[s.id]
+            total_reads += pipeline_run.total_reads || 0
+            adjusted_remaining_reads += pipeline_run.adjusted_remaining_reads || 0
           end
         end
         extended_projects = projects.includes(:users).map do |project|

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -263,9 +263,8 @@ module SamplesHelper
     user
   end
 
-  def sample_derived_data(sample, job_stats_hash)
+  def sample_derived_data(sample, pipeline_run, job_stats_hash)
     output_data = {}
-    pipeline_run = sample.first_pipeline_run
     summary_stats = job_stats_hash.present? ? get_summary_stats(job_stats_hash, pipeline_run) : nil
     output_data[:pipeline_run] = pipeline_run
     output_data[:host_genome_name] = sample.host_genome ? sample.host_genome.name : nil
@@ -367,7 +366,7 @@ module SamplesHelper
       job_info[:metadata] = metadata_by_sample_id[sample.id]
       top_pipeline_run = top_pipeline_run_by_sample_id[sample.id]
       job_stats_hash = top_pipeline_run ? job_stats_by_pipeline_run_id[top_pipeline_run.id] : {}
-      job_info[:derived_sample_output] = sample_derived_data(sample, job_stats_hash)
+      job_info[:derived_sample_output] = sample_derived_data(sample, top_pipeline_run, job_stats_hash)
       job_info[:run_info] = pipeline_run_info(top_pipeline_run, report_ready_pipeline_run_ids,
                                               pipeline_run_stages_by_pipeline_run_id, output_states_by_pipeline_run_id)
       job_info[:uploader] = sample_uploader(sample)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -717,6 +717,7 @@ class Sample < ApplicationRecord
 
   # Explicit getter because we had issues with ":pipeline_runs, -> { order(created_at: :desc) }"
   # not being applied with the non-admin path in self.viewable when combined with an 'includes'.
+  # Be careful when using this because it may cause an extra query for each of your samples!
   def first_pipeline_run
     pipeline_runs.order(created_at: :desc).first
   end


### PR DESCRIPTION
- Calling sample.first_pipeline_run caused many order by queries to be run
- This refactors the affected endpoints a little to prevent slowdown but still have the proper ordering

### Testing
- Verified that we still get the pipeline runs in the right order and the logs don't have all the mass of order queries