### PR TITLE
Add coverage_viz pipeline step to experimental dag template json

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -37,7 +37,10 @@ import HoverActions from "./views/report/ReportTable/HoverActions";
 import { numberWithCommas } from "../helpers/strings";
 import { getTaxonName, getGeneraContainingTags } from "../helpers/taxon";
 import ThresholdMap from "./utils/ThresholdMap";
-import { pipelineVersionHasAssembly } from "./utils/sample";
+import {
+  pipelineVersionHasAssembly,
+  pipelineVersionHasCoverageViz
+} from "./utils/sample";
 
 const DEFAULT_MIN_CONTIG_SIZE = 4;
 const HUMAN_TAX_IDS = [9605, 9606];
@@ -787,7 +790,10 @@ class PipelineSampleReport extends React.Component {
       this.sampleId
     }/alignment_viz/nt_${taxLevel}_${taxId}?pipeline_version=${pipelineVersion}`;
 
-    if (this.admin || this.allowedFeatures.includes("coverage_viz")) {
+    if (
+      (this.admin || this.allowedFeatures.includes("coverage_viz")) &&
+      pipelineVersionHasCoverageViz(pipelineVersion)
+    ) {
       this.props.onCoverageVizClick({
         taxId,
         taxName,

--- a/app/assets/src/components/utils/sample.js
+++ b/app/assets/src/components/utils/sample.js
@@ -3,7 +3,17 @@ import { last } from "lodash/fp";
 export const pipelineVersionHasAssembly = pipelineVersion => {
   if (!pipelineVersion) return false;
   const versionNums = pipelineVersion.split(".");
-  return +versionNums[0] >= 3 && +versionNums[1] >= 1;
+  return (
+    +versionNums[0] >= 4 || (+versionNums[0] === 3 && +versionNums[1] >= 1)
+  );
+};
+
+export const pipelineVersionHasCoverageViz = pipelineVersion => {
+  if (!pipelineVersion) return false;
+  const versionNums = pipelineVersion.split(".");
+  return (
+    +versionNums[0] >= 4 || (+versionNums[0] === 3 && +versionNums[1] >= 6)
+  );
 };
 
 // Get the basename from a file path

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -16,7 +16,10 @@ import {
   ANALYTICS_EVENT_NAMES
 } from "~/api/analytics";
 import PropTypes from "~/components/utils/propTypes";
-import { pipelineVersionHasAssembly } from "~/components/utils/sample";
+import {
+  pipelineVersionHasAssembly,
+  pipelineVersionHasCoverageViz
+} from "~/components/utils/sample";
 import AMRView from "~/components/AMRView";
 import BasicPopup from "~/components/BasicPopup";
 import PipelineSampleReport from "~/components/PipelineSampleReport";
@@ -71,12 +74,14 @@ class SampleView extends React.Component {
   }
 
   fetchAdditionalData = async () => {
-    const { sample } = this.props;
-    const coverageVizSummary = await getCoverageVizSummary(sample.id);
+    if (this.coverageVizEnabled()) {
+      const { sample } = this.props;
+      const coverageVizSummary = await getCoverageVizSummary(sample.id);
 
-    this.setState({
-      coverageVizDataByTaxon: coverageVizSummary
-    });
+      this.setState({
+        coverageVizDataByTaxon: coverageVizSummary
+      });
+    }
   };
 
   generateGsnapFilterStatus = jobStats => {
@@ -375,6 +380,10 @@ class SampleView extends React.Component {
     await saveVisualization(params.view || "table", params);
   };
 
+  coverageVizEnabled = () =>
+    (this.props.admin || this.props.allowedFeatures.includes("coverage_viz")) &&
+    pipelineVersionHasCoverageViz(this.props.pipelineRun.pipeline_version);
+
   render() {
     const versionDisplay = this.renderVersionDisplay();
 
@@ -514,8 +523,7 @@ class SampleView extends React.Component {
           )}
           params={this.getSidebarParams()}
         />
-        {(this.props.admin ||
-          this.props.allowedFeatures.includes("coverage_viz")) && (
+        {this.coverageVizEnabled() && (
           <CoverageVizBottomSidebar
             visible={this.state.coverageVizVisible}
             onClose={withAnalytics(

--- a/app/lib/dags/experimental.json.erb
+++ b/app/lib/dags/experimental.json.erb
@@ -7,6 +7,18 @@
       "gsnap.hitsummary.tab",
       "rapsearch2.hitsummary.tab"
     ],
+    <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+      "refined_gsnap_in": [
+        "gsnap.reassigned.m8",
+        "gsnap.hitsummary2.tab",
+        "gsnap.blast.top.m8"
+      ],
+      "contig_in": [
+        "contig_coverage.json",
+        "contig_stats.json",
+        "contigs.fasta"
+      ],
+    <% end %>
     "gsnap_m8": ["gsnap.deduped.m8"],
     "taxid_fasta_out": ["taxid_annot.fasta"],
     "taxid_locator_out": [
@@ -26,6 +38,9 @@
     ],
     "alignment_viz_out": ["align_viz.summary"],
     "srst2_out": ["output.log", "output__genes__ARGannot_r2__results.txt", "output__fullgenes__ARGannot_r2__results.txt", "amr_processed_results.csv", "amr_summary_results.csv"],
+    <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+      "coverage_viz_out": ["coverage_viz_summary.json"],
+    <% end %>
     <% if @attribute_dict[:fastq2] %>
       "fastqs": ["<%= @attribute_dict[:fastq1] %>", "<%= @attribute_dict[:fastq2] %>"],
     <% else %>
@@ -67,7 +82,7 @@
     },
     {
       "in": [
-        "gsnap_m8", 
+        "gsnap_m8",
         "taxid_locator_out"
       ],
       "out": "alignment_viz_out",
@@ -92,6 +107,18 @@
         "file_ext": "<%= @attribute_dict[:file_ext] %>"
       }
     },
+    <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+      {
+        "in": ["refined_gsnap_in", "contig_in", "gsnap_m8"],
+        "out": "coverage_viz_out",
+        "class": "PipelineStepGenerateCoverageViz",
+        "module": "idseq_dag.steps.generate_coverage_viz",
+        "additional_files": {
+          "info_db": "s3://idseq-database/alignment_data/2018-12-01/nt_info.sqlite3"
+        },
+        "additional_attributes": {}
+      },
+    <% end %>
     {
       "in": ["fastqs", "nonhost_fasta"],
       "out": "nonhost_fastq_out",
@@ -104,11 +131,18 @@
   "given_targets": {
     "taxid_fasta_in": {
       "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/results/<%= @attribute_dict[:pipeline_version] %>"
-
     },
     "gsnap_m8": {
       "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/results/<%= @attribute_dict[:pipeline_version] %>"
     },
+    <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+      "refined_gsnap_in": {
+        "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/postprocess/<%= @attribute_dict[:pipeline_version] %>/assembly"
+      },
+      "contig_in": {
+        "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/postprocess/<%= @attribute_dict[:pipeline_version] %>/assembly"
+      },
+    <% end %>
     "fastqs": {
       "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/fastqs"
     },

--- a/app/lib/dags/postprocess.json.erb
+++ b/app/lib/dags/postprocess.json.erb
@@ -36,15 +36,25 @@
       "assembly/gsnap.blast.m8",
       "assembly/gsnap.reassigned.m8",
       "assembly/gsnap.hitsummary2.tab",
-      "assembly/refined_gsnap_counts.json", 
-      "assembly/gsnap_contig_summary.json"
+      "assembly/refined_gsnap_counts.json",
+      <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+        "assembly/gsnap_contig_summary.json",
+        "assembly/gsnap.blast.top.m8"
+      <% else %>
+        "assembly/gsnap_contig_summary.json"
+      <% end %>
     ],
     "refined_rapsearch2_out": [
       "assembly/rapsearch2.blast.m8",
       "assembly/rapsearch2.reassigned.m8",
       "assembly/rapsearch2.hitsummary2.tab",
       "assembly/refined_rapsearch2_counts.json",
-      "assembly/rapsearch2_contig_summary.json"
+      <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+        "assembly/rapsearch2_contig_summary.json",
+        "assembly/rapsearch2.blast.top.m8"
+      <% else %>
+        "assembly/rapsearch2_contig_summary.json"
+      <% end %>
     ],
     "refined_taxon_count_out": ["assembly/refined_taxon_counts.json"],
     "contig_summary_out": ["assembly/combined_contig_summary.json"],
@@ -188,7 +198,7 @@
   "given_targets": {
       "host_filter_out": {
         "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/results/<%= @attribute_dict[:pipeline_version] %>"
-      } 
+      }
       ,"gsnap_out": {
         "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/results/<%= @attribute_dict[:pipeline_version] %>"
       },

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -66,6 +66,7 @@ class PipelineRun < ApplicationRecord
   ASSEMBLY_PREFIX = 'assembly/refined_'.freeze
   ASSEMBLED_CONTIGS_NAME = 'assembly/contigs.fasta'.freeze
   ASSEMBLED_STATS_NAME = 'assembly/contig_stats.json'.freeze
+  COVERAGE_VIZ_SUMMARY_JSON_NAME = 'coverage_viz_summary.json'.freeze
   CONTIG_SUMMARY_JSON_NAME = 'assembly/combined_contig_summary.json'.freeze
   CONTIG_NT_TOP_M8 = 'assembly/gsnap.blast.top.m8'.freeze
   CONTIG_NR_TOP_M8 = 'assembly/rapsearch2.blast.top.m8'.freeze
@@ -76,6 +77,7 @@ class PipelineRun < ApplicationRecord
 
   PIPELINE_VERSION_WHEN_NULL = '1.0'.freeze
   ASSEMBLY_PIPELINE_VERSION = 3.1
+  COVERAGE_VIZ_PIPELINE_VERSION = 3.6
   MIN_CONTIG_SIZE = 4 # minimal # reads mapped to the  contig
   M8_FIELDS = ["Query", "Accession", "Percentage Identity", "Alignment Length",
                "Number of mismatches", "Number of gap openings",
@@ -422,13 +424,15 @@ class PipelineRun < ApplicationRecord
   end
 
   def coverage_viz_summary_s3_path
-    # TODO(mark): Replace mock data with real data once we are running the sample.
-    return "s3://assets.idseq.net/coverage_viz_summary.json"
+    return "#{postprocess_output_s3_path}/#{COVERAGE_VIZ_SUMMARY_JSON_NAME}" if pipeline_version && pipeline_version.to_f >= COVERAGE_VIZ_PIPELINE_VERSION
   end
 
   def coverage_viz_data_s3_path(accession_id)
-    # TODO(mark): Replace mock data with real data once we are running the sample.
-    return "s3://assets.idseq.net/coverage_viz/#{accession_id}_coverage_viz.json"
+    "#{coverage_viz_output_s3_path}/#{accession_id}_coverage_viz.json" if pipeline_version && pipeline_version.to_f >= COVERAGE_VIZ_PIPELINE_VERSION
+  end
+
+  def coverage_viz_output_s3_path
+    "#{postprocess_output_s3_path}/coverage_viz"
   end
 
   def contigs_fasta_s3_path


### PR DESCRIPTION
Add coverage viz to idseq-web dag template.

Also a slight modification to the postprocessing step.

Currently gated with pipeline version >= 3.6.

As soon as the coverage viz step gets pushed to idseq_dag master, idseq_web will start
running that pipeline (due to this change).
We plan to test the coverage viz step in staging and prod using admin options before pushing
the coverage viz step to master.

The front-end is further gated on allowed_feature=coverage_viz_enabled and admin-only,
which we will remove in an upcoming PR.

---

Tested that:
* Existing samples can still be viewed without issue.
* A new sample that is run without admin-options will have pipeline-version v3.5 and succeed without issue.
* A new sample that is run with idseq-dag branch = markzhang/coverage_viz will have pipeline-version v3.6 and succeed without issue. The coverage viz properly loads on the sample.