### PR TITLE
[Landing] Update interest form submit message + update Greenhouse link

### DIFF
--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -71,7 +71,8 @@ class Landing extends React.Component {
           email: "",
           institution: "",
           usage: "",
-          submitMessage: "Form completed. Thanks for your interest!"
+          submitMessage:
+            "Thanks for your interest! Our product team will be in touch about accessing IDseq. If your team is already on IDseq, ask a collaborator to add you to a project to get immediate access."
         });
       })
       .catch(() => {
@@ -97,7 +98,11 @@ class Landing extends React.Component {
           <div className="fill" />
           <div className="hiring-ad">
             {"Join our team! We're hiring "}
-            <a href="https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1003911">
+            <a
+              href="https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1620152"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               engineers
             </a>
             !

--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -72,7 +72,7 @@ class Landing extends React.Component {
           institution: "",
           usage: "",
           submitMessage:
-            "Thanks dfor your interest! Our product team will be in touch about accessing IDseq. If your team is already on IDseq, ask a collaborator to add you to a project to get immediate access."
+            "Thanks for your interest! Our product team will be in touch about accessing IDseq. If your team is already on IDseq, ask a collaborator to add you to a project to get immediate access."
         });
       })
       .catch(() => {

--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -72,7 +72,7 @@ class Landing extends React.Component {
           institution: "",
           usage: "",
           submitMessage:
-            "Thanks for your interest! Our product team will be in touch about accessing IDseq. If your team is already on IDseq, ask a collaborator to add you to a project to get immediate access."
+            "Thanks dfor your interest! Our product team will be in touch about accessing IDseq. If your team is already on IDseq, ask a collaborator to add you to a project to get immediate access."
         });
       })
       .catch(() => {


### PR DESCRIPTION
### Description
- Type of change: Enhancement
- Sometimes we still have users who submit the interest form multiple times because they expect it to automatically create an account. Or collaborators of collaborators try to sign up and don't get immediate access to their project. This updates the interest form submitted message to clarify. Copy came from Design.
- Also update the jobs link to our new IDseq-specific SWE Greenhouse listing.

### Demo
![Screen Shot 2019-04-08 at 5 03 21 PM](https://user-images.githubusercontent.com/5652739/55764426-41266780-5a20-11e9-98da-cc4c5eae0ede.png)

### Test and Reproduce
- Pull the branch, log out or go to Incognito, go to localhost:3000, test the Greenhouse link and a test form submission.