### PR TITLE
Add frontend analytics to heatmap and phylo trees

### DIFF
--- a/app/assets/src/api/analytics.js
+++ b/app/assets/src/api/analytics.js
@@ -11,8 +11,7 @@ import { isArray, isObject, camelCase, snakeCase, lowerFirst } from "lodash/fp";
 // ANALYTICS_EVENT_NAMES, which does not require registration here and uses a
 // more elaborate naming convention.
 export const ANALYTICS_EVENT_NAMES = {
-  sampleViewed: "sample_viewed",
-  userInterestFormSubmitted: "user_interest_form_submitted"
+  sampleViewed: "sample_viewed"
 };
 
 // See https://czi.quip.com/bKDnAITc6CbE/How-to-start-instrumenting-analytics-2019-03-06

--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -18,7 +18,6 @@ import DiscoverIcon from "../ui/icons/DiscoverIcon";
 import DetectIcon from "../ui/icons/DetectIcon";
 import DecipherIcon from "../ui/icons/DecipherIcon";
 import LogoIcon from "../ui/icons/LogoIcon";
-import { logAnalyticsEvent, ANALYTICS_EVENT_NAMES } from "~/api/analytics";
 
 class Landing extends React.Component {
   constructor(props) {
@@ -56,14 +55,6 @@ class Landing extends React.Component {
         }
       })
       .then(() => {
-        logAnalyticsEvent(ANALYTICS_EVENT_NAMES.userInterestFormSubmitted, {
-          first_name: this.state.firstName,
-          last_name: this.state.lastName,
-          email: this.state.email,
-          institution: this.state.institution,
-          usage: this.state.usage
-        });
-
         this.setState({
           firstName: "",
           lastName: "",

--- a/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView.jsx
@@ -720,7 +720,7 @@ class SamplesHeatmapView extends React.Component {
       this.updateHeatmap
     );
     logAnalyticsEvent("SamplesHeatmapView_specificity-filter_changed", {
-      readspecificity: specificity
+      readSpecificity: specificity
     });
   };
 

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import SvgSaver from "svgsaver";
 
+import { logAnalyticsEvent } from "~/api/analytics";
+
 import DownloadButtonDropdown from "../../ui/controls/dropdowns/DownloadButtonDropdown";
 
 class PhyloTreeDownloadButton extends React.Component {
@@ -25,19 +27,21 @@ class PhyloTreeDownloadButton extends React.Component {
       location.href = `/phylo_trees/${
         this.props.tree.id
       }/download?output=${option}`;
-      return;
     } else if (option == "svg") {
       // TODO (gdingle): filename per tree?
       this.svgSaver.asSvg(this.getNode(), "phylo_tree.svg");
-      return;
     } else if (option == "png") {
       // TODO (gdingle): filename per tree?
       this.svgSaver.asPng(this.getNode(), "phylo_tree.png");
-      return;
     } else {
       // eslint-disable-next-line no-console
       console.error(`Bad download option: ${option}`);
     }
+    logAnalyticsEvent("PhyloTreeDownloadButton_option_clicked", {
+      option,
+      treeName: this.props.tree.name,
+      treeId: this.props.tree.id
+    });
   }
 
   // TODO (gdingle): should we pass in a reference with React somehow?

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -75,6 +75,10 @@ class HomeController < ApplicationController
     Rails.logger.info("New sign up:\n#{body}")
     # DEPRECATED. Use log_analytics_event.
     MetricUtil.put_metric_now("users.sign_ups", 1)
+    MetricUtil.log_analytics_event("user_interest_form_submitted", nil, {
+                                     # Google Analytics does not allow PII, so we only log institution
+                                     institution: home_params[:institution]
+                                   }, request)
 
     UserMailer.landing_sign_up_email(body).deliver_now
     render json: {


### PR DESCRIPTION
# Description

This adds analytics to the remaining controls of the heatmap and phylo tree pages. See https://czi.quip.com/67RCAIiHN0Qc/IDseq-product-analytics-How-to-log for methodology.

![image](https://user-images.githubusercontent.com/28797/56516378-24ddfc80-64ef-11e9-835e-38be0ca88bb5.png)


# Test and Reproduce

Click on all new added analytics such as download button
Observe events in chrome debugger
Observe no new errors