### PR TITLE
Add metadata to accession select in coverage viz.

### DIFF
--- a/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
@@ -191,3 +191,20 @@
   // So the tooltip appears on the top-right instead of bottom-right of mouse.
   transform: translateY(-100%);
 }
+
+// TODO(mark):
+// If text-subtext options become more common, add this to BareDropdown as an official alternative option.
+.option {
+  padding: 6px 16px;
+
+  .optionText {
+    @include font-body-xs;
+    color: $darkest-grey;
+  }
+
+  .optionSubtext {
+    @include font-body-xxs;
+    color: $light-grey;
+    font-weight: $font-weight-regular;
+  }
+}

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/temporary_data/AE017283.1_coverage_viz.json
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/temporary_data/AE017283.1_coverage_viz.json
@@ -102,7 +102,7 @@
   ],
   "coverage_bin_size": 5120.53,
   "max_aligned_length": 151,
-  "avg_coverage_depth": 0,
+  "coverage_depth": 0,
   "coverage_breadth": 0,
   "avg_prop_mismatch": 0
 }

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/temporary_data/CP012350.1_coverage_viz.json
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/temporary_data/CP012350.1_coverage_viz.json
@@ -26,7 +26,7 @@
   ],
   "coverage_bin_size": 5061.416,
   "max_aligned_length": 151,
-  "avg_coverage_depth": 0,
+  "coverage_depth": 0,
   "coverage_breadth": 0,
   "avg_prop_mismatch": 0
 }

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/temporary_data/CP012352.1_coverage_viz.json
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/temporary_data/CP012352.1_coverage_viz.json
@@ -26,7 +26,7 @@
   ],
   "coverage_bin_size": 5080.016,
   "max_aligned_length": 151,
-  "avg_coverage_depth": 0,
+  "coverage_depth": 0,
   "coverage_breadth": 0,
   "avg_prop_mismatch": 0
 }

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/temporary_data/CP012647.1_coverage_viz.json
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/temporary_data/CP012647.1_coverage_viz.json
@@ -64,7 +64,7 @@
   ],
   "coverage_bin_size": 5044.876,
   "max_aligned_length": 239,
-  "avg_coverage_depth": 0.001,
+  "coverage_depth": 0.001,
   "coverage_breadth": 0,
   "avg_prop_mismatch": 0.003
 }

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
@@ -1,4 +1,5 @@
 import memoize from "memoize-one";
+import { sortBy } from "lodash/fp";
 
 // Gets called on every mouse move, so need to memoize.
 export const getHistogramTooltipData = memoize(
@@ -116,3 +117,7 @@ export const generateContigReadVizData = (hitGroups, coverageBinSize) => {
 
   return hitGroups.map(hit => getDisplayNumbers(hit));
 };
+
+// Sort by score descending.
+export const getSortedAccessionSummaries = summaries =>
+  sortBy(summary => -summary.score, summaries);

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -1,6 +1,15 @@
 // This component allows you to easily add a dropdown of options to any trigger element
 // Wraps around Semantic UI Dropdown, with react-popper as an alternative.
 
+// NOTE ABOUT CUSTOMIZING THE DROPDOWN:
+// If you don't want the user to be able to select a value, and you want to specify
+// custom onClick behavior yourself, use props.options. For example, if you want to provide the user
+// with a menu of options.
+// If you do want the user to be able to select a value, and you want the option to be rendered in a
+// custom way, use props.items and specify a "customNode" for each item.
+
+// TODO(mark): Refactor this component to remove props.options and props.itemSearchStrings, which are confusing and
+// redundant with props.items.customNode and props.children.
 import React from "react";
 import cx from "classnames";
 import { omit, zip, filter, map, nth, sortBy } from "lodash/fp";
@@ -22,16 +31,30 @@ class BareDropdown extends React.Component {
 
   // If the user provides us options instead of items, we will render them like this.
   renderItemsDefault = options => {
-    return options.map(option => (
-      <BaseDropdown.Item
-        key={option.value}
-        onClick={() => this.props.onChange(option.value)}
-        active={this.props.value === option.value}
-        className={cs.item}
-      >
-        {option.text}
-      </BaseDropdown.Item>
-    ));
+    return options.map(
+      option =>
+        option.customNode ? (
+          <div
+            key={option.value}
+            onClick={() => this.props.onChange(option.value)}
+            className={cx(
+              cs.item,
+              this.props.value === option.value && cs.active
+            )}
+          >
+            {option.customNode}
+          </div>
+        ) : (
+          <BaseDropdown.Item
+            key={option.value}
+            onClick={() => this.props.onChange(option.value)}
+            active={this.props.value === option.value}
+            className={cs.item}
+          >
+            {option.text}
+          </BaseDropdown.Item>
+        )
+    );
   };
 
   handleFilterChange = filterString => {
@@ -227,7 +250,9 @@ BareDropdown.propTypes = forbidExtraProps({
   options: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.any,
-      text: PropTypes.node
+      text: PropTypes.node,
+      // Custom node to render for the option.
+      customNode: PropTypes.node
     })
   ),
   value: PropTypes.any,

--- a/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
@@ -86,6 +86,8 @@ class Dropdown extends React.Component {
         trigger={this.renderTrigger()}
         usePortal={this.props.usePortal}
         withinModal={this.props.withinModal}
+        items={this.props.items}
+        itemSearchStrings={this.props.itemSearchStrings}
       />
     );
   }
@@ -102,9 +104,17 @@ Dropdown.propTypes = {
     PropTypes.shape({
       text: PropTypes.string.isRequired,
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-        .isRequired
+        .isRequired,
+      // Optional node element will be rendered instead of text.
+      // Text will still be used in the <DropdownTrigger>
+      customNode: PropTypes.node
     })
   ).isRequired,
+  // Custom props for rendering items
+  items: PropTypes.arrayOf(PropTypes.node),
+  // If search is true, and you provide pre-rendered "items" instead of "options",
+  // you must also provide a list of strings to search by.
+  itemSearchStrings: PropTypes.arrayOf(PropTypes.string),
   onChange: PropTypes.func.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   search: PropTypes.bool,

--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -54,6 +54,18 @@
     }
   }
 
+  .item {
+    cursor: pointer;
+
+    &:hover {
+      background-color: $transparent-lightest-grey;
+    }
+
+    &.active {
+      font-weight: bold;
+    }
+  }
+
   .menu {
     min-width: 100%;
     background-color: $white;

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -350,31 +350,39 @@ class SampleView extends React.Component {
       taxonName: "Cutibacterium acnes",
       accessionSummaries: [
         {
-          id: "CP012352.1",
-          num_contigs: 0,
-          num_reads: 2,
-          name:
-            "Cutibacterium acnes strain PA_15_2_L1 chromosome, complete genome"
-        },
-        {
           id: "CP012647.1",
+          name:
+            "Cutibacterium acnes strain KCOM 1861 (= ChDC B594) chromosome, complete genome",
           num_contigs: 1,
           num_reads: 4,
-          name:
-            "Cutibacterium acnes strain KCOM 1861 (= ChDC B594) chromosome, complete genome"
+          score: 478,
+          coverage_depth: 0.001
         },
         {
           id: "AE017283.1",
+          name: "Propionibacterium acnes KPA171202, complete genome",
           num_contigs: 0,
           num_reads: 10,
-          name: "Propionibacterium acnes KPA171202, complete genome"
+          score: 0,
+          coverage_depth: 0
         },
         {
           id: "CP012350.1",
+          name:
+            "Cutibacterium acnes strain PA_30_2_L1 chromosome, complete genome",
           num_contigs: 0,
           num_reads: 2,
+          score: 0,
+          coverage_depth: 0
+        },
+        {
+          id: "CP012352.1",
           name:
-            "Cutibacterium acnes strain PA_30_2_L1 chromosome, complete genome"
+            "Cutibacterium acnes strain PA_15_2_L1 chromosome, complete genome",
+          num_contigs: 0,
+          num_reads: 2,
+          score: 0,
+          coverage_depth: 0
         }
       ]
     };


### PR DESCRIPTION
Update mock data to latest format.

Accession select now shows contig count and coverage.
Augmented BareDropdown and Dropdown slightly to handle this.
Accession select is now sorted by best score, descending.

Accession select now has popup showing the accession name.

![Screen Shot 2019-04-15 at 6 23 34 PM](https://user-images.githubusercontent.com/837004/56175323-a1cb1c80-5fab-11e9-956a-b95dd2910b2a.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Open the coverage viz sidebar and select different accessions. Note that the best accession is at the top. 
2. Non-admin users are not affected.


