### PR TITLE
Add Bee Genome.

### DIFF
--- a/db/migrate/20190426002714_add_bee_genome.rb
+++ b/db/migrate/20190426002714_add_bee_genome.rb
@@ -1,0 +1,22 @@
+class AddBeeGenome < ActiveRecord::Migration[5.1]
+  def up
+    return if HostGenome.find_by(name: "Bee")
+
+    hg = HostGenome.new
+    hg.name = "Bee"
+    hg.s3_star_index_path = "s3://idseq-database/host_filter/bee/2019-04-25/STAR_genome.tar"
+    hg.s3_bowtie2_index_path = "s3://idseq-database/host_filter/bee/2019-04-25/bowtie2_genome.tar"
+
+    human_host = HostGenome.find_by(name: "Human")
+    # For lack of a better default, use Human background.
+    # In the future, consider asking bee users to make a background model
+    # from their uninfected samples that we can substitute as the default.
+    hg.default_background_id = human_host.default_background_id if human_host
+    hg.save
+  end
+
+  def down
+    hg = HostGenome.find_by(name: "Bee")
+    hg.destroy if hg
+  end
+end


### PR DESCRIPTION
Generated a sample with apis mellifera using idseq_bench.

Verified locally that sample has "apis" when host genome is Human.
![Screen Shot 2019-04-29 at 2 41 34 PM](https://user-images.githubusercontent.com/837004/56928863-f03ce880-6a8c-11e9-9795-9cb156a6339e.png)

Verified locally that sample does not have "apis" when host genome is Bee.
![Screen Shot 2019-04-29 at 2 41 38 PM](https://user-images.githubusercontent.com/837004/56928870-f4690600-6a8c-11e9-9dec-a31d32a47819.png)

Verified that metadata fields were added for host genome.