### PR TITLE
BugFix: Fix condition to determine icon to show for projects (public vs private)

### DIFF
--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -64,7 +64,7 @@ class ProjectsView extends React.Component {
   }
 
   visibilityIconRenderer(project) {
-    return project && project.publicAccess ? (
+    return project && project.public_access ? (
       <PublicProjectIcon />
     ) : (
       <PrivateProjectIcon />


### PR DESCRIPTION
* Fixed the name of the variable checked for determining public or private icon project