### PR TITLE
Log more context to segment

### DIFF
--- a/app/assets/src/api/constants.js
+++ b/app/assets/src/api/constants.js
@@ -3,6 +3,7 @@
 // if it makes sense, and a past tense action. Keep names meaningful, descriptive, and non-redundant
 // (e.g. prefer sample_viewed to sample_view_viewed).
 // ANALYTICS_EVENT_NAMES will have the camelCase key and snake_case value.
+// TODO: (gdingle): coordinate with ANALYTICS_EVENT_NAMES in server ruby
 
 export const ANALYTICS_EVENT_NAMES = {
   sampleViewed: "sample_viewed",

--- a/app/assets/src/api/constants.js
+++ b/app/assets/src/api/constants.js
@@ -3,8 +3,8 @@
 // if it makes sense, and a past tense action. Keep names meaningful, descriptive, and non-redundant
 // (e.g. prefer sample_viewed to sample_view_viewed).
 // ANALYTICS_EVENT_NAMES will have the camelCase key and snake_case value.
+// See https://czi.quip.com/bKDnAITc6CbE/How-to-start-instrumenting-analytics-2019-03-06
 // TODO: (gdingle): coordinate with ANALYTICS_EVENT_NAMES in server ruby
-
 export const ANALYTICS_EVENT_NAMES = {
   sampleViewed: "sample_viewed",
   userInterestFormSubmitted: "user_interest_form_submitted"

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -227,6 +227,7 @@ const createProject = params =>
     project: params
   });
 
+// See https://czi.quip.com/bKDnAITc6CbE/How-to-start-instrumenting-analytics-2019-03-06
 const logAnalyticsEvent = (eventName, eventData = {}) => {
   // Wrapper around Segment analytics so we can add things later
   // eventData should have keys in snake_case for the database

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -74,6 +74,7 @@ class HomeController < ApplicationController
       body += "#{k}: #{v}\n"
     end
     Rails.logger.info("New sign up:\n#{body}")
+    # DEPRECATED. Use log_analytics_event.
     MetricUtil.put_metric_now("users.sign_ups", 1)
 
     UserMailer.landing_sign_up_email(body).deliver_now

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -345,14 +345,13 @@ class ProjectsController < ApplicationController
 
     respond_to do |format|
       if @project.save
-        # Send to Datadog
-        # TODO: Replace with Segment
+        # Send to Datadog (DEPRECATED)
         tags = %W[project_id:#{@project.id} user_id:#{current_user.id}]
         MetricUtil.put_metric_now("projects.created", 1, tags)
 
         # Send to Segment
         event = MetricUtil::ANALYTICS_EVENT_NAMES[:project_created]
-        MetricUtil.log_analytics_event(event, current_user, id: @project.id)
+        MetricUtil.log_analytics_event(event, current_user, id: @project.id, request: request)
 
         format.html { redirect_to @project, notice: 'Project was successfully created.' }
         format.json { render :show, status: :created, location: @project, project: @project }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -395,10 +395,10 @@ class SamplesController < ApplicationController
 
     respond_to do |format|
       if @errors.empty? && !@samples.empty?
-        # Send to Datadog and Segment
+        # Send to Datadog (DEPRECATED) and Segment
         tags = %W[client:web type:bulk user_id:#{current_user.id}]
         MetricUtil.put_metric_now("samples.created", @samples.count, tags)
-        MetricUtil.log_upload_batch_analytics(@samples, current_user, "web")
+        MetricUtil.log_upload_batch_analytics(@samples, current_user, "web", request)
         format.json { render json: { samples: @samples, sample_ids: @samples.pluck(:id) } }
       else
         format.json { render json: { samples: @samples, errors: @errors }, status: :unprocessable_entity }
@@ -456,6 +456,7 @@ class SamplesController < ApplicationController
     respond_to do |format|
       if samples.count > 0
         tags = %W[client:web type:bulk user_id:#{current_user.id}]
+        # DEPRECATED. Use log_analytics_event.
         MetricUtil.put_metric_now("samples.created", samples.count, tags)
       end
       format.json { render json: { samples: samples, sample_ids: samples.pluck(:id), errors: errors } }
@@ -593,6 +594,7 @@ class SamplesController < ApplicationController
     @saved_param_values = viz ? viz.data : {}
 
     tags = %W[sample_id:#{@sample.id} user_id:#{current_user.id}]
+    # DEPRECATED. Use log_analytics_event.
     MetricUtil.put_metric_now("samples.showed", 1, tags)
   end
 
@@ -901,9 +903,9 @@ class SamplesController < ApplicationController
         # Currently bulk CLI upload just calls this action repeatedly so we can't
         # distinguish between bulk or single there. Web bulk goes to bulk_upload.
         tags << "type:single" if client == "web"
-        # Send to Datadog and Segment
+        # Send to Datadog (DEPRECATED) and Segment
         MetricUtil.put_metric_now("samples.created", 1, tags)
-        MetricUtil.log_upload_batch_analytics([@sample], current_user, client)
+        MetricUtil.log_upload_batch_analytics([@sample], current_user, client, request)
 
         format.html { redirect_to @sample, notice: 'Sample was successfully created.' }
         format.json { render :show, status: :created, location: @sample }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,11 +22,11 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       if @user.save
-        # Send event to Datadog and Segment
+        # Send event to Datadog (DEPRECATED) and Segment
         # TODO: Remove Datadog once Segment pipeline is set up
         MetricUtil.put_metric_now("users.created", 1, ["user_id:#{@user.id}"])
         event = MetricUtil::ANALYTICS_EVENT_NAMES[:user_created]
-        MetricUtil.log_analytics_event(event, current_user, id: @user.id, email_domain: @user.email.split("@").last, institution: @user.institution, admin: @user.admin)
+        MetricUtil.log_analytics_event(event, current_user, id: @user.id, email_domain: @user.email.split("@").last, institution: @user.institution, admin: @user.admin, request: request)
 
         format.html { redirect_to edit_user_path(@user), notice: "User was successfully created" }
         format.json { render :show, status: :created, location: root_path }

--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -1,6 +1,7 @@
 require "uri"
 require "net/http"
 
+# TODO: (gdingle): update description
 # MetricUtil is currently used for posting metrics to Datadog's metrics endpoints.
 class MetricUtil
   SEGMENT_ANALYTICS = if ENV["SEGMENT_RUBY_ID"]
@@ -24,16 +25,19 @@ class MetricUtil
     sample_upload_batch_created: "sample_upload_batch_created"
   }.freeze
 
+  # TODO: (gdingle): mark as deprecated and all callers
   def self.put_metric_now(name, value, tags = [], type = "count")
     put_metric(name, value, Time.now.to_i, tags, type)
   end
 
+  # TODO: (gdingle): make private
   def self.put_metric(name, value, time, tags = [], type = "count")
     # Time = POSIX time with just seconds
     points = [[time, value]]
     put_metric_point_series(name, points, tags, type)
   end
 
+  # TODO: (gdingle): make private
   def self.put_metric_point_series(name, points, tags = [], type = "count")
     # Tags look like: ["environment:test", "type:bulk"]
     name = "idseq.web.#{Rails.env}.#{name}"
@@ -46,6 +50,7 @@ class MetricUtil
     post_to_datadog(data)
   end
 
+  # TODO: (gdingle): make private
   def self.post_to_datadog(data)
     if ENV["DATADOG_API_KEY"]
       endpoint = "https://api.datadoghq.com/api/v1/series"
@@ -57,6 +62,7 @@ class MetricUtil
     end
   end
 
+  # TODO: (gdingle): make private
   def self.https_post(uri, data)
     # Don't block the rest of the flow
     Thread.new do
@@ -77,6 +83,8 @@ class MetricUtil
     end
   end
 
+  # TODO: (gdingle): make public
+  # TODO: (gdingle): add more from https://segment.com/docs/sources/server/ruby/
   def self.log_analytics_event(event, user, properties = {})
     if SEGMENT_ANALYTICS
       # current_user should be passed from a controller
@@ -85,6 +93,7 @@ class MetricUtil
     end
   end
 
+  # TODO: (gdingle): make public
   # Log analytics from a batch of new samples from an upload session
   def self.log_upload_batch_analytics(samples, user, client)
     # Send off an event for each project and host genome combo

--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -4,6 +4,7 @@ require "net/http"
 # MetricUtil is currently used for:
 #  * tracking user initiated actions with Segment
 #  * posting metrics to Datadog's metrics endpoints (DEPRECATED)
+# See https://czi.quip.com/bKDnAITc6CbE/How-to-start-instrumenting-analytics-2019-03-06
 class MetricUtil
   SEGMENT_ANALYTICS = if ENV["SEGMENT_RUBY_ID"]
                         Segment::Analytics.new(

--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -1,8 +1,9 @@
 require "uri"
 require "net/http"
 
-# TODO: (gdingle): update description
-# MetricUtil is currently used for posting metrics to Datadog's metrics endpoints.
+# MetricUtil is currently used for:
+#  * tracking user initiated actions with Segment
+#  * posting metrics to Datadog's metrics endpoints (DEPRECATED)
 class MetricUtil
   SEGMENT_ANALYTICS = if ENV["SEGMENT_RUBY_ID"]
                         Segment::Analytics.new(
@@ -17,6 +18,7 @@ class MetricUtil
   # Follow object_action convention with object being the name of the core model or component name
   # if it makes sense, and a past tense action. Keep names meaningful, descriptive, and
   # non-redundant (e.g. prefer sample_viewed to sample_view_viewed).
+  # TODO: (gdingle): coordinate with ANALYTICS_EVENT_NAMES in client JS
   ANALYTICS_EVENT_NAMES = {
     user_created: "user_created",
     project_created: "project_created",
@@ -25,84 +27,116 @@ class MetricUtil
     sample_upload_batch_created: "sample_upload_batch_created"
   }.freeze
 
-  # TODO: (gdingle): mark as deprecated and all callers
+  # DEPRECATED. Use log_analytics_event.
   def self.put_metric_now(name, value, tags = [], type = "count")
     put_metric(name, value, Time.now.to_i, tags, type)
   end
 
-  # TODO: (gdingle): make private
-  def self.put_metric(name, value, time, tags = [], type = "count")
-    # Time = POSIX time with just seconds
-    points = [[time, value]]
-    put_metric_point_series(name, points, tags, type)
-  end
-
-  # TODO: (gdingle): make private
-  def self.put_metric_point_series(name, points, tags = [], type = "count")
-    # Tags look like: ["environment:test", "type:bulk"]
-    name = "idseq.web.#{Rails.env}.#{name}"
-    data = JSON.dump("series" => [{
-                       "metric" => name,
-                       "points" => points,
-                       "type" => type,
-                       "tags" => tags
-                     }])
-    post_to_datadog(data)
-  end
-
-  # TODO: (gdingle): make private
-  def self.post_to_datadog(data)
-    if ENV["DATADOG_API_KEY"]
-      endpoint = "https://api.datadoghq.com/api/v1/series"
-      api_key = ENV["DATADOG_API_KEY"]
-      uri = URI.parse("#{endpoint}?api_key=#{api_key}")
-      https_post(uri, data)
-    else
-      Rails.logger.warn("Cannot send metrics data. No Datadog API key set.")
-    end
-  end
-
-  # TODO: (gdingle): make private
-  def self.https_post(uri, data)
-    # Don't block the rest of the flow
-    Thread.new do
-      Rails.logger.info("Sending data: #{data}")
-      request = Net::HTTP::Post.new(uri)
-      request.content_type = "application/json"
-      request.body = data
-      req_options = {
-        use_ssl: uri.scheme == "https"
-      }
-
-      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
-        http.request(request)
-      end
-      unless response.is_a?(Net::HTTPSuccess)
-        Rails.logger.warn("Unable to send data: #{response.message}")
-      end
-    end
-  end
-
-  # TODO: (gdingle): make public
-  # TODO: (gdingle): add more from https://segment.com/docs/sources/server/ruby/
-  def self.log_analytics_event(event, user, properties = {})
+  # This should never block on error.
+  def self.log_analytics_event(event, user, properties = {}, request = nil)
     if SEGMENT_ANALYTICS
       # current_user should be passed from a controller
       user_id = user ? user.id : 0
-      SEGMENT_ANALYTICS.track(event: event, user_id: user_id, properties: properties)
+
+      if user
+        SEGMENT_ANALYTICS.identify(
+          user_id: user_id,
+          traits: user.traits_for_segment,
+          context: request ? context_for_segment(request) : {}
+        )
+      end
+
+      SEGMENT_ANALYTICS.track(
+        event: event,
+        user_id: user_id,
+        properties: properties,
+        context: request ? context_for_segment(request) : {}
+      )
     end
+  rescue => err
+    LogUtil.log_err_and_airbrake("Failed to log to Segment '#{event}': #{err}")
   end
 
-  # TODO: (gdingle): make public
   # Log analytics from a batch of new samples from an upload session
-  def self.log_upload_batch_analytics(samples, user, client)
+  def self.log_upload_batch_analytics(samples, user, client, request = nil)
     # Send off an event for each project and host genome combo
     samples.group_by { |s| [s.project_id, s.host_genome_id] }.each do |(project_id, host_genome_id), entries|
       log_analytics_event(
         ANALYTICS_EVENT_NAMES[:sample_upload_batch_created],
         user,
-        count: entries.count, project_id: project_id, host_genome_id: host_genome_id, client: client
+        { count: entries.count, project_id: project_id, host_genome_id: host_genome_id, client: client },
+        request
       )
+    end
+  end
+
+  # Start private class methods
+  class << self
+    private
+
+    # See https://segment.com/docs/spec/common/#context
+    # See https://api.rubyonrails.org/classes/ActionDispatch/Request.html
+    def context_for_segment(request)
+      {
+        page: {
+          path: request.fullpath().split("?")[0],
+
+          referrer: request.referer,
+          search: request.fullpath().split("?")[1],
+          url: request.original_url()
+        },
+        userAgent: request.user_agent,
+        ip: request.remote_ip()
+      }
+    end
+
+    def put_metric(name, value, time, tags = [], type = "count")
+      # Time = POSIX time with just seconds
+      points = [[time, value]]
+      put_metric_point_series(name, points, tags, type)
+    end
+
+    def put_metric_point_series(name, points, tags = [], type = "count")
+      # Tags look like: ["environment:test", "type:bulk"]
+      name = "idseq.web.#{Rails.env}.#{name}"
+      data = JSON.dump("series" => [{
+                         "metric" => name,
+                         "points" => points,
+                         "type" => type,
+                         "tags" => tags
+                       }])
+      post_to_datadog(data)
+    end
+
+    def post_to_datadog(data)
+      if ENV["DATADOG_API_KEY"]
+        endpoint = "https://api.datadoghq.com/api/v1/series"
+        api_key = ENV["DATADOG_API_KEY"]
+        uri = URI.parse("#{endpoint}?api_key=#{api_key}")
+        https_post(uri, data)
+      else
+        Rails.logger.warn("Cannot send metrics data. No Datadog API key set.")
+      end
+    end
+
+    def https_post(uri, data)
+      # Don't block the rest of the flow
+      Thread.new do
+        Rails.logger.info("Sending data: #{data}")
+        request = Net::HTTP::Post.new(uri)
+        request.content_type = "application/json"
+        request.body = data
+        req_options = {
+          use_ssl: uri.scheme == "https"
+        }
+
+        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+          http.request(request)
+        end
+        unless response.is_a?(Net::HTTPSuccess)
+          Rails.logger.warn("Unable to send data: #{response.message}")
+        end
+      end
     end
   end
 end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -772,6 +772,7 @@ class PipelineRun < ApplicationRecord
 
         # Send to Datadog and Segment
         tags = ["sample_id:#{sample.id}"]
+        # DEPRECATED. Use log_analytics_event.
         MetricUtil.put_metric_now("samples.succeeded.run_time", run_time, tags, "gauge")
         event = MetricUtil::ANALYTICS_EVENT_NAMES[:pipeline_run_succeeded]
       else
@@ -849,6 +850,7 @@ class PipelineRun < ApplicationRecord
     # Check for long-running pipeline runs and log/alert if needed:
     run_time = Time.current - created_at
     tags = ["sample_id:#{sample.id}"]
+    # DEPRECATED. Use log_analytics_event.
     MetricUtil.put_metric_now("samples.running.run_time", run_time, tags, "gauge")
 
     if alert_sent.zero?

--- a/app/views/layouts/_page_header.html.erb
+++ b/app/views/layouts/_page_header.html.erb
@@ -13,6 +13,7 @@
 
       <% if ENV["SEGMENT_JS_ID"] %>
         <!-- Associate user ID with Segment -->
+        TODO: add stuff: traits, options
         analytics.identify(<%= current_user.id %>);
       <% end %>
     <% end %>

--- a/app/views/layouts/_page_header.html.erb
+++ b/app/views/layouts/_page_header.html.erb
@@ -11,10 +11,12 @@
         userSignedIn: true
       }, 'page_header', JSON.parse('<%= raw escape_json(request_context)%>'))
 
+
       <% if ENV["SEGMENT_JS_ID"] %>
         <!-- Associate user ID with Segment -->
-        TODO: add stuff: traits, options
-        analytics.identify(<%= current_user.id %>);
+        analytics.identify(
+          <%= current_user.id %>,
+          <%= raw escape_json(current_user.traits_for_segment) %>);
       <% end %>
     <% end %>
   <% else %>

--- a/app/views/layouts/_segment_analytics.html.erb
+++ b/app/views/layouts/_segment_analytics.html.erb
@@ -5,8 +5,6 @@
     // Segment ID is designed to be public: https://community.segment.com/t/m26sng/writekey-accessible-by-anyone
     !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
       analytics.load("<%= ENV["SEGMENT_JS_ID"] %>");
-      // TODO (gdingle): add more frmo https://segment.com/docs/sources/website/analytics.js/#page
-      // todo: add group:https://segment.com/docs/sources/website/analytics.js/#group
       analytics.page();
     }}();
   </script>

--- a/app/views/layouts/_segment_analytics.html.erb
+++ b/app/views/layouts/_segment_analytics.html.erb
@@ -5,6 +5,8 @@
     // Segment ID is designed to be public: https://community.segment.com/t/m26sng/writekey-accessible-by-anyone
     !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
       analytics.load("<%= ENV["SEGMENT_JS_ID"] %>");
+      // TODO (gdingle): add more frmo https://segment.com/docs/sources/website/analytics.js/#page
+      // todo: add group:https://segment.com/docs/sources/website/analytics.js/#group
       analytics.page();
     }}();
   </script>


### PR DESCRIPTION
# Description

This makes full use of segment in the client and server given the data we have at call-time. 

# Test

Load a page and see log data such as 
```
{
  "email": "gdingle@chanzuckerberg.com",
  "name": "Greg Dingle",
  "created_at": "2018-06-08T13:20:09.000-07:00",
  "updated_at": "2019-02-21T11:44:53.000-08:00",
  "role": 1,
  "allowed_features": [
    "data_discovery"
  ],
  "institution": null,
  "admin": true,
  "demo_user": false,
  "biohub_user": false,
  "czi_user": true,
  "createdAt": "2018-06-08T13:20:09-07:00",
  "firstName": "Greg",
  "lastName": "Dingle",
  "sign_in_count": 3,
  "current_sign_in_at": "2019-02-21T11:44:53.000-08:00",
  "last_sign_in_at": "2019-02-08T15:08:14.000-08:00",
  "current_sign_in_ip": "172.19.0.1",
  "last_sign_in_ip": "172.19.0.1"
}
```
