### PR TITLE
Add analytics to taxon and sample sidebar

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -6,6 +6,7 @@ import { set, values } from "lodash/fp";
 import PropTypes from "~/components/utils/propTypes";
 import Input from "~/components/ui/controls/Input";
 import MetadataInput from "~/components/common/MetadataInput";
+import { logAnalyticsEvent } from "~/api/analytics";
 
 import MetadataSection from "./MetadataSection";
 import { SAMPLE_ADDITIONAL_INFO } from "./constants";
@@ -48,8 +49,9 @@ class MetadataTab extends React.Component {
 
   toggleSection = section => {
     const { sectionOpen, sectionEditing } = this.state;
+    const newValue = !sectionOpen[section.name];
     const newState = {
-      sectionOpen: set(section.name, !sectionOpen[section.name], sectionOpen)
+      sectionOpen: set(section.name, newValue, sectionOpen)
     };
 
     // If we are closing a section, stop editing it.
@@ -58,16 +60,18 @@ class MetadataTab extends React.Component {
     }
 
     this.setState(newState);
+    logAnalyticsEvent("MetadataTab_section_toggled", {
+      section: section.name,
+      sectionOpen: newValue,
+      ...this.props.additionalInfo
+    });
   };
 
   toggleSectionEdit = section => {
     const { sectionEditing, sectionOpen } = this.state;
+    const newValue = !sectionEditing[section.name];
     const newState = {
-      sectionEditing: set(
-        section.name,
-        !sectionEditing[section.name],
-        sectionEditing
-      )
+      sectionEditing: set(section.name, newValue, sectionEditing)
     };
 
     if (!sectionEditing[section.name]) {
@@ -78,6 +82,11 @@ class MetadataTab extends React.Component {
       newState.sectionOpen = set(section.name, true, sectionOpen);
     }
     this.setState(newState);
+    logAnalyticsEvent("MetadataTab_section-edit_toggled", {
+      section: section.name,
+      sectionEditing: newValue,
+      ...this.props.additionalInfo
+    });
   };
 
   renderInput = metadataType => {

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -44,7 +44,7 @@ class PipelineTab extends React.Component {
     this.setState({
       sectionOpen: set(section, newValue, sectionOpen)
     });
-    logAnalyticsEvent("MetadataTab_section_toggled", {
+    logAnalyticsEvent("PipelineTab_section_toggled", {
       section: section,
       sectionOpen: newValue,
       sampleId: this.props.sampleId

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { set } from "lodash/fp";
-import { PIPELINE_INFO_FIELDS } from "./constants";
-import MetadataSection from "./MetadataSection";
+
 import ERCCScatterPlot from "~/components/ERCCScatterPlot";
 import PropTypes from "~/components/utils/propTypes";
 import { getDownloadLinks } from "~/components/views/report/utils/download";
+import { logAnalyticsEvent } from "~/api/analytics";
+
+import { PIPELINE_INFO_FIELDS } from "./constants";
+import MetadataSection from "./MetadataSection";
 import cs from "./sample_details_mode.scss";
 
 class PipelineTab extends React.Component {
@@ -37,8 +40,9 @@ class PipelineTab extends React.Component {
   toggleSection = section => {
     const { sectionOpen } = this.state;
 
+    const newValue = !sectionOpen[section];
     this.setState({
-      sectionOpen: set(section, !sectionOpen[section], sectionOpen)
+      sectionOpen: set(section, newValue, sectionOpen)
     });
   };
 
@@ -102,6 +106,15 @@ class PipelineTab extends React.Component {
                   className={cs.downloadLink}
                   href={option.path}
                   target={option.newPage ? "_blank" : "_self"}
+                  onClick={logAnalyticsEvent(
+                    "PipelineTab_download-link_clicked",
+                    {
+                      newPage: option.newPage,
+                      label: option.label,
+                      href: option.path,
+                      sampleId: this.props.sampleId
+                    }
+                  )}
                 >
                   {option.label}
                 </a>

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -44,6 +44,11 @@ class PipelineTab extends React.Component {
     this.setState({
       sectionOpen: set(section, newValue, sectionOpen)
     });
+    logAnalyticsEvent("MetadataTab_section_toggled", {
+      section: section,
+      sectionOpen: newValue,
+      sampleId: this.props.sampleId
+    });
   };
 
   renderPipelineInfoField = field => {
@@ -106,15 +111,14 @@ class PipelineTab extends React.Component {
                   className={cs.downloadLink}
                   href={option.path}
                   target={option.newPage ? "_blank" : "_self"}
-                  onClick={logAnalyticsEvent(
-                    "PipelineTab_download-link_clicked",
-                    {
+                  onClick={() =>
+                    logAnalyticsEvent("PipelineTab_download-link_clicked", {
                       newPage: option.newPage,
                       label: option.label,
                       href: option.path,
                       sampleId: this.props.sampleId
-                    }
-                  )}
+                    })
+                  }
                 >
                   {option.label}
                 </a>

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
@@ -97,15 +97,18 @@ class SampleDetailsMode extends React.Component {
       return;
     }
 
-    this.setState({
-      metadata: set(key, value, this.state.metadata),
-      metadataChanged: set(key, !shouldSave, this.state.metadataChanged),
-      metadataErrors: set(key, null, this.state.metadataErrors)
-    });
-
-    if (shouldSave) {
-      this._save(this.props.sampleId, key, value);
-    }
+    this.setState(
+      {
+        metadata: set(key, value, this.state.metadata),
+        metadataChanged: set(key, !shouldSave, this.state.metadataChanged),
+        metadataErrors: set(key, null, this.state.metadataErrors)
+      },
+      () => {
+        if (shouldSave) {
+          this._save(this.props.sampleId, key, value);
+        }
+      }
+    );
 
     logAnalyticsEvent("SampleDetailsMode_metadata_changed", {
       sampleId: this.props.sampleId,
@@ -123,11 +126,15 @@ class SampleDetailsMode extends React.Component {
           ? this.state.additionalInfo[key]
           : this.state.metadata[key];
 
-      this.setState({
-        metadataChanged: set(key, false, this.state.metadataChanged)
-      });
+      this.setState(
+        {
+          metadataChanged: set(key, false, this.state.metadataChanged)
+        },
+        () => {
+          this._save(this.props.sampleId, key, newValue);
+        }
+      );
 
-      this._save(this.props.sampleId, key, newValue);
       logAnalyticsEvent("SampleDetailsMode_metadata_saved", {
         sampleId: this.props.sampleId,
         key,

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { some } from "lodash";
 import { set } from "lodash/fp";
+
 import PropTypes from "~/components/utils/propTypes";
 import Tabs from "~/components/ui/controls/Tabs";
 import { saveSampleName, saveSampleNotes } from "~/api";
@@ -9,11 +10,12 @@ import {
   saveSampleMetadata,
   getSampleMetadataFields
 } from "~/api/metadata";
+import { logAnalyticsEvent } from "~/api/analytics";
+import { processMetadata, processMetadataTypes } from "~utils/metadata";
 
 import MetadataTab from "./MetadataTab";
 import PipelineTab from "./PipelineTab";
 import NotesTab from "./NotesTab";
-import { processMetadata, processMetadataTypes } from "~utils/metadata";
 import { processPipelineInfo, processAdditionalInfo } from "./utils";
 import cs from "./sample_details_mode.scss";
 
@@ -34,6 +36,10 @@ class SampleDetailsMode extends React.Component {
 
   onTabChange = tab => {
     this.setState({ currentTab: tab });
+    logAnalyticsEvent("SampleDetailsMode_tab_changed", {
+      sampleId: this.props.sampleId,
+      tab
+    });
   };
 
   componentDidMount() {
@@ -100,6 +106,14 @@ class SampleDetailsMode extends React.Component {
     if (shouldSave) {
       this._save(this.props.sampleId, key, value);
     }
+
+    logAnalyticsEvent("SampleDetailsMode_metadata_changed", {
+      sampleId: this.props.sampleId,
+      key,
+      value,
+      shouldSave,
+      metadataErrors: Object.keys(this.state.metadataErrors).length
+    });
   };
 
   handleMetadataSave = async key => {
@@ -114,6 +128,11 @@ class SampleDetailsMode extends React.Component {
       });
 
       this._save(this.props.sampleId, key, newValue);
+      logAnalyticsEvent("SampleDetailsMode_metadata_saved", {
+        sampleId: this.props.sampleId,
+        key,
+        newValue
+      });
     }
   };
 

--- a/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
@@ -1,8 +1,11 @@
 import React from "react";
 import cx from "classnames";
 import PropTypes from "prop-types";
+
 import { getTaxonDescriptions, getTaxonDistributionForBackground } from "~/api";
 import Histogram from "~/components/visualizations/Histogram";
+import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
+
 import cs from "./taxon_details_mode.scss";
 
 const COLLAPSED_HEIGHT = 120;
@@ -204,6 +207,13 @@ export default class TaxonDetailsMode extends React.Component {
 
     if (url) {
       window.open(url, "_blank", "noopener", "noreferrer");
+      logAnalyticsEvent("TaxonDetailsMode_external-link_clicked", {
+        source,
+        url,
+        taxonId: this.props.taxonId,
+        taxonName: this.props.taxonName,
+        parentTaxonId: this.props.parentTaxonId
+      });
     }
   }
 
@@ -230,7 +240,15 @@ export default class TaxonDetailsMode extends React.Component {
               this.state.taxonDescriptionTall && (
                 <div
                   className={cs.expandLink}
-                  onClick={this.expandTaxonDescription}
+                  onClick={withAnalytics(
+                    this.expandTaxonDescription,
+                    "TaxonDetailsMode_show-more-link_clicked",
+                    {
+                      taxonId: this.props.taxonId,
+                      taxonName: this.props.taxonName,
+                      parentTaxonId: this.props.parentTaxonId
+                    }
+                  )}
                 >
                   Show More
                 </div>
@@ -259,7 +277,15 @@ export default class TaxonDetailsMode extends React.Component {
               this.state.parentDescriptionTall && (
                 <div
                   className={cs.expandLink}
-                  onClick={this.expandParentDescription}
+                  onClick={withAnalytics(
+                    this.expandParentDescription,
+                    "TaxonDetailsMode_show-more-link_clicked",
+                    {
+                      taxonId: this.props.taxonId,
+                      taxonName: this.props.taxonName,
+                      parentTaxonId: this.props.parentTaxonId
+                    }
+                  )}
                 >
                   Show More
                 </div>

--- a/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
@@ -242,7 +242,7 @@ export default class TaxonDetailsMode extends React.Component {
                   className={cs.expandLink}
                   onClick={withAnalytics(
                     this.expandTaxonDescription,
-                    "TaxonDetailsMode_show-more-link_clicked",
+                    "TaxonDetailsMode_show-more-description-link_clicked",
                     {
                       taxonId: this.props.taxonId,
                       taxonName: this.props.taxonName,
@@ -279,7 +279,7 @@ export default class TaxonDetailsMode extends React.Component {
                   className={cs.expandLink}
                   onClick={withAnalytics(
                     this.expandParentDescription,
-                    "TaxonDetailsMode_show-more-link_clicked",
+                    "TaxonDetailsMode_show-more-parent-description-link_clicked",
                     {
                       taxonId: this.props.taxonId,
                       taxonName: this.props.taxonName,


### PR DESCRIPTION
# Description

As title. 

I also fixed a race condition of multiple `setState` calls. This was affecting my testing in localhost but did not appear to affect prod. 

![image](https://user-images.githubusercontent.com/28797/56925313-e2369a00-6a83-11e9-8928-915e952fb31c.png)

----

![image](https://user-images.githubusercontent.com/28797/56927006-e2389900-6a87-11e9-8130-337f3f279909.png)

# Test and Reproduce

1. open sample page
2. click on "details"
3. click on everything, edit fields
4. see segment logs
5. do the same for pipeline, notes, and taxon sidebar