### PR TITLE
[Mapping] Start initial migration for Locations model

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,4 +1,4 @@
-class Location
+class Location < ApplicationRecord
   # Search request to Location IQ API
   def self.geosearch(query)
     raise ArgumentError, "No query for geosearch" if query.blank?

--- a/db/migrate/20190422185437_add_location_table.rb
+++ b/db/migrate/20190422185437_add_location_table.rb
@@ -1,0 +1,31 @@
+class AddLocationTable < ActiveRecord::Migration[5.1]
+  def up
+    # Check conditions
+
+    create_table :locations do |t|
+      t.string name, default: "", null: false, comment: "Full display name, like a complete address"
+      t.string level_name, default: "", null: false, limit: 20, comment: "Level of specificity (country, state, subdivision, or city)"
+      t.string country_name, default: "", null: false, limit: 100, comment: "The country of this location if available"
+      t.string state_name, default: "", null: false, limit: 100, comment: "The state of this location if available"
+      t.string subdivision_name, default: "", null: false, limit: 100, comment: "Simplification for second-level administrative division (e.g. county/district/division/province/etc.) of this location if available"
+      t.string city_name, default: "", null: false, limit: 100, comment: "The city of this location (or closest administrative equivalent) if available"
+
+      # Recommended settings for lat/lon
+      t.decimal lat, precision: 10, scale: 6, comment: "The latitude of this location if available"
+      t.decimal lon, precision: 10, scale: 6, comment: "The longitude of this location if available"
+
+      t.timestamps
+    end
+
+    # Add indexes
+    add_index :locations, :name
+    add_index :locations, :level_name
+    add_index :locations, :country_name
+    add_index :locations, :state_name
+    add_index :locations, :subdivision_name
+    add_index :locations, :city_name
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20190422185437_add_location_table.rb
+++ b/db/migrate/20190422185437_add_location_table.rb
@@ -11,7 +11,7 @@ class AddLocationTable < ActiveRecord::Migration[5.1]
       t.integer :osm_id, comment: "OpenStreetMap ID for traceability. May change at any time."
       t.integer :locationiq_id, comment: "Data provider API ID for traceability."
 
-      # Recommended settings for lat/lon
+      # Recommended settings for lat/lng
       t.decimal :lat, precision: 10, scale: 6, comment: "The latitude of this location if available"
       t.decimal :lng, precision: 10, scale: 6, comment: "The longitude of this location if available"
 

--- a/db/migrate/20190422185437_add_location_table.rb
+++ b/db/migrate/20190422185437_add_location_table.rb
@@ -2,15 +2,18 @@ class AddLocationTable < ActiveRecord::Migration[5.1]
   def up
     create_table :locations, force: true do |t|
       t.string :name, default: "", null: false, comment: "Full display name, such as a complete address"
-      t.string :level_name, default: "", null: false, limit: 20, comment: "Level of specificity (country, state, subdivision, or city)"
+      t.string :geo_level, default: "", null: false, limit: 20, comment: "Level of specificity (country, state, subdivision, or city)"
       t.string :country_name, default: "", null: false, limit: 100, comment: "Country (or equivalent) of this location if available"
+      t.string :country_code, default: "", null: false, limit: 5, comment: "ISO 3166 alpha-2 country codes. Can be used to resolve country_name if data sources ever change."
       t.string :state_name, default: "", null: false, limit: 100, comment: "State (or equivalent) of this location if available"
       t.string :subdivision_name, default: "", null: false, limit: 100, comment: "Second-level administrative division (e.g. county/district/division/province/etc.) of this location if available"
       t.string :city_name, default: "", null: false, limit: 100, comment: "City (or equivalent) of this location if available"
+      t.integer :osm_id, comment: "OpenStreetMap ID for traceability. May change at any time."
+      t.integer :locationiq_id, comment: "Data provider API ID for traceability."
 
       # Recommended settings for lat/lon
       t.decimal :lat, precision: 10, scale: 6, comment: "The latitude of this location if available"
-      t.decimal :lon, precision: 10, scale: 6, comment: "The longitude of this location if available"
+      t.decimal :lng, precision: 10, scale: 6, comment: "The longitude of this location if available"
 
       t.timestamps
     end

--- a/db/migrate/20190422185437_add_location_table.rb
+++ b/db/migrate/20190422185437_add_location_table.rb
@@ -20,7 +20,7 @@ class AddLocationTable < ActiveRecord::Migration[5.1]
 
     # Add indexes
     add_index :locations, :name, comment: "Index for lookup by location name"
-    add_index :locations, :level_name, comment: "Index for lookup by level of specificity"
+    add_index :locations, :geo_level, comment: "Index for lookup by level of specificity"
     add_index :locations, [:country_name, :state_name, :subdivision_name, :city_name], name: "index_locations_levels", comment: "Index for lookup within regions. Composite works for any left subset of columns."
   end
 

--- a/db/migrate/20190422185437_add_location_table.rb
+++ b/db/migrate/20190422185437_add_location_table.rb
@@ -1,31 +1,27 @@
 class AddLocationTable < ActiveRecord::Migration[5.1]
   def up
-    # Check conditions
-
-    create_table :locations do |t|
-      t.string name, default: "", null: false, comment: "Full display name, like a complete address"
-      t.string level_name, default: "", null: false, limit: 20, comment: "Level of specificity (country, state, subdivision, or city)"
-      t.string country_name, default: "", null: false, limit: 100, comment: "The country of this location if available"
-      t.string state_name, default: "", null: false, limit: 100, comment: "The state of this location if available"
-      t.string subdivision_name, default: "", null: false, limit: 100, comment: "Simplification for second-level administrative division (e.g. county/district/division/province/etc.) of this location if available"
-      t.string city_name, default: "", null: false, limit: 100, comment: "The city of this location (or closest administrative equivalent) if available"
+    create_table :locations, force: true do |t|
+      t.string :name, default: "", null: false, comment: "Full display name, such as a complete address"
+      t.string :level_name, default: "", null: false, limit: 20, comment: "Level of specificity (country, state, subdivision, or city)"
+      t.string :country_name, default: "", null: false, limit: 100, comment: "Country (or equivalent) of this location if available"
+      t.string :state_name, default: "", null: false, limit: 100, comment: "State (or equivalent) of this location if available"
+      t.string :subdivision_name, default: "", null: false, limit: 100, comment: "Second-level administrative division (e.g. county/district/division/province/etc.) of this location if available"
+      t.string :city_name, default: "", null: false, limit: 100, comment: "City (or equivalent) of this location if available"
 
       # Recommended settings for lat/lon
-      t.decimal lat, precision: 10, scale: 6, comment: "The latitude of this location if available"
-      t.decimal lon, precision: 10, scale: 6, comment: "The longitude of this location if available"
+      t.decimal :lat, precision: 10, scale: 6, comment: "The latitude of this location if available"
+      t.decimal :lon, precision: 10, scale: 6, comment: "The longitude of this location if available"
 
       t.timestamps
     end
 
     # Add indexes
-    add_index :locations, :name
-    add_index :locations, :level_name
-    add_index :locations, :country_name
-    add_index :locations, :state_name
-    add_index :locations, :subdivision_name
-    add_index :locations, :city_name
+    add_index :locations, :name, comment: "Index for lookup by location name"
+    add_index :locations, :level_name, comment: "Index for lookup by level of specificity"
+    add_index :locations, [:country_name, :state_name, :subdivision_name, :city_name], name: "index_locations_levels", comment: "Index for lookup within regions. Composite works for any left subset of columns."
   end
 
   def down
+    drop_table :locations
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_416_003_917) do
+ActiveRecord::Schema.define(version: 20_190_424_003_917) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -131,6 +131,25 @@ ActiveRecord::Schema.define(version: 20_190_416_003_917) do
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
+  end
+
+  create_table "locations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string "name", default: "", null: false, comment: "Full display name, such as a complete address"
+    t.string "geo_level", limit: 20, default: "", null: false, comment: "Level of specificity (country, state, subdivision, or city)"
+    t.string "country_name", limit: 100, default: "", null: false, comment: "Country (or equivalent) of this location if available"
+    t.string "country_code", limit: 5, default: "", null: false, comment: "ISO 3166 alpha-2 country codes. Can be used to resolve country_name if data sources ever change."
+    t.string "state_name", limit: 100, default: "", null: false, comment: "State (or equivalent) of this location if available"
+    t.string "subdivision_name", limit: 100, default: "", null: false, comment: "Second-level administrative division (e.g. county/district/division/province/etc.) of this location if available"
+    t.string "city_name", limit: 100, default: "", null: false, comment: "City (or equivalent) of this location if available"
+    t.integer "osm_id", comment: "OpenStreetMap ID for traceability. May change at any time."
+    t.integer "locationiq_id", comment: "Data provider API ID for traceability."
+    t.decimal "lat", precision: 10, scale: 6, comment: "The latitude of this location if available"
+    t.decimal "lng", precision: 10, scale: 6, comment: "The longitude of this location if available"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["country_name", "state_name", "subdivision_name", "city_name"], name: "index_locations_levels", comment: "Index for lookup within regions. Composite works for any left subset of columns."
+    t.index ["geo_level"], name: "index_locations_on_geo_level", comment: "Index for lookup by level of specificity"
+    t.index ["name"], name: "index_locations_on_name", comment: "Index for lookup by location name"
   end
 
   create_table "job_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
### Description
- Open for discussion!
- Create a model for storing Locations with multiple levels of specificity as discussed previously. I will add the cleaned up db/schema.rb file once before merging.

- Why do we need to store different broken down levels of regions for each location?
The main reason for wanting to store explicit levels (country/state/subdivision/city) is for efficient filtering and also strict compliance before storing anything (e.g. never storing belong state level on sensitive samples).

- Why do we have these particular 4 levels + coordinates?
This was a simplification of all the types of potential administrative levels (https://wiki.openstreetmap.org/wiki/Key:place#Relationship_with_admin_level) and also the geosearch providers will return these levels in almost all cases, so we are offloading most of the burden of categorization onto their APIs. These will not be perfect categorizations for every location but they should work well enough for our uses.

- Why not have additional columns country_id/state_id/subdivision_id/etc. referencing other entries in the table?
If the user added a new entry for MyCountry|MyState|MySubdivision|MyCity, you'd need to do a query to fill in MyCountry with the existing country entry id if any, or disambiguate between two subdivisions named MySubdivision for the sake of assigning the right unique ID. I don't think these additional columns would yield much benefit over composite queries over country_name|state_name|etc, but I could be convinced otherwise..

- How will you query between ambiguous names, e.g. 31 counties in the U.S. named Washington County?
We will assume that 'taxonomically' there are no duplicates with identical upwards lineages. E.g. that there are not multiple Washington Counties in the same state and country. So queries will need to specify their ancestors.

- Why set the fields to default empty string and not null?
This simplifies some queries because "!=" queries would not return null values, even though you might expect them to logically.

- Is there not a unique place identifier like OpenStreetMaps (OSM) IDs that we can store?
Unfortunately OSM IDs are not stable so we should not rely on them ("the element node 1 represents has changed many times: tree in Germany (v13), buoy in the Atlantic Ocean (v15), memorial stone in London (v17), bike rental in Edinburgh (v19)"). Also depending on the geosearch API, we may get unique IDs from the API, but I would rather not couple ourselves to a particular geosearch provider in that way. https://help.openstreetmap.org/questions/66577/how-often-the-osm_id-was-unsolicitedly-changed-what-the-risk-before-2020 and https://gis.stackexchange.com/questions/279755/can-i-depend-on-the-country-city-ids-of-osm

- How will we associate these with the actual Metadata/MetadataFields/Samples?
Open to suggestions but I plan to special-case MetadataField base_type #3 and have the Metadatum entry have a "location_id" pointer value.

### Test and Reproduce
- Pull the branch, run `docker-compose run web "rake db:migrate"`, see the migration run. Reload and make sure the app works. Run `docker exec -ti idseq-web_web rails console development` or similar. Type Location.all in the console and see `#<ActiveRecord::Relation []>`. 