### PR TITLE
Optimizing TaxonCount inserts by using a bulk insert operation.

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -613,7 +613,7 @@ class PipelineRun < ApplicationRecord
       tcnt["count_type"] += "+" if refined
       tcnt.merge!(tcnt_attrs_to_merge)
     end
-    TaxonCount.import taxon_counts_attributes_filtered
+    TaxonCount.import!(taxon_counts_attributes_filtered)
 
     # aggregate the data at genus level
     generate_aggregate_counts('genus') unless multihit?

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -586,8 +586,7 @@ class PipelineRun < ApplicationRecord
 
   def load_taxons(downloaded_json_path, refined = false)
     json_dict = JSON.parse(File.read(downloaded_json_path))
-    pipeline_output_dict = json_dict['pipeline_output']
-    pipeline_output_dict.slice!('taxon_counts_attributes')
+    taxon_counts_attributes = json_dict.dig('pipeline_output', 'taxon_counts_attributes')
 
     # check if there's any record loaded into taxon_counts. If so, skip
     check_count_type = refined ? 'NT+' : 'NT'
@@ -596,24 +595,25 @@ class PipelineRun < ApplicationRecord
     return if loaded_records > 0
 
     # only keep counts at certain taxonomic levels
-    taxon_counts_attributes_filtered = []
     acceptable_tax_levels = [TaxonCount::TAX_LEVEL_SPECIES]
     acceptable_tax_levels << TaxonCount::TAX_LEVEL_GENUS if multihit?
     acceptable_tax_levels << TaxonCount::TAX_LEVEL_FAMILY if multihit?
-    pipeline_output_dict['taxon_counts_attributes'].each do |tcnt|
+    taxon_counts_attributes_filtered = taxon_counts_attributes.select do |tcnt|
       # TODO:  Better family support.
-      if acceptable_tax_levels.include?(tcnt['tax_level'].to_i) && !invalid_family_call?(tcnt)
-        taxon_counts_attributes_filtered << tcnt
-      end
+      acceptable_tax_levels.include?(tcnt['tax_level'].to_i) && !invalid_family_call?(tcnt)
     end
     # Set created_at and updated_at
     current_time = Time.now.utc # to match TaxonLineage date range comparison
+    tcnt_attrs_to_merge = {
+      'created_at' => current_time,
+      'updated_at' => current_time,
+      'pipeline_run_id' => id
+    }
     taxon_counts_attributes_filtered.each do |tcnt|
-      tcnt["created_at"] = current_time
-      tcnt["updated_at"] = current_time
       tcnt["count_type"] += "+" if refined
+      tcnt.merge!(tcnt_attrs_to_merge)
     end
-    update(taxon_counts_attributes: taxon_counts_attributes_filtered)
+    TaxonCount.import taxon_counts_attributes_filtered
 
     # aggregate the data at genus level
     generate_aggregate_counts('genus') unless multihit?


### PR DESCRIPTION
# Description

Issue [IDSEQ-335](https://jira.czi.team/browse/IDSEQ-335).
We were facing some deadlock conditions in our result_monitor that led to this optimization.
I noticed the insert operation was taking several minutes (in my local environment, I had a sample taking around 3 minutes).
The bulk insert operation (using activerecord-import) is around 30X faster, and since we are speeding up this insert operation. 
Although this change might reduce the likelihood of index/page locks conditions on that table, I have the impression the reason behind this issue might be a race condition that is processing same `pipeline_run_id`. Please, refer to this [JIRA comment](https://jira.czi.team/browse/IDSEQ-335?#comment-70786) for a more detailed investigation.

## Type of change

- [X] Performance improvement

# Test and Reproduce

Dead-locks are tricky to reproduce, and might be triggered by different conditions. The exact nature of this aforementioned issue is unknown, but I could reproduce it by executing load_taxons in parallel for the same `pipeline_run_id`. We cannot assume this is the reason behind this error (although I suspect it is related, as I described in this [JIRA comment](https://jira.czi.team/browse/IDSEQ-335?#comment-70786)).

Steps I used to reproduce it locally:
1. Open two `rails console` instances pointing to your local database (please, don't do that in production, since it can destroy data)
2. Find an existing `pipeline_run_id` (in my tests I used `18840`)
3. Get a test `refined_taxon_counts.json`. Best way to do that is visiting the corresponding sample result_folder (https://idseq.net/samples/10399/results_folder) and finding the file `refined_taxon_counts.json` there. Save it to a local folder. I created a folder `~tmp`.
4. In both consoles, execute `p = PipelineRun.find(18840)`.
5. In ONE console, execute `TaxonCount.where(pipeline_run_id: p.id).delete_all()`. This will delete previous lines from `taxon_counts` table, so we can insert new entries.
6. Now in BOTH console, type `p.load_taxons("~tmp/refined_taxon_counts.json", true)` and try to hit ENTER fast enough to execute them in parallel (2 or 3 seconds difference is fine). If the sample is large enough, that will trigger the race condition
(you can see evidence here in this [Google Slides](https://docs.google.com/presentation/d/1iKHUAGGNLKOMAVPJwfoDCdvzpqgVdS4JTMcxjYkNa00/edit?usp=sharing))

Note that if you use this test procedure after applying this PR, you will see a different error, related to duplicated lines. This is expected, since this PR is not fixing the race-condition scenario, it is only optimizing the operation.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Result Monitor

# Testing Script:

###Single Upload
* Using an AWS path that doesn't exist throws an error
* Successfully uploaded files from a folder (use test host)
* Uploading a duplicate file throws an error
* Pipeline gets initiated successfully 
* Sample is processed without errors

# Checklist:

- [ ] I have run through the testing script to make sure current functionality is unchanged.
- [X] I have done relevant tests that prove my fix is effective or that my feature works
- [X] I have spent time testing out edge cases for my feature
- [X] I have updated the test script or pull request template if necessary
- [X] New and existing unit tests pass locally with my changes

