### PR TITLE
[Discovery Sidebar] Update date histogram style for edge cases

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -130,12 +130,12 @@ export default class DiscoverySidebar extends React.Component {
     const lastDate = dateKeys[dateKeys.length - 1];
     return (
       <div className={cs.histogramContainer}>
-        <div className={cx(cs.dateHistogram)}>
+        <div className={cs.dateHistogram}>
           {dateKeys.map(key => {
             const percent = Math.round(100 * dates[key] / total, 0);
             const element = (
               <div
-                className={cx(cs.bar)}
+                className={cs.bar}
                 key={key}
                 style={{ height: percent + "px" }}
                 onClick={() => this.handleFilterClick(key)}
@@ -162,10 +162,8 @@ export default class DiscoverySidebar extends React.Component {
         <div
           className={cx(cs.histogramLabels, dateKeys.length < 3 && cs.evenly)}
         >
-          <div className={cx(cs.label)}>{firstDate}</div>
-          {firstDate !== lastDate && (
-            <div className={cx(cs.label)}>{lastDate}</div>
-          )}
+          <div className={cs.label}>{firstDate}</div>
+          {firstDate !== lastDate && <div className={cs.label}>{lastDate}</div>}
         </div>
       </div>
     );
@@ -188,7 +186,7 @@ export default class DiscoverySidebar extends React.Component {
     const extraRows = sorted.slice(defaultN);
     const total = sum(Object.values(fieldData));
     return (
-      <dl className={cx(cs.dataList)}>
+      <dl className={cs.dataList}>
         {this.renderMetadataRowBlock(defaultRows, total)}
         {expandedMetadataGroups.has(field) &&
           this.renderMetadataRowBlock(extraRows, total)}
@@ -262,7 +260,7 @@ export default class DiscoverySidebar extends React.Component {
             header={<div className={cs.title}>Overall</div>}
           >
             <div className={cs.hasBackground}>
-              <dl className={cx(cs.dataList)}>
+              <dl className={cs.dataList}>
                 <dt className={cs.statsDt}>
                   <strong>Samples</strong>
                 </dt>
@@ -272,7 +270,7 @@ export default class DiscoverySidebar extends React.Component {
               </dl>
             </div>
             <div className={cs.hasBackground}>
-              <dl className={cx(cs.dataList)}>
+              <dl className={cs.dataList}>
                 <dt className={cs.statsDt}>
                   <strong>Projects</strong>
                 </dt>
@@ -284,7 +282,7 @@ export default class DiscoverySidebar extends React.Component {
             {currentTab === "samples" && (
               <div>
                 <div className={cs.hasBackground}>
-                  <dl className={cx(cs.dataList)}>
+                  <dl className={cs.dataList}>
                     <dt className={cs.statsDt}>
                       <strong>Avg. reads per sample</strong>
                     </dt>
@@ -294,7 +292,7 @@ export default class DiscoverySidebar extends React.Component {
                   </dl>
                 </div>
                 <div className={cs.hasBackground}>
-                  <dl className={cx(cs.dataList)}>
+                  <dl className={cs.dataList}>
                     <dt className={cs.statsDt}>
                       <strong>Avg. reads passing filters per sample</strong>
                     </dt>

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -122,12 +122,10 @@ export default class DiscoverySidebar extends React.Component {
   // TODO (gdingle): auto scale to day week or month?
   buildDateHistogram(field) {
     const dates = this.state.metadata[field];
-    console.log("dates: ", dates);
 
     const total = sum(Object.values(dates));
     const dateKeys = Object.keys(dates);
     dateKeys.sort();
-    console.log("dateKeys: ", dateKeys);
     const firstDate = dateKeys[0];
     const lastDate = dateKeys[dateKeys.length - 1];
     return (
@@ -161,7 +159,9 @@ export default class DiscoverySidebar extends React.Component {
             );
           })}
         </div>
-        <div className={cx(cs.dateHistogramLabels)}>
+        <div
+          className={cx(cs.histogramLabels, dateKeys.length < 3 && cs.evenly)}
+        >
           <div className={cx(cs.label)}>{firstDate}</div>
           {firstDate !== lastDate && (
             <div className={cx(cs.label)}>{lastDate}</div>

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -122,10 +122,12 @@ export default class DiscoverySidebar extends React.Component {
   // TODO (gdingle): auto scale to day week or month?
   buildDateHistogram(field) {
     const dates = this.state.metadata[field];
+    console.log("dates: ", dates);
 
     const total = sum(Object.values(dates));
     const dateKeys = Object.keys(dates);
     dateKeys.sort();
+    console.log("dateKeys: ", dateKeys);
     const firstDate = dateKeys[0];
     const lastDate = dateKeys[dateKeys.length - 1];
     return (
@@ -137,7 +139,7 @@ export default class DiscoverySidebar extends React.Component {
               <div
                 className={cx(cs.bar)}
                 key={key}
-                style={{ height: percent * 2 + "px" }}
+                style={{ height: percent + "px" }}
                 onClick={() => this.handleFilterClick(key)}
               >
                 &nbsp;
@@ -159,9 +161,11 @@ export default class DiscoverySidebar extends React.Component {
             );
           })}
         </div>
-        <div className={cx(cs.dateHistogram)}>
+        <div className={cx(cs.dateHistogramLabels)}>
           <div className={cx(cs.label)}>{firstDate}</div>
-          <div className={cx(cs.label)}>{lastDate}</div>
+          {firstDate !== lastDate && (
+            <div className={cx(cs.label)}>{lastDate}</div>
+          )}
         </div>
       </div>
     );

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -48,15 +48,24 @@
   .dateHistogram {
     display: flex;
     flex-flow: row nowrap;
-    justify-content: space-between;
+    justify-content: space-evenly;
     align-items: flex-end;
 
     .bar {
-      margin: 0 1px;
+      margin-left: auto;
+      margin-right: auto;
       flex: 1 0;
       background-color: $melrose;
       cursor: pointer;
+      max-width: 14px;
     }
+  }
+
+  .dateHistogramLabels {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-around;
+    align-items: flex-end;
 
     .label {
       margin: 4px 0;
@@ -104,9 +113,8 @@
 
   .bar {
     display: inline-block;
-    vertical-align: top;
-    height: 18px;
-    margin-top: 1px;
+    vertical-align: middle;
+    height: 12px;
     margin-left: 5px;
     margin-right: 7px;
     padding: 0 5px;
@@ -126,6 +134,7 @@
   }
 
   .count {
+    vertical-align: middle;
     color: $dark-grey;
     font-weight: 600;
   }

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -52,8 +52,7 @@
     align-items: flex-end;
 
     .bar {
-      margin-left: auto;
-      margin-right: auto;
+      margin: 0 1px;
       flex: 1 0;
       background-color: $melrose;
       cursor: pointer;
@@ -61,10 +60,10 @@
     }
   }
 
-  .dateHistogramLabels {
+  .histogramLabels {
     display: flex;
     flex-flow: row nowrap;
-    justify-content: space-around;
+    justify-content: space-between;
     align-items: flex-end;
 
     .label {
@@ -72,6 +71,10 @@
       flex: 0 0;
       white-space: nowrap;
       font-size: smaller;
+    }
+
+    &.evenly {
+      justify-content: space-evenly;
     }
   }
 }


### PR DESCRIPTION
- Update date histogram style for edge cases. Behavior from Design for special casing 1 date, 2 dates displayed.
- Also makes the metadata bars a little skinnier.
- Mocks: https://chanzuckerberg.invisionapp.com/d/main#/console/17022287/352866509/preview

### 1 bar case
![Screen Shot 2019-03-28 at 2 55 24 PM](https://user-images.githubusercontent.com/5652739/55195383-a13c2480-5169-11e9-9e2e-7fd7dcfe610b.png)

### 2 bar case
![Screen Shot 2019-03-28 at 2 55 17 PM](https://user-images.githubusercontent.com/5652739/55195407-b0bb6d80-5169-11e9-95d4-f9678cc37e75.png)

### 3 or more bar case
![Screen Shot 2019-03-28 at 2 55 34 PM](https://user-images.githubusercontent.com/5652739/55195391-a8633280-5169-11e9-8bfd-85f713bbcfe0.png)
![Screen Shot 2019-03-28 at 2 55 40 PM](https://user-images.githubusercontent.com/5652739/55195395-aac58c80-5169-11e9-8533-c8d19504bea7.png)

### Testing
- Go to Data Discovery view, click through Project/Samples, use the filters to limit your date selection, and verify the sidebar behaves as expected.