### PR TITLE
[Data Discovery] Use new metadata fields instead of sample model fields.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -79,7 +79,6 @@ class ProjectsController < ApplicationController
         adjusted_remaining_reads = 0
 
         metadata = metadata_multiget(samples.pluck(:id))
-        Rails.logger.debug("metadata: #{metadata}")
         samples.includes(:host_genome, :user, :pipeline_runs).each do |s|
           (host_genome_names_by_project_id[s.project_id] ||= Set.new) << s.host_genome.name if s.host_genome && s.host_genome.name
           (tissues_by_project_id[s.project_id] ||= Set.new) << metadata[s.id][:sample_type] if (metadata[s.id] || {})[:sample_type]

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -144,7 +144,7 @@ class SamplesController < ApplicationController
     limited_samples = samples.offset(offset).limit(limit)
 
     limited_samples_json = limited_samples.as_json(
-      only: [:id, :name, :sample_tissue, :host_genome_id, :project_id, :created_at, :public],
+      only: [:id, :name, :host_genome_id, :project_id, :created_at, :public],
       methods: []
     )
     samples_visibility = visibility(limited_samples)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -159,7 +159,7 @@ class PipelineRun < ApplicationRecord
   #        +-----v------+                              |    !output_ready?
   #        | QUEUED FOR |                              |    && pipeline_finalized
   #        | LOADING    |                              |    (RM)
-  #        +-----+------+                              |P
+  #        +-----+------+                              |
   #              |                                     |
   #              | (Resque)                            |
   #              |                                     |

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -159,7 +159,7 @@ class PipelineRun < ApplicationRecord
   #        +-----v------+                              |    !output_ready?
   #        | QUEUED FOR |                              |    && pipeline_finalized
   #        | LOADING    |                              |    (RM)
-  #        +-----+------+                              |
+  #        +-----+------+                              |P
   #              |                                     |
   #              | (Resque)                            |
   #              |                                     |


### PR DESCRIPTION
* Use only metadata fields (in particular, for location and sample tissue/type) in projects and samples routes.