### PR TITLE
 Address subtle edge case with metadata upload.

### DIFF
--- a/app/helpers/error_helper.rb
+++ b/app/helpers/error_helper.rb
@@ -107,8 +107,8 @@ module ErrorHelper
       },
       # This should theoretically never happen since we now have custom fields.
       invalid_key_for_host_genome: {
-        headers: ["Row #", "Sample Name", "Host Genome Name", "Invalid Field"],
-        title: ->(num_rows, _) { "#{num_rows} rows specify values for fields that are incompatible with the sample's host genome." }
+        headers: ["Row #", "Sample Name", "Host Genome Name", "Incompatible Field"],
+        title: ->(num_rows, _) { "#{num_rows} metadata fields are incompatible with their sample's host genome. Please check the metadata dictionary." }
       },
       value_already_exists: {
         headers: ["Row #", "Sample Name", "Field", "Old Value", "New Value"],

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -46,7 +46,7 @@ class Metadatum < ApplicationRecord
     # Check if the key is valid. Metadata_field was supposed to be set.
     valid_keys = sample.host_genome.metadata_fields.pluck(:name, :display_name).flatten
     unless key && valid_keys.include?(key) && metadata_field
-      errors.add(:invalid_host_genome, MetadataValidationErrors::INVALID_FIELD_FOR_HOST_GENOME)
+      errors.add(:invalid_field_for_host_genome, MetadataValidationErrors::INVALID_FIELD_FOR_HOST_GENOME)
       return
     end
 

--- a/test/controllers/samples_bulk_upload_test.rb
+++ b/test/controllers/samples_bulk_upload_test.rb
@@ -334,6 +334,56 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert_equal 0, Sample.where(name: "RR004_water_2_S23A").length
   end
 
+  # If the metadata field isn't supported by the sample's host genome, throw an error.
+  test 'bulk upload invalid key for  host genome' do
+    post user_session_path, params: @user_params
+
+    post bulk_upload_with_metadata_samples_url, params: {
+      client: "web",
+      metadata: {
+        "RR004_water_2_S23A" => {
+          'sex' => 'Female',
+          'age' => 100,
+          'admission_date' => '2018-01',
+          'sample_type' => 'blood',
+          'nucleotide_type' => 'DNA',
+          'blood_fed' => 'Yes'
+        }
+      },
+      samples: [
+        {
+          host_genome_id: @host_genome_human.id,
+          input_files_attributes: [
+            {
+              name: "RR004_water_2_S23D_R1_001.fastq",
+              source: "s3://idseq-samples-test/markazhang/RR004_water_2_S23D_R1_001.fastq",
+              source_type: "s3"
+            },
+            {
+              name: "RR004_water_2_S23D_R2_001.fastq",
+              source: "s3://idseq-samples-test/markazhang/RR004_water_2_S23D_R2_001.fastq",
+              source_type: "s3"
+            }
+          ],
+          name: "RR004_water_2_S23A",
+          # project_id is currently passed from front-end as a string, so need to test this works.
+          project_id: String(@metadata_validation_project.id),
+          status: "created"
+        }
+      ]
+    }, as: :json
+
+    assert_response :success
+    assert_equal 1, @response.parsed_body["errors"].length
+    assert_equal MetadataUploadErrors.save_error('blood_fed', 'Yes'), @response.parsed_body["errors"][0]
+
+    # The sample should still upload, minus the invalid metadata.
+    assert_equal 1, Sample.where(name: "RR004_water_2_S23A").length
+    sample_id = Sample.where(name: "RR004_water_2_S23A").first.id
+    # The invalid metadata should not be uploaded.
+    assert_equal 5, Metadatum.where(sample_id: sample_id).length
+  end
+
   test 'bulk upload core and custom fields' do
     post user_session_path, params: @user_params
 


### PR DESCRIPTION
Edge case:
Our official "Blood Fed" metadata field is only for Mosquitoes. If you try to upload a value for "Blood Fed" to a human sample, we currently create a new Blood Fed custom field that only accepts Human Samples. This is quite confusing, as we now have two metadata fields with the same name for the project (the official one for mosquitoes, and the custom one for humans). It also defeats the point of specifying a schema for each host genome.

With this fix, if a user tries to upload Blood Fed for humans, and Blood Fed is an official metadata field, an error is thrown. The user can either rename their column (which will create a custom field), or message us to let us know that our schema should be more permissive. It was probably an accident that the user uploaded a value for Blood Fed for a human sample...so this will help them catch errors.

![Screen Shot 2019-04-29 at 6 15 08 PM](https://user-images.githubusercontent.com/837004/56936250-399c3080-6aab-11e9-9110-8c26356d2c4f.png)


