### PR TITLE
[Data Discovery] Fix data discovery tables for safari.

### DIFF
--- a/app/assets/src/components/views/discovery/discovery_view.scss
+++ b/app/assets/src/components/views/discovery/discovery_view.scss
@@ -73,6 +73,8 @@
 
   .dataContainer {
     flex: 1 0 50px;
+    display: flex;
+    flex-direction: column;
 
     &:not(:only-child) {
       flex: 0 0 50px;


### PR DESCRIPTION
Fixes a bug where content of react virtualized tables had no height due to the parent container not having flex display set (worked on chrome, but not safari).