### PR TITLE
[Data Discovery] Fix bug were samples created in current day were filtered out by timeframe filters.

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -177,7 +177,9 @@ class DiscoveryView extends React.Component {
 
       preparedFilters.time = [
         startDate[preparedFilters.time]().format("YYYYMMDD"),
-        moment().format("YYYYMMDD")
+        moment()
+          .add(1, "days")
+          .format("YYYYMMDD")
       ];
     }
 

--- a/app/assets/src/components/views/discovery/discovery_view.scss
+++ b/app/assets/src/components/views/discovery/discovery_view.scss
@@ -73,6 +73,8 @@
 
   .dataContainer {
     flex: 1 0 50px;
+    display: flex;
+    flex-direction: column;
 
     &:not(:only-child) {
       flex: 0 0 50px;


### PR DESCRIPTION
Fixes a bug were samples created in current day were filtered out by timeframe filters, by using next day as end date.
Note: Using end data is not necessary but will keep it generic for when adding custom filters. 