### PR TITLE
IDSEQ-899 Remove uses of Array.flat.

### DIFF
--- a/app/assets/src/api/metadata.js
+++ b/app/assets/src/api/metadata.js
@@ -1,4 +1,4 @@
-import { set } from "lodash/fp";
+import { set, flatten } from "lodash/fp";
 
 import { get, postWithCSRF } from "./core";
 
@@ -16,7 +16,7 @@ const getSampleMetadata = (id, pipelineVersion) => {
 const getSampleMetadataFields = ids =>
   get("/samples/metadata_fields", {
     params: {
-      sampleIds: [ids].flat()
+      sampleIds: flatten([ids])
     }
   });
 
@@ -24,7 +24,7 @@ const getSampleMetadataFields = ids =>
 const getProjectMetadataFields = ids =>
   get("/projects/metadata_fields", {
     params: {
-      projectIds: [ids].flat()
+      projectIds: flatten([ids])
     }
   });
 

--- a/app/assets/src/helpers/url.js
+++ b/app/assets/src/helpers/url.js
@@ -6,7 +6,11 @@ import {
   toPairs,
   pickBy,
   isPlainObject,
-  isUndefined
+  isUndefined,
+  flow,
+  map,
+  flatten,
+  join
 } from "lodash/fp";
 import { shortenUrl } from "~/api";
 import copy from "copy-to-clipboard";
@@ -37,8 +41,9 @@ export const getURLParamString = params => {
     (v, k) => !isPlainObject(v) && !isUndefined(v),
     params
   );
-  return toPairs(filtered)
-    .map(
+  return flow(
+    toPairs,
+    map(
       ([key, value]) =>
         isArray(value)
           ? // Convert array parameters correctly.
@@ -48,9 +53,10 @@ export const getURLParamString = params => {
               eachValue => `${key}[]=${eachValue}`
             )
           : `${key}=${value}`
-    )
-    .flat()
-    .join("&");
+    ),
+    flatten,
+    join("&")
+  )(filtered);
 };
 
 export const copyShortUrlToClipboard = async url => {


### PR DESCRIPTION
This doesn't work for fairly recent versions of Firefox (as recent as v61)
Replace with lodash/fp flatten instead.

Verified that:
* Metadata fields can still be fetched on sample details sidebar and heatmap.
* URL is properly replaced on sample page.
* URL is properly formatted when opening heatmap.