### PR TITLE
[Data Discovery] Remove dates from details columns and move them into their own.

### DIFF
--- a/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
@@ -2,43 +2,13 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { Table } from "~/components/visualizations/table";
-import BasicPopup from "~/components/BasicPopup";
-import cx from "classnames";
 // CSS file must be loaded after any elements you might want to override
 import cs from "./base_discovery_view.scss";
 
 class BaseDiscoveryView extends React.Component {
-  static renderItemDetails = ({
-    cellData: item,
-    detailsRenderer,
-    nameRenderer,
-    visibilityIconRenderer
-  }) => {
-    let icon = visibilityIconRenderer(item);
-    return (
-      <div className={cs.item}>
-        <div className={cs.visibility}>
-          {icon &&
-            React.cloneElement(icon, {
-              className: `${cx(cs.icon, icon.props.className)}`
-            })}
-        </div>
-        <div className={cs.itemRightPane}>
-          <BasicPopup
-            trigger={<div className={cs.itemName}>{nameRenderer(item)}</div>}
-            content={nameRenderer(item)}
-          />
-          <div className={cs.itemDescription}>{item.description}</div>
-          <div className={cs.itemDetails}>{detailsRenderer(item)}</div>
-        </div>
-      </div>
-    );
-  };
-
-  static renderList = ({ cellData: list }) => {
-    return list && list.length > 0 ? list.join(", ") : "N/A";
-  };
-
+  // Note: This class guarantees that a couple of settings are synced
+  // between views that use it (at the time of this comment, ProjectsView and VisualizationsView)
+  // We might be able to get rid of it once we implement dynamic row height on the tables.
   render() {
     const { columns, data, handleRowClick } = this.props;
 
@@ -49,6 +19,7 @@ class BaseDiscoveryView extends React.Component {
         columns={columns}
         defaultRowHeight={68}
         onRowClick={handleRowClick}
+        rowClassName={cs.tableDataRow}
       />
     );
   }

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -67,8 +67,8 @@ export default class DiscoverySidebar extends React.Component {
     return (find({ dimension: dimensionKey }, dimensions) || {}).values || [];
   }
 
-  static formatDate(createdAt) {
-    return moment(createdAt).format("YYYY-MM-DD");
+  static formatDate(date) {
+    return moment(date).format("DD-MM-YYYY");
   }
 
   static formatNumber(value) {
@@ -92,6 +92,9 @@ export default class DiscoverySidebar extends React.Component {
         ? dates[dates.length - 1].interval.end
         : dates[0].value
       : null;
+    const formattedFirstDate = DiscoverySidebar.formatDate(firstDate);
+    const formattedLastDate = DiscoverySidebar.formatDate(lastDate);
+
     // Special case design to show 1 or 2 bars just side-by-side.
     const realBars = dates.filter(d => d.count > 0);
     if (realBars.length < 3) dates = realBars;
@@ -110,9 +113,11 @@ export default class DiscoverySidebar extends React.Component {
                 &nbsp;
               </div>
             );
+
+            const text = `${formattedFirstDate} - ${formattedLastDate};`;
             const tooltipMessage = (
               <span>
-                <span className={cs.boldText}>Date:</span> {entry.text}
+                <span className={cs.boldText}>Date:</span> {text}
                 <br />
                 <span className={cs.boldText}>{`Sample${
                   entry.count > 1 ? "s" : ""
@@ -130,8 +135,10 @@ export default class DiscoverySidebar extends React.Component {
           })}
         </div>
         <div className={cx(cs.histogramLabels, dates.length < 3 && cs.evenly)}>
-          <div className={cs.label}>{firstDate}</div>
-          {firstDate !== lastDate && <div className={cs.label}>{lastDate}</div>}
+          <div className={cs.label}>{formattedFirstDate}</div>
+          {firstDate !== lastDate && (
+            <div className={cs.label}>{formattedLastDate}</div>
+          )}
         </div>
       </div>
     );

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -68,7 +68,7 @@ export default class DiscoverySidebar extends React.Component {
   }
 
   static formatDate(date) {
-    return moment(date).format("DD-MM-YYYY");
+    return moment(date).format("YYYY-MM-DD");
   }
 
   static formatNumber(value) {

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -20,7 +20,7 @@ import {
 } from "lodash/fp";
 import NarrowContainer from "~/components/layout/NarrowContainer";
 import { Divider } from "~/components/layout";
-import DiscoveryHeader from "../discovery/DiscoveryHeader";
+import DiscoveryHeader from "./DiscoveryHeader";
 import ProjectsView from "../projects/ProjectsView";
 import SamplesView from "../samples/SamplesView";
 import VisualizationsView from "../visualizations/VisualizationsView";

--- a/app/assets/src/components/views/discovery/TableRenderers.jsx
+++ b/app/assets/src/components/views/discovery/TableRenderers.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+import cx from "classnames";
+import moment from "moment";
+
+import BasicPopup from "~/components/BasicPopup";
+// CSS file must be loaded after any elements you might want to override
+import cs from "./table_renderers.scss";
+
+class TableRenderers extends React.Component {
+  static renderItemDetails = ({
+    cellData: item,
+    detailsRenderer,
+    nameRenderer,
+    visibilityIconRenderer
+  }) => {
+    let icon = visibilityIconRenderer(item);
+    return (
+      <div className={cs.item}>
+        <div className={cs.visibility}>
+          {icon &&
+            React.cloneElement(icon, {
+              className: `${cx(cs.icon, icon.props.className)}`
+            })}
+        </div>
+        <div className={cs.itemRightPane}>
+          <BasicPopup
+            trigger={<div className={cs.itemName}>{nameRenderer(item)}</div>}
+            content={nameRenderer(item)}
+          />
+          <div className={cs.itemDescription}>{item.description}</div>
+          <div className={cs.itemDetails}>{detailsRenderer(item)}</div>
+        </div>
+      </div>
+    );
+  };
+
+  static renderList = ({ cellData: list }) => {
+    return list && list.length > 0 ? list.join(", ") : "";
+  };
+
+  static renderDate = ({ cellData: date }) => {
+    return (
+      <div className={cs.date}>
+        {date ? moment(date).format("DD-MM-YYYY") : ""}
+      </div>
+    );
+  };
+
+  static renderDateWithElapsed = ({ cellData: date }) => {
+    return (
+      <div className={cs.dateContainer}>
+        {TableRenderers.renderDate({ cellData: date })}
+        <div className={cs.elapsed}>{date ? moment(date).fromNow() : ""}</div>
+      </div>
+    );
+  };
+}
+
+export default TableRenderers;

--- a/app/assets/src/components/views/discovery/TableRenderers.jsx
+++ b/app/assets/src/components/views/discovery/TableRenderers.jsx
@@ -42,7 +42,7 @@ class TableRenderers extends React.Component {
   static renderDate = ({ cellData: date }) => {
     return (
       <div className={cs.date}>
-        {date ? moment(date).format("DD-MM-YYYY") : ""}
+        {date ? moment(date).format("YYYY-MM-DD") : ""}
       </div>
     );
   };

--- a/app/assets/src/components/views/discovery/base_discovery_view.scss
+++ b/app/assets/src/components/views/discovery/base_discovery_view.scss
@@ -1,61 +1,7 @@
 @import "~styles/themes/colors";
 @import "~styles/themes/typography";
 
-.item {
-  text-align: left;
+.tableDataRow {
+  align-items: flex-start;
   padding: 13px 0;
-  display: flex;
-
-  .visibility {
-    display: flex;
-    flex: 0 0 40px;
-    align-items: center;
-    justify-items: center;
-    margin-right: 12px;
-  }
-
-  .itemName {
-    color: $black;
-    font-weight: $font-weight-semibold;
-    font-size: $font-size-h5;
-    line-height: 22px;
-    margin-bottom: 2px;
-  }
-
-  .itemDescription {
-    color: $dark-grey;
-    font-size: $font-size-h6;
-    line-height: 16px;
-    // remove description for now
-    // (we have no descriptions yet, but want to keep the placeholder)
-    height: 0;
-    overflow: hidden;
-    // height: 32px;
-    // margin-bottom: 8px;
-    vertical-align: middle;
-  }
-
-  .itemDetails {
-    @include font-body-xxs;
-
-    color: $medium-grey;
-    font-weight: $font-weight-regular;
-
-    span:not(:last-child) {
-      margin-right: 8px;
-    }
-
-    span:not(:first-child) {
-      margin-left: 8px;
-    }
-  }
-}
-
-.itemHeader {
-  text-align: left;
-}
-
-.icon {
-  fill: $primary-light;
-  width: 36px;
 }

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -72,13 +72,13 @@ const processRawSample = sample => {
       publicAccess: !!sample.public,
       user: get("uploader.name", sample.details),
       project: get("derived_sample_output.project_name", sample.details),
-      createdAt: sample.created_at,
       status: get(
         "run_info.result_status_description",
         sample.details
       ).toLowerCase()
     },
     collectionLocation: get("metadata.collection_location", sample.details),
+    createdAt: sample.created_at,
     duplicateCompressionRatio: get(
       "derived_sample_output.summary_stats.compression_ratio",
       sample.details

--- a/app/assets/src/components/views/discovery/table_renderers.scss
+++ b/app/assets/src/components/views/discovery/table_renderers.scss
@@ -1,0 +1,68 @@
+@import "~styles/themes/colors";
+@import "~styles/themes/typography";
+
+.item {
+  text-align: left;
+  display: flex;
+
+  .visibility {
+    display: flex;
+    flex: 0 0 40px;
+    align-items: center;
+    justify-items: center;
+    margin-right: 12px;
+  }
+
+  .itemName {
+    color: $black;
+    font-weight: $font-weight-semibold;
+    font-size: $font-size-h5;
+    line-height: 22px;
+    margin-bottom: 2px;
+  }
+
+  .itemDescription {
+    color: $dark-grey;
+    font-size: $font-size-h6;
+    line-height: 16px;
+    // remove description for now
+    // (we have no descriptions yet, but want to keep the placeholder)
+    height: 0;
+    overflow: hidden;
+    // height: 32px;
+    // margin-bottom: 8px;
+    vertical-align: middle;
+  }
+
+  .itemDetails {
+    @include font-body-xxs;
+
+    color: $medium-grey;
+    font-weight: $font-weight-regular;
+
+    span:not(:last-child) {
+      margin-right: 8px;
+    }
+
+    span:not(:first-child) {
+      margin-left: 8px;
+    }
+  }
+}
+
+.dateContainer {
+  .elapsed {
+    @include font-body-xxs;
+
+    font-weight: $font-weight-regular;
+  }
+}
+
+.itemHeader {
+  text-align: left;
+}
+
+.icon {
+  fill: $primary-light;
+  width: 36px;
+}

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -4,11 +4,11 @@ import PropTypes from "prop-types";
 import PrivateProjectIcon from "~ui/icons/PrivateProjectIcon";
 import PublicProjectIcon from "~ui/icons/PublicProjectIcon";
 import BaseDiscoveryView from "~/components/views/discovery/BaseDiscoveryView";
+import TableRenderers from "~/components/views/discovery/TableRenderers";
 // CSS file must be loaded after any elements you might want to override
 import cs from "./projects_view.scss";
 
 import { find, merge, pick } from "lodash/fp";
-import moment from "moment";
 
 class ProjectsView extends React.Component {
   constructor(props) {
@@ -20,7 +20,7 @@ class ProjectsView extends React.Component {
         flexGrow: 1,
         width: 350,
         cellRenderer: ({ cellData }) =>
-          BaseDiscoveryView.renderItemDetails(
+          TableRenderers.renderItemDetails(
             merge(
               { cellData },
               {
@@ -34,21 +34,27 @@ class ProjectsView extends React.Component {
         sortFunction: p => (p.name || "").toLowerCase()
       },
       {
+        dataKey: "created_at",
+        label: "Created On",
+        width: 120,
+        cellRenderer: TableRenderers.renderDateWithElapsed
+      },
+      {
         dataKey: "hosts",
         width: 200,
         disableSort: true,
-        cellRenderer: this.renderList
+        cellRenderer: TableRenderers.renderList
       },
       {
         dataKey: "tissues",
         width: 200,
         disableSort: true,
-        cellRenderer: BaseDiscoveryView.renderList
+        cellRenderer: TableRenderers.renderList
       },
       {
         dataKey: "number_of_samples",
         width: 140,
-        label: "No. of Samples"
+        label: "No. of Samples!!"
       }
     ];
   }
@@ -68,7 +74,6 @@ class ProjectsView extends React.Component {
   detailsRenderer(project) {
     return (
       <div>
-        <span>{moment(project.created_at).fromNow()}</span>|
         <span>{project.owner}</span>
       </div>
     );
@@ -86,11 +91,14 @@ class ProjectsView extends React.Component {
       return merge(
         {
           project: pick(
-            ["name", "description", "created_at", "owner", "public_access"],
+            ["name", "description", "owner", "public_access"],
             project
           )
         },
-        pick(["id", "hosts", "tissues", "number_of_samples"], project)
+        pick(
+          ["id", "created_at", "hosts", "tissues", "number_of_samples"],
+          project
+        )
       );
     });
 

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -54,7 +54,7 @@ class ProjectsView extends React.Component {
       {
         dataKey: "number_of_samples",
         width: 140,
-        label: "No. of Samples!!"
+        label: "No. of Samples"
       }
     ];
   }

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { difference, find, isEmpty, union } from "lodash/fp";
 import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 import Label from "~ui/labels/Label";
-import moment from "moment";
 import { numberWithCommas } from "~/helpers/strings";
 import HeatmapIcon from "~ui/icons/HeatmapIcon";
 import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,12 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { difference, find, isEmpty, union } from "lodash/fp";
-import InfiniteTable from "../../visualizations/table/InfiniteTable";
+import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 import Label from "~ui/labels/Label";
 import moment from "moment";
 import { numberWithCommas } from "~/helpers/strings";
-import cs from "./samples_view.scss";
-import cx from "classnames";
 import HeatmapIcon from "~ui/icons/HeatmapIcon";
 import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";
 import SamplePublicIcon from "~ui/icons/SamplePublicIcon";
@@ -17,6 +15,9 @@ import { DownloadIconDropdown } from "~ui/controls/dropdowns";
 import ReportsDownloader from "./ReportsDownloader";
 import CollectionModal from "./CollectionModal";
 import BasicPopup from "~/components/BasicPopup";
+import TableRenderers from "~/components/views/discovery/TableRenderers";
+import cs from "./samples_view.scss";
+import cx from "classnames";
 
 class SamplesView extends React.Component {
   constructor(props) {
@@ -34,6 +35,13 @@ class SamplesView extends React.Component {
         width: 350,
         cellRenderer: this.renderSample,
         headerClassName: cs.sampleHeader
+      },
+      {
+        dataKey: "createdAt",
+        label: "Uploaded On",
+        width: 120,
+        className: cs.basicCell,
+        cellRenderer: TableRenderers.renderDateWithElapsed
       },
       {
         dataKey: "host",
@@ -217,9 +225,6 @@ class SamplesView extends React.Component {
           )}
           {sample ? (
             <div className={cs.sampleDetails}>
-              <span className={cs.createdAt}>
-                {moment(sample.createdAt).fromNow()}
-              </span>|
               <span className={cs.user}>{sample.user}</span>|
               <span className={cs.project}>{sample.project}</span>
             </div>
@@ -386,6 +391,7 @@ class SamplesView extends React.Component {
 SamplesView.defaultProps = {
   activeColumns: [
     "sample",
+    "createdAt",
     "host",
     "collectionLocation",
     "nonHostReads",

--- a/app/assets/src/components/views/visualizations/VisualizationsView.jsx
+++ b/app/assets/src/components/views/visualizations/VisualizationsView.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { merge, pick } from "lodash/fp";
-import moment from "moment";
 
 import { humanize } from "~/helpers/strings";
 import { openUrl } from "~utils/links";
@@ -9,8 +8,9 @@ import HeatmapPublic from "~ui/icons/HeatmapPublic";
 import HeatmapPrivate from "~ui/icons/HeatmapPrivate";
 import PhyloTreePublic from "~ui/icons/PhyloTreePublic";
 import PhyloTreePrivate from "~ui/icons/PhyloTreePrivate";
-import cs from "./visualizations_view.scss";
 import BaseDiscoveryView from "~/components/views/discovery/BaseDiscoveryView";
+import TableRenderers from "~/components/views/discovery/TableRenderers";
+import cs from "./visualizations_view.scss";
 
 // See also ProjectsView which is very similar
 class VisualizationsView extends React.Component {
@@ -23,7 +23,7 @@ class VisualizationsView extends React.Component {
         flexGrow: 1,
         width: 350,
         cellRenderer: ({ cellData }) =>
-          BaseDiscoveryView.renderItemDetails(
+          TableRenderers.renderItemDetails(
             merge(
               { cellData },
               {
@@ -35,6 +35,12 @@ class VisualizationsView extends React.Component {
           ),
         headerClassName: cs.visualizationHeader,
         sortFunction: p => p.updated_at
+      },
+      {
+        dataKey: "updated_at",
+        label: "Updated On",
+        width: 120,
+        cellRenderer: TableRenderers.renderDate
       },
       {
         dataKey: "project_name",
@@ -79,7 +85,6 @@ class VisualizationsView extends React.Component {
   detailsRenderer(visualization) {
     return (
       <div>
-        <span>{moment(visualization.updated_at).fromNow()}</span>|
         <span>{visualization.user_name}</span>
       </div>
     );
@@ -98,17 +103,14 @@ class VisualizationsView extends React.Component {
       return merge(
         {
           visualization: pick(
-            [
-              "user_name",
-              "visualization_type",
-              "updated_at",
-              "name",
-              "publicAccess"
-            ],
+            ["user_name", "visualization_type", "name", "publicAccess"],
             visualization
           )
         },
-        pick(["id", "project_name", "samples_count"], visualization)
+        pick(
+          ["id", "updated_at", "project_name", "samples_count"],
+          visualization
+        )
       );
     });
 


### PR DESCRIPTION
## Description

The dates that we previously shown in the main column, have their own column now. On non-infinite tables (projects and visualizations) that column is sortable.

![Apr-11-2019 09-32-49](https://user-images.githubusercontent.com/37312125/55974596-dc942400-5c3c-11e9-83f0-dc98ffd7482e.gif)

Smaller changes also in this PR:
* Refactor: move static functions for rendering table fields to their own class `TableRenderers`
* Changed date format to `DD-MM-YYYY` both on the table and sidebar
* Fixed an alignment issue of cells in same table rows (all cells need to align to the top text of the main cell)

# Test and Reproduce

On projects, visualizations and samples view notice the presence of a date column whose header might vary (Created, Uploaded, Updated, ...). The columns must:
* Be the first column after the main column with details for the model
* Have content
* Have two rows: absolute date and approx. time elapsed since then.
The details column should not have date information (neither absolute nor elapsed).