### PR TITLE
[Metadata] Fix bug where Apply to All added invalid metadata fields.

### DIFF
--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -1,6 +1,7 @@
 class MetadataField < ApplicationRecord
   has_and_belongs_to_many :host_genomes
   has_and_belongs_to_many :projects
+  has_many :metadata, dependent: :destroy
 
   # ActiveRecord documentation summary
 

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -14,8 +14,7 @@ class Metadatum < ApplicationRecord
 
   # ActiveRecord related
   belongs_to :sample
-  # TODO: metadata_field type will be required after migration.
-  belongs_to :metadata_field, optional: true
+  belongs_to :metadata_field
   STRING_TYPE = 0
   NUMBER_TYPE = 1
   DATE_TYPE = 2


### PR DESCRIPTION
Apply to All would change the value for metadata fields of samples whose host genomes weren't compatible with that metadata field.

This would cause an extra custom metadata field to be created on the back-end.

Also destroy metadata when their metadata field is destroyed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Outline the steps to test or reproduce the PR here.

1. Find a project with samples of both Human and Mosquito.
2. Open "Upload Metadata", and select Host Age.
3. Modify Host Age for one sample and click "Apply to All".
4. Go to the Review page.
5. Verify that Mosquito samples do not appear in the list of modified metadata (they did prior to this change) 
