### PR TITLE
Show warning on low number of reads

### DIFF
--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -327,6 +327,9 @@ class SampleView extends React.Component {
             <h6 className={cs.failed}>
               {this.props.pipelineRun.error_message}
             </h6>
+            <h6 className={cs.failed}>
+              {this.props.pipelineRun.total_reads} Total Reads
+            </h6>
           </div>
         );
       }

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -330,6 +330,12 @@ class SampleView extends React.Component {
             <h6 className={cs.failed}>
               {this.props.pipelineRun.total_reads} Total Reads
             </h6>
+            {this.props.pipelineRun.adjusted_remaining_reads && (
+              <h6 className={cs.failed}>
+                {this.props.pipelineRun.adjusted_remaining_reads} Reads Passed
+                Filters
+              </h6>
+            )}
           </div>
         );
       }

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -76,7 +76,11 @@ const processRawSample = sample => {
       status: get(
         "run_info.result_status_description",
         sample.details
-      ).toLowerCase()
+      ).toLowerCase(),
+      lowReadsWarning: get(
+        "derived_sample_output.summary_stats.low_reads_warning",
+        sample.details
+      )
     },
     collectionLocation: get("metadata.collection_location", sample.details),
     createdAt: sample.created_at,

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -224,6 +224,9 @@ class SamplesView extends React.Component {
               <div className={cx(cs.sampleStatus, cs[sample.status])}>
                 {sample.status}
               </div>
+              <div className={cx(cs.sampleStatus, cs[sample.status])}>
+                {sample.status}
+              </div>
             </div>
           ) : (
             <div className={cs.sampleNameAndStatus} />

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -224,9 +224,9 @@ class SamplesView extends React.Component {
               <div className={cx(cs.sampleStatus, cs[sample.status])}>
                 {sample.status}
               </div>
-              <div className={cx(cs.sampleStatus, cs[sample.status])}>
-                {sample.status}
-              </div>
+              {sample.lowReadsWarning && (
+                <div className={cx(cs.sampleStatus, cs.warning)}>Low Reads</div>
+              )}
             </div>
           ) : (
             <div className={cs.sampleNameAndStatus} />

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -160,7 +160,8 @@
         }
 
         &.waiting,
-        &.uploading {
+        &.uploading,
+        &.warning {
           background-color: $warning-bg;
           color: $warning;
         }

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -24,6 +24,7 @@ module SamplesHelper
                         overall_job_status: run_info ? run_info[:result_status_description] : '',
                         runtime_seconds: run_info ? run_info[:total_runtime] : '',
                         total_reads: pipeline_run ? pipeline_run.total_reads : '',
+                        # TODO: (gdingle): change nonhost to "reads_passed_filters"
                         nonhost_reads: pipeline_run ? pipeline_run.adjusted_remaining_reads : '',
                         nonhost_reads_percent: derived_output[:summary_stats] && derived_output[:summary_stats][:percent_remaining] ? derived_output[:summary_stats][:percent_remaining].round(3) : '',
                         total_ercc_reads: pipeline_run ? pipeline_run.total_ercc_reads : '',
@@ -86,7 +87,8 @@ module SamplesHelper
       qc_percent: compute_qc_value(job_stats_hash),
       percent_remaining: compute_percentage_reads(pr),
       unmapped_reads: unmapped_reads,
-      last_processed_at: last_processed_at }
+      last_processed_at: last_processed_at,
+      low_reads_warning: pr.nil? ? nil : pr.low_reads_warning? }
   end
 
   def get_adjusted_remaining_reads(pr)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -395,6 +395,20 @@ class PipelineRun < ApplicationRecord
     job_status == STATUS_CHECKED
   end
 
+  # This was added to warn users of input files that are very unlikely to
+  # produce any meaningful output.
+  def low_reads_warning?
+    if total_reads.present? && total_reads < 1000
+      return true
+    end
+
+    if adjusted_remaining_reads.present? && adjusted_remaining_reads < 100
+      return true
+    end
+
+    return false
+  end
+
   def db_load_input_validations
     file = Tempfile.new
     downloaded = PipelineRun.download_file_with_retries(s3_file_for("input_validations"),


### PR DESCRIPTION
# Description

Following a high percent of failed runs (18/96) in Vida's project, I thought we should show a warning when the number of reads makes meaningful results very unlikely. 

In discussion with @cdebourcy , we decided on initial threshold of 1000 total reads, then I added a threshold 100 passed filter reads. Happy to change either. 

![image](https://user-images.githubusercontent.com/28797/57000957-f5706500-6b6a-11e9-8080-b0081bef99c2.png)

Note: I artificially increased the thresholds here to see more warnings. 

@happyimadesignr please review the visual look

# Test and Reproduce

1. Load a project with low read samples
2. See warning 