### PR TITLE
Add cached counts to user model for analytics

### DIFF
--- a/app/models/favorite_project.rb
+++ b/app/models/favorite_project.rb
@@ -1,4 +1,4 @@
 class FavoriteProject < ApplicationRecord
   belongs_to :project
-  belongs_to :user, counter_cache: true # count for analytics
+  belongs_to :user, counter_cache: true # use .size for cache, use .count to force COUNT query
 end

--- a/app/models/favorite_project.rb
+++ b/app/models/favorite_project.rb
@@ -1,4 +1,4 @@
 class FavoriteProject < ApplicationRecord
   belongs_to :project
-  belongs_to :user
+  belongs_to :user, counter_cache: true # count for analytics
 end

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -4,7 +4,7 @@ class PhyloTree < ApplicationRecord
   include SamplesHelper
   include ActionView::Helpers::DateHelper
   has_and_belongs_to_many :pipeline_runs
-  belongs_to :user
+  belongs_to :user, counter_cache: true # count for analytics
   belongs_to :project
   validates :name, presence: true, uniqueness: true
   after_create :create_visualization

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -4,7 +4,7 @@ class PhyloTree < ApplicationRecord
   include SamplesHelper
   include ActionView::Helpers::DateHelper
   has_and_belongs_to_many :pipeline_runs
-  belongs_to :user, counter_cache: true # count for analytics
+  belongs_to :user, counter_cache: true # use .size for cache, use .count to force COUNT query
   belongs_to :project
   validates :name, presence: true, uniqueness: true
   after_create :create_visualization

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,7 @@ class Project < ApplicationRecord
     include Elasticsearch::Model::Callbacks
   end
 
+  # TODO: (gdingle): add counter_cache if we ever migrate user assoc to "has_many :through"
   has_and_belongs_to_many :users
   has_many :samples
   has_many :favorite_projects

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,7 +4,6 @@ class Project < ApplicationRecord
     include Elasticsearch::Model::Callbacks
   end
 
-  # TODO: (gdingle): add counter_cache if we ever migrate user assoc to "has_many :through"
   has_and_belongs_to_many :users
   has_many :samples
   has_many :favorite_projects

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -45,7 +45,7 @@ class Sample < ApplicationRecord
 
   belongs_to :project
   # This is the user who uploaded the sample, possibly distinct from the user(s) owning the sample's project
-  belongs_to :user, optional: true, counter_cache: true # count for analytics
+  belongs_to :user, optional: true, counter_cache: true # use .size for cache, use .count to force COUNT query
   belongs_to :host_genome, optional: true
   has_many :pipeline_runs, -> { order(created_at: :desc) }, dependent: :destroy
   has_and_belongs_to_many :backgrounds, through: :pipeline_runs

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -44,7 +44,8 @@ class Sample < ApplicationRecord
   attr_accessor :bulk_mode
 
   belongs_to :project
-  belongs_to :user, optional: true # This is the user who uploaded the sample, possibly distinct from the user(s) owning the sample's project
+  # This is the user who uploaded the sample, possibly distinct from the user(s) owning the sample's project
+  belongs_to :user, optional: true, counter_cache: true # count for analytics
   belongs_to :host_genome, optional: true
   has_many :pipeline_runs, -> { order(created_at: :desc) }, dependent: :destroy
   has_and_belongs_to_many :backgrounds, through: :pipeline_runs

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :recoverable,
          :rememberable, :trackable, :validatable
 
+  # NOTE: counter_cache is not supported for has_and_belongs_to_many.
   has_and_belongs_to_many :projects
   # All one-to-many assocs are counter cached for per-user analytics.
   # See traits_for_segment.
@@ -125,8 +126,9 @@ class User < ApplicationRecord
       favorites: favorites.size,
       visualizations: visualizations.size,
       phylo_trees: phylo_trees.size,
-      # Has-some (this is important for Google Custom Dimensions)
-      # See https://segment.com/docs/destinations/google-analytics/#custom-dimensions
+      # Has-some (this is important for Google Custom Dimensions, which require
+      # categorical values--there is no way to derive them from raw counts.) See
+      # https://segment.com/docs/destinations/google-analytics/#custom-dimensions
       has_projects: !projects.empty?,
       has_samples: !samples.empty?,
       has_favorite_projects: !favorite_projects.empty?,

--- a/app/models/visualization.rb
+++ b/app/models/visualization.rb
@@ -2,7 +2,7 @@
 class Visualization < ApplicationRecord
   serialize :data, JSON
   has_and_belongs_to_many :samples
-  belongs_to :user, counter_cache: true # count for analytics
+  belongs_to :user, counter_cache: true # use .size for cache, use .count to force COUNT query
   validates :name, presence: true
   validates :data, presence: true
 

--- a/app/models/visualization.rb
+++ b/app/models/visualization.rb
@@ -2,7 +2,7 @@
 class Visualization < ApplicationRecord
   serialize :data, JSON
   has_and_belongs_to_many :samples
-  belongs_to :user
+  belongs_to :user, counter_cache: true # count for analytics
   validates :name, presence: true
   validates :data, presence: true
 

--- a/db/migrate/20190328190745_add_counts_to_users.rb
+++ b/db/migrate/20190328190745_add_counts_to_users.rb
@@ -1,0 +1,9 @@
+class AddCountsToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :samples_count, :integer, default: 0, null: false
+    add_column :users, :favorite_projects_count, :integer, default: 0, null: false
+    add_column :users, :favorites_count, :integer, default: 0, null: false
+    add_column :users, :visualizations_count, :integer, default: 0, null: false
+    add_column :users, :phylo_trees_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20190328191732_populate_user_counts.rb
+++ b/db/migrate/20190328191732_populate_user_counts.rb
@@ -1,0 +1,12 @@
+class PopulateUserCounts < ActiveRecord::Migration[5.1]
+  def up
+    User.find_each do |user|
+      User.reset_counters(user.id,
+                          :samples,
+                          :favorite_projects,
+                          :favorites,
+                          :visualizations,
+                          :phylo_trees)
+    end
+  end
+end


### PR DESCRIPTION
# Description

Request for comment. Based on https://github.com/chanzuckerberg/idseq-web/pull/2087 . 

We need to define user groups by the level of usage of the app. For example, users that have uploaded a sample. See https://czi.quip.com/hgbzAVVqAbC6/Metrics-Design-and-Segment-Breakdown . And joining the user table with a large set of other tables on any tracking call seems like a bad idea. 

An easy way to get the counts efficiently is with cached counts in the user model of the numbers of associated objects. See https://blog.appsignal.com/2018/06/19/activerecords-counter-cache.html for more background. 

This means every `INSERT` to the affected assocs would add an `UPDATE` to the user table. Given the low expected write rate, I think this is an acceptable cost, and it would be useful in the app anywhere we want a count of a user's objects. 

The alternative would be to compute the same counts downstream by SQL query in the warehouse. This puts more burden on the analyst, and it also wouldn't work for Google analytics dimensions or other analytics tools we may want to use. 

# Test

Run migrations
Check user in rails console for non zero counts
Check for correct SQL queries in console