### PR TITLE
[Data Discovery] Fix sidebar 'accordion needs double-click to toggle' and 'doesn't update when samples filter to 0' with new empty state

### DIFF
--- a/app/assets/src/components/layout/Accordion.jsx
+++ b/app/assets/src/components/layout/Accordion.jsx
@@ -8,7 +8,7 @@ class Accordion extends React.Component {
 
   onToggle = () => {
     this.setState({
-      open: !this.state.open,
+      open: this.state.wasToggled ? !this.state.open : !this.props.open,
       wasToggled: true
     });
   };

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -39,9 +39,10 @@ export default class DiscoverySidebar extends React.Component {
   }
 
   static getDerivedStateFromProps(newProps, prevState) {
-    const { currentTab, projects } = newProps;
+    const { currentTab, projects, loading } = newProps;
+    if (loading) return prevState;
 
-    if (currentTab == "samples") {
+    if (currentTab === "samples") {
       const samples = DiscoverySidebar.selectSampleData(newProps.samples);
       return {
         stats: {
@@ -63,7 +64,7 @@ export default class DiscoverySidebar extends React.Component {
           location: countBy("sampleLocation", samples)
         }
       };
-    } else if (currentTab == "projects") {
+    } else if (currentTab === "projects") {
       const hosts = flatten(map("hosts", projects));
       const tissues = flatten(map("tissues", projects));
       const locations = flatten(map("locations", projects));
@@ -207,7 +208,7 @@ export default class DiscoverySidebar extends React.Component {
   }
 
   render() {
-    if (!this.hasData()) {
+    if (!this.props.loading && !this.hasData()) {
       return (
         <div className={cx(this.props.className, cs.sidebar)}>
           <div className={cs.emptyMessage}>
@@ -309,5 +310,6 @@ DiscoverySidebar.propTypes = {
   className: PropTypes.string,
   projects: PropTypes.arrayOf(PropTypes.Project),
   samples: PropTypes.arrayOf(PropTypes.Sample),
-  currentTab: PropTypes.string
+  currentTab: PropTypes.string,
+  loading: PropTypes.bool
 };

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -43,10 +43,6 @@ export default class DiscoverySidebar extends React.Component {
 
     if (currentTab == "samples") {
       const samples = DiscoverySidebar.selectSampleData(newProps.samples);
-      // if (!samples || !samples.length) {
-      //   console.log("zeroed out");
-      //   return prevState;
-      // }
       return {
         stats: {
           numSamples: samples.length,
@@ -68,10 +64,6 @@ export default class DiscoverySidebar extends React.Component {
         }
       };
     } else if (currentTab == "projects") {
-      if (!projects || !projects.length) {
-        return prevState;
-      }
-
       const hosts = flatten(map("hosts", projects));
       const tissues = flatten(map("tissues", projects));
       const locations = flatten(map("locations", projects));
@@ -215,6 +207,16 @@ export default class DiscoverySidebar extends React.Component {
   }
 
   render() {
+    if (!this.hasData()) {
+      return (
+        <div className={cx(this.props.className, cs.sidebar)}>
+          <div className={cs.emptyMessage}>
+            Try another search to see summary info.
+          </div>
+        </div>
+      );
+    }
+
     // This represents the unique dataset loaded and will force a refresh of the
     // Accordions when it changes.
     const dataKey = this.state.stats.avgTotalReads;

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -43,9 +43,10 @@ export default class DiscoverySidebar extends React.Component {
 
     if (currentTab == "samples") {
       const samples = DiscoverySidebar.selectSampleData(newProps.samples);
-      if (!samples || !samples.length) {
-        return prevState;
-      }
+      // if (!samples || !samples.length) {
+      //   console.log("zeroed out");
+      //   return prevState;
+      // }
       return {
         stats: {
           numSamples: samples.length,

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -211,7 +211,7 @@ export default class DiscoverySidebar extends React.Component {
     if (!this.props.loading && !this.hasData()) {
       return (
         <div className={cx(this.props.className, cs.sidebar)}>
-          <div className={cs.emptyMessage}>
+          <div className={cs.noData}>
             Try another search to see summary info.
           </div>
         </div>

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -448,6 +448,7 @@ class DiscoveryView extends React.Component {
                   samples={samples}
                   projects={projects}
                   currentTab={currentTab}
+                  loading={loadingSamples || loadingProjects}
                 />
               )}
           </div>

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -166,6 +166,8 @@ class DiscoveryView extends React.Component {
     const { domain } = this.props;
     const { project } = this.state;
 
+    console.log("hi from refreshDimensions 10:49am");
+
     const {
       projectDimensions,
       sampleDimensions
@@ -174,12 +176,19 @@ class DiscoveryView extends React.Component {
       projectId: project && project.id
     });
 
+    console.log("end of refreshDimensions");
+    console.log(projectDimensions);
+    console.log(sampleDimensions);
+
     this.setState(pickBy(identity, { projectDimensions, sampleDimensions }));
   };
 
   refreshAll = () => {
     const { project } = this.state;
+    console.log("refreshAll called");
+    console.log("project is: ", project);
     !project && this.refreshSynchronousData();
+    console.log("finished refresh sync data");
     this.refreshDimensions();
   };
 

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -343,6 +343,7 @@ class DiscoveryView extends React.Component {
       filters,
       loadingProjects,
       loadingVisualizations,
+      loadingSamples,
       project,
       projects,
       sampleIds,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -166,7 +166,7 @@ class DiscoveryView extends React.Component {
     const { domain } = this.props;
     const { project } = this.state;
 
-    console.log("hi from refreshDimensions 10:49am");
+    console.log("hi from refreshDimensions 2:13pm");
 
     const {
       projectDimensions,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -166,8 +166,6 @@ class DiscoveryView extends React.Component {
     const { domain } = this.props;
     const { project } = this.state;
 
-    console.log("hi from refreshDimensions 2:13pm");
-
     const {
       projectDimensions,
       sampleDimensions
@@ -176,19 +174,12 @@ class DiscoveryView extends React.Component {
       projectId: project && project.id
     });
 
-    console.log("end of refreshDimensions");
-    console.log(projectDimensions);
-    console.log(sampleDimensions);
-
     this.setState(pickBy(identity, { projectDimensions, sampleDimensions }));
   };
 
   refreshAll = () => {
     const { project } = this.state;
-    console.log("refreshAll called");
-    console.log("project is: ", project);
     !project && this.refreshSynchronousData();
-    console.log("finished refresh sync data");
     this.refreshDimensions();
   };
 

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -49,6 +49,7 @@ class DiscoveryView extends React.Component {
         filters: {},
         loadingProjects: true,
         loadingVisualizations: true,
+        loadingSamples: true,
         project: this.props.project,
         projectDimensions: [],
         projects: [],
@@ -145,7 +146,8 @@ class DiscoveryView extends React.Component {
 
     this.setState({
       loadingProjects: true,
-      loadingVisualizations: true
+      loadingVisualizations: true,
+      loadingSamples: true
     });
 
     const { projects = [], visualizations = [] } = await getDiscoverySyncData({
@@ -158,7 +160,8 @@ class DiscoveryView extends React.Component {
       projects,
       visualizations,
       loadingProjects: false,
-      loadingVisualizations: false
+      loadingVisualizations: false,
+      loadingSamples: false
     });
   };
 

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -7,6 +7,8 @@
   overflow-y: scroll;
 
   .emptyMessage {
+    color: $medium-grey;
+    margin: 20px;
   }
 }
 

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -6,7 +6,7 @@
   width: 300px;
   overflow-y: scroll;
 
-  .emptyMessage {
+  .noData {
     color: $medium-grey;
     margin: 20px;
   }

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -5,6 +5,9 @@
   font-size: 12px;
   width: 300px;
   overflow-y: scroll;
+
+  .emptyMessage {
+  }
 }
 
 .metadataContainer {


### PR DESCRIPTION
- In the Accordion there was a wasToggled flag that wasn't checked onToggle (so this.state.open starts as null and then gets set to open and then needed another click)
- Previous state check would return prevState if the results filter down to 0, so the sidebar would still have results. New change adds a loadingSamples state so the sidebar will show an empty state if not loading and results went to 0.

![Mar-27-2019 10-15-51](https://user-images.githubusercontent.com/5652739/55097922-103a5000-507a-11e9-8603-b9cfea96f9d4.gif)

### Testing
- Go to My Data and Public and click through Projects and Samples tabs. Restrict filters so that you get 0 matching results.