### PR TITLE
More robust pipeline version checking.

### DIFF
--- a/app/assets/src/components/utils/sample.js
+++ b/app/assets/src/components/utils/sample.js
@@ -1,20 +1,37 @@
 import { last } from "lodash/fp";
 
-export const pipelineVersionHasAssembly = pipelineVersion => {
+export const pipelineVersionAtLeast = (pipelineVersion, testVersion) => {
   if (!pipelineVersion) return false;
-  const versionNums = pipelineVersion.split(".");
-  return (
-    +versionNums[0] >= 4 || (+versionNums[0] === 3 && +versionNums[1] >= 1)
-  );
+
+  // turn undefined to 0.
+  const toInt = versionNumber => +versionNumber || 0;
+
+  const pipelineNums = pipelineVersion.split(".");
+  const testNums = testVersion.split(".");
+
+  if (toInt(pipelineNums[0]) > toInt(testNums[0])) {
+    return true;
+  } else if (toInt(pipelineNums[0]) === toInt(testNums[0])) {
+    if (toInt(pipelineNums[1]) > toInt(testNums[1])) {
+      return true;
+    } else if (toInt(pipelineNums[1]) === toInt(testNums[1])) {
+      if (toInt(pipelineNums[2]) >= toInt(testNums[2])) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 };
 
-export const pipelineVersionHasCoverageViz = pipelineVersion => {
-  if (!pipelineVersion) return false;
-  const versionNums = pipelineVersion.split(".");
-  return (
-    +versionNums[0] >= 4 || (+versionNums[0] === 3 && +versionNums[1] >= 6)
-  );
-};
+const ASSEMBLY_PIPELINE_VERSION = "3.1";
+const COVERAGE_VIZ_PIPELINE_VERSION = "3.6";
+
+export const pipelineVersionHasAssembly = pipelineVersion =>
+  pipelineVersionAtLeast(pipelineVersion, ASSEMBLY_PIPELINE_VERSION);
+
+export const pipelineVersionHasCoverageViz = pipelineVersion =>
+  pipelineVersionAtLeast(pipelineVersion, COVERAGE_VIZ_PIPELINE_VERSION);
 
 // Get the basename from a file path
 export const baseName = str => {

--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -141,4 +141,44 @@ module PipelineRunsHelper
   def exists_in_s3?(s3_path)
     Open3.capture3("aws", "s3", "ls", s3_path)[2].success?
   end
+
+  PIPELINE_VERSION_2 = '2.0'.freeze
+  ASSEMBLY_PIPELINE_VERSION = '3.1'.freeze
+  COVERAGE_VIZ_PIPELINE_VERSION = '3.6'.freeze
+
+  def pipeline_version_at_least(pipeline_version, test_version)
+    unless pipeline_version
+      return false
+    end
+
+    pipeline_nums = pipeline_version.split(".")
+    test_nums = test_version.split(".")
+
+    # nil.to_i = 0, so we don't need to special-case versions like 3 and 3.1.
+    if pipeline_nums[0].to_i > test_nums[0].to_i
+      return true
+    elsif pipeline_nums[0].to_i == test_nums[0].to_i
+      if pipeline_nums[1].to_i > test_nums[1].to_i
+        return true
+      elsif pipeline_nums[1].to_i == test_nums[1].to_i
+        if pipeline_nums[2].to_i >= test_nums[2].to_i
+          return true
+        end
+      end
+    end
+
+    return false
+  end
+
+  def pipeline_version_has_assembly(pipeline_version)
+    pipeline_version_at_least(pipeline_version, ASSEMBLY_PIPELINE_VERSION)
+  end
+
+  def pipeline_version_has_coverage_viz(pipeline_version)
+    pipeline_version_at_least(pipeline_version, COVERAGE_VIZ_PIPELINE_VERSION)
+  end
+
+  def pipeline_version_at_least_2(pipeline_version)
+    pipeline_version_at_least(pipeline_version, PIPELINE_VERSION_2)
+  end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -12,6 +12,7 @@ class Sample < ApplicationRecord
   end
   include TestHelper
   include MetadataHelper
+  include PipelineRunsHelper
 
   STATUS_CREATED = 'created'.freeze
   STATUS_UPLOADED = 'uploaded'.freeze
@@ -217,7 +218,7 @@ class Sample < ApplicationRecord
     pr = first_pipeline_run
     return list_outputs(sample_output_s3_path) unless pr
     file_list = []
-    if pr.pipeline_version.to_f >= 2.0
+    if pipeline_version_at_least_2(pr.pipeline_version)
       file_list = list_outputs(pr.output_s3_path_with_version)
       file_list += list_outputs(sample_output_s3_path)
       file_list += list_outputs(pr.postprocess_output_s3_path)


### PR DESCRIPTION
When we get to 3.10, we will run into issues when using the current comparison method.

Tested that features such as the list of report files and the coverage viz sidebar show up as expected. Also manually tested the pipeline version function in Ruby and JS.


