### PR TITLE
IDSEQ-913 Add error message when min contig size is too small.

### DIFF
--- a/app/assets/src/components/views/report/filters/MinContigSizeFilter.jsx
+++ b/app/assets/src/components/views/report/filters/MinContigSizeFilter.jsx
@@ -11,6 +11,7 @@ const MIN_CONTIG_SIZE_LOWER_BOUND = 4;
 class MinContigSizeFilter extends React.Component {
   state = {
     value: this.props.value,
+    error: "",
     previousValue: this.props.value
   };
 
@@ -33,9 +34,13 @@ class MinContigSizeFilter extends React.Component {
     if (isNaN(newValue) || newValue < MIN_CONTIG_SIZE_LOWER_BOUND) {
       // Reset back to the previous value.
       this.setState({
-        value: this.state.previousValue
+        value: this.state.previousValue,
+        error: "Size must be at least 4."
       });
     } else {
+      this.setState({
+        error: ""
+      });
       if (this.props.onChange) {
         this.props.onChange(newValue);
       }
@@ -61,6 +66,7 @@ class MinContigSizeFilter extends React.Component {
           type="number"
           className={cs.input}
         />
+        {this.state.error && <div className={cs.error}>{this.state.error}</div>}
       </div>
     );
   };

--- a/app/assets/src/components/views/report/filters/min_contig_size_filter.scss
+++ b/app/assets/src/components/views/report/filters/min_contig_size_filter.scss
@@ -1,4 +1,5 @@
 @import "~styles/themes/colors";
+@import "~styles/themes/typography";
 
 .minContigSizeFilter {
   &:global(.active) {
@@ -25,5 +26,11 @@
     margin-right: 3px;
     font-size: 13px;
     letter-spacing: 0.4px;
+  }
+
+  .error {
+    @include font-body-xxs;
+    color: $error;
+    margin-top: 5px;
   }
 }


### PR DESCRIPTION
This reduces confusion for the user. Right now, when the user types an invalid value, the value resets to the old one, but there is no error message to explain what is going on.

<img width="325" alt="Screen Shot 2019-04-24 at 3 15 16 PM" src="https://user-images.githubusercontent.com/837004/56697566-d3c33980-66a3-11e9-9cba-dfc974167d2c.png">
