### PR TITLE
[Data Discovery] Add 'clicking on sample brings you to the report'

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -130,14 +130,14 @@ export default class DiscoverySidebar extends React.Component {
     const lastDate = dateKeys[dateKeys.length - 1];
     return (
       <div className={cs.histogramContainer}>
-        <div className={cx(cs.dateHistogram)}>
+        <div className={cs.dateHistogram}>
           {dateKeys.map(key => {
             const percent = Math.round(100 * dates[key] / total, 0);
             const element = (
               <div
-                className={cx(cs.bar)}
+                className={cs.bar}
                 key={key}
-                style={{ height: percent * 2 + "px" }}
+                style={{ height: percent + "px" }}
                 onClick={() => this.handleFilterClick(key)}
               >
                 &nbsp;
@@ -159,9 +159,11 @@ export default class DiscoverySidebar extends React.Component {
             );
           })}
         </div>
-        <div className={cx(cs.dateHistogram)}>
-          <div className={cx(cs.label)}>{firstDate}</div>
-          <div className={cx(cs.label)}>{lastDate}</div>
+        <div
+          className={cx(cs.histogramLabels, dateKeys.length < 3 && cs.evenly)}
+        >
+          <div className={cs.label}>{firstDate}</div>
+          {firstDate !== lastDate && <div className={cs.label}>{lastDate}</div>}
         </div>
       </div>
     );
@@ -184,7 +186,7 @@ export default class DiscoverySidebar extends React.Component {
     const extraRows = sorted.slice(defaultN);
     const total = sum(Object.values(fieldData));
     return (
-      <dl className={cx(cs.dataList)}>
+      <dl className={cs.dataList}>
         {this.renderMetadataRowBlock(defaultRows, total)}
         {expandedMetadataGroups.has(field) &&
           this.renderMetadataRowBlock(extraRows, total)}
@@ -258,7 +260,7 @@ export default class DiscoverySidebar extends React.Component {
             header={<div className={cs.title}>Overall</div>}
           >
             <div className={cs.hasBackground}>
-              <dl className={cx(cs.dataList)}>
+              <dl className={cs.dataList}>
                 <dt className={cs.statsDt}>
                   <strong>Samples</strong>
                 </dt>
@@ -268,7 +270,7 @@ export default class DiscoverySidebar extends React.Component {
               </dl>
             </div>
             <div className={cs.hasBackground}>
-              <dl className={cx(cs.dataList)}>
+              <dl className={cs.dataList}>
                 <dt className={cs.statsDt}>
                   <strong>Projects</strong>
                 </dt>
@@ -280,7 +282,7 @@ export default class DiscoverySidebar extends React.Component {
             {currentTab === "samples" && (
               <div>
                 <div className={cs.hasBackground}>
-                  <dl className={cx(cs.dataList)}>
+                  <dl className={cs.dataList}>
                     <dt className={cs.statsDt}>
                       <strong>Avg. reads per sample</strong>
                     </dt>
@@ -290,7 +292,7 @@ export default class DiscoverySidebar extends React.Component {
                   </dl>
                 </div>
                 <div className={cs.hasBackground}>
-                  <dl className={cx(cs.dataList)}>
+                  <dl className={cs.dataList}>
                     <dt className={cs.statsDt}>
                       <strong>Avg. reads passing filters per sample</strong>
                     </dt>

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -380,8 +380,8 @@ class DiscoveryView extends React.Component {
     });
   };
 
-  handleSampleSelected = () => {
-    console.log("yoyo");
+  handleSampleSelected = ({ sample, event }) => {
+    openUrl(`/samples/${sample.id}`, event);
   };
 
   render() {
@@ -476,6 +476,7 @@ class DiscoveryView extends React.Component {
                   onLoadRows={this.handleLoadSampleRows}
                   samples={samples}
                   selectableIds={sampleIds}
+                  onSampleSelected={this.handleSampleSelected}
                 />
               )}
               {currentTab == "visualizations" && (

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -380,6 +380,10 @@ class DiscoveryView extends React.Component {
     });
   };
 
+  handleSampleSelected = () => {
+    console.log("yoyo");
+  };
+
   render() {
     const {
       currentTab,

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -48,7 +48,7 @@
   .dateHistogram {
     display: flex;
     flex-flow: row nowrap;
-    justify-content: space-between;
+    justify-content: space-evenly;
     align-items: flex-end;
 
     .bar {
@@ -56,13 +56,25 @@
       flex: 1 0;
       background-color: $melrose;
       cursor: pointer;
+      max-width: 14px;
     }
+  }
+
+  .histogramLabels {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    align-items: flex-end;
 
     .label {
       margin: 4px 0;
       flex: 0 0;
       white-space: nowrap;
       font-size: smaller;
+    }
+
+    &.evenly {
+      justify-content: space-evenly;
     }
   }
 }
@@ -104,9 +116,8 @@
 
   .bar {
     display: inline-block;
-    vertical-align: top;
-    height: 18px;
-    margin-top: 1px;
+    vertical-align: middle;
+    height: 12px;
     margin-left: 5px;
     margin-right: 7px;
     padding: 0 5px;
@@ -126,6 +137,7 @@
   }
 
   .count {
+    vertical-align: middle;
     color: $dark-grey;
     font-weight: 600;
   }

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -304,7 +304,7 @@ class SamplesView extends React.Component {
   handleRowClick = ({ event, index, rowData }) => {
     const { onSampleSelected, samples } = this.props;
     const sample = find({ id: rowData.id }, samples);
-    onSampleSelected && onSampleSelected({ sample });
+    onSampleSelected && onSampleSelected({ sample, event });
   };
 
   render() {

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { difference, isEmpty, union } from "lodash/fp";
+import { difference, find, isEmpty, union } from "lodash/fp";
 import InfiniteTable from "../../visualizations/table/InfiniteTable";
 import Label from "~ui/labels/Label";
 import moment from "moment";
@@ -301,6 +301,12 @@ class SamplesView extends React.Component {
     this.setState({ phyloTreeCreationModalOpen: false });
   };
 
+  handleRowClick = ({ event, index, rowData }) => {
+    const { onSampleSelected, samples } = this.props;
+    const sample = find({ id: rowData.id }, samples);
+    onSampleSelected && onSampleSelected({ sample });
+  };
+
   render() {
     const { activeColumns, onLoadRows, protectedColumns } = this.props;
     const { phyloTreeCreationModalOpen, selectedSampleIds } = this.state;
@@ -322,6 +328,7 @@ class SamplesView extends React.Component {
             onLoadRows={onLoadRows}
             onSelectAllRows={this.handleSelectAllRows}
             onSelectRow={this.handleSelectRow}
+            onRowClick={this.handleRowClick}
             protectedColumns={protectedColumns}
             rowClassName={cs.tableDataRow}
             selectableKey="id"
@@ -358,7 +365,8 @@ SamplesView.propTypes = {
   projectId: PropTypes.number,
   protectedColumns: PropTypes.array,
   samples: PropTypes.array,
-  selectableIds: PropTypes.array.isRequired
+  selectableIds: PropTypes.array.isRequired,
+  onSampleSelected: PropTypes.func
 };
 
 export default SamplesView;


### PR DESCRIPTION
- Followed the pattern in ProjectsView
- Support the Command+click as previously

![Mar-28-2019 17-19-08](https://user-images.githubusercontent.com/5652739/55200951-e5392480-517d-11e9-8b00-27c962e48532.gif)

### Testing
- Go to data discovery view -> Go to Samples tab -> Click on a sample -> See the report load. Or Command+Click and see the report open in a new tab.