### PR TITLE
change non-host reads to passed filters

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1140,7 +1140,7 @@ class PipelineSampleReport extends React.Component {
           subsampled_reads +
           " out of " +
           this.report_details.pipeline_info.adjusted_remaining_reads +
-          " non-host reads."
+          " reads passing filters."
         : "";
     const disable_filter = this.anyFilterSet() ? (
       <span className="disable" onClick={e => this.resetAllFilters()}>

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/constants.js
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/constants.js
@@ -27,7 +27,7 @@ export const PIPELINE_INFO_FIELDS = [
     key: "totalErccReads"
   },
   {
-    name: "Non-host Reads",
+    name: "Passed Filters",
     key: "nonhostReads"
   },
   {

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -292,7 +292,7 @@ export default class DiscoverySidebar extends React.Component {
                 <div className={cs.hasBackground}>
                   <dl className={cx(cs.dataList)}>
                     <dt className={cs.statsDt}>
-                      <strong>Avg. non-host reads per sample</strong>
+                      <strong>Avg. reads passing filters per sample</strong>
                     </dt>
                     <dd className={cs.statsDd}>
                       {this.state.stats.avgNonHostReads}

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -43,7 +43,7 @@ class SamplesView extends React.Component {
       },
       {
         dataKey: "nonHostReads",
-        label: "Non Host Reads",
+        label: "Passed Filters",
         flexGrow: 1,
         cellRenderer: this.renderNumberAndPercentage
       },

--- a/app/assets/src/components/views/samples/constants.js
+++ b/app/assets/src/components/views/samples/constants.js
@@ -6,7 +6,7 @@ export const SAMPLE_TABLE_COLUMNS = {
     type: "pipeline_data"
   },
   nonhost_reads: {
-    display_name: "Non-host reads",
+    display_name: "Passed filters",
     type: "pipeline_data"
   },
   total_ercc_reads: {


### PR DESCRIPTION
Renames a metric which had been confusing for users. Checked new naming with Katrina