### PR TITLE
Fix typo in analytics event name

### DIFF
--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1685,7 +1685,7 @@ class BackgroundModal extends React.Component {
           <Form
             onSubmit={withAnalytics(
               this.handleSubmit,
-              "Samples_collection-form-submitted",
+              "Samples_collection-form_submitted",
               {
                 new_background_name: this.state.new_background_name,
                 new_background_description: this.state


### PR DESCRIPTION
Fixes this issue. 

![image (5)](https://user-images.githubusercontent.com/28797/56608509-c59bed00-65bf-11e9-94d4-6035a4075cc9.png)
