### PR TITLE
[Data Discovery] Fix bug on clicking sample checkbox triggering report load

### DIFF
--- a/app/assets/src/components/ui/controls/Checkbox.jsx
+++ b/app/assets/src/components/ui/controls/Checkbox.jsx
@@ -23,8 +23,9 @@ class Checkbox extends React.Component {
   }
 
   handleClick(event) {
-    const { value, onChange } = this.props;
+    event.stopPropagation();
 
+    const { value, onChange } = this.props;
     this.setState({ isChecked: !this.state.isChecked }, () => {
       onChange(value, this.state.isChecked, event);
     });

--- a/app/assets/src/components/ui/controls/Checkbox.jsx
+++ b/app/assets/src/components/ui/controls/Checkbox.jsx
@@ -23,9 +23,9 @@ class Checkbox extends React.Component {
   }
 
   handleClick(event) {
-    event.stopPropagation();
-
     const { value, onChange } = this.props;
+
+    event.stopPropagation();
     this.setState({ isChecked: !this.state.isChecked }, () => {
       onChange(value, this.state.isChecked, event);
     });

--- a/app/assets/src/components/ui/controls/Checkbox.jsx
+++ b/app/assets/src/components/ui/controls/Checkbox.jsx
@@ -24,7 +24,7 @@ class Checkbox extends React.Component {
 
   handleClick(event) {
     event.stopPropagation();
-    //
+
     const { value, onChange } = this.props;
     this.setState({ isChecked: !this.state.isChecked }, () => {
       onChange(value, this.state.isChecked, event);

--- a/app/assets/src/components/ui/controls/Checkbox.jsx
+++ b/app/assets/src/components/ui/controls/Checkbox.jsx
@@ -24,7 +24,7 @@ class Checkbox extends React.Component {
 
   handleClick(event) {
     event.stopPropagation();
-
+    //
     const { value, onChange } = this.props;
     this.setState({ isChecked: !this.state.isChecked }, () => {
       onChange(value, this.state.isChecked, event);


### PR DESCRIPTION
- The event propagates down to the whole sample row and triggers the report load, so we just need stopPropagation.
- I tried moving the `stop` more downstream and got `Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're accessing the method `stopPropagation` on a released/nullified synthetic event. This is a no-op function. If you must keep the original synthetic event around, use event.persist(). See https://fb.me/react-event-pooling for more information.` so I thought it'd be fine to keep it in Checkbox

### Testing
- Go to data discovery, samples tab, and verify that you can check boxes without triggering a report load.