### PR TITLE
[Mapping] Update the hover tooltip and add a basic popup window on click

### DIFF
--- a/app/assets/src/components/BasicPopup.jsx
+++ b/app/assets/src/components/BasicPopup.jsx
@@ -4,17 +4,19 @@ import PropTypes from "prop-types";
 
 class BasicPopup extends React.Component {
   render() {
-    return <Popup on="hover" {...this.props} basic inverted />;
+    return <Popup on="hover" {...this.props} basic />;
   }
 }
 
 BasicPopup.propTypes = {
   size: PropTypes.string,
-  wide: PropTypes.string
+  wide: PropTypes.string,
+  inverted: PropTypes.bool
 };
 
 BasicPopup.defaultProps = {
-  size: "tiny"
+  size: "tiny",
+  inverted: true
 };
 
 export default BasicPopup;

--- a/app/assets/src/components/BasicPopup.jsx
+++ b/app/assets/src/components/BasicPopup.jsx
@@ -4,19 +4,17 @@ import PropTypes from "prop-types";
 
 class BasicPopup extends React.Component {
   render() {
-    return <Popup on="hover" {...this.props} basic />;
+    return <Popup on="hover" {...this.props} basic inverted />;
   }
 }
 
 BasicPopup.propTypes = {
   size: PropTypes.string,
-  wide: PropTypes.string,
-  inverted: PropTypes.bool
+  wide: PropTypes.string
 };
 
 BasicPopup.defaultProps = {
-  size: "tiny",
-  inverted: true
+  size: "tiny"
 };
 
 export default BasicPopup;

--- a/app/assets/src/components/ui/containers/DataTooltip.jsx
+++ b/app/assets/src/components/ui/containers/DataTooltip.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import cs from "./data_tooltip.scss";
 
-const DataTooltip = ({ data, subtitle, title }) => {
+const DataTooltip = ({ data, subtitle, title, singleColumn }) => {
   // DataTooltip receives:
   // - title
   // - subtitle
@@ -18,9 +18,13 @@ const DataTooltip = ({ data, subtitle, title }) => {
               className={cs.dataTooltipValuePair}
               key={`value-${sectionName}-${keyValuePair[0]}`}
             >
-              <div className={cs.dataTooltipLabel}>{keyValuePair[0]}</div>
-              {keyValuePair[1] && (
-                <div className={cs.dataTooltipValue}>{keyValuePair[1]}</div>
+              {singleColumn ? (
+                <div className={cs.dataTooltipValue}>{keyValuePair[0]}</div>
+              ) : (
+                <React.Fragment>
+                  <div className={cs.dataTooltipLabel}>{keyValuePair[0]}</div>
+                  <div className={cs.dataTooltipValue}>{keyValuePair[1]}</div>
+                </React.Fragment>
               )}
             </div>
           );
@@ -45,7 +49,12 @@ const DataTooltip = ({ data, subtitle, title }) => {
 DataTooltip.propTypes = {
   data: PropTypes.array,
   subtitle: PropTypes.string,
-  title: PropTypes.string
+  title: PropTypes.string,
+  singleColumn: PropTypes.bool
+};
+
+DataTooltip.defaultProps = {
+  singleColumn: false
 };
 
 export default DataTooltip;

--- a/app/assets/src/components/ui/containers/DataTooltip.jsx
+++ b/app/assets/src/components/ui/containers/DataTooltip.jsx
@@ -6,7 +6,7 @@ const DataTooltip = ({ data, subtitle, title }) => {
   // DataTooltip receives:
   // - title
   // - subtitle
-  // - an object(section_name: array([label, value], [..]))
+  // - an array of object(section_name, data: array([label, value], [..]))
 
   const renderSection = (sectionName, dataValues) => {
     return (
@@ -45,4 +45,5 @@ DataTooltip.propTypes = {
   subtitle: PropTypes.string,
   title: PropTypes.string
 };
+
 export default DataTooltip;

--- a/app/assets/src/components/ui/containers/DataTooltip.jsx
+++ b/app/assets/src/components/ui/containers/DataTooltip.jsx
@@ -19,7 +19,9 @@ const DataTooltip = ({ data, subtitle, title }) => {
               key={`value-${sectionName}-${keyValuePair[0]}`}
             >
               <div className={cs.dataTooltipLabel}>{keyValuePair[0]}</div>
-              <div className={cs.dataTooltipValue}>{keyValuePair[1]}</div>
+              {keyValuePair[1] && (
+                <div className={cs.dataTooltipValue}>{keyValuePair[1]}</div>
+              )}
             </div>
           );
         })}

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -27,13 +27,7 @@ class BaseMap extends React.Component {
   };
 
   render() {
-    const {
-      mapTilerKey,
-      markers,
-      renderMarker,
-      popups,
-      renderPopup
-    } = this.props;
+    const { mapTilerKey, markers, popups } = this.props;
     const { viewport } = this.state;
 
     const styleID = "6041e288-ea0e-4a64-b0f6-78172d56a657";
@@ -45,8 +39,8 @@ class BaseMap extends React.Component {
           onViewportChange={this.updateViewport}
           mapStyle={styleURL}
         >
-          {markers && markers.map(renderMarker)}
-          {popups && renderPopup && popups.map(renderPopup)}
+          {markers}
+          {popups}
 
           <NavigationControl
             onViewportChange={this.updateViewport}
@@ -68,9 +62,7 @@ BaseMap.propTypes = {
   longitude: PropTypes.number,
   zoom: PropTypes.number,
   markers: PropTypes.array,
-  renderMarker: PropTypes.func,
-  popups: PropTypes.array,
-  renderPopup: PropTypes.func
+  popups: PropTypes.array
 };
 
 BaseMap.defaultProps = {

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -27,7 +27,13 @@ class BaseMap extends React.Component {
   };
 
   render() {
-    const { mapTilerKey, renderMarker, markers } = this.props;
+    const {
+      mapTilerKey,
+      markers,
+      renderMarker,
+      popups,
+      renderPopup
+    } = this.props;
     const { viewport } = this.state;
 
     const styleID = "6041e288-ea0e-4a64-b0f6-78172d56a657";
@@ -40,6 +46,7 @@ class BaseMap extends React.Component {
           mapStyle={styleURL}
         >
           {markers && markers.map(renderMarker)}
+          {popups && renderPopup && popups.map(renderPopup)}
 
           <NavigationControl
             onViewportChange={this.updateViewport}
@@ -55,13 +62,15 @@ class BaseMap extends React.Component {
 BaseMap.propTypes = {
   mapTilerKey: PropTypes.string.isRequired,
   updateViewport: PropTypes.func,
-  markers: PropTypes.array,
-  renderMarker: PropTypes.func,
   width: PropTypes.number,
   height: PropTypes.number,
   latitude: PropTypes.number,
   longitude: PropTypes.number,
-  zoom: PropTypes.number
+  zoom: PropTypes.number,
+  markers: PropTypes.array,
+  renderMarker: PropTypes.func,
+  popups: PropTypes.array,
+  renderPopup: PropTypes.func
 };
 
 BaseMap.defaultProps = {

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -62,6 +62,7 @@ BaseMap.propTypes = {
   latitude: PropTypes.number,
   longitude: PropTypes.number,
   zoom: PropTypes.number,
+  hoverTooltip: PropTypes.node,
   markers: PropTypes.array,
   popups: PropTypes.array
 };

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -27,7 +27,7 @@ class BaseMap extends React.Component {
   };
 
   render() {
-    const { mapTilerKey, markers, popups } = this.props;
+    const { mapTilerKey, hoverTooltip, markers, popups } = this.props;
     const { viewport } = this.state;
 
     const styleID = "6041e288-ea0e-4a64-b0f6-78172d56a657";
@@ -39,6 +39,7 @@ class BaseMap extends React.Component {
           onViewportChange={this.updateViewport}
           mapStyle={styleURL}
         >
+          {hoverTooltip}
           {markers}
           {popups}
 

--- a/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
@@ -8,19 +8,6 @@ class CircleMarker extends React.Component {
   render() {
     const { size, onMouseOver, onMouseOut, onClick } = this.props;
 
-    const circleBody = (
-      <circle
-        // Circle in the center of the viewBox
-        cx="50%"
-        cy="50%"
-        // Don't let edges get cut off of the viewBox. Adjust stroke-width in CSS.
-        r={size / 2 - 1}
-        onMouseOver={onMouseOver}
-        onMouseOut={onMouseOut}
-        onClick={onClick}
-        className={cx(cs.circle, cs.hoverable)}
-      />
-    );
     return (
       <svg
         height={size}
@@ -28,7 +15,17 @@ class CircleMarker extends React.Component {
         // Place the viewBox over the point
         style={{ transform: `translate(${-size / 2}px, ${-size / 2}px)` }}
       >
-        {circleBody}
+        <circle
+          className={cx(cs.circle, onMouseOver && cs.hoverable)}
+          // Circle in the center of the viewBox
+          cx="50%"
+          cy="50%"
+          // Don't let edges get cut off of the viewBox. Adjust stroke-width in CSS.
+          r={size / 2 - 1}
+          onMouseOver={onMouseOver}
+          onMouseOut={onMouseOut}
+          onClick={onClick}
+        />
       </svg>
     );
   }

--- a/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
@@ -2,12 +2,11 @@ import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 
-import BasicPopup from "~/components/BasicPopup";
 import cs from "./circle_marker.scss";
 
 class CircleMarker extends React.Component {
   render() {
-    const { size, onClick, hoverContent } = this.props;
+    const { size, onMouseOver, onMouseOut, onClick } = this.props;
 
     const circleBody = (
       <circle
@@ -16,8 +15,10 @@ class CircleMarker extends React.Component {
         cy="50%"
         // Don't let edges get cut off of the viewBox. Adjust stroke-width in CSS.
         r={size / 2 - 1}
+        onMouseOver={onMouseOver}
+        onMouseOut={onMouseOut}
         onClick={onClick}
-        className={cx(cs.circle, hoverContent && cs.hoverable)}
+        className={cx(cs.circle, cs.hoverable)}
       />
     );
     return (
@@ -27,15 +28,7 @@ class CircleMarker extends React.Component {
         // Place the viewBox over the point
         style={{ transform: `translate(${-size / 2}px, ${-size / 2}px)` }}
       >
-        {hoverContent ? (
-          <BasicPopup
-            trigger={circleBody}
-            content={hoverContent}
-            inverted={false}
-          />
-        ) : (
-          circleBody
-        )}
+        {circleBody}
       </svg>
     );
   }
@@ -43,8 +36,9 @@ class CircleMarker extends React.Component {
 
 CircleMarker.propTypes = {
   size: PropTypes.number,
-  onClick: PropTypes.func,
-  hoverContent: PropTypes.node
+  onMouseOver: PropTypes.func,
+  onMouseOut: PropTypes.func,
+  onClick: PropTypes.func
 };
 
 CircleMarker.defaultProps = {

--- a/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
@@ -28,7 +28,11 @@ class CircleMarker extends React.Component {
         style={{ transform: `translate(${-size / 2}px, ${-size / 2}px)` }}
       >
         {hoverContent ? (
-          <BasicPopup trigger={circleBody} content={hoverContent} />
+          <BasicPopup
+            trigger={circleBody}
+            content={hoverContent}
+            inverted={false}
+          />
         ) : (
           circleBody
         )}
@@ -40,7 +44,7 @@ class CircleMarker extends React.Component {
 CircleMarker.propTypes = {
   size: PropTypes.number,
   onClick: PropTypes.func,
-  hoverContent: PropTypes.string
+  hoverContent: PropTypes.node
 };
 
 CircleMarker.defaultProps = {

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -17,20 +17,20 @@ class MapPlayground extends React.Component {
     const locationsToSamples = {};
     results.forEach(result => {
       // Match locations that look like coordinates separated by a comma
-      let loc = result.location.replace(/_/g, ", ");
-      const match = /^([-0-9.]+),\s?([-0-9.]+)$/g.exec(loc);
+      let locationName = result.location.replace(/_/g, ", ");
+      const match = /^([-0-9.]+),\s?([-0-9.]+)$/g.exec(locationName);
       if (match) {
         const lat = parseFloat(match[1]).toFixed(2);
         const lon = parseFloat(match[2]).toFixed(2);
-        loc = `${lat}, ${lon}`;
+        locationName = `${lat}, ${lon}`;
         const formatted = {
           name: result.name,
           id: result.id
         };
-        if (locationsToSamples.hasOwnProperty(loc)) {
-          locationsToSamples[loc].push(formatted);
+        if (locationsToSamples.hasOwnProperty(locationName)) {
+          locationsToSamples[locationName].push(formatted);
         } else {
-          locationsToSamples[loc] = [formatted];
+          locationsToSamples[locationName] = [formatted];
         }
       }
     });
@@ -105,8 +105,10 @@ class MapPlayground extends React.Component {
       >
         <div>
           <div className={cs.title}>{popupInfo.name}</div>
-          {popupInfo.samples.map(sample => (
-            <div className={cs.description}>{sample.name}</div>
+          {popupInfo.samples.map((sample, i) => (
+            <div className={cs.description} key={`popup-${i}`}>
+              {sample.name}
+            </div>
           ))}
         </div>
       </MapPopup>

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -7,6 +7,8 @@ import BaseMap from "~/components/views/discovery/mapping/BaseMap";
 import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
 import CheckmarkIcon from "../../../ui/icons/CheckmarkIcon";
 
+import cs from "./map_playground.scss";
+
 class MapPlayground extends React.Component {
   constructor(props) {
     super(props);
@@ -59,9 +61,17 @@ class MapPlayground extends React.Component {
       >
         <CircleMarker
           size={markerSize}
-          hoverContent={`${pointCount} sample${pointCount > 1 ? "s" : ""}`}
+          // hoverContent={`${pointCount} sample${pointCount > 1 ? "s" : ""}`}
+          hoverContent={
+            <div>
+              <div>{markerData[0]}</div>
+              <div>{"Samples:"}</div>
+            </div>
+          }
+          className={cs.hoverTooltip}
           onClick={() =>
             this.openPopup({
+              name: markerData[0],
               latitude: parseFloat(lat),
               longitude: parseFloat(lon),
               markerIndex: index
@@ -93,7 +103,7 @@ class MapPlayground extends React.Component {
         onClose={() => this.closePopup(popupInfo)}
       >
         <div>
-          <CheckmarkIcon />
+          <div>{popupInfo.name}</div>
         </div>
       </MapPopup>
     );

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -104,11 +104,11 @@ class MapPlayground extends React.Component {
   handleMarkerMouseOver = hoverInfo => {
     const hoverTooltip = (
       <MapPopup
+        className={cs.dataTooltipContainer}
         anchor="top-left"
         tipSize={0}
         latitude={hoverInfo.lat}
         longitude={hoverInfo.lon}
-        className={cs.dataTooltipContainer}
         closeButton={false}
         offsetLeft={15}
         offsetTop={15}
@@ -143,11 +143,11 @@ class MapPlayground extends React.Component {
   renderPopupBox = popupInfo => {
     return (
       <MapPopup
+        className={cs.dataTooltipContainer}
         anchor="top-left"
         tipSize={0}
         latitude={popupInfo.lat}
         longitude={popupInfo.lon}
-        className={cs.dataTooltipContainer}
         offsetLeft={15}
         offsetTop={15}
         onClose={() => this.closePopup(popupInfo)}

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -56,6 +56,7 @@ class MapPlayground extends React.Component {
     lon = parseFloat(parseFloat(lon).toFixed(2));
     // Reject invalid coordinates
     if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+      // eslint-disable-next-line no-console
       console.log(`Skipping invalid coordinates ${lat}, ${lon}`);
       return [null, null];
     } else {

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -162,6 +162,7 @@ class MapPlayground extends React.Component {
               data: popupInfo.items.map(sample => [sample.name])
             }
           ]}
+          singleColumn={true}
         />
       </MapPopup>
     );

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -20,9 +20,9 @@ class MapPlayground extends React.Component {
       let loc = result.location.replace(/_/g, ", ");
       const match = /^([-0-9.]+),\s?([-0-9.]+)$/g.exec(loc);
       if (match) {
-        loc = `${parseFloat(match[1]).toFixed(2)}, ${parseFloat(
-          match[2]
-        ).toFixed(2)}`;
+        const lat = parseFloat(match[1]).toFixed(2);
+        const lon = parseFloat(match[2]).toFixed(2);
+        loc = `${lat}, ${lon}`;
         const formatted = {
           name: result.name,
           id: result.id
@@ -48,37 +48,30 @@ class MapPlayground extends React.Component {
 
   renderMarker = (markerData, index) => {
     const { viewport } = this.state;
-    const [lat, lon] = markerData[0].split(",");
-    const pointCount = markerData[1].length;
+    const [locationName, samples] = markerData;
+    const [lat, lon] = locationName.split(",").map(parseFloat);
+    const pointCount = samples.length;
     const minSize = 12;
-    const maxSize = 500;
     // Scale based on the zoom and point count (zoomed-in = higher zoom)
-    const markerSize = Math.min(
-      Math.max(
-        Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
-        minSize
-      ),
-      maxSize
+    const markerSize = Math.max(
+      Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
+      minSize
     );
     const hoverContent = (
       <div>
-        <div className={cs.title}>{markerData[0]}</div>
+        <div className={cs.title}>{locationName}</div>
         <div className={cs.description}>{`Samples: ${pointCount}`}</div>
       </div>
     );
     const popupInfo = {
-      name: markerData[0],
-      latitude: parseFloat(lat),
-      longitude: parseFloat(lon),
+      name: locationName,
+      latitude: lat,
+      longitude: lon,
       markerIndex: index,
-      samples: markerData[1]
+      samples: samples
     };
     return (
-      <Marker
-        key={`marker-${index}`}
-        latitude={parseFloat(lat)}
-        longitude={parseFloat(lon)}
-      >
+      <Marker key={`marker-${index}`} latitude={lat} longitude={lon}>
         <CircleMarker
           size={markerSize}
           hoverContent={hoverContent}

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -20,7 +20,6 @@ class MapPlayground extends React.Component {
       let locationName = result.location.replace(/_/g, ", ");
       const match = /^([-0-9.]+),\s?([-0-9.]+)$/g.exec(locationName);
       if (match) {
-        // Round the coordinates for some minimal aggregation
         let [lat, lon] = this.parseLatLon(match[1], match[2]);
         if (!(lat && lon)) return;
         locationName = `${lat}, ${lon}`;
@@ -50,8 +49,10 @@ class MapPlayground extends React.Component {
   }
 
   parseLatLon = (lat, lon) => {
+    // Round the coordinates for some minimal aggregation
     lat = parseFloat(parseFloat(lat).toFixed(2));
     lon = parseFloat(parseFloat(lon).toFixed(2));
+    // Reject invalid coordinates
     if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
       return [null, null];
     } else {

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -68,7 +68,9 @@ class MapPlayground extends React.Component {
 
   renderMarker = (marker, index) => {
     const { viewport } = this.state;
-    const [locationName, markerData] = marker;
+    const [name, markerData] = marker;
+    const lat = markerData.lat;
+    const lon = markerData.lon;
     const pointCount = markerData.items.length;
     const minSize = 12;
     // Scale based on the zoom and point count (zoomed-in = higher zoom)
@@ -76,46 +78,48 @@ class MapPlayground extends React.Component {
       Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
       minSize
     );
+
+    return (
+      <Marker key={`marker-${index}`} latitude={lat} longitude={lon}>
+        <CircleMarker
+          size={markerSize}
+          onMouseOver={() =>
+            this.handleMarkerMouseOver({ lat, lon, name, pointCount })
+          }
+          onMouseOut={this.handleMarkerMouseOut}
+          onClick={() =>
+            this.openPopup({
+              lat,
+              lon,
+              name,
+              index,
+              items: markerData.items
+            })
+          }
+        />
+      </Marker>
+    );
+  };
+
+  handleMarkerMouseOver = hoverInfo => {
     const hoverTooltip = (
       <MapPopup
         anchor="top-left"
         tipSize={0}
-        latitude={markerData.lat}
-        longitude={markerData.lon}
+        latitude={hoverInfo.lat}
+        longitude={hoverInfo.lon}
         className={cs.dataTooltipContainer}
         closeButton={false}
         offsetLeft={15}
         offsetTop={15}
       >
         <DataTooltip
-          data={[{ name: locationName, data: [["Samples", pointCount]] }]}
+          data={[
+            { name: hoverInfo.name, data: [["Samples", hoverInfo.pointCount]] }
+          ]}
         />
       </MapPopup>
     );
-    const popupInfo = {
-      name: locationName,
-      lat: markerData.lat,
-      lon: markerData.lon,
-      markerIndex: index,
-      items: markerData.items
-    };
-    return (
-      <Marker
-        key={`marker-${index}`}
-        latitude={markerData.lat}
-        longitude={markerData.lon}
-      >
-        <CircleMarker
-          size={markerSize}
-          onMouseOver={() => this.handleMarkerMouseOver(hoverTooltip)}
-          onMouseOut={this.handleMarkerMouseOut}
-          onClick={() => this.openPopup(popupInfo)}
-        />
-      </Marker>
-    );
-  };
-
-  handleMarkerMouseOver = hoverTooltip => {
     this.setState({ hoverTooltip });
   };
 
@@ -123,18 +127,18 @@ class MapPlayground extends React.Component {
     this.setState({ hoverTooltip: null });
   };
 
-  openPopup(popupInfo) {
+  openPopup = popupInfo => {
     this.setState({
       popups: concat(this.state.popups, popupInfo),
-      hoverTooltip: null // Replace the tooltip open
+      hoverTooltip: null // Replace the open tooltip
     });
-  }
+  };
 
-  closePopup(popupInfo) {
+  closePopup = popupInfo => {
     this.setState({
-      popups: reject({ markerIndex: popupInfo.markerIndex }, this.state.popups)
+      popups: reject({ index: popupInfo.index }, this.state.popups)
     });
-  }
+  };
 
   renderPopupBox = popupInfo => {
     return (

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -76,17 +76,19 @@ class MapPlayground extends React.Component {
       Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
       minSize
     );
-    let hoverContent = (
-      <div>
-        <div className={cs.title}>{locationName}</div>
-        <div className={cs.description}>{`Samples: ${pointCount}`}</div>
-      </div>
-    );
-    hoverContent = (
-      <DataTooltip
-        title={locationName}
-        data={[{ data: [[`Samples: ${pointCount}`, "val"]] }]}
-      />
+    const hoverTooltip = (
+      <MapPopup
+        anchor="top-left"
+        tipSize={0}
+        latitude={markerData.lat}
+        longitude={markerData.lon}
+        className={cs.dataTooltipPopup}
+        closeButton={false}
+      >
+        <DataTooltip
+          data={[{ name: locationName, data: [["Samples:", pointCount]] }]}
+        />
+      </MapPopup>
     );
     const popupInfo = {
       name: locationName,
@@ -103,12 +105,20 @@ class MapPlayground extends React.Component {
       >
         <CircleMarker
           size={markerSize}
-          hoverContent={hoverContent}
-          onHover={this.handleMarkerHover}
+          onMouseOver={() => this.handleMarkerMouseOver(hoverTooltip)}
+          onMouseOut={this.handleMarkerMouseOut}
           onClick={() => this.openPopup(popupInfo)}
         />
       </Marker>
     );
+  };
+
+  handleMarkerMouseOver = hoverTooltip => {
+    this.setState({ hoverTooltip });
+  };
+
+  handleMarkerMouseOut = () => {
+    this.setState({ hoverTooltip: null });
   };
 
   openPopup(popupInfo) {
@@ -122,14 +132,6 @@ class MapPlayground extends React.Component {
       popups: reject({ markerIndex: popupInfo.markerIndex }, this.state.popups)
     });
   }
-
-  handleMarkerHover = node => {
-    this.setState({ hoverTooltip: this.getTooltipData(node) });
-  };
-
-  handleMarkerHoverOut = () => {
-    this.setState({ hoverTooltip: null });
-  };
 
   renderPopupBox = popupInfo => {
     return (
@@ -155,12 +157,13 @@ class MapPlayground extends React.Component {
 
   render() {
     const { mapTilerKey } = this.props;
-    const { locationsToItems, popups } = this.state;
+    const { locationsToItems, hoverTooltip, popups } = this.state;
 
     return (
       <BaseMap
         mapTilerKey={mapTilerKey}
         updateViewport={this.updateViewport}
+        hoverTooltip={hoverTooltip}
         markers={Object.entries(locationsToItems).map(this.renderMarker)}
         popups={popups.map(this.renderPopupBox)}
       />

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -82,11 +82,13 @@ class MapPlayground extends React.Component {
         tipSize={0}
         latitude={markerData.lat}
         longitude={markerData.lon}
-        className={cs.dataTooltipPopup}
+        className={cs.dataTooltipContainer}
         closeButton={false}
+        offsetLeft={15}
+        offsetTop={15}
       >
         <DataTooltip
-          data={[{ name: locationName, data: [["Samples:", pointCount]] }]}
+          data={[{ name: locationName, data: [["Samples", pointCount]] }]}
         />
       </MapPopup>
     );
@@ -123,7 +125,8 @@ class MapPlayground extends React.Component {
 
   openPopup(popupInfo) {
     this.setState({
-      popups: concat(this.state.popups, popupInfo)
+      popups: concat(this.state.popups, popupInfo),
+      hoverTooltip: null // Replace the tooltip open
     });
   }
 
@@ -136,21 +139,23 @@ class MapPlayground extends React.Component {
   renderPopupBox = popupInfo => {
     return (
       <MapPopup
-        anchor="bottom"
+        anchor="top-left"
         tipSize={0}
         latitude={popupInfo.lat}
         longitude={popupInfo.lon}
+        className={cs.dataTooltipContainer}
+        offsetLeft={15}
+        offsetTop={15}
         onClose={() => this.closePopup(popupInfo)}
-        className={cs.dataBox}
       >
-        <div>
-          <div className={cs.title}>{popupInfo.name}</div>
-          {popupInfo.items.map((sample, i) => (
-            <div className={cs.description} key={`popup-${i}`}>
-              {sample.name}
-            </div>
-          ))}
-        </div>
+        <DataTooltip
+          data={[
+            {
+              name: popupInfo.name,
+              data: popupInfo.items.map(sample => [sample.name])
+            }
+          ]}
+        />
       </MapPopup>
     );
   };

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -56,6 +56,7 @@ class MapPlayground extends React.Component {
     lon = parseFloat(parseFloat(lon).toFixed(2));
     // Reject invalid coordinates
     if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+      console.log(`Skipping invalid coordinates ${lat}, ${lon}`);
       return [null, null];
     } else {
       return [lat, lon];
@@ -74,6 +75,7 @@ class MapPlayground extends React.Component {
     const pointCount = markerData.items.length;
     const minSize = 12;
     // Scale based on the zoom and point count (zoomed-in = higher zoom)
+    // Log1.5 of the count looked nice visually for not getting too large with many points.
     const markerSize = Math.max(
       Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
       minSize

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -16,10 +16,14 @@
   box-shadow: 0 2px 4px 0 $light-grey;
 }
 
-.dataTooltipPopup {
+.dataTooltipContainer {
+  // Stay above regular markers
+  z-index: 1;
+
   :global(.mapboxgl-popup-content) {
     // Override some MapboxGL styling
     padding: 0;
     box-shadow: none;
+    background: transparent;
   }
 }

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -1,21 +1,6 @@
 @import "~styles/themes/colors";
 @import "~styles/themes/typography";
 
-.title {
-  @include font-header-xs;
-  margin-bottom: 5px;
-}
-
-.description {
-  @include font-body-xs;
-}
-
-.dataBox {
-  border: 1px solid $light-grey;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px 0 $light-grey;
-}
-
 .dataTooltipContainer {
   // Stay above regular markers
   z-index: 1;

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -15,3 +15,11 @@
   border-radius: 5px;
   box-shadow: 0 2px 4px 0 $light-grey;
 }
+
+.dataTooltipPopup {
+  :global(.mapboxgl-popup-content) {
+    // Override some MapboxGL styling
+    padding: 0;
+    box-shadow: none;
+  }
+}

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -11,8 +11,7 @@
 }
 
 .dataBox {
-  background-color: $white;
   border: 1px solid $light-grey;
   border-radius: 5px;
-  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 4px 0 $light-grey;
 }

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -1,3 +1,18 @@
-.hoverTooltip {
-  background-color: white;
+@import "~styles/themes/colors";
+@import "~styles/themes/typography";
+
+.title {
+  @include font-header-xs;
+  margin-bottom: 5px;
+}
+
+.description {
+  @include font-body-xs;
+}
+
+.dataBox {
+  background-color: $white;
+  border: 1px solid $light-grey;
+  border-radius: 5px;
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
 }

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -1,0 +1,3 @@
+.hoverTooltip {
+  background-color: white;
+}


### PR DESCRIPTION
### Description
- Update the hover tooltip to have the location name / sample count
- Add a basic onClick popup that will enumerate the samples at that point
- Refactor some of the demo locationsToSamples parsing
- Tweak the bubble size scaling
- Need to sync up with design on more details/adjustments
- Open to suggestions on what to name "hover tooltips" vs "onclick persistent popups" >:)

### Demo
![Screen Shot 2019-04-19 at 3 51 00 PM](https://user-images.githubusercontent.com/5652739/56447154-87e74d80-62bb-11e9-85d1-b78d995172fd.png)
![Screen Shot 2019-04-19 at 3 51 16 PM](https://user-images.githubusercontent.com/5652739/56447156-89b11100-62bb-11e9-9a82-ef604f34e2c7.png)

### Test and Reproduce
- Pull the branch, retrieve MAPTILER_API_KEY from Parameter Store, start locally with `MAPTILER_API_KEY=key_here docker-compose up web`
- Visit http://localhost:3000/locations/map_playground
- Hover over a bubble to see the hover. Click on a bubble to see the onClick popup.