### PR TITLE
Show total number of accessions in coverage viz, even hidden ones.

### DIFF
--- a/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
@@ -26,6 +26,15 @@
     .subtitle {
       @include font-body-xs;
     }
+
+    .notShownMsg {
+      color: $light-grey;
+      margin-left: 5px;
+    }
+
+    .helpIcon {
+      margin-left: 5px;
+    }
   }
 
   .fill {

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
@@ -1,5 +1,6 @@
 import memoize from "memoize-one";
 import { sortBy } from "lodash/fp";
+import { formatPercent } from "~/components/utils/format";
 
 // Gets called on every mouse move, so need to memoize.
 export const getHistogramTooltipData = memoize(
@@ -15,12 +16,13 @@ export const getHistogramTooltipData = memoize(
         data: [
           [
             "Base Pair Range",
-            `${Math.round(coverageObj[0] * binSize)} - ${Math.round(
+            // \u2013 is en-dash
+            `${Math.round(coverageObj[0] * binSize)}\u2013${Math.round(
               (coverageObj[0] + 1) * binSize
             )}`
           ],
-          ["Average Coverage Depth", coverageObj[1]],
-          ["Coverage Breadth", coverageObj[2]],
+          ["Average Coverage Depth", `${coverageObj[1]}x`],
+          ["Coverage Breadth", formatPercent(coverageObj[2])],
           ["Overlapping Contigs", coverageObj[3]],
           ["Overlapping Reads", coverageObj[4]]
         ]
@@ -59,10 +61,10 @@ export const getGenomeVizTooltipData = memoize((accessionData, dataIndex) => {
     name = "Read";
   } else if (numContigs > 1) {
     name = "Aggregated Contigs";
-    counts = [["# Contigs", numContigs], ["Read Count", hitObj[2]]];
+    counts = [["# Contigs", numContigs], ["Contig Read Count", hitObj[2]]];
   } else if (numContigs == 1) {
     name = "Contig";
-    counts = [["Read Count", hitObj[2]]];
+    counts = [["Contig Read Count", hitObj[2]]];
   }
 
   const averagePrefix = multipleHits ? "Avg. " : "";
@@ -74,7 +76,8 @@ export const getGenomeVizTooltipData = memoize((accessionData, dataIndex) => {
         ...counts,
         [
           "Reference Alignment Range",
-          `${Math.round(hitObj[3])} - ${Math.round(hitObj[4])}`
+          // \u2013 is en-dash
+          `${Math.round(hitObj[3])}\u2013${Math.round(hitObj[4])}`
         ],
         [averagePrefix + "Alignment Length", hitObj[5]],
         [averagePrefix + "Percentage Matched", hitObj[6]],
@@ -119,5 +122,5 @@ export const generateContigReadVizData = (hitGroups, coverageBinSize) => {
 };
 
 // Sort by score descending.
-export const getSortedAccessionSummaries = summaries =>
-  sortBy(summary => -summary.score, summaries);
+export const getSortedAccessionSummaries = data =>
+  sortBy(summary => -summary.score, data.best_accessions);

--- a/app/assets/src/components/utils/format.js
+++ b/app/assets/src/components/utils/format.js
@@ -1,0 +1,1 @@
+export const formatPercent = number => `${(100 * number).toFixed(1)}%`;

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -342,7 +342,7 @@ class SampleView extends React.Component {
         ...coverageVizParams,
         taxonId: "1747",
         taxonName: "Cutibacterium acnes",
-        accessionSummaries: []
+        accessionData: null
       };
     }
 
@@ -351,43 +351,46 @@ class SampleView extends React.Component {
       // TODO(mark): Use getTaxonName to get the taxonName.
       taxonId: "1747",
       taxonName: "Cutibacterium acnes",
-      accessionSummaries: [
-        {
-          id: "CP012647.1",
-          name:
-            "Cutibacterium acnes strain KCOM 1861 (= ChDC B594) chromosome, complete genome",
-          num_contigs: 1,
-          num_reads: 4,
-          score: 478,
-          coverage_depth: 0.001
-        },
-        {
-          id: "AE017283.1",
-          name: "Propionibacterium acnes KPA171202, complete genome",
-          num_contigs: 0,
-          num_reads: 10,
-          score: 0,
-          coverage_depth: 0
-        },
-        {
-          id: "CP012350.1",
-          name:
-            "Cutibacterium acnes strain PA_30_2_L1 chromosome, complete genome",
-          num_contigs: 0,
-          num_reads: 2,
-          score: 0,
-          coverage_depth: 0
-        },
-        {
-          id: "CP012352.1",
-          name:
-            "Cutibacterium acnes strain PA_15_2_L1 chromosome, complete genome",
-          num_contigs: 0,
-          num_reads: 2,
-          score: 0,
-          coverage_depth: 0
-        }
-      ]
+      accessionData: {
+        best_accessions: [
+          {
+            id: "CP012647.1",
+            name:
+              "Cutibacterium acnes strain KCOM 1861 (= ChDC B594) chromosome, complete genome",
+            num_contigs: 1,
+            num_reads: 4,
+            score: 478,
+            coverage_depth: 0.001
+          },
+          {
+            id: "AE017283.1",
+            name: "Propionibacterium acnes KPA171202, complete genome",
+            num_contigs: 0,
+            num_reads: 10,
+            score: 0,
+            coverage_depth: 0
+          },
+          {
+            id: "CP012350.1",
+            name:
+              "Cutibacterium acnes strain PA_30_2_L1 chromosome, complete genome",
+            num_contigs: 0,
+            num_reads: 2,
+            score: 0,
+            coverage_depth: 0
+          },
+          {
+            id: "CP012352.1",
+            name:
+              "Cutibacterium acnes strain PA_15_2_L1 chromosome, complete genome",
+            num_contigs: 0,
+            num_reads: 2,
+            score: 0,
+            coverage_depth: 0
+          }
+        ],
+        num_accessions: 4
+      }
     };
   };
 


### PR DESCRIPTION
Also adjust names and ordering of metric.

Use en-dash for ranges of numbers.

Add Help Icon to explain hidden accessions.

![Screen Shot 2019-04-16 at 2 35 29 PM](https://user-images.githubusercontent.com/837004/56245873-4b1a1d00-6055-11e9-90f9-bac7fb3026ba.png)
