### PR TITLE
Add analytics to new upload flow and site header

### DIFF
--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -1,14 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { forbidExtraProps } from "airbnb-prop-types";
+import cx from "classnames";
+
 import { RequestContext } from "~/components/common/RequestContext";
 import ToastContainer from "~ui/containers/ToastContainer";
 import BareDropdown from "~ui/controls/dropdowns/BareDropdown";
 import LogoIcon from "~ui/icons/LogoIcon";
 import { openUrl } from "~utils/links";
 import { deleteAsync } from "~/api/core";
-import { forbidExtraProps } from "airbnb-prop-types";
+import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
+
 import cs from "./header.scss";
-import cx from "classnames";
 
 class Header extends React.Component {
   render() {
@@ -119,6 +122,9 @@ const UserMenuDropDown = ({
           <a
             className={cs.option}
             href={`mailto:${email}?Subject=Report%20Feedback`}
+            onClick={() =>
+              logAnalyticsEvent("Header_dropdown-feedback-option_clicked")
+            }
           >
             Report Feedback
           </a>
@@ -132,6 +138,9 @@ const UserMenuDropDown = ({
             target="_blank"
             rel="noopener noreferrer"
             href="https://assets.idseq.net/Terms.pdf"
+            onClick={() =>
+              logAnalyticsEvent("Header_dropdown-terms-option_clicked")
+            }
           >
             Terms of Use
           </a>
@@ -145,12 +154,22 @@ const UserMenuDropDown = ({
             target="_blank"
             rel="noopener noreferrer"
             href="https://assets.idseq.net/Privacy.pdf"
+            onClick={() =>
+              logAnalyticsEvent("Header_dropdown-privacy-policy-option_clicked")
+            }
           >
             Privacy Policy
           </a>
         }
       />,
-      <BareDropdown.Item key="7" text="Logout" onClick={signOut} />
+      <BareDropdown.Item
+        key="7"
+        text="Logout"
+        onClick={withAnalytics(
+          signOut,
+          "Header_dropdown-logout-option_clicked"
+        )}
+      />
     );
     return userDropdownItems;
   };

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -267,7 +267,7 @@ class MetadataManualInput extends React.Component {
   isHostGenomeIdValidForField = (hostGenomeId, field) =>
     includes(
       hostGenomeId,
-      get([field, "host_genome_ids"], this.props.projectMetadataFields) || false
+      get([field, "host_genome_ids"], this.props.projectMetadataFields)
     );
 
   // Create form fields for the table.

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -152,7 +152,7 @@ class MetadataManualInput extends React.Component {
   // Convert metadata headers and fields to a CSV-like format before passing to parent.
   onMetadataChange = (newHeaders, newFields) => {
     // Only send fields for the selected samples to the parent component.
-    // If a sample was added, and then later removed, that sample's metadata thll not be sent up,
+    // If a sample was added, and then later removed, that sample's metadata will not be sent up,
     // but will still persist in this component.
     const sampleNames = map("name", this.props.samples);
     const fieldsForSamples = pickBy(

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -50,7 +50,9 @@ class MetadataUpload extends React.Component {
       wasManual: tab === "Manual Input"
     });
     logAnalyticsEvent("MetadataUpload_tab_changed", {
-      tab
+      tab,
+      projectId: this.props.project.id,
+      projectName: this.props.project.name
     });
   };
 
@@ -61,16 +63,15 @@ class MetadataUpload extends React.Component {
       issues,
       validatingCSV
     });
-    if (validatingCSV) {
-      logAnalyticsEvent("MetadataUpload_csv-metadata_validated", {
+    if (!validatingCSV) {
+      // We only want to log on the second call when issues are present
+      logAnalyticsEvent("MetadataUpload_csv-metadata_changed", {
         errors: issues.errors.length,
-        warnings: issues.warnings.length
+        warnings: issues.warnings.length,
+        projectId: this.props.project.id,
+        projectName: this.props.project.name
       });
     }
-    logAnalyticsEvent("MetadataUpload_csv-metadata_changed", {
-      errors: issues.errors.length,
-      warnings: issues.warnings.length
-    });
   };
 
   // MetadataManualInput doesn't validate metadata before calling onMetadataChangeManual.
@@ -80,7 +81,10 @@ class MetadataUpload extends React.Component {
       this.props.onDirty();
     }
     this.props.onMetadataChange({ metadata, wasManual: true });
-    logAnalyticsEvent("MetadataUpload_manual-metadata_changed", metadata);
+    logAnalyticsEvent("MetadataUpload_manual-metadata_changed", {
+      projectId: this.props.project.id,
+      projectName: this.props.project.name
+    });
   };
 
   getCSVUrl = () => {
@@ -142,7 +146,13 @@ class MetadataUpload extends React.Component {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() =>
-              logAnalyticsEvent("MetadataUpload_download-csv-template_clicked")
+              logAnalyticsEvent(
+                "MetadataUpload_download-csv-template_clicked",
+                {
+                  projectId: this.props.project.id,
+                  projectName: this.props.project.name
+                }
+              )
             }
           >
             Download Metadata CSV Template
@@ -247,7 +257,11 @@ class MetadataUpload extends React.Component {
                   target="_blank"
                   onClick={() =>
                     logAnalyticsEvent(
-                      "MetadataUpload_full-dictionary-link_clicked"
+                      "MetadataUpload_full-dictionary-link_clicked",
+                      {
+                        projectId: this.props.project.id,
+                        projectName: this.props.project.name
+                      }
                     )
                   }
                 >
@@ -265,7 +279,10 @@ class MetadataUpload extends React.Component {
                 className={cs.link}
                 target="_blank"
                 onClick={() =>
-                  logAnalyticsEvent("MetadataUpload_dictionary-link_clicked")
+                  logAnalyticsEvent("MetadataUpload_dictionary-link_clicked", {
+                    projectId: this.props.project.id,
+                    projectName: this.props.project.name
+                  })
                 }
               >
                 View Metadata Dictionary

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -61,10 +61,15 @@ class MetadataUpload extends React.Component {
       issues,
       validatingCSV
     });
+    if (validatingCSV) {
+      logAnalyticsEvent("MetadataUpload_csv-metadata_validated", {
+        errors: issues.errors.length,
+        warnings: issues.warnings.length
+      });
+    }
     logAnalyticsEvent("MetadataUpload_csv-metadata_changed", {
       errors: issues.errors.length,
-      warnings: issues.warnings.length,
-      validatingCSV
+      warnings: issues.warnings.length
     });
   };
 
@@ -75,7 +80,7 @@ class MetadataUpload extends React.Component {
       this.props.onDirty();
     }
     this.props.onMetadataChange({ metadata, wasManual: true });
-    logAnalyticsEvent("MetadataUpload_manual-metadata_changed");
+    logAnalyticsEvent("MetadataUpload_manual-metadata_changed", metadata);
   };
 
   getCSVUrl = () => {
@@ -136,6 +141,9 @@ class MetadataUpload extends React.Component {
             href={this.getCSVUrl()}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() =>
+              logAnalyticsEvent("MetadataUpload_download-csv-template_clicked")
+            }
           >
             Download Metadata CSV Template
           </a>

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -8,12 +8,13 @@ import AlertIcon from "~ui/icons/AlertIcon";
 import Tabs from "~/components/ui/controls/Tabs";
 import { getAllHostGenomes } from "~/api";
 import { getProjectMetadataFields } from "~/api/metadata";
+import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import LoadingIcon from "~ui/icons/LoadingIcon";
+import { getURLParamString } from "~/helpers/url";
 
 import cs from "./metadata_upload.scss";
 import MetadataManualInput from "./MetadataManualInput";
 import IssueGroup from "./IssueGroup";
-import { getURLParamString } from "~/helpers/url";
 
 const map = _fp.map.convert({ cap: false });
 
@@ -48,6 +49,9 @@ class MetadataUpload extends React.Component {
       issues: null,
       wasManual: tab === "Manual Input"
     });
+    logAnalyticsEvent("MetadataUpload_tab_changed", {
+      tab
+    });
   };
 
   // MetadataCSVUpload validates metadata before calling onMetadataChangeCSV.
@@ -55,6 +59,11 @@ class MetadataUpload extends React.Component {
     this.props.onMetadataChange({ metadata, issues, wasManual: false });
     this.setState({
       issues,
+      validatingCSV
+    });
+    logAnalyticsEvent("MetadataUpload_csv-metadata_changed", {
+      errors: issues.errors.length,
+      warnings: issues.warnings.length,
       validatingCSV
     });
   };
@@ -66,6 +75,7 @@ class MetadataUpload extends React.Component {
       this.props.onDirty();
     }
     this.props.onMetadataChange({ metadata, wasManual: true });
+    logAnalyticsEvent("MetadataUpload_manual-metadata_changed");
   };
 
   getCSVUrl = () => {
@@ -104,7 +114,10 @@ class MetadataUpload extends React.Component {
           <div>
             <span
               className={cs.link}
-              onClick={this.props.onShowCSVInstructions}
+              onClick={withAnalytics(
+                this.props.onShowCSVInstructions,
+                "MetadataUpload_instruction-link_clicked"
+              )}
             >
               View CSV Upload Instructions
             </span>
@@ -224,6 +237,11 @@ class MetadataUpload extends React.Component {
                   href="/metadata/dictionary"
                   className={cs.link}
                   target="_blank"
+                  onClick={() =>
+                    logAnalyticsEvent(
+                      "MetadataUpload_full-dictionary-link_clicked"
+                    )
+                  }
                 >
                   View Full Metadata Dictionary
                 </a>
@@ -238,6 +256,9 @@ class MetadataUpload extends React.Component {
                 href="/metadata/dictionary"
                 className={cs.link}
                 target="_blank"
+                onClick={() =>
+                  logAnalyticsEvent("MetadataUpload_dictionary-link_clicked")
+                }
               >
                 View Metadata Dictionary
               </a>

--- a/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
@@ -9,11 +9,13 @@ import _fp, {
   slice,
   sumBy
 } from "lodash/fp";
+import cx from "classnames";
+
 import { sampleNameFromFileName, cleanFilePath } from "~utils/sample";
 import FilePicker from "~ui/controls/FilePicker";
 import PropTypes from "~/components/utils/propTypes";
+
 import cs from "./sample_upload_flow.scss";
-import cx from "classnames";
 
 const map = _fp.map.convert({ cap: false });
 

--- a/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
@@ -14,6 +14,7 @@ import cx from "classnames";
 import { sampleNameFromFileName, cleanFilePath } from "~utils/sample";
 import FilePicker from "~ui/controls/FilePicker";
 import PropTypes from "~/components/utils/propTypes";
+import { logAnalyticsEvent } from "~/api/analytics";
 
 import cs from "./sample_upload_flow.scss";
 
@@ -63,9 +64,14 @@ class LocalSampleFileUpload extends React.Component {
     );
 
   toggleInfo = () => {
-    this.setState({
-      showInfo: !this.state.showInfo
-    });
+    this.setState(
+      {
+        showInfo: !this.state.showInfo
+      },
+      logAnalyticsEvent("LocalSampleFileUpload_more-info-toggle_clicked", {
+        showInfo: this.state.showInfo
+      })
+    );
   };
 
   render() {

--- a/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { compact } from "lodash/fp";
+
 import Input from "~ui/controls/Input";
 import PrimaryButton from "~ui/controls/buttons/PrimaryButton";
 import PropTypes from "~/components/utils/propTypes";
 import { bulkImportRemoteSamples } from "~/api";
+
 import cs from "./sample_upload_flow.scss";
 
 class RemoteSampleFileUpload extends React.Component {

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -300,7 +300,13 @@ class ReviewStep extends React.Component {
                 className={cs.link}
                 href={`/home?project_id=${this.props.project.id}`}
               >
-                <SecondaryButton text="Go to Project" rounded={false} />
+                <SecondaryButton
+                  text="Go to Project"
+                  rounded={false}
+                  onClick={() =>
+                    logAnalyticsEvent("ReviewStep_go-to-project-button_clicked")
+                  }
+                />
               </a>
             </div>
           )}

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -8,6 +8,7 @@ import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import SecondaryButton from "~/components/ui/controls/buttons/SecondaryButton";
 import TermsAgreement from "~ui/controls/TermsAgreement";
 import { bulkUploadLocalWithMetadata, bulkUploadRemote } from "~/api/upload";
+import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import PublicProjectIcon from "~ui/icons/PublicProjectIcon";
 import PrivateProjectIcon from "~ui/icons/PrivateProjectIcon";
 import LoadingIcon from "~ui/icons/LoadingIcon";
@@ -54,6 +55,9 @@ class ReviewStep extends React.Component {
             createdSampleIds: response.sample_ids
           });
           this.props.onUploadComplete();
+          logAnalyticsEvent("ReviewStep_remote-upload_succeeded", {
+            createdSampleIds: response.sample_ids.length
+          });
         })
         // TODO(mark): Display better errors.
         // For example, some samples may have successfully saved, but not others. Should explain to user.
@@ -61,6 +65,9 @@ class ReviewStep extends React.Component {
           // eslint-disable-next-line no-console
           console.error("onBulkUploadRemote error:", error);
           this.onUploadError("There were some issues creating your samples.");
+          logAnalyticsEvent("ReviewStep_remote-upload_failed", {
+            error
+          });
         });
     }
     // For uploading samples with local files
@@ -75,12 +82,18 @@ class ReviewStep extends React.Component {
             submitState: "success"
           });
           this.props.onUploadComplete();
+          logAnalyticsEvent("ReviewStep_local-upload_succeeded", {
+            samples: this.props.samples.length
+          });
         },
         onCreateSamplesError: errors => {
           // TODO(mark): Display better errors.
           // eslint-disable-next-line no-console
           console.error("onCreateSamplesError:", errors);
           this.onUploadError("There were some issues creating your samples.");
+          logAnalyticsEvent("ReviewStep_local-upload_failed", {
+            errors: errors.length
+          });
         },
         // TODO(mark): Display better errors.
         // For example, some samples may have successfuly saved, but not others. Should explain to user.
@@ -88,11 +101,18 @@ class ReviewStep extends React.Component {
           // eslint-disable-next-line no-console
           console.error("onUploadError:", error);
           this.onUploadError("There were some issues creating your samples.");
+          logAnalyticsEvent("ReviewStep_local-upload_failed", {
+            fileName: file.name,
+            error
+          });
         },
         onMarkSampleUploadedError: sampleName => {
           this.onUploadError(
             `Failed to mark sample ${sampleName} as uploaded.`
           );
+          logAnalyticsEvent("ReviewStep_local-upload_failed", {
+            sampleName
+          });
         }
       });
     }
@@ -169,7 +189,13 @@ class ReviewStep extends React.Component {
               <div className={cx(cs.links, this.linksEnabled() && cs.enabled)}>
                 <div
                   className={cs.link}
-                  onClick={() => this.onLinkClick("uploadSamples")}
+                  onClick={() => {
+                    this.onLinkClick("uploadSamples");
+                    logAnalyticsEvent("ReviewStep_edit-project-link_clicked", {
+                      projectId: this.props.project.id,
+                      projectName: this.props.project.name
+                    });
+                  }}
                 >
                   Edit Project
                 </div>
@@ -203,14 +229,26 @@ class ReviewStep extends React.Component {
               <div className={cx(cs.links, this.linksEnabled() && cs.enabled)}>
                 <div
                   className={cs.link}
-                  onClick={() => this.onLinkClick("uploadSamples")}
+                  onClick={() => {
+                    this.onLinkClick("uploadSamples");
+                    logAnalyticsEvent("ReviewStep_edit-samples-link_clicked", {
+                      projectId: this.props.project.id,
+                      projectName: this.props.project.name
+                    });
+                  }}
                 >
                   Edit Samples
                 </div>
                 <div className={cs.divider}>|</div>
                 <div
                   className={cs.link}
-                  onClick={() => this.onLinkClick("uploadMetadata")}
+                  onClick={() => {
+                    this.onLinkClick("uploadMetadata");
+                    logAnalyticsEvent("ReviewStep_edit-metadata-link_clicked", {
+                      projectId: this.props.project.id,
+                      projectName: this.props.project.name
+                    });
+                  }}
                 >
                   Edit Metadata
                 </div>
@@ -231,9 +269,15 @@ class ReviewStep extends React.Component {
             <TermsAgreement
               checked={this.state.consentChecked}
               onChange={() =>
-                this.setState({
-                  consentChecked: !this.state.consentChecked
-                })
+                this.setState(
+                  {
+                    consentChecked: !this.state.consentChecked
+                  },
+                  () =>
+                    logAnalyticsEvent("ReviewStep_consent-checkbox_checked", {
+                      consentChecked: this.state.consentChecked
+                    })
+                )
               }
             />
           )}
@@ -264,7 +308,13 @@ class ReviewStep extends React.Component {
             <PrimaryButton
               text="Start Upload"
               disabled={!this.state.consentChecked}
-              onClick={this.uploadSamplesAndMetadata}
+              onClick={withAnalytics(
+                this.uploadSamplesAndMetadata,
+                "ReviewStep_start-upload-button_clicked",
+                {
+                  samples: this.props.samples.length
+                }
+              )}
               rounded={false}
             />
           )}

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
@@ -5,6 +5,7 @@ import cx from "classnames";
 import PropTypes from "~/components/utils/propTypes";
 import Label from "~ui/labels/Label";
 import NarrowContainer from "~/components/layout/NarrowContainer";
+import { logAnalyticsEvent } from "~/api/analytics";
 
 import cs from "./sample_upload_flow.scss";
 
@@ -79,7 +80,16 @@ class SampleUploadFlowHeader extends React.Component {
                       cs.enabled
                   )}
                   key={val.text}
-                  onClick={() => this.onStepSelect(val.step)}
+                  onClick={() => {
+                    this.onStepSelect(val.step);
+                    logAnalyticsEvent(
+                      "SampleUploadFlowHeader_step-option_clicked",
+                      {
+                        step: val.step,
+                        text: val.text
+                      }
+                    );
+                  }}
                 >
                   <Label className={cs.circle} circular text={index + 1} />
                   <div className={cs.text}>{val.text}</div>

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -7,7 +7,7 @@ import PropTypes from "~/components/utils/propTypes";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import SecondaryButton from "~/components/ui/controls/buttons/SecondaryButton";
 import { validateManualMetadataForNewSamples } from "~/api/metadata";
-import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
+import { logAnalyticsEvent } from "~/api/analytics";
 
 import cs from "./sample_upload_flow.scss";
 

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import cx from "classnames";
+
 import MetadataUpload from "~/components/common/MetadataUpload";
 import Instructions from "~/components/views/samples/MetadataUploadModal/Instructions";
 import PropTypes from "~/components/utils/propTypes";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import SecondaryButton from "~/components/ui/controls/buttons/SecondaryButton";
 import { validateManualMetadataForNewSamples } from "~/api/metadata";
+import { withAnalytics } from "~/api/analytics";
+
 import cs from "./sample_upload_flow.scss";
 
 class UploadMetadataStep extends React.Component {
@@ -102,7 +105,10 @@ class UploadMetadataStep extends React.Component {
           <div className={cs.controls}>
             <PrimaryButton
               text="Continue"
-              onClick={this.handleContinue}
+              onClick={withAnalytics(
+                this.handleContinue,
+                "UploadMetadataStep_continue-button_clicked"
+              )}
               disabled={this.state.continueDisabled}
               rounded={false}
               className={cs.continueButton}

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -7,7 +7,7 @@ import PropTypes from "~/components/utils/propTypes";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import SecondaryButton from "~/components/ui/controls/buttons/SecondaryButton";
 import { validateManualMetadataForNewSamples } from "~/api/metadata";
-import { withAnalytics } from "~/api/analytics";
+import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 
 import cs from "./sample_upload_flow.scss";
 
@@ -114,7 +114,13 @@ class UploadMetadataStep extends React.Component {
               className={cs.continueButton}
             />
             <a href="/home">
-              <SecondaryButton text="Cancel" rounded={false} />
+              <SecondaryButton
+                text="Cancel"
+                rounded={false}
+                onClick={() =>
+                  logAnalyticsEvent("UploadMetadataStep_cancel-button_clicked")
+                }
+              />
             </a>
           </div>
         </div>

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -42,6 +42,7 @@ class UploadMetadataStep extends React.Component {
 
   handleContinue = async () => {
     // If manual input, validate when user presses Continue.
+    let result = null;
     if (this.state.wasManual) {
       this.setState({
         issues: null
@@ -49,7 +50,7 @@ class UploadMetadataStep extends React.Component {
 
       const metadata = this.state.metadata;
 
-      const result = await validateManualMetadataForNewSamples(
+      result = await validateManualMetadataForNewSamples(
         this.props.samples,
         metadata
       );
@@ -71,8 +72,9 @@ class UploadMetadataStep extends React.Component {
       });
     }
     logAnalyticsEvent("UploadMetadataStep_continue-button_clicked", {
-      errors: this.state.issues.errors.length,
-      warnings: this.state.issues.warnings.length,
+      wasManual: this.state.wasManual,
+      errors: (result || this.state).issues.errors.length,
+      warnings: (result || this.state).issues.warnings.length,
       samples: this.props.samples.length,
       projectId: this.props.project.id,
       projectName: this.props.project.name

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -122,7 +122,13 @@ class UploadMetadataStep extends React.Component {
                 text="Cancel"
                 rounded={false}
                 onClick={() =>
-                  logAnalyticsEvent("UploadMetadataStep_cancel-button_clicked")
+                  logAnalyticsEvent(
+                    "UploadMetadataStep_cancel-button_clicked",
+                    {
+                      projectId: this.props.project.id,
+                      projectName: this.props.project.name
+                    }
+                  )
                 }
               />
             </a>

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -70,6 +70,13 @@ class UploadMetadataStep extends React.Component {
         issues: this.state.issues
       });
     }
+    logAnalyticsEvent("UploadMetadataStep_continue-button_clicked", {
+      errors: this.state.issues.errors.length,
+      warnings: this.state.issues.warnings.length,
+      samples: this.props.samples.length,
+      projectId: this.props.project.id,
+      projectName: this.props.project.name
+    });
   };
 
   render() {
@@ -105,10 +112,7 @@ class UploadMetadataStep extends React.Component {
           <div className={cs.controls}>
             <PrimaryButton
               text="Continue"
-              onClick={withAnalytics(
-                this.handleContinue,
-                "UploadMetadataStep_continue-button_clicked"
-              )}
+              onClick={this.handleContinue}
               disabled={this.state.continueDisabled}
               rounded={false}
               className={cs.continueButton}

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -440,6 +440,17 @@ class UploadSampleStep extends React.Component {
         uploadType: "remote"
       });
     }
+
+    logAnalyticsEvent("UploadSampleStep_continue-button_clicked", {
+      errors: this.state.issues.errors.length,
+      warnings: this.state.issues.warnings.length,
+      localSamples: this.state.localSamples.length,
+      remoteSamples: this.state.remoteSamples.length,
+      project: this.state.selectedProject,
+      currentTab: this.state.currentTab,
+      projectId: this.state.selectedProject.id,
+      projectName: this.state.selectedProject.name
+    });
   };
 
   getSampleNamesToFiles = () => {
@@ -543,10 +554,7 @@ class UploadSampleStep extends React.Component {
         <div className={cs.controls}>
           <PrimaryButton
             text="Continue"
-            onClick={withAnalytics(
-              this.handleContinue,
-              "UploadSampleStep_continue-button_clicked"
-            )}
+            onClick={this.handleContinue}
             disabled={!this.isValid()}
             rounded={false}
             className={cs.continueButton}

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import cx from "classnames";
 import QueryString from "query-string";
+
 import PropTypes from "~/components/utils/propTypes";
 import ProjectSelect from "~/components/common/ProjectSelect";
 import Tabs from "~/components/ui/controls/Tabs";
@@ -33,6 +34,7 @@ import BulkSampleUploadTable from "~ui/controls/BulkSampleUploadTable";
 import ProjectCreationForm from "~/components/common/ProjectCreationForm";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import SecondaryButton from "~/components/ui/controls/buttons/SecondaryButton";
+
 import LocalSampleFileUpload from "./LocalSampleFileUpload";
 import RemoteSampleFileUpload from "./RemoteSampleFileUpload";
 import cs from "./sample_upload_flow.scss";

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -369,7 +369,9 @@ class UploadSampleStep extends React.Component {
     logAnalyticsEvent("UploadSampleStep_local-sample_changed", {
       localSamples: localSamples.length,
       validatedLocalSamples: validatedLocalSamples.length,
-      removedLocalFiles: removedLocalFiles.length
+      removedLocalFiles: removedLocalFiles.length,
+      projectId: this.state.selectedProject.id,
+      projectName: this.state.selectedProject.name
     });
   };
 
@@ -393,7 +395,9 @@ class UploadSampleStep extends React.Component {
 
     logAnalyticsEvent("UploadSampleStep_remote-sample_changed", {
       remoteSamples: remoteSamples.length,
-      validatedRemoteSamples: validatedRemoteSamples.length
+      validatedRemoteSamples: validatedRemoteSamples.length,
+      projectId: this.state.selectedProject.id,
+      projectName: this.state.selectedProject.name
     });
   };
 
@@ -419,7 +423,9 @@ class UploadSampleStep extends React.Component {
     }
     logAnalyticsEvent("UploadSampleStep_sample_removed", {
       sampleName,
-      currentTab: this.state.currentTab
+      currentTab: this.state.currentTab,
+      projectId: this.state.selectedProject.id,
+      projectName: this.state.selectedProject.name
     });
   };
 
@@ -564,7 +570,10 @@ class UploadSampleStep extends React.Component {
               text="Cancel"
               rounded={false}
               onClick={() =>
-                logAnalyticsEvent("UploadSampleStep_cancel-button_clicked")
+                logAnalyticsEvent("UploadSampleStep_cancel-button_clicked", {
+                  projectId: this.state.selectedProject.id,
+                  projectName: this.state.selectedProject.name
+                })
               }
             />
           </a>

--- a/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
@@ -2,10 +2,13 @@
 import React from "react";
 import { keyBy, flow, mapValues, omit } from "lodash/fp";
 import PropTypes from "prop-types";
+
 import Wizard from "~ui/containers/Wizard";
 import Modal from "~ui/containers/Modal";
 import { getSamplesV1 } from "~/api";
 import { uploadMetadataForProject } from "~/api/metadata";
+import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
+
 import ReviewPage from "./ReviewPage";
 import UploadPage from "./UploadPage";
 import cs from "./metadata_upload_modal.scss";
@@ -44,6 +47,10 @@ class MetadataUploadModal extends React.Component {
       )(this.state.metadata.rows)
     );
     this.props.onClose();
+    logAnalyticsEvent("MetadataUploadModal_modal_completed", {
+      projectId: this.props.project.id,
+      projectSamples: this.state.projectSamples.length
+    });
   };
 
   getPages = () => {
@@ -83,7 +90,10 @@ class MetadataUploadModal extends React.Component {
         open
         tall
         wide
-        onClose={this.props.onClose}
+        onClose={withAnalytics(
+          this.props.onClose,
+          "MetadataUploadModal_modal_closed"
+        )}
         className={cs.metadataUploadModal}
       >
         <Wizard onComplete={this.handleComplete}>{this.getPages()}</Wizard>

--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -8,15 +8,16 @@ import {
 } from "react-virtualized";
 import "react-virtualized/styles.css";
 import cx from "classnames";
-import cs from "./base_table.scss";
+import { concat, difference, find, includes, map } from "lodash/fp";
 
 import BasicPopup from "~/components/BasicPopup";
 import Checkbox from "~ui/controls/Checkbox";
 import MultipleDropdown from "~ui/controls/dropdowns/MultipleDropdown";
 import PlusIcon from "~ui/icons/PlusIcon";
-
-import { concat, difference, find, includes, map } from "lodash/fp";
 import { humanize } from "~/helpers/strings";
+import { logAnalyticsEvent } from "~/api/analytics";
+
+import cs from "./base_table.scss";
 
 class BaseTable extends React.Component {
   // This class is a wrapper class to React Virtualized Table.
@@ -73,6 +74,10 @@ class BaseTable extends React.Component {
   handleColumnChange = selectedColumns => {
     const { protectedColumns } = this.props;
     this.setState({ activeColumns: concat(protectedColumns, selectedColumns) });
+    logAnalyticsEvent("BaseTable_column-selector_changed", {
+      selectedColumns: selectedColumns.length,
+      protectedColumns: protectedColumns.length
+    });
   };
 
   renderColumnSelector = () => {


### PR DESCRIPTION
# Description

This adds analytics tracking to the last big parts of the frontend of the app. 

![image](https://user-images.githubusercontent.com/28797/56530802-d7ba5480-6507-11e9-98ce-07ab9f17fabb.png)

![image](https://user-images.githubusercontent.com/28797/56530823-dee16280-6507-11e9-9eae-0123f871f922.png)

![image](https://user-images.githubusercontent.com/28797/56537820-5ddd9780-6516-11e9-99a4-8c4644b031ee.png)

# Test and Reproduce

Click on all new added analytics such as project selector
Observe events in chrome debugger
Observe no new errors