### PR TITLE
[Discovery Sidebar] Make styling adjustments

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/metadata_section.scss
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/metadata_section.scss
@@ -5,12 +5,12 @@
   .title {
     color: $black;
     font-weight: 600;
-    letter-spacing: 1.45px;
-    font-size: $font-size-body;
+    letter-spacing: 1.3px;
+    font-size: $font-size-caption;
     text-transform: uppercase;
     padding: 0 10px;
-    height: 50px;
-    line-height: 50px;
+    height: 40px;
+    line-height: 40px;
   }
 
   .editLink {

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/metadata_section.scss
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/metadata_section.scss
@@ -1,16 +1,10 @@
 @import "~styles/themes/colors";
 @import "~styles/typography";
+@import "~styles/themes/typography";
 
 .metadataSection {
   .title {
-    color: $black;
-    font-weight: 600;
-    letter-spacing: 1.3px;
-    font-size: $font-size-caption;
-    text-transform: uppercase;
-    padding: 0 10px;
-    height: 40px;
-    line-height: 40px;
+    @include font-header-tall-section-title;
   }
 
   .editLink {

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/metadata_section.scss
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/metadata_section.scss
@@ -4,7 +4,11 @@
 
 .metadataSection {
   .title {
-    @include font-header-tall-section-title;
+    @include font-header-accordion;
+
+    color: $black;
+    padding: 0 10px;
+    height: 40px;
   }
 
   .editLink {

--- a/app/assets/src/components/layout/accordion.scss
+++ b/app/assets/src/components/layout/accordion.scss
@@ -14,8 +14,8 @@
   }
 
   .toggleIcon {
-    padding: 0 20px;
-    font-size: 30px;
+    padding: 0 10px;
+    font-size: 22px;
     color: $medium-grey;
 
     &:hover {

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -79,7 +79,7 @@ export default class DiscoverySidebar extends React.Component {
     const { onFilterClick } = this.props;
     const { metadata } = this.state;
 
-    const dates = metadata[field];
+    let dates = metadata[field];
     const total = (maxBy("count", dates) || {}).count;
     const isIntervalBased = !!dates.length && dates[0].interval;
     const firstDate = dates.length
@@ -92,6 +92,9 @@ export default class DiscoverySidebar extends React.Component {
         ? dates[dates.length - 1].interval.end
         : dates[0].value
       : null;
+    // Special case design to show 1 or 2 bars just side-by-side.
+    const realBars = dates.filter(d => d.count > 0);
+    if (realBars.length < 3) dates = realBars;
     return (
       <div className={cs.histogramContainer}>
         <div className={cs.dateHistogram}>

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -185,11 +185,7 @@ export default class DiscoverySidebar extends React.Component {
             </a>
           </dt>
           <dd key={`${value}_value_${i}`}>
-            <span
-              className={cs.bar}
-              // TODO(gdingle): make width depend on container
-              style={{ width: percent * 1.4 + "px" }}
-            />
+            <span className={cs.bar} style={{ width: percent * 1.4 + "px" }} />
             <span className={cs.count}>{count}</span>
           </dd>
         </div>

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -112,8 +112,11 @@ export default class DiscoverySidebar extends React.Component {
             );
             const tooltipMessage = (
               <span>
-                {entry.text}
+                <span className={cs.boldText}>Date:</span> {entry.text}
                 <br />
+                <span className={cs.boldText}>{`Sample${
+                  entry.count > 1 ? "s" : ""
+                }: `}</span>
                 {entry.count}
               </span>
             );
@@ -174,21 +177,23 @@ export default class DiscoverySidebar extends React.Component {
     return rows.map((entry, i) => {
       const { count, text, value } = entry;
       const percent = Math.round(100 * count / total, 0);
-      return [
-        <dt className={cs.barLabel} key={`${value}_label_${i}`}>
-          <a onClick={() => this.handleFilterClick(value)}>
-            {value === "not_set" ? <i>{text}</i> : text}
-          </a>
-        </dt>,
-        <dd key={`${value}_value_${i}`}>
-          <span
-            className={cs.bar}
-            // TODO(gdingle): make width depend on container
-            style={{ width: percent * 1.3 + "px" }}
-          />
-          <span className={cs.count}>{count}</span>
-        </dd>
-      ];
+      return (
+        <div className={cs.barChartRow} key={`${value}_row_${i}`}>
+          <dt className={cs.barLabel} key={`${value}_label_${i}`}>
+            <a onClick={() => this.handleFilterClick(value)}>
+              {value === "not_set" ? <i>{text}</i> : text}
+            </a>
+          </dt>
+          <dd key={`${value}_value_${i}`}>
+            <span
+              className={cs.bar}
+              // TODO(gdingle): make width depend on container
+              style={{ width: percent * 1.6 + "px" }}
+            />
+            <span className={cs.count}>{count}</span>
+          </dd>
+        </div>
+      );
     });
   }
 
@@ -219,38 +224,40 @@ export default class DiscoverySidebar extends React.Component {
             open={this.hasData()}
             header={<div className={cs.title}>Overall</div>}
           >
-            <div className={cs.hasBackground}>
+            <div className={cx(cs.hasBackground, cs.statsRow)}>
               <dl className={cs.dataList}>
                 <dt className={cs.statsDt}>
-                  <strong>Samples</strong>
+                  <span className={cs.rowLabel}>Samples</span>
                 </dt>
                 <dd className={cs.statsDd}>{this.state.stats.numSamples}</dd>
               </dl>
             </div>
-            <div className={cs.hasBackground}>
+            <div className={cx(cs.hasBackground, cs.statsRow)}>
               <dl className={cs.dataList}>
                 <dt className={cs.statsDt}>
-                  <strong>Projects</strong>
+                  <span className={cs.rowLabel}>Projects</span>
                 </dt>
                 <dd className={cs.statsDd}>{this.state.stats.numProjects}</dd>
               </dl>
             </div>
             {currentTab === "samples" && (
               <div>
-                <div className={cs.hasBackground}>
+                <div className={cx(cs.hasBackground, cs.statsRow)}>
                   <dl className={cs.dataList}>
                     <dt className={cs.statsDt}>
-                      <strong>Avg. reads per sample</strong>
+                      <span className={cs.rowLabel}>Avg. reads per sample</span>
                     </dt>
                     <dd className={cs.statsDd}>
                       {this.state.stats.avgTotalReads}
                     </dd>
                   </dl>
                 </div>
-                <div className={cs.hasBackground}>
+                <div className={cx(cs.hasBackground, cs.statsRow)}>
                   <dl className={cs.dataList}>
                     <dt className={cs.statsDt}>
-                      <strong>Avg. reads passing filters per sample</strong>
+                      <span className={cs.rowLabel}>
+                        Avg. reads passing filters per sample
+                      </span>
                     </dt>
                     <dd className={cs.statsDd}>
                       {this.state.stats.avgAdjustedRemainingReads}
@@ -277,15 +284,15 @@ export default class DiscoverySidebar extends React.Component {
             header={<div className={cs.title}>Metadata</div>}
           >
             <div className={cs.hasBackground}>
-              <strong>Host</strong>
+              <span className={cs.rowLabel}>Host</span>
               {this.buildMetadataRows("host")}
             </div>
             <div className={cs.hasBackground}>
-              <strong>Tissue</strong>
+              <span className={cs.rowLabel}>Tissue</span>
               {this.buildMetadataRows("tissue")}
             </div>
             <div className={cs.hasBackground}>
-              <strong>Location</strong>
+              <span className={cs.rowLabel}>Location</span>
               {this.buildMetadataRows("location")}
             </div>
           </Accordion>

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -188,7 +188,7 @@ export default class DiscoverySidebar extends React.Component {
             <span
               className={cs.bar}
               // TODO(gdingle): make width depend on container
-              style={{ width: percent * 1.6 + "px" }}
+              style={{ width: percent * 1.4 + "px" }}
             />
             <span className={cs.count}>{count}</span>
           </dd>

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -103,6 +103,7 @@
       min-width: 33%;
       margin: 5px 0;
       padding: 0px;
+      display: inline-block;
     }
 
     dt {
@@ -111,51 +112,49 @@
 
     dd {
       width: 66%;
+      vertical-align: top;
     }
+  }
 
-    .statsDt {
-      min-width: 50%;
-    }
+  .statsDt {
+    min-width: 50%;
+  }
 
-    .statsDd {
-      max-width: 50%;
-    }
+  .statsDd {
+    max-width: 50%;
+  }
 
-    .barChartRow {
-    }
+  .barLabel {
+    text-align: right;
+    padding-right: 3px;
+  }
 
-    .barLabel {
-      text-align: right;
-      padding-right: 3px;
-    }
+  .bar {
+    display: inline-block;
+    vertical-align: middle;
+    height: 10px;
+    margin-left: 5px;
+    margin-right: 5px;
+    padding-left: 1px;
+    background-color: $melrose;
+    text-align: right;
+    color: white;
+  }
 
-    .bar {
-      display: inline-block;
-      vertical-align: middle;
-      height: 10px;
-      margin-left: 5px;
-      margin-right: 5px;
-      padding-left: 1px;
-      background-color: $melrose;
-      text-align: right;
-      color: white;
-    }
+  .showHide {
+    text-transform: uppercase;
+    margin-top: 15px;
+    margin-bottom: 10px;
+    color: $primary-light;
+    font-size: $font-size-smallest;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+  }
 
-    .showHide {
-      text-transform: uppercase;
-      margin-top: 15px;
-      margin-bottom: 10px;
-      color: $primary-light;
-      font-size: $font-size-smallest;
-      letter-spacing: 0.5px;
-      cursor: pointer;
-    }
-
-    .count {
-      vertical-align: middle;
-      color: $dark-grey;
-      font-weight: 600;
-    }
+  .count {
+    vertical-align: middle;
+    color: $dark-grey;
+    font-weight: 600;
   }
 }
 

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -29,7 +29,11 @@
 
   // See SampleDetailsMode/metadata_section.scss
   .title {
-    @include font-header-tall-section-title;
+    @include font-header-accordion;
+
+    color: $black;
+    padding: 0 10px;
+    height: 40px;
   }
 
   .rowLabel {

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -117,6 +117,7 @@
 
   .statsDd {
     max-width: 50%;
+    line-height: 18px;
   }
 
   .barLabel {

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -100,6 +100,7 @@
 
   dt,
   dd {
+    word-break: break-word;
     min-width: 33%;
     margin: 5px 0;
     padding: 0px;

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -50,6 +50,7 @@
     flex-flow: row nowrap;
     justify-content: space-evenly;
     align-items: flex-end;
+    border-bottom: 1px solid $lightest-grey;
 
     .bar {
       margin: 0 1px;

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -128,7 +128,7 @@
   .bar {
     display: inline-block;
     height: 10px;
-    margin-top: 5px;
+    margin-top: 4.5px;
     margin-left: 5px;
     margin-right: 5px;
     background-color: $melrose;
@@ -149,6 +149,7 @@
   .count {
     color: $dark-grey;
     font-weight: 600;
+    vertical-align: top;
   }
 }
 

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -14,11 +14,12 @@
 
 .metadataContainer {
   .hasBackground {
-    padding: 5px 10px;
+    padding-left: 10px;
+    padding-right: 5px;
 
-    strong {
-      display: block;
-      margin: 5px 0;
+    &:not(.statsRow) {
+      padding-top: 5px;
+      padding-bottom: 5px;
     }
   }
 
@@ -32,11 +33,18 @@
 
     color: $black;
     font-weight: 600;
-    letter-spacing: 1.45px;
+    font-size: 12px;
+    letter-spacing: 1.3px;
     text-transform: uppercase;
     padding: 0 10px;
-    height: 50px;
-    line-height: 50px;
+    height: 40px;
+    line-height: 40px;
+  }
+
+  .rowLabel {
+    display: block;
+    margin: 3px 0;
+    @include font-header-xxs;
   }
 }
 
@@ -86,60 +94,71 @@
   align-items: center;
   margin: 0;
 
-  dt,
-  dd {
-    word-break: break-word;
-    min-width: 33%;
-    margin: 5px 0;
-    padding: 0px;
-  }
+  .barChartRow {
+    width: 100%;
 
-  dt {
-    max-width: 33%;
-  }
+    dt,
+    dd {
+      word-break: break-word;
+      min-width: 33%;
+      margin: 5px 0;
+      padding: 0px;
+    }
 
-  dd {
-    padding: 0 0 0 10px;
-    width: 66%;
-  }
+    dt {
+      max-width: 33%;
+    }
 
-  .statsDt {
-    min-width: 50%;
-  }
+    dd {
+      width: 66%;
+    }
 
-  .statsDd {
-    max-width: 50%;
-  }
+    .statsDt {
+      min-width: 50%;
+    }
 
-  .barLabel {
-    text-align: right;
-  }
+    .statsDd {
+      max-width: 50%;
+    }
 
-  .bar {
-    display: inline-block;
-    vertical-align: middle;
-    height: 12px;
-    margin-left: 5px;
-    margin-right: 7px;
-    padding-left: 1px;
-    background-color: $melrose;
-    text-align: right;
-    color: white;
-  }
+    .barChartRow {
+    }
 
-  .showHide {
-    text-transform: uppercase;
-    margin-top: 15px;
-    margin-bottom: 10px;
-    color: $primary-light;
-    font-size: $font-size-smallest;
-    letter-spacing: 0.5px;
-    cursor: pointer;
-  }
+    .barLabel {
+      text-align: right;
+      padding-right: 3px;
+    }
 
-  .count {
-    vertical-align: middle;
-    color: $dark-grey;
-    font-weight: 600;
+    .bar {
+      display: inline-block;
+      vertical-align: middle;
+      height: 10px;
+      margin-left: 5px;
+      margin-right: 5px;
+      padding-left: 1px;
+      background-color: $melrose;
+      text-align: right;
+      color: white;
+    }
+
+    .showHide {
+      text-transform: uppercase;
+      margin-top: 15px;
+      margin-bottom: 10px;
+      color: $primary-light;
+      font-size: $font-size-smallest;
+      letter-spacing: 0.5px;
+      cursor: pointer;
+    }
+
+    .count {
+      vertical-align: middle;
+      color: $dark-grey;
+      font-weight: 600;
+    }
   }
+}
+
+.boldText {
+  font-weight: $font-weight-semibold;
 }

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -29,22 +29,13 @@
 
   // See SampleDetailsMode/metadata_section.scss
   .title {
-    @include font-body-s;
-
-    color: $black;
-    font-weight: 600;
-    font-size: 12px;
-    letter-spacing: 1.3px;
-    text-transform: uppercase;
-    padding: 0 10px;
-    height: 40px;
-    line-height: 40px;
+    @include font-header-tall-section-title;
   }
 
   .rowLabel {
+    @include font-header-xxs;
     display: block;
     margin: 3px 0;
-    @include font-header-xxs;
   }
 }
 

--- a/app/assets/src/components/views/discovery/discovery_sidebar.scss
+++ b/app/assets/src/components/views/discovery/discovery_sidebar.scss
@@ -96,24 +96,23 @@
 
   .barChartRow {
     width: 100%;
+  }
 
-    dt,
-    dd {
-      word-break: break-word;
-      min-width: 33%;
-      margin: 5px 0;
-      padding: 0px;
-      display: inline-block;
-    }
+  dt,
+  dd {
+    min-width: 33%;
+    margin: 5px 0;
+    padding: 0px;
+    display: inline-block;
+  }
 
-    dt {
-      max-width: 33%;
-    }
+  dt {
+    max-width: 33%;
+  }
 
-    dd {
-      width: 66%;
-      vertical-align: top;
-    }
+  dd {
+    width: 66%;
+    vertical-align: top;
   }
 
   .statsDt {
@@ -131,11 +130,10 @@
 
   .bar {
     display: inline-block;
-    vertical-align: middle;
     height: 10px;
+    margin-top: 5px;
     margin-left: 5px;
     margin-right: 5px;
-    padding-left: 1px;
     background-color: $melrose;
     text-align: right;
     color: white;
@@ -143,7 +141,7 @@
 
   .showHide {
     text-transform: uppercase;
-    margin-top: 15px;
+    margin-top: 5px;
     margin-bottom: 10px;
     color: $primary-light;
     font-size: $font-size-smallest;
@@ -152,7 +150,6 @@
   }
 
   .count {
-    vertical-align: middle;
     color: $dark-grey;
     font-weight: 600;
   }

--- a/app/assets/src/components/views/discovery/discovery_view.scss
+++ b/app/assets/src/components/views/discovery/discovery_view.scss
@@ -40,7 +40,8 @@
       border-left: 2px solid $lightest-grey;
       flex: 0 0 auto;
       overflow: auto;
-      padding: 0 14px 0 14px;
+      padding-left: 10px;
+      padding-right: 5px;
     }
   }
 }

--- a/app/assets/src/components/views/discovery/discovery_view.scss
+++ b/app/assets/src/components/views/discovery/discovery_view.scss
@@ -40,7 +40,7 @@
       border-left: 2px solid $lightest-grey;
       flex: 0 0 auto;
       overflow: auto;
-      padding: 10px 20px 0 20px;
+      padding: 0 14px 0 14px;
     }
   }
 }

--- a/app/assets/src/styles/themes/_typography.scss
+++ b/app/assets/src/styles/themes/_typography.scss
@@ -76,15 +76,12 @@ $font-weight-heavy: 800;
   letter-spacing: 0.3px;
 }
 
-@mixin font-header-tall-section-title {
+@mixin font-header-accordion {
   font-size: 12px;
   line-height: 40px;
   font-weight: 600;
   letter-spacing: 1.3px;
-  color: $black;
   text-transform: uppercase;
-  padding: 0 10px;
-  height: 40px;
 }
 
 @mixin font-body-l {

--- a/app/assets/src/styles/themes/_typography.scss
+++ b/app/assets/src/styles/themes/_typography.scss
@@ -76,6 +76,17 @@ $font-weight-heavy: 800;
   letter-spacing: 0.3px;
 }
 
+@mixin font-header-tall-section-title {
+  font-size: 12px;
+  line-height: 40px;
+  font-weight: 600;
+  letter-spacing: 1.3px;
+  color: $black;
+  text-transform: uppercase;
+  padding: 0 10px;
+  height: 40px;
+}
+
 @mixin font-body-l {
   font-size: 18px;
   line-height: 28px;


### PR DESCRIPTION
### Description
- Type of change: Enhancement
- Bunch of sidebar styling changes requested by Design. See side panel section here for full enumeration: https://czi.quip.com/FH4jAt2wzKXp/Data-Discovery-Team-Feedback

### Demo
(ignore the missing location)
![Screen Shot 2019-04-05 at 6 17 41 PM](https://user-images.githubusercontent.com/5652739/55663092-2ad59d00-57cf-11e9-8656-38172f87f38f.png)

Accordion styling was also supposed to be applied to the sample report sidebar (tightened up the title bar mostly)
![Screen Shot 2019-04-05 at 6 22 03 PM](https://user-images.githubusercontent.com/5652739/55663147-c830d100-57cf-11e9-9f19-52592d1d7cf4.png)

### Test and Reproduce
- Go to the data discovery view, open up the sidebar, verify that the elements are displaying as visually intended.