### PR TITLE
add alignment length to report

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -97,6 +97,7 @@ class PipelineSampleReport extends React.Component {
       { text: "NT contigs", value: "NT_contigs" },
       { text: "NT contig reads", value: "NT_contigreads" },
       { text: "NT %id", value: "NT_percentidentity" },
+      { text: "NT L (alignment length in bp)", value: "NT_alignmentlength" },
       { text: "NT log(1/e)", value: "NT_neglogevalue" },
       { text: "NR Z Score", value: "NR_zscore" },
       { text: "NR rPM", value: "NR_rpm" },
@@ -104,6 +105,7 @@ class PipelineSampleReport extends React.Component {
       { text: "NR contigs", value: "NR_contigs" },
       { text: "NR contig reads", value: "NR_contigreads" },
       { text: "NR %id", value: "NR_percentidentity" },
+      { text: "NR L (alignment length in bp)", value: "NR_alignmentlength" },
       { text: "NR log(1/e)", value: "NR_neglogevalue" }
     ];
     this.categoryChildParent = { Phage: "Viruses" };

--- a/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
+++ b/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
@@ -64,6 +64,11 @@ export default class DetailCells extends React.Component {
           taxInfo.NR.percentidentity,
           1
         )}
+        {renderNumber(
+          taxInfo.NT.alignmentlength,
+          taxInfo.NR.alignmentlength,
+          1
+        )}
         {renderNumber(taxInfo.NT.neglogevalue, taxInfo.NR.neglogevalue, 0)}
         {renderNumber(
           taxInfo.NT.percentconcordant,

--- a/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
+++ b/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
@@ -94,6 +94,11 @@ export default class ReportTable extends React.Component {
                 `Average percent-identity of alignments to NCBI NT/NR`
               )}
               {renderColumnHeader(
+                "L",
+                `${countType}_alignmentlength`,
+                `Average length (bp) of alignments to NCBI NT/NR`
+              )}
+              {renderColumnHeader(
                 "log(1/E)",
                 `${countType}_neglogevalue`,
                 `Average log-10-transformed expect value for alignments to NCBI NT/NR`


### PR DESCRIPTION
Helps users remove spurious hits by filtering on alignment length