### PR TITLE
[Data Discovery] Client upload instructions on header menu only new Upload feature is not enabled

### DIFF
--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -88,16 +88,18 @@ const UserMenuDropDown = ({
           />
         );
       }
-      userDropdownItems.push(
-        <BareDropdown.Item
-          key="2"
-          text={
-            <a className={cs.option} href="/cli_user_instructions">
-              New Sample (Command Line)
-            </a>
-          }
-        />
-      );
+      if (!newSampleUpload) {
+        userDropdownItems.push(
+          <BareDropdown.Item
+            key="2"
+            text={
+              <a className={cs.option} href="/cli_user_instructions">
+                New Sample (Command Line)
+              </a>
+            }
+          />
+        );
+      }
     }
 
     adminUser &&

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -87,8 +87,6 @@ const UserMenuDropDown = ({
             }
           />
         );
-      }
-      if (!newSampleUpload) {
         userDropdownItems.push(
           <BareDropdown.Item
             key="2"


### PR DESCRIPTION
## Description

Only show client upload instruction on header menu if the user Data Discovery is not enabled.
The new upload has a link with instructions and this option would appear by itself on the header menu, possibly leading to confusion due to the lack of the web upload option.