### PR TITLE
[IDSEQ-901] Fix loss of work issues in Sample Upload Flow.

### DIFF
--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -62,6 +62,9 @@ class MetadataUpload extends React.Component {
   // MetadataManualInput doesn't validate metadata before calling onMetadataChangeManual.
   // This happens when Continue is clicked in the parent component.
   onMetadataChangeManual = ({ metadata }) => {
+    if (this.props.onDirty) {
+      this.props.onDirty();
+    }
     this.props.onMetadataChange({ metadata, wasManual: true });
   };
 
@@ -112,6 +115,8 @@ class MetadataUpload extends React.Component {
             onMetadataChange={this.onMetadataChangeCSV}
             project={this.props.project}
             samplesAreNew={this.props.samplesAreNew}
+            visible={this.props.visible}
+            onDirty={this.props.onDirty}
           />
           <a className={cs.link} href={this.getCSVUrl()}>
             Download Metadata CSV Template
@@ -258,7 +263,11 @@ MetadataUpload.propTypes = {
   project: PropTypes.Project,
   samples: PropTypes.arrayOf(PropTypes.Sample),
   samplesAreNew: PropTypes.bool,
-  withinModal: PropTypes.bool
+  withinModal: PropTypes.bool,
+  visible: PropTypes.bool,
+  // Immediately called when the user changes anything, even before validation has returned.
+  // Can be used to disable the header navigation.
+  onDirty: PropTypes.func
 };
 
 export default MetadataUpload;

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -21,7 +21,12 @@ class SampleUploadFlow extends React.Component {
     metadata: null, //
     metadataIssues: null,
     // Once the upload has started, the user cannot return to past steps.
-    isUploading: false
+    isUploading: false,
+    stepsEnabled: {
+      uploadSamples: true,
+      uploadMetadata: false,
+      review: false
+    }
   };
 
   handleUploadSamples = ({
@@ -35,7 +40,8 @@ class SampleUploadFlow extends React.Component {
       project,
       uploadType,
       sampleNamesToFiles,
-      currentStep: "uploadMetadata"
+      currentStep: "uploadMetadata",
+      stepsEnabled: set("uploadMetadata", true, this.state.stepsEnabled)
     });
   };
 
@@ -73,24 +79,34 @@ class SampleUploadFlow extends React.Component {
       samples: newSamples,
       metadata: newMetadata,
       metadataIssues: issues,
-      currentStep: "review"
+      currentStep: "review",
+      stepsEnabled: set("review", true, this.state.stepsEnabled)
+    });
+  };
+
+  samplesChanged = () => {
+    this.setState({
+      stepsEnabled: {
+        uploadSamples: true,
+        uploadMetadata: false,
+        review: false
+      }
+    });
+  };
+
+  metadataChanged = () => {
+    this.setState({
+      stepsEnabled: {
+        uploadSamples: true,
+        uploadMetadata: true,
+        review: false
+      }
     });
   };
 
   handleStepSelect = step => {
     this.setState({
-      currentStep: step,
-      // If the user returns to the Upload Samples step, clear the samples and metadata,
-      // so that the UploadMetadataStep is unmounted.
-      // This is for simplicity. Ideally, we'd be more intelligent about keeping metadata for
-      // samples that weren't changed.
-      ...(step === "uploadSamples"
-        ? {
-            metadata: null,
-            metadataIssues: null,
-            samples: null
-          }
-        : {})
+      currentStep: step
     });
   };
 
@@ -107,6 +123,7 @@ class SampleUploadFlow extends React.Component {
     return (
       <div>
         <UploadSampleStep
+          onDirty={this.samplesChanged}
           onUploadSamples={this.handleUploadSamples}
           visible={this.state.currentStep === "uploadSamples"}
         />
@@ -116,6 +133,7 @@ class SampleUploadFlow extends React.Component {
             samples={this.getSamplesForMetadataValidation()}
             project={this.state.project}
             visible={this.state.currentStep === "uploadMetadata"}
+            onDirty={this.metadataChanged}
           />
         )}
         {this.state.samples &&
@@ -151,6 +169,7 @@ class SampleUploadFlow extends React.Component {
           project={this.state.project}
           onStepSelect={this.handleStepSelect}
           isUploading={this.state.isUploading}
+          stepsEnabled={this.state.stepsEnabled}
         />
         <NarrowContainer className={cx(cs.sampleUploadFlow)}>
           <div className={cs.inner}>{this.renderSteps()}</div>

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { startCase, findIndex } from "lodash/fp";
+import { startCase } from "lodash/fp";
 import cx from "classnames";
 
 import PropTypes from "~/components/utils/propTypes";
@@ -25,10 +25,7 @@ const MENU_OPTIONS = [
 
 class SampleUploadFlowHeader extends React.Component {
   isStepEnabled = step => {
-    const index = findIndex(["step", step], MENU_OPTIONS);
-    const curIndex = findIndex(["step", this.props.currentStep], MENU_OPTIONS);
-
-    return index < curIndex && !this.props.isUploading;
+    return this.props.stepsEnabled[step];
   };
 
   onStepSelect = step => {
@@ -77,7 +74,9 @@ class SampleUploadFlowHeader extends React.Component {
                   className={cx(
                     cs.option,
                     currentStep === val.step && cs.active,
-                    this.isStepEnabled(val.step) && cs.enabled
+                    currentStep !== val.step &&
+                      this.isStepEnabled(val.step) &&
+                      cs.enabled
                   )}
                   key={val.text}
                   onClick={() => this.onStepSelect(val.step)}
@@ -99,7 +98,8 @@ SampleUploadFlowHeader.propTypes = {
   samples: PropTypes.arrayOf(PropTypes.Sample),
   project: PropTypes.Project,
   onStepSelect: PropTypes.func.isRequired,
-  isUploading: PropTypes.bool
+  isUploading: PropTypes.bool,
+  stepsEnabled: PropTypes.objectOf(PropTypes.bool)
 };
 
 export default SampleUploadFlowHeader;

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -90,6 +90,8 @@ class UploadMetadataStep extends React.Component {
               onMetadataChange={this.handleMetadataChange}
               samplesAreNew
               issues={this.state.wasManual ? this.state.issues : null}
+              visible={this.props.visible}
+              onDirty={this.props.onDirty}
             />
           </div>
           <div className={cs.controls}>
@@ -122,7 +124,10 @@ UploadMetadataStep.propTypes = {
     id: PropTypes.number,
     name: PropTypes.string
   }),
-  visible: PropTypes.bool
+  visible: PropTypes.bool,
+  // Immediately called when the user changes anything, even before validation has returned.
+  // Can be used to disable the header navigation.
+  onDirty: PropTypes.func.isRequired
 };
 
 export default UploadMetadataStep;

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -118,6 +118,7 @@ class UploadSampleStep extends React.Component {
   };
 
   handleProjectChange = async project => {
+    this.props.onDirty();
     this.setState({
       validatingSamples: true
     });
@@ -245,6 +246,7 @@ class UploadSampleStep extends React.Component {
   };
 
   handleProjectCreate = async project => {
+    this.props.onDirty();
     this.setState({
       validatingSamples: true
     });
@@ -276,6 +278,7 @@ class UploadSampleStep extends React.Component {
   };
 
   handleTabChange = tab => {
+    this.props.onDirty();
     this.setState({ currentTab: tab });
   };
 
@@ -310,6 +313,7 @@ class UploadSampleStep extends React.Component {
   };
 
   handleLocalSampleChange = async (localSamples, sampleNamesToFiles) => {
+    this.props.onDirty();
     this.setState({
       validatingSamples: true,
       removedLocalFiles: []
@@ -344,6 +348,7 @@ class UploadSampleStep extends React.Component {
   };
 
   handleRemoteSampleChange = async remoteSamples => {
+    this.props.onDirty();
     this.setState({
       validatingSamples: true
     });
@@ -362,6 +367,7 @@ class UploadSampleStep extends React.Component {
   };
 
   handleSampleRemoved = sampleName => {
+    this.props.onDirty();
     const newSamples = reject(["name", sampleName], this.getCurrentSamples());
     const newSampleNamesToFiles = omit(
       sampleName,
@@ -512,6 +518,9 @@ class UploadSampleStep extends React.Component {
 
 UploadSampleStep.propTypes = {
   onUploadSamples: PropTypes.func.isRequired,
+  // Immediately called when the user changes anything, even before validation has returned.
+  // Can be used to disable the header navigation.
+  onDirty: PropTypes.func.isRequired,
   visible: PropTypes.bool
 };
 

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -112,6 +112,8 @@
       align-items: center;
       justify-content: center;
       margin-bottom: 6px;
+      // Disable semantic-ui transition.
+      transition: none;
     }
 
     .text {


### PR DESCRIPTION
We no longer delete the metadata when the user goes back to the Upload Samples step.

For CSV metadata, we re-validate the metadata when MetadataCSVUpload becomes visible again if we detect
that the samples have changed. For manual metadata, the validate is still done when the user clicks
Continue (as before).

We are also more intelligent about when to disable the header navigation.

Now, we only disable the nav once the user has changed something
(which is tracked via the "onDirty" method). In this case, the user has to
click the "Continue" button to go through the steps again.
This is because (among other reasons) metadata validation only happens at the Upload Metadata step.
We don't want the user to be able to change the samples and then jump straight to the Review step, so
we make them go through the flow again.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

Test Local Sample and Manual Input:
1. Go to /samples/upload.
2. Fill in the samples step using local samples and metadata step using manual input and go to the Review Step.
3. Verify that you can go back and forth between the steps via the header nav and "Edit Samples/Metadata/Project" button.
4. Modify a metadatum in the metadata input.
5. Verify that the "Review" Header Nav is disabled.
6. Click Continue to go to the Review Step.
7. Now go back to the Sample Step. Remove one of the samples and verify that "Metadata" and"Review" header navs are both disabled.
8. Click "Continue" and verify that there is no error on the metadata step (the previous metadata still persists).
9. Return to the sample step and add the previous sample back.
10. Go to the next step and verify that the metadata from the sample you had deleted has been added back.
11. Return to the sample step and ADD a new sample different from the previous.
12. Go to the next step and verify that the new sample has defaulted to Human and the other fields are not filled in.
13. Fill in the new fields.
14. Go to the review step and submit the sample.
15. Verify that the samples are submitted correctly.

Test Remote Sample and CSV Input:
1. Go to /samples/upload.
2. Fill in the samples step using remote samples and metadata step using CSV input and go to the Review Step.
3. Verify that you can go back and forth between the steps via the header nav and "Edit Samples/Metadata/Project" button.
4. Upload a modified CSV file.
5. Verify that the "Review" Header Nav is disabled.
6. Click Continue to go to the Review Step.
7. Now go back to the Sample Step. Remove one of the samples and verify that "Metadata" and"Review" header navs are both disabled.
8. Click "Continue" and verify that there is an error on the metadata step (1 sample names do not match any samples being uploaded.).
9. Return to the sample step and add the previous sample back.
10. Go to the next step and verify that the CSV now validates without errors.
11. Return to the sample step and ADD a new sample different from the previous.
12. Submit the samples and verify that the samples are submitted correctly.

# Checklist:

- [ ] I have run through the testing script to make sure current functionality is unchanged
- [X] I have done relevant tests that prove my fix is effective or that my feature works
- [X] I have spent time testing out edge cases for my feature
- [ ] I have updated the test script or pull request template if necessary
- [X] New and existing unit tests pass locally with my changes

