### PR TITLE
Disable the upload flow header nav once user starts uploading.

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -20,8 +20,6 @@ class SampleUploadFlow extends React.Component {
     // Metadata upload information
     metadata: null, //
     metadataIssues: null,
-    // Once the upload has started, the user cannot return to past steps.
-    isUploading: false,
     stepsEnabled: {
       uploadSamples: true,
       uploadMetadata: false,
@@ -167,7 +165,11 @@ class SampleUploadFlow extends React.Component {
 
   onUploadStatusChange = uploadStatus => {
     this.setState({
-      isUploading: uploadStatus
+      stepsEnabled: {
+        uploadSamples: !uploadStatus,
+        uploadMetadata: !uploadStatus,
+        review: !uploadStatus
+      }
     });
   };
 
@@ -179,7 +181,6 @@ class SampleUploadFlow extends React.Component {
           samples={this.state.samples}
           project={this.state.project}
           onStepSelect={this.handleStepSelect}
-          isUploading={this.state.isUploading}
           stepsEnabled={this.state.stepsEnabled}
         />
         <NarrowContainer className={cx(cs.sampleUploadFlow)}>

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
@@ -98,7 +98,6 @@ SampleUploadFlowHeader.propTypes = {
   samples: PropTypes.arrayOf(PropTypes.Sample),
   project: PropTypes.Project,
   onStepSelect: PropTypes.func.isRequired,
-  isUploading: PropTypes.bool,
   stepsEnabled: PropTypes.objectOf(PropTypes.bool)
 };
 


### PR DESCRIPTION
This is something we overlooked in an earlier PR. Also remove unused var isUploading.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Go through the upload flow and click "Upload Sample."
2. Verify that the header nav grays out once the uploading starts.

1. Change the back-end so that bulk_upload_with_metadata throws an error. (it's hard to test the error state, so I did this on dev)
2. Go through the upload flow again.  When you upload, it should error out. "There was an issue uploading your samples."
3. Verify that when the error returns, the header nav is re-enabled.

# Checklist:

- [X] I have run through the testing script to make sure current functionality is unchanged
- [ ] I have done relevant tests that prove my fix is effective or that my feature works
- [X] I have spent time testing out edge cases for my feature
- [ ] I have updated the test script or pull request template if necessary
- [X] New and existing unit tests pass locally with my changes

