### PR TITLE
Fix user name regex

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,8 @@ class User < ApplicationRecord
   has_many :phylo_trees
 
   validates :email, presence: true
-  validates :name, presence: true, format: { with: /\A[a-zA-Z -]+\z/, message: "only allows letters" }
+  # TODO: (gdingle): write unit test
+  validates :name, presence: true, format: { with: /\A(\w|[ -])+\z/, message: "Name must be letters or spaces" }
   attr_accessor :email_arguments
   ROLE_ADMIN = 1
   DEMO_USER_EMAILS = ['idseq.guest@chanzuckerberg.com'].freeze

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,8 @@ class User < ApplicationRecord
 
   validates :email, presence: true
   validates :name, presence: true, format: {
-    # See https://www.ascii-code.com/
+    # See https://www.ascii-code.com/. These were the ranges that captured the
+    # common accented chars I knew from experience, leaving out pure symbols.
     with: /\A[- 'a-zA-ZÀ-ÖØ-öø-ÿ]+\z/, message: "Name must contain only letters, apostrophes, dashes or spaces"
   }
   attr_accessor :email_arguments

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,8 +24,10 @@ class User < ApplicationRecord
   has_many :phylo_trees
 
   validates :email, presence: true
-  # TODO: (gdingle): write unit test
-  validates :name, presence: true, format: { with: /\A(\w|[ -])+\z/, message: "Name must be letters or spaces" }
+  validates :name, presence: true, format: {
+    # See https://www.ascii-code.com/
+    with: /\A[- 'a-zA-ZÀ-ÖØ-öø-ÿ]+\z/, message: "Name must contain only letters, apostrophes, dashes or spaces"
+  }
   attr_accessor :email_arguments
   ROLE_ADMIN = 1
   DEMO_USER_EMAILS = ['idseq.guest@chanzuckerberg.com'].freeze

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,8 +1,42 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # TODO: (gdingle): add test logic here for name validation
-  # test "the truth" do
-  #   assert true
-  # end
+  test "user name validates" do
+    user = new_user
+
+    user.name = "foobar"
+    assert user.valid?
+
+    user.name = "foo bar"
+    assert user.valid?
+
+    user.name = "Foo Bar"
+    assert user.valid?
+
+    user.name = "foo-bar"
+    assert user.valid?
+  end
+
+  test "user name special chars allowed" do
+    user = new_user
+
+    user.name = "fé bår"
+    assert user.valid?
+
+    user.name = "Yazín Hernández"
+    assert user.valid?
+  end
+
+  test "user name numbers not allowed" do
+    user = new_user
+
+    user.name = "1234 abcd"
+    assert !user.valid?
+  end
+
+  private
+
+  def new_user
+    User.new(email: "test@test.com", password: "password123")
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -15,6 +15,9 @@ class UserTest < ActiveSupport::TestCase
 
     user.name = "foo-bar"
     assert user.valid?
+
+    user.name = "foo'bar"
+    assert user.valid?
   end
 
   test "user name special chars allowed" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+  # TODO: (gdingle): add test logic here for name validation
   # test "the truth" do
   #   assert true
   # end


### PR DESCRIPTION
# Description

See https://jira.czi.team/browse/IDSEQ-925 . I decided to increase the char class to include accent chars. 

# Test and Reproduce

`rails t test/models/user_test.rb`