### PR TITLE
Fix issue where only top 20 samples were shown in metadata upload modal.

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -98,7 +98,14 @@ class SamplesController < ApplicationController
     results = filter_by_metadatum(results, "collection_location", params[:location].split(',')) if params[:location].present?
     results = filter_by_host(results, host_query) if host_query.present?
 
-    @samples = sort_by(results, sort).paginate(page: page, per_page: params[:per_page] || PAGE_SIZE).includes([:user, :host_genome, :pipeline_runs, :input_files])
+    page_size = params[:per_page] || PAGE_SIZE
+
+    # If just returning basic fields, return all samples.
+    if basic
+      page_size = results.length
+    end
+
+    @samples = sort_by(results, sort).paginate(page: page, per_page: page_size).includes([:user, :host_genome, :pipeline_runs, :input_files])
     @samples_count = results.size
     @samples_formatted = basic ? format_samples_basic(@samples) : format_samples(@samples)
 


### PR DESCRIPTION
When user requests basic info for samples, return all samples, not just
the first page.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Go to a project with more than 30 samples and open the "Upload Metadata" panel.
2. Verify that all samples are displayed in the Manual Input tab.

# UI Performance issues
This does cause performance issues in the user interface when the user has more than 100 samples in their project. The manual input fields start becoming sluggish. Since this interface may change soon due to Data Discovery (Jenn has mentioned a tab for Metadata), I decided to defer addressing these perf issues for now. We can still direct users to upload metadata via CSV upload as a workaround.

The central perf issue is that every time the user does anything, all the Metadata Inputs get re-processed by React (though not re-rendered in the DOM unless they change). One solution is to be smarter about what gets re-processed by caching all the input component instances, checking which metadata values actually changed, and telling React to use cached components when possible. Another solution is to use something like react-virtualized to only render the components in view. Both solutions are not straightforward and will take some tweaking to get right.