### PR TITLE
add report lineage test

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_321_214_445) do
+ActiveRecord::Schema.define(version: 20_190_325_215_059) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -146,7 +146,6 @@ ActiveRecord::Schema.define(version: 20_190_321_214_445) do
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key", null: false, collation: "latin1_swedish_ci"
-    t.integer "data_type", limit: 1, null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.float "number_validated_value", limit: 24
@@ -347,6 +346,13 @@ ActiveRecord::Schema.define(version: 20_190_321_214_445) do
     t.index ["user_id"], name: "index_samples_on_user_id"
   end
 
+  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "visualization_id", null: false
+    t.bigint "sample_id", null: false
+    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
+    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
+  end
+
   create_table "shortened_urls", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "owner_id"
     t.string "owner_type", limit: 20
@@ -535,13 +541,7 @@ ActiveRecord::Schema.define(version: 20_190_321_214_445) do
     t.integer "public_access", limit: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
     t.index ["user_id"], name: "index_visualizations_on_user_id"
-  end
-
-  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "visualization_id", null: false
-    t.bigint "sample_id", null: false
-    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
-    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_325_215_059) do
+ActiveRecord::Schema.define(version: 20_190_321_214_445) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -146,6 +146,7 @@ ActiveRecord::Schema.define(version: 20_190_325_215_059) do
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key", null: false, collation: "latin1_swedish_ci"
+    t.integer "data_type", limit: 1, null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.float "number_validated_value", limit: 24
@@ -346,13 +347,6 @@ ActiveRecord::Schema.define(version: 20_190_325_215_059) do
     t.index ["user_id"], name: "index_samples_on_user_id"
   end
 
-  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "visualization_id", null: false
-    t.bigint "sample_id", null: false
-    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
-    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
-  end
-
   create_table "shortened_urls", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "owner_id"
     t.string "owner_type", limit: 20
@@ -541,7 +535,13 @@ ActiveRecord::Schema.define(version: 20_190_325_215_059) do
     t.integer "public_access", limit: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name"
     t.index ["user_id"], name: "index_visualizations_on_user_id"
+  end
+
+  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "visualization_id", null: false
+    t.bigint "sample_id", null: false
+    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
+    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
   end
 end

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -126,6 +126,14 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2_428_411_754.8, species_result["NR"]["aggregatescore"].round(1)
     assert_equal 16.9101009, species_result["NR"]["neglogevalue"]
 
+    assert_equal "Klebsiella pneumoniae", species_result["lineage"]["species_name"]
+    assert_equal "Klebsiella", species_result["lineage"]["genus_name"]
+    assert_equal "Enterobacteriaceae", species_result["lineage"]["family_name"]
+    assert_equal "Enterobacterales", species_result["lineage"]["order_name"]
+    assert_equal "Gammaproteobacteria", species_result["lineage"]["class_name"]
+    assert_equal "Proteobacteria", species_result["lineage"]["phylum_name"]
+    assert_equal "Bacteria", species_result["lineage"]["superkingdom_name"]
+
     assert_equal 217.0, genus_result["NT"]["r"]
     assert_equal "193404.634", genus_result["NT"]["rpm"]
     assert_equal 99.0, genus_result["NT"]["zscore"]

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -160,6 +160,14 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 12_583.63, species_result["NR"]["aggregatescore"].round(2)
     assert_equal 9.3000002, species_result["NR"]["neglogevalue"]
 
+    assert_equal "Streptococcus pneumoniae", species_result["lineage"]["species_name"]
+    assert_equal "Streptococcus", species_result["lineage"]["genus_name"]
+    assert_equal "Streptococcaceae", species_result["lineage"]["family_name"]
+    assert_equal "Lactobacillales", species_result["lineage"]["order_name"]
+    assert_equal "Bacilli", species_result["lineage"]["class_name"]
+    assert_equal "Firmicutes", species_result["lineage"]["phylum_name"]
+    assert_equal "Bacteria", species_result["lineage"]["superkingdom_name"]
+
     assert_equal 4.0, genus_result["NT"]["r"]
     assert_equal "3565.062", genus_result["NT"]["rpm"]
     assert_equal 2.2081236, genus_result["NT"]["zscore"]

--- a/test/fixtures/taxon_lineages.yml
+++ b/test/fixtures/taxon_lineages.yml
@@ -1,2 +1,28 @@
 one:
   taxid: 1
+
+kleb_pneumo:
+  version_start: 1
+  version_end: 1
+  taxid: 573
+  species_taxid: 573
+  genus_taxid: 570
+  family_taxid: 543
+  order_taxid: 91347
+  class_taxid: 1236
+  phylum_taxid: 1224
+  superkingdom_taxid: 2
+  species_name: "Klebsiella pneumoniae"
+  genus_name: "Klebsiella"
+  family_name: "Enterobacteriaceae"
+  order_name: "Enterobacterales"
+  class_name: "Gammaproteobacteria"
+  phylum_name: "Proteobacteria"
+  superkingdom_name: "Bacteria"
+  superkingdom_common_name: "eubacteria"
+  phylum_common_name: ""
+  class_common_name: ""
+  order_common_name: ""
+  family_common_name: ""
+  genus_common_name: ""
+  species_common_name: ""

--- a/test/fixtures/taxon_lineages.yml
+++ b/test/fixtures/taxon_lineages.yml
@@ -26,3 +26,33 @@ kleb_pneumo:
   family_common_name: ""
   genus_common_name: ""
   species_common_name: ""
+
+strep_pneumo:
+  taxid: 1313
+  superkingdom_taxid: 2
+  phylum_taxid: 1239
+  class_taxid: 91061
+  order_taxid: 186826
+  family_taxid: 1300
+  genus_taxid: 1301
+  species_taxid: 1313
+  superkingdom_name: "Bacteria"
+  phylum_name: "Firmicutes"
+  class_name: "Bacilli"
+  order_name: "Lactobacillales"
+  family_name: "Streptococcaceae"
+  genus_name: "Streptococcus"
+  species_name: "Streptococcus pneumoniae"
+  superkingdom_common_name: "eubacteria"
+  phylum_common_name: ""
+  class_common_name: ""
+  order_common_name: ""
+  family_common_name: ""
+  genus_common_name: ""
+  species_common_name: ""
+  kingdom_taxid: -650
+  kingdom_name: ""
+  kingdom_common_name: ""
+  tax_name: "Streptococcus pneumoniae"
+  version_start: 1
+  version_end: 3


### PR DESCRIPTION
Prevent future occurrences of missing lineage names in taxon tree or report.