### PR TITLE
[Discovery Sidebar] Show 'unknown' location instead of null

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -107,7 +107,7 @@ export default class DiscoverySidebar extends React.Component {
       project: sample.sample.project,
       sampleTissue: sample.sampleType || "Unknown",
       createdAt: DiscoverySidebar.formatDate(sample.sample.createdAt),
-      sampleLocation: sample.sampleLocation || "Unknown",
+      sampleLocation: sample.sampleLocation || "Unknownj",
       totalReads: sample.totalReads,
       nonHostReads: sample.nonHostReads.value
     }));

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -107,7 +107,7 @@ export default class DiscoverySidebar extends React.Component {
       project: sample.sample.project,
       sampleTissue: sample.sampleType || "Unknown",
       createdAt: DiscoverySidebar.formatDate(sample.sample.createdAt),
-      sampleLocation: sample.sampleLocation,
+      sampleLocation: sample.sampleLocation || "Unknown",
       totalReads: sample.totalReads,
       nonHostReads: sample.nonHostReads.value
     }));

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -107,7 +107,7 @@ export default class DiscoverySidebar extends React.Component {
       project: sample.sample.project,
       sampleTissue: sample.sampleType || "Unknown",
       createdAt: DiscoverySidebar.formatDate(sample.sample.createdAt),
-      sampleLocation: sample.sampleLocation || "Unknownj",
+      sampleLocation: sample.sampleLocation || "Unknown",
       totalReads: sample.totalReads,
       nonHostReads: sample.nonHostReads.value
     }));


### PR DESCRIPTION
- Sidebar was just showing 'null' instead of Unknown. Tiny fix

![Screen Shot 2019-03-27 at 3 44 45 PM](https://user-images.githubusercontent.com/5652739/55117226-43df9f00-50a7-11e9-92ab-760f141efec8.png)
