### PR TITLE
[User Emails] Fix error catch line in reset_password_instructions

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -15,7 +15,6 @@ class CustomDeviseMailer < Devise::Mailer
       @shared_project_name = Project.find(@email_arguments[:shared_project_id]).name
       @shared_project_id = @email_arguments[:shared_project_id]
     end
-
     super # Calls DeviseMailer
   rescue => exception
     LogUtil.log_err_and_airbrake("Error sending reset_password_instructions to #{record.email} #{@email_arguments || ''}")

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -5,22 +5,21 @@ class CustomDeviseMailer < Devise::Mailer
 
   def reset_password_instructions(record, token, opts = {})
     assign_email_arguments record
+    Rails.logger.info("Going to send password reset email to: #{record.email}")
+
+    # Block for adding extra arguments
     if @email_arguments
-      begin
-        Rails.logger.info("Going to send password reset email to: #{record.email}")
-        opts[:template_name] = @email_arguments[:email_template] if @email_arguments[:email_template]
-        opts[:subject] = @email_arguments[:email_subject] if @email_arguments[:email_subject]
-        @sharing_user = User.find(@email_arguments[:sharing_user_id])
-        @shared_project_name = Project.find(@email_arguments[:shared_project_id]).name
-        @shared_project_id = @email_arguments[:shared_project_id]
-      rescue => exception
-        LogUtil.log_err_and_airbrake("reset_password_instructions with #{@email_arguments} failed")
-        LogUtil.log_backtrace(exception)
-      end
-    else
-      LogUtil.log_err_and_airbrake("Couldn't send reset_password_instructions to #{record.email} failed due to missing arguments")
+      opts[:template_name] = @email_arguments[:email_template] if @email_arguments[:email_template]
+      opts[:subject] = @email_arguments[:email_subject] if @email_arguments[:email_subject]
+      @sharing_user = User.find(@email_arguments[:sharing_user_id])
+      @shared_project_name = Project.find(@email_arguments[:shared_project_id]).name
+      @shared_project_id = @email_arguments[:shared_project_id]
     end
-    super
+
+    super # Calls DeviseMailer
+  rescue => exception
+    LogUtil.log_err_and_airbrake("Error sending reset_password_instructions to #{record.email} #{@email_arguments || ''}")
+    LogUtil.log_backtrace(exception)
   end
 
   private


### PR DESCRIPTION
- I misread the function previously as requiring @email_arguments so it would Airbrake without @email_arguments. This moves the Airbrake to the bottom so that we can potentially catch errors from the Devise function called with 'super'.

### Test and Reproduce
- Open up the browser in a logged-out state, go to password reset page, type in an email, see output in the logs about sending the email (and no error). Log in, go to project page, add a new email to a project, see logs about sending email via project addition.