### PR TITLE
Add generic analytics logging on active record create, update or destroy

### DIFF
--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -20,7 +20,9 @@ class MetricUtil
   # if it makes sense, and a past tense action. Keep names meaningful, descriptive, and
   # non-redundant (e.g. prefer sample_viewed to sample_view_viewed).
   # TODO: (gdingle): coordinate with ANALYTICS_EVENT_NAMES in client JS
+  # See also auto named events in ApplicationRecord#log_analytics.
   ANALYTICS_EVENT_NAMES = {
+    # TODO: (gdingle): remove user_created and project_created when auto events are working
     user_created: "user_created",
     project_created: "project_created",
     pipeline_run_succeeded: "pipeline_run_succeeded",
@@ -35,6 +37,11 @@ class MetricUtil
   end
 
   # This should never block on error.
+
+  # Anything less than 500 r/s should be fine. See
+  # https://segment.com/docs/sources/server/http/#rate-limits. In addition,
+  # segment says the server lib batches automatically. See
+  # https://segment.com/docs/sources/server/http/#batch.
   def self.log_analytics_event(event, user, properties = {}, request = nil)
     if SEGMENT_ANALYTICS
       # current_user should be passed from a controller

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  # NOTE: Batch ActiveRecord operations such as update_all and delete_all do not
+  # fire callbacks.
   after_create { |record| log_analytics record, "created" }
   after_update { |record| log_analytics record, "updated" }
   after_destroy { |record| log_analytics record, "destroyed" }
@@ -27,6 +29,7 @@ class ApplicationRecord < ActiveRecord::Base
     Thread.current[:_current_request]
   end
 
+  # See also ANALYTICS_EVENT_NAMES
   def log_analytics(record, action)
     # example: "visualization_updated"
     event = "#{record.class.name.underscore}_#{action}"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,58 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  after_create { |record| log_analytics record, "created" }
+  after_update { |record| log_analytics record, "updated" }
+  after_destroy { |record| log_analytics record, "destroyed" }
+
+  # Set current user and request to global for use in logging.
+  # See https://stackoverflow.com/a/11670283/200312
+  class << self
+    def _current_user=(user)
+      Thread.current[:_current_user] = user
+    end
+
+    def _current_request=(request)
+      Thread.current[:_current_request] = request
+    end
+  end
+
+  private
+
+  def _current_user
+    Thread.current[:_current_user]
+  end
+
+  def _current_request
+    Thread.current[:_current_request]
+  end
+
+  def log_analytics(record, action)
+    # example: "visualization_updated"
+    event = "#{record.class.name.underscore}_#{action}"
+
+    properties = {
+      # There should always be an id but just in case...
+      id: record.respond_to?(:id) ? record.id : nil,
+      # Add string name for convenience if available
+      name: record.respond_to?(:name) ? record.name : nil,
+      # Set common belongs_to IDs if available
+      user_id: record.respond_to?(:user_id) ? record.user_id : nil,
+      project_id: record.respond_to?(:project_id) ? record.project_id : nil,
+      sample_id: record.respond_to?(:sample_id) ? record.sample_id : nil,
+      pipeline_run_id: record.respond_to?(:pipeline_run_id) ? record.pipeline_run_id : nil
+    }
+
+    # Remove empty keys
+    properties = properties.delete_if { |_k, v| v.nil? }
+
+    # log_analytics_event will never block
+    MetricUtil.log_analytics_event(
+      event,
+      _current_user,
+      properties,
+      _current_request
+    )
+    Rails.logger.debug("Event '#{event}' logged with properties #{properties}")
+  end
 end


### PR DESCRIPTION
# Description

This will turn on analytics tracking of all current and future CRUD operations at the ActiveRecord level. 

I believe it is better to do this generically at the ActiveRecord level instead of at a higher level in ActiveController or in React because we can get automatic, reliable coverage and consistent meaning, all derived from the Rails framework. I plan on adding more granular events at higher levels where needed, as well as all read-only events, such as viewing a taxon tree. 

QUESTION: Are there any tables which are updated so frequently as to cause too much data to be logged? 

## Test

1. Create and update a heatmap.
2. See log message such as 
```
visualization_updated logged with properties {:id=>81, :name=>"Heatmap", :user_id=>94}
```

In staging
1. View new event traffic in segment