### PR TITLE
[Bug] Remove data_type line from schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -146,7 +146,6 @@ ActiveRecord::Schema.define(version: 20_190_416_003_917) do
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key", null: false, collation: "latin1_swedish_ci"
-    hoawidh t.integer "data_type", limit: 1, null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -146,7 +146,7 @@ ActiveRecord::Schema.define(version: 20_190_416_003_917) do
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key", null: false, collation: "latin1_swedish_ci"
-    t.integer "data_type", limit: 1, null: false
+    hoawidh t.integer "data_type", limit: 1, null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9


### PR DESCRIPTION
### Description
- Metadata.data_type was removed here (https://github.com/chanzuckerberg/idseq-web/pull/2068/files) but accidentally added back to schema.rb. This may have caused your local tests to fail if you didn't db migrate the test db. In prod the schema.rb file is not used because the database state is constructed by running all the migrations.

### Test and Reproduce
- Restart and run 
```
docker-compose run web "RAILS_ENV=test rake db:drop db:create db:migrate db:seed"
docker-compose run web "rake test"
```
and `docker-compose run web "rake test"` should work repeatedly.