### PR TITLE
[Data Discovery] Fix "my_data" link highlight on first open

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -30,7 +30,7 @@ class HomeController < ApplicationController
 
   def index
     if current_user.allowed_feature_list.include?("data_discovery")
-      render 'my_data'
+      redirect_to my_data_path
     else
       legacy
     end


### PR DESCRIPTION
Fix "my_data" link highlight on first open by redirecting instead of just rendering a different end point.