### PR TITLE
[Data Discovery] Associate saving heatmaps with data discovery feature.

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -37,7 +37,7 @@ class SamplesHeatmapView extends React.Component {
       ...this.urlParams
     };
 
-    // TODO (gdingle): remove admin gating when we go live with saved visualizations
+    // TODO (gdingle): remove gating when we go live with data discovery
     if (this.props.allowedFeatures.includes("data_discovery")) {
       this.initOnBeforeUnload(props.savedParamValues);
     }
@@ -777,7 +777,7 @@ class SamplesHeatmapView extends React.Component {
                 on="click"
                 hideOnScroll
               />
-              {/* TODO: (gdingle): this is admin-only until we have a way of browsing visualizations */}
+              {/* TODO: (gdingle): this is gated until we release data discovery */}
               {allowedFeatures.includes("data_discovery") && (
                 <SaveButton
                   onClick={this.onSaveClick}

--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -38,7 +38,7 @@ class SamplesHeatmapView extends React.Component {
     };
 
     // TODO (gdingle): remove admin gating when we go live with saved visualizations
-    if (this.props.admin) {
+    if (this.props.allowedFeatures.includes("data_discovery")) {
       this.initOnBeforeUnload(props.savedParamValues);
     }
 
@@ -752,6 +752,7 @@ class SamplesHeatmapView extends React.Component {
       { text: "Download PNG", value: "png" }
     ];
 
+    const { allowedFeatures } = this.props;
     return (
       <div className={cs.heatmap}>
         <div>
@@ -777,12 +778,12 @@ class SamplesHeatmapView extends React.Component {
                 hideOnScroll
               />
               {/* TODO: (gdingle): this is admin-only until we have a way of browsing visualizations */}
-              {this.props.admin && (
+              {allowedFeatures.includes("data_discovery") && (
                 <SaveButton
                   onClick={this.onSaveClick}
                   className={cs.controlElement}
                 />
-              )}{" "}
+              )}
               <DownloadButtonDropdown
                 className={cs.controlElement}
                 options={downloadOptions}
@@ -814,16 +815,16 @@ class SamplesHeatmapView extends React.Component {
 }
 
 SamplesHeatmapView.propTypes = {
+  allowedFeatures: PropTypes.object,
   backgrounds: PropTypes.array,
   categories: PropTypes.array,
   metrics: PropTypes.array,
   sampleIds: PropTypes.array,
+  savedParamValues: PropTypes.object,
   subcategories: PropTypes.object,
   removedTaxonIds: PropTypes.array,
   taxonLevels: PropTypes.array,
-  thresholdFilters: PropTypes.object,
-  savedParamValues: PropTypes.object,
-  admin: PropTypes.bool
+  thresholdFilters: PropTypes.object
 };
 
 export default SamplesHeatmapView;

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -34,7 +34,8 @@ module HeatmapHelper
         ],
         operators: [">=", "<="]
       },
-      admin: current_user.admin?
+      admin: current_user.admin?,
+      allowedFeatures: current_user.allowed_features
     }
   end
 

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -36,7 +36,6 @@ module HeatmapHelper
         ],
         operators: [">=", "<="]
       },
-      admin: current_user.admin?,
       allowedFeatures: current_user.allowed_features
     }
   end


### PR DESCRIPTION
Guard heatmap saving with "data_discovery" feature flag (instead of admin). Will allow enabling saving heatmaps for regular users.

Testing:
With a user *with data_discovery* in her allowed_features:
* verify that the save button shows up on the heatmap
* make some changes (e.g. filters)
* verify that an alert is triggered when you try to leave the visualization without saving
With a user *with (no data_discovery* in her allowed_features:
* verify that the save button does not show up on the heatmap
* verify that an alert is *not* triggered when you try to leave the visualization without saving
