### PR TITLE
Add browser warning when user navigates away from Upload Flow.

### DIFF
--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -48,17 +48,12 @@ export const bulkUploadLocalWithMetadata = ({
             )
           ) {
             allUploadsCompleteRan = true;
-            window.onbeforeunload = null;
             onAllUploadsComplete();
           }
         })
         .catch(() => onMarkSampleUploadedError(sampleName));
     }
   };
-
-  // Latest browsers will only show a generic warning
-  window.onbeforeunload = () =>
-    "Uploading is in progress. Are you sure you want to exit?";
 
   bulkUploadWithMetadata(samples, metadata)
     .then(response => {

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -118,7 +118,12 @@ class MetadataUpload extends React.Component {
             visible={this.props.visible}
             onDirty={this.props.onDirty}
           />
-          <a className={cs.link} href={this.getCSVUrl()}>
+          <a
+            className={cs.link}
+            href={this.getCSVUrl()}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Download Metadata CSV Template
           </a>
           {this.state.validatingCSV && (

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -53,6 +53,7 @@ class ReviewStep extends React.Component {
             submitState: "success",
             createdSampleIds: response.sample_ids
           });
+          this.props.onUploadComplete();
         })
         // TODO(mark): Display better errors.
         // For example, some samples may have successfully saved, but not others. Should explain to user.
@@ -73,6 +74,7 @@ class ReviewStep extends React.Component {
           this.setState({
             submitState: "success"
           });
+          this.props.onUploadComplete();
         },
         onCreateSamplesError: errors => {
           // TODO(mark): Display better errors.
@@ -299,7 +301,8 @@ ReviewStep.propTypes = {
   visible: PropTypes.bool,
   // Triggers when we start or stop uploading. Lets the parent know to disable header link.
   onUploadStatusChange: PropTypes.func,
-  onStepSelect: PropTypes.func
+  onStepSelect: PropTypes.func,
+  onUploadComplete: PropTypes.func.isRequired
 };
 
 export default ReviewStep;

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -29,6 +29,16 @@ class SampleUploadFlow extends React.Component {
     }
   };
 
+  componentDidMount() {
+    // Latest browsers will only show a generic warning
+    window.onbeforeunload = () =>
+      "Are you sure you want to leave? All data will be lost.";
+  }
+
+  onUploadComplete = () => {
+    window.onbeforeunload = null;
+  };
+
   handleUploadSamples = ({
     samples,
     project,
@@ -148,6 +158,7 @@ class SampleUploadFlow extends React.Component {
               visible={this.state.currentStep === "review"}
               onUploadStatusChange={this.onUploadStatusChange}
               onStepSelect={this.handleStepSelect}
+              onUploadComplete={this.onUploadComplete}
             />
           )}
       </div>

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -72,7 +72,12 @@ class UploadMetadataStep extends React.Component {
   render() {
     return (
       <div className={cs.uploadMetadataStep}>
-        <div className={cx(!this.state.showInstructions && cs.hide)}>
+        <div
+          className={cx(
+            cs.uploadInstructions,
+            !this.state.showInstructions && cs.hide
+          )}
+        >
           <Instructions onClose={() => this.setShowInstructions(false)} />
         </div>
         <div

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -244,6 +244,10 @@
     margin-bottom: 8px;
   }
 
+  .uploadInstructions {
+    margin-top: 10px;
+  }
+
   .hide {
     display: none;
   }

--- a/app/assets/src/components/views/samples/MetadataUploadModal/Instructions.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/Instructions.jsx
@@ -24,7 +24,8 @@ class UploadInstructions extends React.Component {
               Review the fields in our{" "}
               <a
                 href="/metadata/dictionary"
-                onClick={this.openDictionary}
+                target="_blank"
+                rel="noopener noreferrer"
                 className={cs.link}
               >
                 metadata dictionary
@@ -34,7 +35,12 @@ class UploadInstructions extends React.Component {
             </li>
             <li>
               You can use your own CSV or copy your metadata into our{" "}
-              <a className={cs.link} href="/metadata/metadata_template_csv">
+              <a
+                href="/metadata/metadata_template_csv"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cs.link}
+              >
                 CSV template.
               </a>
             </li>


### PR DESCRIPTION
Also make links, including the metadata csv template, open in new tabs.
Otherwise, the warning will also show when the user clicks those links.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Go to the Sample Upload.
2. Attempt to reload the page. Note the browser popup. Click cancel.
3. Go through the Sample Flow, reloading at each step.
4. Click on the CSV Upload, and click on the download template link. Also click on the links in the "CSV Upload Instructions". Make sure no browser warning appears in these cases.
5. Complete the upload. Verify that after the upload is successful, navigating away or refreshing no longer triggers the browser popup.
6. Do 1-5 for both remote and local uploads.

1. Go to Metadata Upload Modal.
2. Verify that you can still download the CSV template and view the dictionary without any problems.

Which pages?
- Sample Upload
- Metadata Upload Modal

# Checklist:

- [] I have run through the testing script to make sure current functionality is unchanged
- [X] I have done relevant tests that prove my fix is effective or that my feature works
- [X] I have spent time testing out edge cases for my feature
- [] I have updated the test script or pull request template if necessary
- [X] New and existing unit tests pass locally with my changes

