### PR TITLE
Fix issue where sample page crashes if pipelineRun is null.

### DIFF
--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -382,7 +382,9 @@ class SampleView extends React.Component {
 
   coverageVizEnabled = () =>
     (this.props.admin || this.props.allowedFeatures.includes("coverage_viz")) &&
-    pipelineVersionHasCoverageViz(this.props.pipelineRun.pipeline_version);
+    pipelineVersionHasCoverageViz(
+      get("pipeline_version", this.props.reportPageParams)
+    );
 
   render() {
     const versionDisplay = this.renderVersionDisplay();


### PR DESCRIPTION
pipelineRun can be null. For example, if the sample is still "Waiting" for files to be uploaded.

reportPageParams is used elsewhere to get pipeline_version, as it should always be present based on the Rails code. (unless the sample has no background id...but it looks like samples have a default background id) 
Just in case, we wrap in `get`, which handles null values gracefully.