### PR TITLE
[Bug fix] Fix feature guarding in heatmap.

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -38,7 +38,10 @@ class SamplesHeatmapView extends React.Component {
     };
 
     // TODO (gdingle): remove gating when we go live with data discovery
-    if (this.props.allowedFeatures.includes("data_discovery")) {
+    if (
+      this.props.allowedFeatures &&
+      this.props.allowedFeatures.includes("data_discovery")
+    ) {
       this.initOnBeforeUnload(props.savedParamValues);
     }
 
@@ -778,12 +781,13 @@ class SamplesHeatmapView extends React.Component {
                 hideOnScroll
               />
               {/* TODO: (gdingle): this is gated until we release data discovery */}
-              {allowedFeatures.includes("data_discovery") && (
-                <SaveButton
-                  onClick={this.onSaveClick}
-                  className={cs.controlElement}
-                />
-              )}
+              {allowedFeatures &&
+                allowedFeatures.includes("data_discovery") && (
+                  <SaveButton
+                    onClick={this.onSaveClick}
+                    className={cs.controlElement}
+                  />
+                )}
               <DownloadButtonDropdown
                 className={cs.controlElement}
                 options={downloadOptions}
@@ -815,7 +819,7 @@ class SamplesHeatmapView extends React.Component {
 }
 
 SamplesHeatmapView.propTypes = {
-  allowedFeatures: PropTypes.object,
+  allowedFeatures: PropTypes.array,
   backgrounds: PropTypes.array,
   categories: PropTypes.array,
   metrics: PropTypes.array,

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -36,7 +36,7 @@ module HeatmapHelper
         ],
         operators: [">=", "<="]
       },
-      allowedFeatures: current_user.allowed_features
+      allowedFeatures: current_user.allowed_feature_list
     }
   end
 


### PR DESCRIPTION
Features were being loaded into a string, instead of an array leading to crashes in the frontend when user had no flags of any kind enabled.

Tested with users:
- With `allowed_features = nil`
- With some features (but not data discovery) enabled
- With at least data discovery enabled