### PR TITLE
IDSEQ-947 Detect duplicate columns during metadata CSV validation.

### DIFF
--- a/app/helpers/error_helper.rb
+++ b/app/helpers/error_helper.rb
@@ -59,6 +59,10 @@ module ErrorHelper
   # Aggregates errors (and warnings) into groups
   class ErrorAggregator
     ERRORS = {
+      duplicate_columns: {
+        headers: ["Column #", "Column Name", "Duplicate Column #"],
+        title: ->(num_cols, _) { "#{num_cols} duplicate columns were found. Please ensure all column names are unique." }
+      },
       no_matching_sample_existing: {
         headers: ["Row #", "Sample Name"],
         title: ->(num_rows, _) { "#{num_rows} sample names do not match any samples in this project." }

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -120,6 +120,43 @@ module MetadataHelper
     end
   end
 
+  # Determines whether a set of columns has duplicates.
+  # We account for both the name and display name of existing metadata fields when determining duplicates.
+  # We add an error to the error_aggregator for each duplicate we find.
+  def metadata_csv_has_duplicate_columns(columns, existing_fields, error_aggregator)
+    column_to_index = {}
+    has_duplicate_columns = false
+
+    # Prevent duplicate columns.
+    columns.each_with_index do |col, index|
+      if column_to_index[col].present?
+        error_aggregator.add_error(:duplicate_columns, [index, col, column_to_index[col]])
+        has_duplicate_columns = true
+      end
+
+      # Account for both the name and the display_name, as both are accepted.
+      if ["sample_name", "Sample Name"].include?(col)
+        column_to_index["sample_name"] = index
+        column_to_index["Sample Name"] = index
+      elsif ["host_genome", "Host Genome"].include?(col)
+        column_to_index["host_genome"] = index
+        column_to_index["Host Genome"] = index
+      else
+        matching_field = existing_fields.select { |field| field.name == col || field.display_name == col }
+
+        if !matching_field.empty?
+          column_to_index[matching_field[0].name] = index
+          column_to_index[matching_field[0].display_name] = index
+        # If it's a custom field, just add the name.
+        else
+          column_to_index[col] = index
+        end
+      end
+    end
+
+    return has_duplicate_columns
+  end
+
   # Receives an array of samples, and validates metadata from a csv.
   def validate_metadata_csv_for_samples(samples, metadata, new_samples = false)
     # If new samples, enforce required metadata constraint, and pull the host genome from the metadata rows for validation.
@@ -138,9 +175,31 @@ module MetadataHelper
     end
 
     # Require host_genome or Host Genome column.
-    unless !extract_host_genome_from_metadata || (metadata["headers"] & ["host_genome", "Host Genome"]).present?
+    if extract_host_genome_from_metadata && (metadata["headers"] & ["host_genome", "Host Genome"]).blank?
       errors.push(MetadataValidationErrors::MISSING_HOST_GENOME_COLUMN)
       return { "errors" => errors, "warnings" => [] }
+    end
+
+    existing_fields = MetadataField.where(is_core: 1)
+
+    if samples[0].project
+      existing_fields |= samples[0].project.metadata_fields
+    end
+
+    # If there are duplicate columns, abort and return with the errors.
+    if metadata_csv_has_duplicate_columns(metadata["headers"], existing_fields, error_aggregator)
+      return { "errors" => errors + error_aggregator.error_groups, "warnings" => [] }
+    end
+
+    # Add a warning for each custom field that will be created.
+    metadata["headers"].each_with_index do |col, index|
+      next if ["sample_name", "Sample Name", "host_genome", "Host Genome"].include?(col)
+
+      matching_field = existing_fields.select { |field| field.name == col || field.display_name == col }
+
+      if matching_field.empty?
+        warning_aggregator.add_error(:custom_field_creation, [index + 1, col])
+      end
     end
 
     sample_name_index = metadata["headers"].find_index("sample_name") || metadata["headers"].find_index("Sample Name")
@@ -152,23 +211,6 @@ module MetadataHelper
     end
 
     processed_samples = []
-
-    if samples[0].project
-      matching_fields =
-        (samples[0].project.metadata_fields | MetadataField.where(is_core: 1))
-        .select { |field| metadata["headers"].include?(field.name) || metadata["headers"].include?(field.display_name) }
-
-      # Add a warning for each custom field that will be created.
-      metadata["headers"].each_with_index do |col, index|
-        next if ["sample_name", "Sample Name", "host_genome", "Host Genome"].include?(col)
-
-        matching_field = matching_fields.select { |field| field.name == col || field.display_name == col }
-
-        if matching_field.empty?
-          warning_aggregator.add_error(:custom_field_creation, [index + 1, col])
-        end
-      end
-    end
 
     metadata["rows"].each_with_index do |row, index|
       # Deleting in Excel may leaves a row of ""s in the CSV, so ignore


### PR DESCRIPTION
Fix issue where user can submit duplicate columns, which causes validation and upload errors.

Duplicate columns are now detected.

![Screen Shot 2019-04-29 at 4 04 17 PM](https://user-images.githubusercontent.com/837004/56932511-f33dd600-6a98-11e9-84d2-cf899e02bc66.png)

Verification:
* Updated tests and made sure they passed. Including for custom fields (an edge case)
* Verified in the UI that duplicate columns throw error.
* Verified that well-formatted CSVs can be uploaded without error.