### PR TITLE
[Alerts] Add job status/stage to LongRunningSampleEvent

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -857,7 +857,7 @@ class PipelineRun < ApplicationRecord
       threshold = 8.hours
       if run_time > threshold
         duration_hrs = (run_time / 60 / 60).round(2)
-        msg = "LongRunningSampleEvent: Sample #{sample.id} has been running for #{duration_hrs} hours. #{job_status_display}"
+        msg = "LongRunningSampleEvent: Sample #{sample.id} has been running for #{duration_hrs} hours. #{job_status_display}."
         LogUtil.log_err_and_airbrake(msg)
         update(alert_sent: 1)
       end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -857,7 +857,7 @@ class PipelineRun < ApplicationRecord
       threshold = 8.hours
       if run_time > threshold
         duration_hrs = (run_time / 60 / 60).round(2)
-        msg = "LongRunningSampleEvent: Sample #{sample.id} has been running for #{duration_hrs} hours. #{job_status_display}."
+        msg = "LongRunningSampleEvent: Sample #{sample.id} has been running for #{duration_hrs} hours. #{job_status_display}"
         LogUtil.log_err_and_airbrake(msg)
         update(alert_sent: 1)
       end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -857,7 +857,7 @@ class PipelineRun < ApplicationRecord
       threshold = 8.hours
       if run_time > threshold
         duration_hrs = (run_time / 60 / 60).round(2)
-        msg = "LongRunningSampleEvent: Sample #{sample.id} has been running for #{duration_hrs} hours."
+        msg = "LongRunningSampleEvent: Sample #{sample.id} has been running for #{duration_hrs} hours. #{job_status_display}."
         LogUtil.log_err_and_airbrake(msg)
         update(alert_sent: 1)
       end


### PR DESCRIPTION
### Description
- We have a Datadog alert on this line like "LongRunningSampleEvent: Sample 12553 has been running for 329.53 hours" so this PR adds the stage to the end for more insight.

### Test and Reproduce
- Go to your Rails console, run `PipelineRun.last.check_and_log_long_run` or similar, see a log msg like `[2019-04-04T17:24:19] ERROR Rails : LongRunningSampleEvent: Sample 12553 has been running for 329.53 hours. Pipeline Initializing.`

### Demo
```
irb(main):065:0> PipelineRun.last.job_status_display
[2019-04-04T17:19:46] DEBUG ActiveRecord::Base :   PipelineRun Load (0.8ms)  SELECT  `pipeline_runs`.* FROM `pipeline_runs` ORDER BY `pipeline_runs`.`id` DESC LIMIT 1
=> "Pipeline Initializing"
irb(main):066:0> PipelineRun.last.check_and_log_long_run
[2019-04-04T17:19:56] DEBUG ActiveRecord::Base :   PipelineRun Load (0.9ms)  SELECT  `pipeline_runs`.* FROM `pipeline_runs` ORDER BY `pipeline_runs`.`id` DESC LIMIT 1
[2019-04-04T17:19:56] DEBUG ActiveRecord::Base :   Sample Load (0.9ms)  SELECT  `samples`.* FROM `samples` WHERE `samples`.`id` = 12554 LIMIT 1
[2019-04-04T17:19:56] DEBUG ActiveRecord::Base : Query Trace:
      app/models/pipeline_run.rb:852:in `check_and_log_long_run'
[2019-04-04T17:19:56] WARN  Rails : Cannot send metrics data. No Datadog API key set.
[2019-04-04T17:19:56] ERROR Rails : LongRunningSampleEvent: Sample 12554 has been running for 329.4 hours. Pipeline Initializing.
[2019-04-04T17:19:56] DEBUG ActiveRecord::Base :    (1.0ms)  BEGIN
[2019-04-04T17:19:56] DEBUG ActiveRecord::Base :   AlignmentConfig Load (6.6ms)  SELECT  `alignment_configs`.* FROM `alignment_configs` WHERE `alignment_configs`.`id` = 4 LIMIT 1
[2019-04-04T17:19:56] DEBUG ActiveRecord::Base : Query Trace:
      app/models/pipeline_run.rb:862:in `check_and_log_long_run'
[2019-04-04T17:19:56] DEBUG ActiveRecord::Base :   SQL (9.1ms)  UPDATE `pipeline_runs` SET `alert_sent` = 1, `updated_at` = '2019-04-04 17:19:56' WHERE `pipeline_runs`.`id` = 18243
[2019-04-04T17:19:56] DEBUG ActiveRecord::Base : Query Trace:
      app/models/pipeline_run.rb:862:in `check_and_log_long_run'
[2019-04-04T17:19:56] DEBUG ActiveRecord::Base :    (6.0ms)  COMMIT
=> true
```