### PR TITLE
Revise narrow container width rules and apply to all view headers.

### DIFF
--- a/app/assets/src/components/layout/NarrowContainer.jsx
+++ b/app/assets/src/components/layout/NarrowContainer.jsx
@@ -4,6 +4,8 @@ import cx from "classnames";
 import cs from "./narrow_container.scss";
 
 const NarrowContainer = ({ children, className, size }) => {
+  // NarrowContainer will enforce our policy for page width
+  // As a general rule, should be applied to most page contents and headers
   return (
     <div className={cx(cs.narrowContainer, className, size && cs[size])}>
       {children}

--- a/app/assets/src/components/layout/ViewHeader/view_header.scss
+++ b/app/assets/src/components/layout/ViewHeader/view_header.scss
@@ -4,10 +4,6 @@
 .viewHeader {
   display: flex;
   align-items: center;
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 1280px;
-  width: 90%;
 
   .content {
     margin-right: 20px;

--- a/app/assets/src/components/layout/narrow_container.scss
+++ b/app/assets/src/components/layout/narrow_container.scss
@@ -1,4 +1,8 @@
 .narrowContainer {
+  // Per design, narrow container has a max-width of 1280px with a minimum margin of 14px.
+  // Since there is no min-margin property we set max-width to 2xmin_margin and
+  // ensure the min margin by removing the margin width from the actual width of
+  // the component (i.e. 100% - 2xmin_margin)
   max-width: 1308px;
   margin: 0 auto;
   width: calc(100% - 28px);

--- a/app/assets/src/components/layout/narrow_container.scss
+++ b/app/assets/src/components/layout/narrow_container.scss
@@ -1,7 +1,7 @@
 .narrowContainer {
-  max-width: 1280px;
+  max-width: 1308px;
   margin: 0 auto;
-  width: 100%;
+  width: calc(100% - 28px);
 
   &.small {
     max-width: 800px;

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -318,61 +318,63 @@ class SampleView extends React.Component {
 
     return (
       <div>
-        <ViewHeader className={cs.viewHeader}>
-          <ViewHeader.Content>
-            <div className={cs.pipelineInfo}>
-              <span>PIPELINE {versionDisplay}</span>
-              <PipelineVersionSelect
-                pipelineRun={pipelineRun}
-                pipelineVersions={pipelineVersions}
-                lastProcessedAt={get("last_processed_at", summaryStats)}
-                onPipelineVersionSelect={this.handlePipelineVersionSelect}
-              />
-              {this.renderPipelineWarnings()}
-            </div>
-            <ViewHeader.Pretitle
-              breadcrumbLink={`/home?project_id=${project.id}`}
-            >
-              {project.name}
-            </ViewHeader.Pretitle>
-            <ViewHeader.Title
-              label={this.state.sampleName}
-              id={sample.id}
-              options={Object.keys(sampleIdToNameMap).map(sampleId => ({
-                label: sampleIdToNameMap[sampleId],
-                id: sampleId,
-                onClick: () => window.open(`/samples/${sampleId}`, "_self")
-              }))}
-            />
-            <div className={cs.sampleDetailsLinkContainer}>
-              <span
-                className={cs.sampleDetailsLink}
-                onClick={this.toggleSampleDetailsSidebar}
+        <NarrowContainer>
+          <ViewHeader className={cs.viewHeader}>
+            <ViewHeader.Content>
+              <div className={cs.pipelineInfo}>
+                <span>PIPELINE {versionDisplay}</span>
+                <PipelineVersionSelect
+                  pipelineRun={pipelineRun}
+                  pipelineVersions={pipelineVersions}
+                  lastProcessedAt={get("last_processed_at", summaryStats)}
+                  onPipelineVersionSelect={this.handlePipelineVersionSelect}
+                />
+                {this.renderPipelineWarnings()}
+              </div>
+              <ViewHeader.Pretitle
+                breadcrumbLink={`/home?project_id=${project.id}`}
               >
-                Sample Details
-              </span>
-            </div>
-          </ViewHeader.Content>
-          <ViewHeader.Controls>
-            <BasicPopup
-              trigger={<ShareButton onClick={this.onShareClick} />}
-              content="A shareable URL was copied to your clipboard!"
-              on="click"
-              hideOnScroll
-            />{" "}
-            {/* TODO: (gdingle): this is admin-only until we have a way of browsing visualizations */}
-            {this.props.admin && <SaveButton onClick={this.onSaveClick} />}{" "}
-            <Controls
-              reportPresent={reportPresent}
-              sample={sample}
-              project={project}
-              pipelineRun={pipelineRun}
-              reportDetails={reportDetails}
-              reportPageParams={reportPageParams}
-              canEdit={this.props.canEdit}
-            />
-          </ViewHeader.Controls>
-        </ViewHeader>
+                {project.name}
+              </ViewHeader.Pretitle>
+              <ViewHeader.Title
+                label={this.state.sampleName}
+                id={sample.id}
+                options={Object.keys(sampleIdToNameMap).map(sampleId => ({
+                  label: sampleIdToNameMap[sampleId],
+                  id: sampleId,
+                  onClick: () => window.open(`/samples/${sampleId}`, "_self")
+                }))}
+              />
+              <div className={cs.sampleDetailsLinkContainer}>
+                <span
+                  className={cs.sampleDetailsLink}
+                  onClick={this.toggleSampleDetailsSidebar}
+                >
+                  Sample Details
+                </span>
+              </div>
+            </ViewHeader.Content>
+            <ViewHeader.Controls>
+              <BasicPopup
+                trigger={<ShareButton onClick={this.onShareClick} />}
+                content="A shareable URL was copied to your clipboard!"
+                on="click"
+                hideOnScroll
+              />{" "}
+              {/* TODO: (gdingle): this is admin-only until we have a way of browsing visualizations */}
+              {this.props.admin && <SaveButton onClick={this.onSaveClick} />}{" "}
+              <Controls
+                reportPresent={reportPresent}
+                sample={sample}
+                project={project}
+                pipelineRun={pipelineRun}
+                reportDetails={reportDetails}
+                reportPageParams={reportPageParams}
+                canEdit={this.props.canEdit}
+              />
+            </ViewHeader.Controls>
+          </ViewHeader>
+        </NarrowContainer>
         <NarrowContainer>
           {showAMR ? (
             <Tabs

--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -758,7 +758,7 @@ class SamplesHeatmapView extends React.Component {
     const { allowedFeatures } = this.props;
     return (
       <div className={cs.heatmap}>
-        <div>
+        <NarrowContainer>
           <ViewHeader className={cs.viewHeader}>
             <ViewHeader.Content>
               <ViewHeader.Pretitle>Heatmap</ViewHeader.Pretitle>
@@ -796,7 +796,7 @@ class SamplesHeatmapView extends React.Component {
               />
             </ViewHeader.Controls>
           </ViewHeader>
-        </div>
+        </NarrowContainer>
         <StickyContainer>
           <Sticky>
             {({ style }) => (

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeListView.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeListView.jsx
@@ -202,44 +202,48 @@ class PhyloTreeListView extends React.Component {
     let currentTree = this.getCurrentTree();
     return (
       <div className={cs.phyloTreeListView}>
-        <ViewHeader title="Phylogenetic Trees" className={cs.viewHeader}>
-          <ViewHeader.Content>
-            <ViewHeader.Pretitle>
-              Phylogenetic Tree{" "}
-              {currentTree.tax_name && (
-                <span>
-                  &nbsp;-&nbsp;
-                  <span
-                    className={cs.taxonName}
-                    onClick={this.handleTaxonModeOpen}
-                  >
-                    {currentTree.tax_name}
+        <NarrowContainer>
+          <ViewHeader title="Phylogenetic Trees" className={cs.viewHeader}>
+            <ViewHeader.Content>
+              <ViewHeader.Pretitle>
+                Phylogenetic Tree{" "}
+                {currentTree.tax_name && (
+                  <span>
+                    &nbsp;-&nbsp;
+                    <span
+                      className={cs.taxonName}
+                      onClick={this.handleTaxonModeOpen}
+                    >
+                      {currentTree.tax_name}
+                    </span>
                   </span>
-                </span>
-              )}
-            </ViewHeader.Pretitle>
-            <ViewHeader.Title
-              label={currentTree.name}
-              id={this.state.selectedPhyloTreeId}
-              options={this.props.phyloTrees.map(tree => ({
-                label: tree.name,
-                id: tree.id,
-                onClick: () => this.handleTreeChange(tree.id)
-              }))}
-            />
-          </ViewHeader.Content>
-          <ViewHeader.Controls>
-            <BasicPopup
-              trigger={<ShareButton onClick={this.handleShareClick} />}
-              content="A shareable URL was copied to your clipboard!"
-              on="click"
-              hideOnScroll
-            />{" "}
-            {/* TODO: (gdingle): this is admin-only until we have a way of browsing visualizations */}
-            {this.props.admin && <SaveButton onClick={this.handleSaveClick} />}{" "}
-            <PhyloTreeDownloadButton tree={currentTree} />
-          </ViewHeader.Controls>
-        </ViewHeader>
+                )}
+              </ViewHeader.Pretitle>
+              <ViewHeader.Title
+                label={currentTree.name}
+                id={this.state.selectedPhyloTreeId}
+                options={this.props.phyloTrees.map(tree => ({
+                  label: tree.name,
+                  id: tree.id,
+                  onClick: () => this.handleTreeChange(tree.id)
+                }))}
+              />
+            </ViewHeader.Content>
+            <ViewHeader.Controls>
+              <BasicPopup
+                trigger={<ShareButton onClick={this.handleShareClick} />}
+                content="A shareable URL was copied to your clipboard!"
+                on="click"
+                hideOnScroll
+              />{" "}
+              {/* TODO: (gdingle): this is admin-only until we have a way of browsing visualizations */}
+              {this.props.admin && (
+                <SaveButton onClick={this.handleSaveClick} />
+              )}{" "}
+              <PhyloTreeDownloadButton tree={currentTree} />
+            </ViewHeader.Controls>
+          </ViewHeader>
+        </NarrowContainer>
         <Divider />
         <DetailsSidebar
           visible={this.state.sidebarVisible}


### PR DESCRIPTION
* Apply narrow containers to view headers to keep sync with the content.
* Fix a lack of sync bug between headers and contents in narrow windows.

# Type of change

Bug fix and clean up.

# Test and Reproduce

Check all pages that use NarrowContainer to check for components with different width behaviors.

![Screen Shot 2019-04-05 at 5 49 17 PM](https://user-images.githubusercontent.com/37312125/55662735-2b6c3480-57cb-11e9-9f42-22cf6c66b72a.png)

