### PR TITLE
[Location] Start geosearch endpoint

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,0 +1,39 @@
+class LocationsController < ApplicationController
+  def external_search
+    query = location_params[:query]
+    render(json: []) && return if query.blank?
+
+    results = []
+    resp = Location.geosearch(query)
+
+    if resp.is_a?(Net::HTTPSuccess)
+      candidates = JSON.parse(resp.body)
+      candidates.each do |c|
+        name_parts = c["display_name"].partition(", ")
+        results << {
+          title: name_parts[0],
+          description: name_parts[-1],
+          country: c["address"]["country"] || "",
+          state: c["address"]["state"] || "",
+          county: c["address"]["county"] || "",
+          city: c["address"]["city"] || "",
+          lat: c["lat"] || "",
+          lon: c["lon"] || ""
+        }
+      end
+    end
+    render json: results
+  rescue => err
+    render json: {
+      status: "failed",
+      message: "Unable to perform geosearch",
+      errors: [err]
+    }, status: :internal_server_error
+  end
+
+  private
+
+  def location_params
+    params.permit(:query)
+  end
+end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -20,6 +20,8 @@ class LocationsController < ApplicationController
         end
       end
     end
+    event = MetricUtil::ANALYTICS_EVENT_NAMES[:location_geosearched]
+    MetricUtil.log_analytics_event(event, current_user, query: query, request: request)
     render json: results
   rescue => err
     render json: {

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -3,10 +3,9 @@ class LocationsController < ApplicationController
     results = []
     query = location_params[:query]
     if query.present?
-      resp = Location.geosearch(query)
-      if resp.is_a?(Net::HTTPSuccess)
-        candidates = JSON.parse(resp.body)
-        candidates.each do |c|
+      success, resp = Location.geosearch(query)
+      if success
+        resp.each do |c|
           name_parts = c["display_name"].partition(", ")
           results << {
             title: name_parts[0],

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,25 +1,24 @@
 class LocationsController < ApplicationController
   def external_search
-    query = location_params[:query]
-    render(json: []) && return if query.blank?
-
     results = []
-    resp = Location.geosearch(query)
-
-    if resp.is_a?(Net::HTTPSuccess)
-      candidates = JSON.parse(resp.body)
-      candidates.each do |c|
-        name_parts = c["display_name"].partition(", ")
-        results << {
-          title: name_parts[0],
-          description: name_parts[-1],
-          country: c["address"]["country"] || "",
-          state: c["address"]["state"] || "",
-          county: c["address"]["county"] || "",
-          city: c["address"]["city"] || "",
-          lat: c["lat"] || "",
-          lon: c["lon"] || ""
-        }
+    query = location_params[:query]
+    if query.present?
+      resp = Location.geosearch(query)
+      if resp.is_a?(Net::HTTPSuccess)
+        candidates = JSON.parse(resp.body)
+        candidates.each do |c|
+          name_parts = c["display_name"].partition(", ")
+          results << {
+            title: name_parts[0],
+            description: name_parts[-1],
+            country: c["address"]["country"] || "",
+            state: c["address"]["state"] || "",
+            county: c["address"]["county"] || "",
+            city: c["address"]["city"] || "",
+            lat: c["lat"] || "",
+            lon: c["lon"] || ""
+          }
+        end
       end
     end
     render json: results

--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -25,7 +25,8 @@ class MetricUtil
     project_created: "project_created",
     pipeline_run_succeeded: "pipeline_run_succeeded",
     pipeline_run_failed: "pipeline_run_failed",
-    sample_upload_batch_created: "sample_upload_batch_created"
+    sample_upload_batch_created: "sample_upload_batch_created",
+    location_geosearched: "location_geosearched"
   }.freeze
 
   # DEPRECATED. Use log_analytics_event.

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,4 +1,4 @@
-class Location < ApplicationRecord
+class Location
   # Search request to Location IQ API
   def self.geosearch(query)
     raise ArgumentError, "No query for geosearch" if query.blank?

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,15 @@
+class Location < ApplicationRecord
+  # Search request to Location IQ API
+  def self.geosearch(query)
+    raise ArgumentError, "No query for geosearch" if query.blank?
+    raise "No API key for geosearch" unless ENV['LOCATION_IQ_API_KEY']
+
+    base_url = "https://us1.locationiq.com/v1/search.php?key=#{ENV['LOCATION_IQ_API_KEY']}&format=json&addressdetails=1&normalizecity=1"
+    query_url = "#{base_url}&q=#{query}"
+    uri = URI.parse(query_url)
+    request = Net::HTTP::Get.new(uri)
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(request)
+    end
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -8,8 +8,9 @@ class Location < ApplicationRecord
     query_url = "#{base_url}&q=#{query}"
     uri = URI.parse(query_url)
     request = Net::HTTP::Get.new(uri)
-    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+    resp = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
       http.request(request)
     end
+    [resp.is_a?(Net::HTTPSuccess), JSON.parse(resp.body)]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,10 @@ Rails.application.routes.draw do
     post :validate_csv_for_new_samples, on: :collection
   end
 
+  resource :locations do
+    get :external_search, on: :collection
+  end
+
   authenticate :user, ->(u) { u.admin? } do
     mount Resque::Server.new, at: "/resque"
   end

--- a/db/migrate/20190403210056_add_location_table.rb
+++ b/db/migrate/20190403210056_add_location_table.rb
@@ -1,5 +1,0 @@
-class AddLocationTable < ActiveRecord::Migration[5.1]
-  def change
-    create_table :locations
-  end
-end

--- a/db/migrate/20190403210056_add_location_table.rb
+++ b/db/migrate/20190403210056_add_location_table.rb
@@ -1,0 +1,5 @@
+class AddLocationTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :locations
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ x-web-variables: &web-variables
   ? RAILS_ENV
   ? SEGMENT_JS_ID
   ? SEGMENT_RUBY_ID
+  ? LOCATION_IQ_API_KEY
 
 x-aws-variables: &aws-variables
   ? AWS_ACCESS_KEY_ID

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+require "minitest/mock"
+
+class LocationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:joe)
+    @user_params = { "user[email]" => @user.email, "user[password]" => "passwordjoe" }
+    @api_response = true, [
+      {
+        "lat" => "37.76",
+        "lon" => "-122.45",
+        "display_name" => "University of California, San Francisco, Parnassus Avenue, Inner Sunset, San Francisco, San Francisco City and County, California, 94131, USA",
+        "address" => {
+          "city" => "San Francisco",
+          "county" => "San Francisco City and County",
+          "state" => "California",
+          "country" => "USA"
+        }
+      }
+    ]
+    @our_results = [
+      {
+        "title" => "University of California",
+        "description" => "San Francisco, Parnassus Avenue, Inner Sunset, San Francisco, San Francisco City and County, California, 94131, USA",
+        "country" => "USA",
+        "state" => "California",
+        "county" => "San Francisco City and County",
+        "city" => "San Francisco",
+        "lat" => "37.76",
+        "lon" => "-122.45"
+      }
+    ]
+    @api_key_error = { "status" => "failed", "message" => "Unable to perform geosearch", "errors" => ["No API key for geosearch"] }
+  end
+
+  test "user can geosearch with results" do
+    post user_session_path, params: @user_params
+
+    Location.stub :geosearch, @api_response do
+      get external_search_locations_path, params: { query: "UCSF" }
+      assert_response :success
+      assert_equal JSON.dump(@our_results), @response.body
+    end
+  end
+
+  test "user can geosearch without results" do
+    post user_session_path, params: @user_params
+
+    Location.stub :geosearch, [true, []] do
+      get external_search_locations_path, params: { query: "ahsdlfkjasfk" }
+      assert_response :success
+      assert_equal "[]", @response.body
+    end
+  end
+
+  test "user can geosearch and see an error" do
+    post user_session_path, params: @user_params
+    get external_search_locations_path, params: { query: "UCSF" }
+    assert_response :error
+    assert_equal JSON.dump(@api_key_error), @response.body
+  end
+end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -50,6 +50,14 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
       get external_search_locations_path, params: { query: "ahsdlfkjasfk" }
       assert_response :success
       assert_equal "[]", @response.body
+
+      get external_search_locations_path, params: { query: "" }
+      assert_response :success
+      assert_equal "[]", @response.body
+
+      get external_search_locations_path
+      assert_response :success
+      assert_equal "[]", @response.body
     end
   end
 


### PR DESCRIPTION
### Notes
- Adds locations/external_search endpoint for geosearch/geocoding queries (only logged in users)
- Location IQ had a Ruby library https://locationiq.com/docs#official-client-libraries but they say it's autogenerated and untested so I thought urls are fine. They also have an autocomplete-specific endpoint that could provide additional results (but it expects you to keep typing so it would keep suggesting "UCSF Medical Center" if you typed in "UCSF").
- Lots of potential fields returned by the API https://locationiq.com/docs-html/index.html#forward_response I found display_name/country/state/county/city/lat/lon to be important for us.
- Rate limiting can be implemented on the backend if we end up using up our usage.
- Formatting behavior like "allow just the plain text input" (like coordinates without resolving) can be done on the frontend.

### Demo
![Screen Shot 2019-04-03 at 3 58 23 PM](https://user-images.githubusercontent.com/5652739/55518636-a85fa880-5629-11e9-9a0b-f478a4f86718.png)
![Screen Shot 2019-04-03 at 3 48 02 PM](https://user-images.githubusercontent.com/5652739/55518638-ab5a9900-5629-11e9-993f-8af142e2c63e.png)
![Screen Shot 2019-04-03 at 3 47 53 PM](https://user-images.githubusercontent.com/5652739/55518642-af86b680-5629-11e9-8e9f-4fdb4d9b5f41.png)
![Screen Shot 2019-04-03 at 3 47 17 PM](https://user-images.githubusercontent.com/5652739/55518646-b44b6a80-5629-11e9-956a-09e4bb53cf08.png)

### Test and Reproduce
- To get the API key locally, either edit your entrypoint.sh to start chamber in production, or retrieve the key from Parameter Store and do `LOCATION_IQ_API_KEY=key docker-compose up web`
- Pull the branch, migrate, and go to pages like http://localhost:3000/locations/external_search?query=bay%20area or http://localhost:3000/locations/external_search?query=UCSF
- See JSON results