### PR TITLE
[Discovery Sidebar] Sort metadata rows by value descending and add show/hide for extra rows

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -169,21 +169,20 @@ export default class DiscoverySidebar extends React.Component {
 
   buildMetadataRows(field) {
     const { metadata, expandedMetadataGroups } = this.state;
-
-    // TODO (gdingle): put "unknowns" last?
     const fieldData = metadata[field];
+
     // Sort by the value desc and then by the label alphabetically
     const sorted = orderBy(
       [k => k[1], k => k[0]],
       ["desc", "asc"],
       Object.entries(fieldData)
     );
-    const total = sum(Object.values(fieldData));
 
     // Display N fields and show/hide the rest
     const defaultN = 4;
     const defaultRows = sorted.slice(0, defaultN);
     const extraRows = sorted.slice(defaultN);
+    const total = sum(Object.values(fieldData));
     return (
       <dl className={cx(cs.dataList)}>
         {this.renderMetadataRowBlock(defaultRows, total)}

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -179,7 +179,7 @@ export default class DiscoverySidebar extends React.Component {
     );
 
     // Display N fields and show/hide the rest
-    const defaultN = 4;
+    const defaultN = this.props.defaultNumberOfMetadataRows;
     const defaultRows = sorted.slice(0, defaultN);
     const extraRows = sorted.slice(defaultN);
     const total = sum(Object.values(fieldData));
@@ -332,7 +332,8 @@ export default class DiscoverySidebar extends React.Component {
 DiscoverySidebar.defaultProps = {
   projects: [],
   samples: [],
-  currentTab: "samples"
+  currentTab: "samples",
+  defaultNumberOfMetadataRows: 4
 };
 
 DiscoverySidebar.propTypes = {
@@ -340,5 +341,6 @@ DiscoverySidebar.propTypes = {
   projects: PropTypes.arrayOf(PropTypes.Project),
   samples: PropTypes.arrayOf(PropTypes.Sample),
   currentTab: PropTypes.string,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  defaultNumberOfMetadataRows: PropTypes.number
 };

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -100,7 +100,7 @@
     margin-top: 10px;
     margin-bottom: 10px;
     color: $primary-light;
-    font-size: 10px;
+    font-size: $font-size-smallest;
     letter-spacing: 0.5px;
     cursor: pointer;
   }

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -100,7 +100,8 @@
     margin-top: 10px;
     margin-bottom: 10px;
     color: $primary-light;
-    font-size: 11px;
+    font-size: 10px;
     letter-spacing: 0.5px;
+    cursor: pointer;
   }
 }

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -94,4 +94,13 @@
     text-align: right;
     color: white;
   }
+
+  .showHide {
+    text-transform: uppercase;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    color: $primary-light;
+    font-size: 11px;
+    letter-spacing: 0.5px;
+  }
 }


### PR DESCRIPTION
- Metadata rows will be sorted by value descending and then by the label alphabetically.
- 4 rows will be shown by default with a show/hide toggle.

![Mar-27-2019 13-30-47](https://user-images.githubusercontent.com/5652739/55110277-f1958280-5094-11e9-857c-62103302e4d5.gif)

### Testing
- Go to Projects/Samples, look at the sidebar, verify that the values are sorted and the toggle works as expected.