### PR TITLE
Log status changes in active record objects

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -47,6 +47,12 @@ class ApplicationRecord < ActiveRecord::Base
       pipeline_run_id: record.respond_to?(:pipeline_run_id) ? record.pipeline_run_id : nil
     }
 
+    # Merge status changes, important for updates, for example:
+    # "status", "job_status", "command_status"
+    properties = properties.merge(
+      record.attributes.select { |k, _v| k.include?("status") }
+    )
+
     # Remove empty keys
     properties = properties.delete_if { |_k, v| v.nil? }
 


### PR DESCRIPTION
# Description

See comment in code. 

# Test and Reproduce
Upload a local sample
See log message 

`Event 'sample_created' logged with properties {:id=>12305, :name=>"RR004_water_2_S23A", :user_id=>94, :project_id=>165, "status"=>"created"`