### PR TITLE
[Data Discovery] Add 'clicking on sample brings you to the report'

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -472,6 +472,7 @@ class DiscoveryView extends React.Component {
                   onLoadRows={this.handleLoadSampleRows}
                   samples={samples}
                   selectableIds={sampleIds}
+                  onSampleSelected={this.handleSampleSelected}
                 />
               )}
               {currentTab == "visualizations" && (

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { difference, isEmpty, union } from "lodash/fp";
+import { difference, find, isEmpty, union } from "lodash/fp";
 import InfiniteTable from "../../visualizations/table/InfiniteTable";
 import Label from "~ui/labels/Label";
 import moment from "moment";
@@ -301,6 +301,12 @@ class SamplesView extends React.Component {
     this.setState({ phyloTreeCreationModalOpen: false });
   };
 
+  handleRowClick = ({ event, index, rowData }) => {
+    const { onSampleSelected, samples } = this.props;
+    const sample = find({ id: rowData.id }, samples);
+    onSampleSelected && onSampleSelected({ sample, currentEvent: event });
+  };
+
   render() {
     const { activeColumns, onLoadRows, protectedColumns } = this.props;
     const { phyloTreeCreationModalOpen, selectedSampleIds } = this.state;
@@ -322,6 +328,7 @@ class SamplesView extends React.Component {
             onLoadRows={onLoadRows}
             onSelectAllRows={this.handleSelectAllRows}
             onSelectRow={this.handleSelectRow}
+            onRowClick={this.handleRowClick}
             protectedColumns={protectedColumns}
             rowClassName={cs.tableDataRow}
             selectableKey="id"
@@ -351,14 +358,15 @@ SamplesView.defaultProps = {
   ],
   protectedColumns: ["sample"]
 };
-
+//
 SamplesView.propTypes = {
   activeColumns: PropTypes.arrayOf(PropTypes.string),
   onLoadRows: PropTypes.func.isRequired,
   projectId: PropTypes.number,
   protectedColumns: PropTypes.array,
   samples: PropTypes.array,
-  selectableIds: PropTypes.array.isRequired
+  selectableIds: PropTypes.array.isRequired,
+  onSampleSelected: PropTypes.func
 };
 
 export default SamplesView;

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -358,7 +358,7 @@ SamplesView.defaultProps = {
   ],
   protectedColumns: ["sample"]
 };
-//
+
 SamplesView.propTypes = {
   activeColumns: PropTypes.arrayOf(PropTypes.string),
   onLoadRows: PropTypes.func.isRequired,


### PR DESCRIPTION
- Sorry, repeat PR b/c I accidentally merged the other PR into Tiago's branch after he had already merged it.
- Base on Tiago's pr

![Mar-28-2019 17-19-08](https://user-images.githubusercontent.com/5652739/55200951-e5392480-517d-11e9-8b00-27c962e48532.gif)

### Testing
- Go to data discovery view -> Go to Samples tab -> Click on a sample -> See the report load. Or Command+Click and see the report open in a new tab.