### PR TITLE
sync db schema with ground truth

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_424_003_917) do
+ActiveRecord::Schema.define(version: 20_190_426_002_714) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -33,9 +33,6 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
     t.float "depth", limit: 24
     t.bigint "pipeline_run_id"
     t.string "drug_family"
-    t.integer "level"
-    t.float "drug_gene_coverage", limit: 24
-    t.float "drug_gene_depth", limit: 24
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["pipeline_run_id", "allele"], name: "index_amr_counts_on_pipeline_run_id_and_allele", unique: true
@@ -117,8 +114,8 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
   create_table "host_genomes_metadata_fields", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "host_genome_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields"
-    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes"
+    t.index ["host_genome_id", "metadata_field_id"], name: "index_host_genomes_metadata_fields", unique: true
+    t.index ["metadata_field_id", "host_genome_id"], name: "index_metadata_fields_host_genomes", unique: true
   end
 
   create_table "input_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -131,6 +128,17 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
+  end
+
+  create_table "job_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string "task"
+    t.integer "reads_before"
+    t.integer "reads_after"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "pipeline_run_id"
+    t.index ["pipeline_run_id"], name: "index_job_stats_on_pipeline_run_id"
+    t.index ["task"], name: "index_job_stats_on_task"
   end
 
   create_table "locations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -152,19 +160,8 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
     t.index ["name"], name: "index_locations_on_name", comment: "Index for lookup by location name"
   end
 
-  create_table "job_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "task"
-    t.integer "reads_before"
-    t.integer "reads_after"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "pipeline_run_id"
-    t.index ["pipeline_run_id"], name: "index_job_stats_on_pipeline_run_id"
-    t.index ["task"], name: "index_job_stats_on_task"
-  end
-
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "key", null: false, collation: "latin1_swedish_ci"
+    t.string "key", null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9
@@ -200,7 +197,7 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
   create_table "metadata_fields_projects", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "project_id", null: false
     t.bigint "metadata_field_id", null: false
-    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields"
+    t.index ["project_id", "metadata_field_id"], name: "index_projects_metadata_fields", unique: true
   end
 
   create_table "output_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -299,7 +296,6 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
     t.string "pipeline_commit"
     t.text "assembled_taxids"
     t.bigint "truncated"
-    t.text "result_status"
     t.integer "results_finalized"
     t.bigint "alignment_config_id"
     t.integer "alert_sent", default: 0
@@ -366,6 +362,13 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
     t.index ["user_id"], name: "index_samples_on_user_id"
   end
 
+  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "visualization_id", null: false
+    t.bigint "sample_id", null: false
+    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
+    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
+  end
+
   create_table "shortened_urls", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "owner_id"
     t.string "owner_type", limit: 20
@@ -430,12 +433,12 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
   end
 
-  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+  create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
-    t.string "title", collation: "utf8mb4_general_ci"
-    t.text "summary", collation: "utf8mb4_general_ci"
-    t.text "description", collation: "utf8mb4_general_ci"
+    t.string "title"
+    t.text "summary"
+    t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -542,6 +545,11 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
     t.integer "role"
     t.text "allowed_features"
     t.string "institution", limit: 100
+    t.integer "samples_count", default: 0, null: false
+    t.integer "favorite_projects_count", default: 0, null: false
+    t.integer "favorites_count", default: 0, null: false
+    t.integer "visualizations_count", default: 0, null: false
+    t.integer "phylo_trees_count", default: 0, null: false
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -551,16 +559,10 @@ ActiveRecord::Schema.define(version: 20_190_424_003_917) do
     t.bigint "user_id"
     t.string "visualization_type"
     t.text "data"
-    t.integer "public_access", limit: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "public_access", limit: 1
+    t.string "name"
     t.index ["user_id"], name: "index_visualizations_on_user_id"
-  end
-
-  create_table "samples_visualizations", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "visualization_id", null: false
-    t.bigint "sample_id", null: false
-    t.index ["sample_id"], name: "index_samples_visualizations_on_sample_id"
-    t.index ["visualization_id"], name: "index_samples_visualizations_on_visualization_id"
   end
 end


### PR DESCRIPTION
This should prevent recurring issues with unwanted schema changes in the diff. The schema was out of sync with truth, e.g. looking at the sequence of migrations, `index_host_genomes_metadata_fields` *is* meant to be unique, and `drug_gene_coverage` should be long gone...