### PR TITLE
Convention for analytics logging in React

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -248,9 +248,9 @@ const createProject = params =>
   });
 
 // See https://czi.quip.com/bKDnAITc6CbE/How-to-start-instrumenting-analytics-2019-03-06
+// See also documentation for withAnalytics below.
 const logAnalyticsEvent = (eventName, eventData = {}) => {
   // Wrapper around Segment analytics so we can add things later
-  // eventData should have keys in snake_case for the database
   if (window.analytics) {
     // Include high value user groups in event properties to avoid JOINs downstream.
     if (window.analytics.user) {
@@ -281,19 +281,22 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
  * context and meaning of an analytics event in a report and locate it in the
  * codebase.
  *
+ * The eventData should be used for extra data that would be useful for an
+ * analysis specific to the event. The keys in should be named the same as in
+ * the calling context for easy interpretation. Only scalars should be passed to
+ * keep things simple downstream. Arrays should be replaced by their lengths.
+ *
  * For example:
  *
  *    withAnalytics(
  *      this.renderMoreReads,
  *      "AccessionViz_more_reads_link_clicked",
- *      { reads: this.state.reads.length, allReads: this.allReads.length }
+ *      { projectId: this.state.projectId, reads: this.state.reads.length }
  *    )
  *
  * React events should have have a single callsite, so there is no need to put
  * them in ANALYTICS_EVENT_NAMES.
  *
- * The eventData should be used for extra data that would be useful for an
- * analysis specific to the event.
  **/
 const withAnalytics = (handleEvent, eventName, eventData = {}) => {
   return (...args) => {

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -291,9 +291,9 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
  * The eventData should be used for extra data that would be useful for an
  * analysis specific to the event.
  **/
-const withAnalytics = (func, eventName, eventData = {}) => {
+const withAnalytics = (handleEvent, eventName, eventData = {}) => {
   return (...args) => {
-    const ret = func.apply(null, args);
+    const ret = handleEvent.apply(null, args);
     logAnalyticsEvent(eventName, eventData);
     return ret;
   };

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -297,7 +297,7 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
  **/
 const withAnalytics = (handleEvent, eventName, eventData = {}) => {
   return (...args) => {
-    const ret = handleEvent.apply(null, args);
+    const ret = handleEvent(...args);
     logAnalyticsEvent(eventName, eventData);
     return ret;
   };

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -262,6 +262,7 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
         czi_user: traits.biohub_user,
         demo_user: traits.demo_user,
         has_samples: traits.has_samples,
+        // caller can override above traits if they know what they are doing
         ...eventData
       };
     }
@@ -286,10 +287,13 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
  *
  * React events should have have a single callsite, so there is no need to put
  * them in ANALYTICS_EVENT_NAMES.
+ *
+ * The eventData should be used for extra data that would be useful for an
+ * analysis specific to the event.
  **/
 const withAnalytics = (func, eventName, eventData = {}) => {
-  return args => {
-    const ret = func(args);
+  return (...args) => {
+    const ret = func.apply(null, args);
     logAnalyticsEvent(eventName, eventData);
     return ret;
   };

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -266,21 +266,7 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
         ...eventData
       };
     }
-
-    // Evaluate lazy values, giving some time for React to set state
-    // See https://reactjs.org/docs/react-component.html#setstate
-    let shouldWait = false;
-    for (var k in eventData) {
-      if (typeof eventData[k] === "function") {
-        shouldWait = true;
-        setTimeout(() => (eventData[k] = eventData[k]()), 1);
-      }
-    }
-    if (shouldWait) {
-      setTimeout(() => window.analytics.track(eventName, eventData), 2);
-    } else {
-      window.analytics.track(eventName, eventData);
-    }
+    window.analytics.track(eventName, eventData);
   }
 };
 
@@ -299,8 +285,6 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
  * analysis specific to the event. The keys in should be named the same as in
  * the calling context for easy interpretation. Only scalars should be passed to
  * keep things simple downstream. Arrays should be replaced by their lengths.
- * Values may be functions, in which case they are evaluated just before logging.
- * This is useful to get state changes that happen inside "handleEvent".
  *
  * For example:
  *

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -275,7 +275,7 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
  * the React component. The middle part should be user-friendly UI name. The
  * last part should be the action taken.
  *
- * <ReactComponent>_<friendly_name_of_ui_element>_<past_tense_action>
+ * <ReactComponent>_<friendly-name-of-ui-element>_<past_tense_action>
  *
  * In this way, we can easily discern the
  * context and meaning of an analytics event in a report and locate it in the
@@ -290,7 +290,7 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
  *
  *    withAnalytics(
  *      this.renderMoreReads,
- *      "AccessionViz_more_reads_link_clicked",
+ *      "AccessionViz_more-reads-link_clicked",
  *      { projectId: this.state.projectId, reads: this.state.reads.length }
  *    )
  *

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -266,7 +266,21 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
         ...eventData
       };
     }
-    window.analytics.track(eventName, eventData);
+
+    // Evaluate lazy values, giving some time for React to set state
+    // See https://reactjs.org/docs/react-component.html#setstate
+    let shouldWait = false;
+    for (var k in eventData) {
+      if (typeof eventData[k] === "function") {
+        shouldWait = true;
+        setTimeout(() => (eventData[k] = eventData[k]()), 1);
+      }
+    }
+    if (shouldWait) {
+      setTimeout(() => window.analytics.track(eventName, eventData), 2);
+    } else {
+      window.analytics.track(eventName, eventData);
+    }
   }
 };
 
@@ -285,6 +299,8 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
  * analysis specific to the event. The keys in should be named the same as in
  * the calling context for easy interpretation. Only scalars should be passed to
  * keep things simple downstream. Arrays should be replaced by their lengths.
+ * Values may be functions, in which case they are evaluated just before logging.
+ * This is useful to get state changes that happen inside "handleEvent".
  *
  * For example:
  *

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -273,7 +273,11 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
 /**
  * For wrapping event handlers in React. The first part of the name should be
  * the React component. The middle part should be user-friendly UI name. The
- * last part should be the action taken. In this way, we can easily discern the
+ * last part should be the action taken.
+ *
+ * <ReactComponent>_<friendly_name_of_ui_element>_<past_tense_action>
+ *
+ * In this way, we can easily discern the
  * context and meaning of an analytics event in a report and locate it in the
  * codebase.
  *

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -254,6 +254,32 @@ const logAnalyticsEvent = (eventName, eventData = {}) => {
   if (window.analytics) window.analytics.track(eventName, eventData);
 };
 
+/**
+ * For wrapping event handlers in React. The first part of the name should be
+ * the React component. The middle part should be user-friendly UI name. The
+ * last part should be the action taken. In this way, we can easily discern the
+ * context and meaning of an analytics event in a report and locate it in the
+ * codebase.
+ *
+ * For example:
+ *
+ *    withAnalytics(
+ *      this.renderMoreReads,
+ *      "AccessionViz_more_reads_link_clicked",
+ *      { reads: this.state.reads.length, allReads: this.allReads.length }
+ *    )
+ *
+ * React events should have have a single callsite, so there is no need to put
+ * them in ANALYTICS_EVENT_NAMES.
+ **/
+const withAnalytics = (func, eventName, eventData = {}) => {
+  return args => {
+    const ret = func(args);
+    logAnalyticsEvent(eventName, eventData);
+    return ret;
+  };
+};
+
 const validateSampleNames = (projectId, sampleNames) => {
   if (!projectId) {
     return Promise.resolve(sampleNames);
@@ -296,16 +322,17 @@ export {
   createProject,
   createSample,
   deleteSample,
+  withAnalytics,
   getAlignmentData,
   getAllHostGenomes,
   getProjectDimensions,
   getProjects,
   getSampleDimensions,
   getSampleReportInfo,
-  getSampleStats,
-  getSampleTaxons,
   getSamples,
+  getSampleStats,
   getSamplesV1,
+  getSampleTaxons,
   getSearchSuggestions,
   getSummaryContigCounts,
   getTaxonDescriptions,
@@ -319,6 +346,6 @@ export {
   shortenUrl,
   uploadFileToUrl,
   uploadFileToUrlWithRetries,
-  validateSampleNames,
-  validateSampleFiles
+  validateSampleFiles,
+  validateSampleNames
 };

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -251,7 +251,22 @@ const createProject = params =>
 const logAnalyticsEvent = (eventName, eventData = {}) => {
   // Wrapper around Segment analytics so we can add things later
   // eventData should have keys in snake_case for the database
-  if (window.analytics) window.analytics.track(eventName, eventData);
+  if (window.analytics) {
+    // Include high value user groups in event properties to avoid JOINs downstream.
+    if (window.analytics.user) {
+      const traits = window.analytics.user().traits();
+      eventData = {
+        // see traits_for_segment
+        admin: traits.admin,
+        biohub_user: traits.biohub_user,
+        czi_user: traits.biohub_user,
+        demo_user: traits.demo_user,
+        has_samples: traits.has_samples,
+        ...eventData
+      };
+    }
+    window.analytics.track(eventName, eventData);
+  }
 };
 
 /**

--- a/app/assets/src/components/AccessionViz.jsx
+++ b/app/assets/src/components/AccessionViz.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReadViz from "./ReadViz";
+import { withAnalytics } from "~/api";
 
 class AccessionViz extends React.Component {
   constructor(props) {
@@ -91,7 +92,14 @@ class AccessionViz extends React.Component {
       this.state.reads.length < this.allReads.length &&
       !this.state.rendering ? (
         <div style={{ textAlign: "right" }}>
-          <a onClick={this.renderMoreReads} style={{ cursor: "pointer" }}>
+          <a
+            onClick={withAnalytics(
+              this.renderMoreReads,
+              "AccessionViz_more_reads_link_clicked",
+              { reads: this.state.reads.length, allReads: this.allReads.length }
+            )}
+            style={{ cursor: "pointer" }}
+          >
             View more reads
           </a>
         </div>

--- a/app/assets/src/components/AccessionViz.jsx
+++ b/app/assets/src/components/AccessionViz.jsx
@@ -95,7 +95,7 @@ class AccessionViz extends React.Component {
           <a
             onClick={withAnalytics(
               this.renderMoreReads,
-              "AccessionViz_more_reads_link_clicked",
+              "AccessionViz_more-reads-link_clicked",
               { reads: this.state.reads.length, allReads: this.allReads.length }
             )}
             style={{ cursor: "pointer" }}

--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -12,7 +12,7 @@ import TermsAgreement from "~ui/controls/TermsAgreement";
 import Icon from "~ui/icons/Icon";
 import { sampleNameFromFileName, joinServerError } from "~utils/sample";
 import { openUrlWithTimeout } from "~utils/links";
-import { validateSampleNames, withAnalytics } from "~/api";
+import { validateSampleNames, withAnalytics, logAnalyticsEvent } from "~/api";
 import PropTypes from "~/components/utils/propTypes";
 
 import SampleUpload from "./SampleUpload";
@@ -614,8 +614,8 @@ class BulkUploadImport extends React.Component {
                                         logAnalyticsEvent(
                                           "BulkUploadImport_host_dropdown_clicked",
                                           {
-                                            samplesId,
-                                            hostGenomeId
+                                            samplesId: i,
+                                            hostGenomeId: j
                                           }
                                         );
                                       }}
@@ -663,8 +663,8 @@ class BulkUploadImport extends React.Component {
                                         logAnalyticsEvent(
                                           "BulkUploadImport_project_dropdown_clicked",
                                           {
-                                            samplesId,
-                                            hostGenomeId
+                                            samplesId: i,
+                                            hostGenomeId: j
                                           }
                                         );
                                       }}

--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -536,7 +536,7 @@ class BulkUploadImport extends React.Component {
                 ref="form"
                 onSubmit={withAnalytics(
                   this.handleRemoteUploadSubmit,
-                  "BulkUploadImport_upload_form_submitted",
+                  "BulkUploadImport_upload-form_submitted",
                   {
                     samples: this.state.samples.length,
                     projectId: this.state.projectId,
@@ -593,11 +593,7 @@ class BulkUploadImport extends React.Component {
                               }
                               onChange={withAnalytics(
                                 this.selectSample,
-                                "BulkUploadImport_samples_checkbox_changed",
-                                {
-                                  selectedSampleIndices: this.state
-                                    .selectedSampleIndices.length
-                                }
+                                "BulkUploadImport_samples-checkbox_changed"
                               )}
                             />
                             <label htmlFor={i}> {sample.name}</label>
@@ -633,7 +629,7 @@ class BulkUploadImport extends React.Component {
                                       onClick={() => {
                                         this.handleHostChangeForSample(i, j);
                                         logAnalyticsEvent(
-                                          "BulkUploadImport_host_dropdown_clicked",
+                                          "BulkUploadImport_host-dropdown_clicked",
                                           {
                                             samplesId: i,
                                             hostGenomeId: j
@@ -682,7 +678,7 @@ class BulkUploadImport extends React.Component {
                                           e
                                         );
                                         logAnalyticsEvent(
-                                          "BulkUploadImport_project_dropdown_clicked",
+                                          "BulkUploadImport_project-dropdown_clicked",
                                           {
                                             samplesId: i,
                                             hostGenomeId: j
@@ -723,7 +719,7 @@ class BulkUploadImport extends React.Component {
                             type="submit"
                             onClick={withAnalytics(
                               this.handleRemoteUploadSubmit,
-                              "BulkUploadImport_run_samples_button_clicked"
+                              "BulkUploadImport_run-samples-button_clicked"
                             )}
                             className="new-button blue-button upload-samples-button"
                           >
@@ -735,7 +731,7 @@ class BulkUploadImport extends React.Component {
                           onClick={() => {
                             window.history.back();
                             logAnalyticsEvent(
-                              "BulkUploadImport_back_button_clicked"
+                              "BulkUploadImport_back-button_clicked"
                             );
                           }}
                           className="new-button secondary-button"
@@ -805,7 +801,7 @@ class BulkUploadImport extends React.Component {
         className="new-button blue-button upload-samples-button"
         onClick={withAnalytics(
           this.handleImportSubmit,
-          "BulkUploadImport_import_button_clicked",
+          "BulkUploadImport_import-button_clicked",
           {
             projectId: this.state.projectId,
             hostId: this.state.hostId,
@@ -916,10 +912,7 @@ class BulkUploadImport extends React.Component {
               <input
                 onChange={withAnalytics(
                   this.handleBulkPathChange,
-                  "BulkUploadImport_bulk_path_changed",
-                  {
-                    selectedBulkPath: this.state.selectedBulkPath
-                  }
+                  "BulkUploadImport_bulk-path_changed"
                 )}
                 onFocus={this.clearError}
                 type="text"
@@ -996,10 +989,7 @@ class BulkUploadImport extends React.Component {
                       id="sample"
                       onChange={withAnalytics(
                         this.handleProjectChange,
-                        "BulkUploadImport_project_select_changed",
-                        {
-                          project: this.state.project
-                        }
+                        "BulkUploadImport_project-select_changed"
                       )}
                       value={this.state.project}
                     >
@@ -1037,10 +1027,7 @@ class BulkUploadImport extends React.Component {
                       type="button"
                       onClick={withAnalytics(
                         this.toggleNewProjectInput,
-                        "BulkUploadImport_new_project_button_clicked",
-                        {
-                          disableProjectSelect: this.state.disableProjectSelect
-                        }
+                        "BulkUploadImport_new-project-button_clicked"
                       )}
                       className="new-project-button new-button secondary-button"
                       data-delay="50"
@@ -1065,7 +1052,7 @@ class BulkUploadImport extends React.Component {
                       if (newProject.length) {
                         this.handleProjectSubmit();
                         logAnalyticsEvent(
-                          "BulkUploadImport_project_button_clicked",
+                          "BulkUploadImport_project-button_clicked",
                           {
                             newProject
                           }
@@ -1091,10 +1078,7 @@ class BulkUploadImport extends React.Component {
                     className="col s8 filled-in"
                     onChange={withAnalytics(
                       this.toggleCheckBox,
-                      "BulkUploadImport_public_checkbox_changed",
-                      {
-                        publicChecked: this.state.publicChecked
-                      }
+                      "BulkUploadImport_public-checkbox_changed"
                     )}
                     value={this.state.publicChecked}
                   />
@@ -1152,7 +1136,7 @@ class BulkUploadImport extends React.Component {
                           onClick={() => {
                             this.handleHostChange(g.id, g.name);
                             logAnalyticsEvent(
-                              "BulkUploadImport_host_selector_clicked",
+                              "BulkUploadImport_host-selector_clicked",
                               {
                                 hostId: g.id,
                                 hostName: g.name

--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -484,8 +484,8 @@ class BulkUploadImport extends React.Component {
         );
       const form = this.props.selectedUser ? "update" : "create";
       logAnalyticsEvent(`BulkUploadImport_errors_displayed`, {
-        serverErrors: serverErrors,
-        errorMessage: formattedError
+        serverErrors,
+        formattedError
       });
       return ret;
     } else {
@@ -540,8 +540,8 @@ class BulkUploadImport extends React.Component {
                   "BulkUploadImport_upload_form_submitted",
                   {
                     samples: this.state.samples.length,
-                    project_id: this.state.projectId,
-                    host_genome_id: this.state.hostId
+                    projectId: this.state.projectId,
+                    hostId: this.state.hostId
                   }
                 )}
               >
@@ -808,9 +808,9 @@ class BulkUploadImport extends React.Component {
           this.handleImportSubmit,
           "BulkUploadImport_import_button_clicked",
           {
-            project_id: this.state.projectId,
-            host_genome_id: this.state.hostId,
-            bulk_path: this.state.selectedBulkPath
+            projectId: this.state.projectId,
+            hostId: this.state.hostId,
+            selectedBulkPath: this.state.selectedBulkPath
           }
         )}
       >
@@ -919,7 +919,7 @@ class BulkUploadImport extends React.Component {
                   this.handleBulkPathChange,
                   "BulkUploadImport_bulk_path_changed",
                   {
-                    bulk_path: this.state.selectedBulkPath
+                    selectedBulkPath: this.state.selectedBulkPath
                   }
                 )}
                 onFocus={this.clearError}
@@ -1062,13 +1062,13 @@ class BulkUploadImport extends React.Component {
                   <span
                     className="input-icon hidden"
                     onClick={e => {
-                      const new_project = this.refs.new_project.value.trim();
-                      if (new_project.length) {
+                      const newProject = this.refs.new_project.value.trim();
+                      if (newProject.length) {
                         this.handleProjectSubmit();
                         logAnalyticsEvent(
                           "BulkUploadImport_project_button_clicked",
                           {
-                            new_project
+                            newProject
                           }
                         );
                       }
@@ -1155,8 +1155,8 @@ class BulkUploadImport extends React.Component {
                             logAnalyticsEvent(
                               "BulkUploadImport_host_selector_clicked",
                               {
-                                host_id: g.id,
-                                host: g.name
+                                hostId: g.id,
+                                hostName: g.name
                               }
                             );
                           }}

--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -482,7 +482,6 @@ class BulkUploadImport extends React.Component {
         ) : (
           <p>{formattedError}</p>
         );
-      const form = this.props.selectedUser ? "update" : "create";
       logAnalyticsEvent(`BulkUploadImport_errors_displayed`, {
         serverErrors,
         formattedError

--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -1052,7 +1052,7 @@ class BulkUploadImport extends React.Component {
                       if (newProject.length) {
                         this.handleProjectSubmit();
                         logAnalyticsEvent(
-                          "BulkUploadImport_project-button_clicked",
+                          "BulkUploadImport_create-project-button_clicked",
                           {
                             newProject
                           }

--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -3,9 +3,6 @@ import ReactDOM from "react-dom";
 import axios from "axios";
 import $ from "jquery";
 import Tipsy from "react-tipsy";
-import PropTypes from "~/components/utils/propTypes";
-import SampleUpload from "./SampleUpload";
-import ObjectHelper from "../helpers/ObjectHelper";
 import { merge, omit, isEmpty, get, size } from "lodash/fp";
 
 import { Menu, MenuItem } from "~ui/controls/Menu";
@@ -15,7 +12,11 @@ import TermsAgreement from "~ui/controls/TermsAgreement";
 import Icon from "~ui/icons/Icon";
 import { sampleNameFromFileName, joinServerError } from "~utils/sample";
 import { openUrlWithTimeout } from "~utils/links";
-import { validateSampleNames } from "~/api";
+import { validateSampleNames, withAnalytics } from "~/api";
+import PropTypes from "~/components/utils/propTypes";
+
+import SampleUpload from "./SampleUpload";
+import ObjectHelper from "../helpers/ObjectHelper";
 
 class BulkUploadImport extends React.Component {
   constructor(props, context) {
@@ -610,6 +611,13 @@ class BulkUploadImport extends React.Component {
                                     <li
                                       onClick={() => {
                                         this.handleHostChangeForSample(i, j);
+                                        logAnalyticsEvent(
+                                          "BulkUploadImport_host_dropdown_clicked",
+                                          {
+                                            samplesId,
+                                            hostGenomeId
+                                          }
+                                        );
                                       }}
                                       ref="genome"
                                       key={j}
@@ -652,6 +660,13 @@ class BulkUploadImport extends React.Component {
                                           j,
                                           e
                                         );
+                                        logAnalyticsEvent(
+                                          "BulkUploadImport_project_dropdown_clicked",
+                                          {
+                                            samplesId,
+                                            hostGenomeId
+                                          }
+                                        );
                                       }}
                                       ref="project"
                                       key={j}
@@ -685,7 +700,10 @@ class BulkUploadImport extends React.Component {
                         ) : (
                           <button
                             type="submit"
-                            onClick={this.handleRemoteUploadSubmit}
+                            onClick={withAnalytics(
+                              this.handleRemoteUploadSubmit,
+                              "BulkUploadImport_run_samples_button_clicked"
+                            )}
                             className="new-button blue-button upload-samples-button"
                           >
                             Run Samples
@@ -693,7 +711,12 @@ class BulkUploadImport extends React.Component {
                         )}
                         <button
                           type="button"
-                          onClick={() => window.history.back()}
+                          onClick={() => {
+                            window.history.back();
+                            logAnalyticsEvent(
+                              "BulkUploadImport_back_button_clicked"
+                            );
+                          }}
                           className="new-button secondary-button"
                         >
                           Cancel

--- a/app/assets/src/components/CreateUser.jsx
+++ b/app/assets/src/components/CreateUser.jsx
@@ -235,7 +235,7 @@ class CreateUser extends React.Component {
         <span>{formattedError}</span>
       );
       const form = this.props.selectedUser ? "update" : "create";
-      logAnalyticsEvent(`CreateUser_${form}_errors_displayed`, {
+      logAnalyticsEvent(`CreateUser_${form}-errors_displayed`, {
         form,
         serverErrors,
         formattedError
@@ -279,10 +279,7 @@ class CreateUser extends React.Component {
                   type="email"
                   onChange={withAnalytics(
                     this.handleEmailChange,
-                    "CreateUser_email_changed",
-                    {
-                      email: () => this.state.email
-                    }
+                    "CreateUser_email_changed"
                   )}
                   className=""
                   onFocus={this.clearError}
@@ -296,10 +293,7 @@ class CreateUser extends React.Component {
                   type="text"
                   onChange={withAnalytics(
                     this.handleNameChange,
-                    "CreateUser_name_changed",
-                    {
-                      name: () => this.state.name
-                    }
+                    "CreateUser_name_changed"
                   )}
                   className=""
                   onFocus={this.clearError}
@@ -313,10 +307,7 @@ class CreateUser extends React.Component {
                   type="text"
                   onChange={withAnalytics(
                     this.handleInstitutionChange,
-                    "CreateUser_institution_changed",
-                    {
-                      institution: () => this.state.institution
-                    }
+                    "CreateUser_institution_changed"
                   )}
                   onFocus={this.clearError}
                   value={this.state.institution}
@@ -329,10 +320,7 @@ class CreateUser extends React.Component {
                   type="password"
                   onChange={withAnalytics(
                     this.handlePasswordChange,
-                    "CreateUser_password_changed",
-                    {
-                      password: () => this.state.password.length
-                    }
+                    "CreateUser_password_changed"
                   )}
                   className=""
                   onFocus={this.clearError}
@@ -346,10 +334,7 @@ class CreateUser extends React.Component {
                   type="password"
                   onChange={withAnalytics(
                     this.handlePConfirmChange,
-                    "CreateUser_pconfirm_changed",
-                    {
-                      pConfirm: () => this.state.pConfirm.length
-                    }
+                    "CreateUser_pconfirm_changed"
                   )}
                   className=""
                   onFocus={this.clearError}
@@ -367,10 +352,7 @@ class CreateUser extends React.Component {
                   checked={this.state.isAdmin ? "checked" : ""}
                   onChange={withAnalytics(
                     this.toggleCheckBox,
-                    "CreateUser_admin_changed",
-                    {
-                      isAdmin: () => this.state.isAdmin
-                    }
+                    "CreateUser_admin_changed"
                   )}
                   value={this.state.isAdmin}
                 />
@@ -401,14 +383,14 @@ class CreateUser extends React.Component {
           ? this.renderUserForm(
               withAnalytics(
                 this.handleUpdate,
-                "CreateUser_update_form_submitted",
+                "CreateUser_update-form_submitted",
                 "Update"
               )
             )
           : this.renderUserForm(
               withAnalytics(
                 this.handleCreate,
-                "CreateUser_create_form_submitted",
+                "CreateUser_create-form_submitted",
                 "Create"
               )
             )}

--- a/app/assets/src/components/CreateUser.jsx
+++ b/app/assets/src/components/CreateUser.jsx
@@ -281,7 +281,7 @@ class CreateUser extends React.Component {
                     this.handleEmailChange,
                     "CreateUser_email_changed",
                     {
-                      email: this.state.email
+                      email: () => this.state.email
                     }
                   )}
                   className=""
@@ -298,7 +298,7 @@ class CreateUser extends React.Component {
                     this.handleNameChange,
                     "CreateUser_name_changed",
                     {
-                      name: this.state.name
+                      name: () => this.state.name
                     }
                   )}
                   className=""
@@ -315,7 +315,7 @@ class CreateUser extends React.Component {
                     this.handleInstitutionChange,
                     "CreateUser_institution_changed",
                     {
-                      institution: this.state.institution
+                      institution: () => this.state.institution
                     }
                   )}
                   onFocus={this.clearError}
@@ -331,7 +331,7 @@ class CreateUser extends React.Component {
                     this.handlePasswordChange,
                     "CreateUser_password_changed",
                     {
-                      password: this.state.password
+                      password: () => this.state.password.length
                     }
                   )}
                   className=""
@@ -348,7 +348,7 @@ class CreateUser extends React.Component {
                     this.handlePConfirmChange,
                     "CreateUser_pconfirm_changed",
                     {
-                      pConfirm: this.state.pConfirm
+                      pConfirm: () => this.state.pConfirm.length
                     }
                   )}
                   className=""
@@ -369,7 +369,7 @@ class CreateUser extends React.Component {
                     this.toggleCheckBox,
                     "CreateUser_admin_changed",
                     {
-                      isAdmin: this.state.isAdmin
+                      isAdmin: () => this.state.isAdmin
                     }
                   )}
                   value={this.state.isAdmin}

--- a/app/assets/src/components/CreateUser.jsx
+++ b/app/assets/src/components/CreateUser.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import axios from "axios";
 
 import { openUrl } from "~utils/links";
-import { withAnalytics } from "~/api";
+import { withAnalytics, logAnalyticsEvent } from "~/api";
 
 class CreateUser extends React.Component {
   constructor(props, context) {
@@ -236,8 +236,8 @@ class CreateUser extends React.Component {
       );
       const form = this.props.selectedUser ? "update" : "create";
       logAnalyticsEvent(`CreateUser_${form}_errors_displayed`, {
-        serverErrors: serverErrors,
-        errorMessage: formattedError
+        serverErrors,
+        formattedError
       });
       return ret;
     } else {

--- a/app/assets/src/components/CreateUser.jsx
+++ b/app/assets/src/components/CreateUser.jsx
@@ -236,6 +236,7 @@ class CreateUser extends React.Component {
       );
       const form = this.props.selectedUser ? "update" : "create";
       logAnalyticsEvent(`CreateUser_${form}_errors_displayed`, {
+        form,
         serverErrors,
         formattedError
       });

--- a/app/assets/src/components/CreateUser.jsx
+++ b/app/assets/src/components/CreateUser.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import axios from "axios";
+
 import { openUrl } from "~utils/links";
+import { withAnalytics } from "~/api";
 
 class CreateUser extends React.Component {
   constructor(props, context) {
@@ -219,10 +221,10 @@ class CreateUser extends React.Component {
       });
   }
 
-  displayError(failedStatus, serverError, formattedError) {
+  displayError(failedStatus, serverErrors, formattedError) {
     if (failedStatus) {
-      return serverError.length ? (
-        serverError.map((error, i) => {
+      const ret = serverErrors.length ? (
+        serverErrors.map((error, i) => {
           return (
             <p className="error center-align" key={i}>
               {error}
@@ -232,6 +234,12 @@ class CreateUser extends React.Component {
       ) : (
         <span>{formattedError}</span>
       );
+      const form = this.props.selectedUser ? "update" : "create";
+      logAnalyticsEvent(`CreateUser_${form}_errors_displayed`, {
+        serverErrors: serverErrors,
+        errorMessage: formattedError
+      });
+      return ret;
     } else {
       return null;
     }
@@ -268,7 +276,13 @@ class CreateUser extends React.Component {
                 <i className="fa fa-envelope" aria-hidden="true" />
                 <input
                   type="email"
-                  onChange={this.handleEmailChange}
+                  onChange={withAnalytics(
+                    this.handleEmailChange,
+                    "CreateUser_email_changed",
+                    {
+                      email: this.state.email
+                    }
+                  )}
                   className=""
                   onFocus={this.clearError}
                   value={this.state.email}
@@ -279,7 +293,13 @@ class CreateUser extends React.Component {
                 <i className="fa fa-envelope" aria-hidden="true" />
                 <input
                   type="text"
-                  onChange={this.handleNameChange}
+                  onChange={withAnalytics(
+                    this.handleNameChange,
+                    "CreateUser_name_changed",
+                    {
+                      name: this.state.name
+                    }
+                  )}
                   className=""
                   onFocus={this.clearError}
                   value={this.state.name}
@@ -290,7 +310,13 @@ class CreateUser extends React.Component {
                 <i className="fa fa-building" aria-hidden="true" />
                 <input
                   type="text"
-                  onChange={this.handleInstitutionChange}
+                  onChange={withAnalytics(
+                    this.handleInstitutionChange,
+                    "CreateUser_institution_changed",
+                    {
+                      institution: this.state.institution
+                    }
+                  )}
                   onFocus={this.clearError}
                   value={this.state.institution}
                 />
@@ -300,7 +326,13 @@ class CreateUser extends React.Component {
                 <i className="fa fa-key" aria-hidden="true" />
                 <input
                   type="password"
-                  onChange={this.handlePasswordChange}
+                  onChange={withAnalytics(
+                    this.handlePasswordChange,
+                    "CreateUser_password_changed",
+                    {
+                      password: this.state.password
+                    }
+                  )}
                   className=""
                   onFocus={this.clearError}
                   value={this.state.password}
@@ -311,7 +343,13 @@ class CreateUser extends React.Component {
                 <i className="fa fa-check-circle" aria-hidden="true" />
                 <input
                   type="password"
-                  onChange={this.handlePConfirmChange}
+                  onChange={withAnalytics(
+                    this.handlePConfirmChange,
+                    "CreateUser_pconfirm_changed",
+                    {
+                      p_confirm: this.state.pConfirm
+                    }
+                  )}
                   className=""
                   onFocus={this.clearError}
                   value={this.state.pConfirm}
@@ -326,7 +364,13 @@ class CreateUser extends React.Component {
                   id="admin"
                   className="filled-in"
                   checked={this.state.isAdmin ? "checked" : ""}
-                  onChange={this.toggleCheckBox}
+                  onChange={withAnalytics(
+                    this.toggleCheckBox,
+                    "CreateUser_admin_changed",
+                    {
+                      admin: this.state.isAdmin
+                    }
+                  )}
                   value={this.state.isAdmin}
                 />
                 <label htmlFor="admin">Admin</label>
@@ -353,8 +397,20 @@ class CreateUser extends React.Component {
     return (
       <div>
         {this.props.selectedUser
-          ? this.renderUserForm(this.handleUpdate, "Update")
-          : this.renderUserForm(this.handleCreate, "Create")}
+          ? this.renderUserForm(
+              withAnalytics(
+                this.handleUpdate,
+                "CreateUser_update_form_submitted",
+                "Update"
+              )
+            )
+          : this.renderUserForm(
+              withAnalytics(
+                this.handleCreate,
+                "CreateUser_create_form_submitted",
+                "Create"
+              )
+            )}
         <div className="bottom">
           <span
             className="back"

--- a/app/assets/src/components/CreateUser.jsx
+++ b/app/assets/src/components/CreateUser.jsx
@@ -347,7 +347,7 @@ class CreateUser extends React.Component {
                     this.handlePConfirmChange,
                     "CreateUser_pconfirm_changed",
                     {
-                      p_confirm: this.state.pConfirm
+                      pConfirm: this.state.pConfirm
                     }
                   )}
                   className=""
@@ -368,7 +368,7 @@ class CreateUser extends React.Component {
                     this.toggleCheckBox,
                     "CreateUser_admin_changed",
                     {
-                      admin: this.state.isAdmin
+                      isAdmin: this.state.isAdmin
                     }
                   )}
                   value={this.state.isAdmin}

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1662,7 +1662,7 @@ class BackgroundModal extends React.Component {
               text="Create Collection"
               onClick={withAnalytics(
                 this.handleOpen,
-                "Samples_collection_create_button_clicked"
+                "Samples_collection-create-button_clicked"
               )}
               disabled={!this.props.selectedSampleIds.length}
             />
@@ -1685,7 +1685,7 @@ class BackgroundModal extends React.Component {
           <Form
             onSubmit={withAnalytics(
               this.handleSubmit,
-              "Samples_collection_form_submitted",
+              "Samples_collection-form-submitted",
               {
                 new_background_name: this.state.new_background_name,
                 new_background_description: this.state
@@ -1708,7 +1708,7 @@ class BackgroundModal extends React.Component {
                 text="Cancel"
                 onClick={withAnalytics(
                   this.handleClose,
-                  "Samples_collection_form_cancel_button_clicked"
+                  "Samples_collection-form-cancel-button_clicked"
                 )}
               />
             </div>

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1657,7 +1657,10 @@ class BackgroundModal extends React.Component {
           <div className="button-container">
             <PrimaryButton
               text="Create Collection"
-              onClick={this.handleOpen}
+              onClick={withAnalytics(
+                this.handleOpen,
+                "Samples_collection_create_button_clicked"
+              )}
               disabled={!this.props.selectedSampleIds.length}
             />
           </div>
@@ -1676,7 +1679,18 @@ class BackgroundModal extends React.Component {
             update the calculated z-score to indicate how much the the sample
             deviates from the norm for that collection.
           </div>
-          <Form onSubmit={this.handleSubmit}>
+          <Form
+            onSubmit={withAnalytics(
+              this.handleSubmit,
+              "Samples_collection_form_submitted",
+              {
+                new_background_name: this.state.new_background_name,
+                new_background_description: this.state
+                  .new_background_description,
+                selectedSampleIds: this.props.parent.state.selectedSampleIds
+              }
+            )}
+          >
             {this.renderTextField("Name", false, "new_background_name", 1)}
             {this.renderTextField(
               "Description",
@@ -1687,7 +1701,13 @@ class BackgroundModal extends React.Component {
             {this.renderSampleList()}
             <div className="background-button-section">
               <PrimaryButton text="Create" type="submit" />
-              <SecondaryButton text="Cancel" onClick={this.handleClose} />
+              <SecondaryButton
+                text="Cancel"
+                onClick={withAnalytics(
+                  this.handleClose,
+                  "Samples_collection_form_cancel_button_clicked"
+                )}
+              />
             </div>
           </Form>
           {background_creation_response.status === "ok" ? (

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -19,10 +19,16 @@ import {
 import { merge, sortBy } from "lodash/fp";
 import { Sidebar, Label, Icon, Modal, Form } from "semantic-ui-react";
 import Nanobar from "nanobar";
+import Cookies from "js-cookie";
+
+import GlobeIcon from "~ui/icons/GlobeIcon";
+import LockIcon from "~ui/icons/LockIcon";
+import UserIcon from "~ui/icons/UserIcon";
+import { withAnalytics } from "~/api";
+
 import SortHelper from "./SortHelper";
 import ProjectSelection from "./ProjectSelection";
 import BasicPopup from "./BasicPopup";
-import Cookies from "js-cookie";
 import CompareButton from "./ui/controls/buttons/CompareButton";
 import PhylogenyButton from "./ui/controls/buttons/PhylogenyButton";
 import DownloadButtonDropdown from "./ui/controls/dropdowns/DownloadButtonDropdown";
@@ -36,9 +42,6 @@ import ProjectUploadMenu from "./views/samples/ProjectUploadMenu";
 import CategorySearchBox from "./ui/controls/CategorySearchBox";
 import FilterTag from "./ui/controls/FilterTag";
 import ProjectSettingsModal from "./views/samples/ProjectSettingsModal";
-import GlobeIcon from "~ui/icons/GlobeIcon";
-import LockIcon from "~ui/icons/LockIcon";
-import UserIcon from "~ui/icons/UserIcon";
 import {
   SAMPLE_TABLE_COLUMNS,
   INITIAL_COLUMNS,


### PR DESCRIPTION
# Description

This establishes a convention for making analytics logging calls in React where user events are handled. It breaks the existing convention in `ANALYTICS_EVENT_NAMES`. 

Design goals:
* convention that can quickly and consistently applied to ~250 onClick, onChange, onClose and onSubmit callsites currently in the codebase
* make frontend and backend events easily distinguishable by name
* make event names findable in the codebase by simple string match
* make names machine parseable (i.e. splittable on delimiter)
* make meaning obvious in the terms of anybody who uses the app (*note* this is one reason why we can't simply automate the name generation completely)
* names are highly likely to be globally unique
* include important user groups automatically
* convention can easily be followed by any future React implementors

I put in a few callsites as examples.

# Test

1. Go to bulk upload form, create form and accession viz and do the following:
2. click around and enter text in inputs and submit
3. see no errors in console
4. see segement events fired with chrome extension

