### PR TITLE
Store number metadata as decimal instead of float.

### DIFF
--- a/app/helpers/error_helper.rb
+++ b/app/helpers/error_helper.rb
@@ -7,6 +7,7 @@ module ErrorHelper
     INVALID_OPTION = "Invalid option for metadata field.".freeze
     INVALID_DATE = "Invalid date for metadata field.".freeze
     INVALID_NUMBER = "Invalid number for metadata field.".freeze
+    NUMBER_OUT_OF_RANGE = "Number is out of range.".freeze
   end
 
   module MetadataUploadErrors

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -82,8 +82,14 @@ class Metadatum < ApplicationRecord
     if /\A[+-]?\d+(\.\d+)?\z/.match(raw_value).nil?
       errors.add(:raw_value, MetadataValidationErrors::INVALID_NUMBER)
     else
-      # to_f will convert "abc" to 0.0, so we need the regex
-      self.number_validated_value = raw_value.to_f
+      # to_d will convert "abc" to 0.0, so we need the regex
+      val = raw_value.to_d
+      # Larger numbers will cause mysql error.
+      if val >= (10**27) || val <= (-10**27)
+        errors.add(:raw_value, MetadataValidationErrors::NUMBER_OUT_OF_RANGE)
+      else
+        self.number_validated_value = val
+      end
     end
   rescue ArgumentError
     errors.add(:raw_value, MetadataValidationErrors::INVALID_NUMBER)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -662,7 +662,18 @@ class Sample < ApplicationRecord
     end
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error(e)
-    return e
+    # Don't send the detailed error message to the user.
+    return {
+      status: "error",
+      error: "There was an error saving your metadata."
+    }
+  rescue ActiveRecord::RangeError => e
+    Rails.logger.error(e)
+    # Don't send the detailed error message to the user.
+    return {
+      status: "error",
+      error: "The value you provided was too large."
+    }
   end
 
   # Validate metadatum entry on this sample, without saving.

--- a/db/migrate/20190415181743_change_metadata_number_validated_value_to_decimal.rb
+++ b/db/migrate/20190415181743_change_metadata_number_validated_value_to_decimal.rb
@@ -1,0 +1,9 @@
+class ChangeMetadataNumberValidatedValueToDecimal < ActiveRecord::Migration[5.1]
+  def up
+    change_column :metadata, :number_validated_value, :decimal, precision: 36, scale: 9
+  end
+
+  def down
+    change_column :metadata, :number_validated_value, :float, limit: 24
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -149,7 +149,7 @@ ActiveRecord::Schema.define(version: 20_190_321_214_445) do
     t.integer "data_type", limit: 1, null: false
     t.string "raw_value"
     t.string "string_validated_value"
-    t.float "number_validated_value", limit: 24
+    t.decimal "number_validated_value", precision: 36, scale: 9
     t.integer "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
This avoids loss of accuracy in metadata.

Unlike float, decimal columns can cause mysql range errors.
We ensure that range errors are properly caught.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Verify that normal values can still be input on Sample Sidebar in both Report page and Heatmap page.
2. Verify that integer and decimal values for "Host Age" are not rounded weirdly when input.
3. Verified that migration can be done forward and backward without error, and that errors are automatically converted with no rounding errors for integers. For floats, we will need to do a check in prod after the migration happens, as 1.0f can become 1.0000000001 as a decimal. A little scary to automatically round in the migration, so we can compare to the raw value manually.
4. Verified that large values throw errors gracefully in the sidebar and metadata upload.

![Screen Shot 2019-04-15 at 12 14 15 PM](https://user-images.githubusercontent.com/837004/56159666-213ff800-5f7a-11e9-868f-59165a526c45.png)

![Screen Shot 2019-04-15 at 12 07 25 PM](https://user-images.githubusercontent.com/837004/56159671-23a25200-5f7a-11e9-88e3-cdbedb9116cc.png)

5. Verified that new sample upload with metadata still works.

## Impacted Areas in Application
List general components of the application that this PR will affect:

(anywhere with metadata)
Report Page
Phylo Tree
Heatmap
Metadata Upload Modal