### PR TITLE
IDSEQ-912 Better positioning for heatmap tooltip.

### DIFF
--- a/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
@@ -16,13 +16,13 @@ import NarrowContainer from "~/components/layout/NarrowContainer";
 import NoResultsBacteriaIcon from "~ui/icons/NoResultsBacteriaIcon";
 import { DataTooltip } from "~ui/containers";
 import { getCoverageVizData } from "~/api";
+import { getTooltipStyle } from "~/components/utils/tooltip";
 
 import HitGroupViz from "./HitGroupViz";
 import {
   getHistogramTooltipData,
   generateCoverageVizData,
-  getSortedAccessionSummaries,
-  getTooltipStyle
+  getSortedAccessionSummaries
 } from "./utils";
 import cs from "./coverage_viz_bottom_sidebar.scss";
 

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/HitGroupViz.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/HitGroupViz.jsx
@@ -11,13 +11,10 @@ import DownloadIcon from "~ui/icons/DownloadIcon";
 import CopyIcon from "~ui/icons/CopyIcon";
 import { getURLParamString } from "~/helpers/url";
 import { getContigsSequencesByByteranges } from "~/api";
+import { getTooltipStyle } from "~/components/utils/tooltip";
 
 import cs from "./coverage_viz_bottom_sidebar.scss";
-import {
-  generateContigReadVizData,
-  getGenomeVizTooltipData,
-  getTooltipStyle
-} from "./utils";
+import { generateContigReadVizData, getGenomeVizTooltipData } from "./utils";
 
 const DEFAULT_CONTIG_COPY_MESSAGE = "Copy Contig Sequence to Clipboard";
 const READ_FILL_COLOR = "#A9BDFC";

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
@@ -124,23 +124,3 @@ export const generateContigReadVizData = (hitGroups, coverageBinSize) => {
 // Sort by score descending.
 export const getSortedAccessionSummaries = data =>
   sortBy(summary => -summary.score, data.best_accessions);
-
-const TOOLTIP_BUFFER = 10;
-const TOOLTIP_MAX_WIDTH = 400;
-
-// Display the tooltip in the top left, unless it is too close
-// to the right side of the screen.
-export const getTooltipStyle = location => {
-  if (location.left > window.innerWidth - TOOLTIP_MAX_WIDTH) {
-    const right = window.innerWidth - location.left;
-    return {
-      right: right + TOOLTIP_BUFFER,
-      top: location.top - TOOLTIP_BUFFER
-    };
-  } else {
-    return {
-      left: location.left + TOOLTIP_BUFFER,
-      top: location.top - TOOLTIP_BUFFER
-    };
-  }
-};

--- a/app/assets/src/components/utils/tooltip.js
+++ b/app/assets/src/components/utils/tooltip.js
@@ -1,0 +1,22 @@
+const TOOLTIP_BUFFER = 10;
+const TOOLTIP_MAX_WIDTH = 400;
+
+// Display the tooltip in the top left, unless it is too close
+// to the right side of the screen.
+export const getTooltipStyle = (location, params = {}) => {
+  const buffer = params.buffer || TOOLTIP_BUFFER;
+  const topBufferSign = params.below ? 1 : -1;
+
+  if (location.left > window.innerWidth - TOOLTIP_MAX_WIDTH) {
+    const right = window.innerWidth - location.left;
+    return {
+      right: right + buffer,
+      top: location.top + topBufferSign * buffer
+    };
+  } else {
+    return {
+      left: location.left + buffer,
+      top: location.top + topBufferSign * buffer
+    };
+  }
+};

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -9,6 +9,7 @@ import { DataTooltip, ContextPlaceholder } from "~ui/containers";
 import { SearchBoxList } from "~ui/controls";
 import { openUrl } from "~utils/links";
 import Heatmap from "~/components/visualizations/heatmap/Heatmap";
+import { getTooltipStyle } from "~/components/utils/tooltip";
 
 import cs from "./samples_heatmap_vis.scss";
 
@@ -20,7 +21,8 @@ class SamplesHeatmapVis extends React.Component {
       addMetadataTrigger: null,
       nodeHoverInfo: null,
       columnMetadataLegend: null,
-      selectedMetadata: new Set(this.props.defaultMetadata)
+      selectedMetadata: new Set(this.props.defaultMetadata),
+      tooltipLocation: null
     };
 
     this.heatmap = null;
@@ -109,8 +111,10 @@ class SamplesHeatmapVis extends React.Component {
   handleMouseHoverMove = (_, currentEvent) => {
     if (currentEvent) {
       this.setState({
-        tooltipX: currentEvent.pageX,
-        tooltipY: currentEvent.pageY
+        tooltipLocation: {
+          left: currentEvent.pageX,
+          top: currentEvent.pageY
+        }
       });
     }
   };
@@ -279,6 +283,13 @@ class SamplesHeatmapVis extends React.Component {
   }
 
   render() {
+    const {
+      tooltipLocation,
+      nodeHoverInfo,
+      columnMetadataLegend,
+      addMetadataTrigger
+    } = this.state;
+
     return (
       <div className={cs.samplesHeatmapVis}>
         <div
@@ -288,35 +299,34 @@ class SamplesHeatmapVis extends React.Component {
           }}
         />
 
-        {this.state.nodeHoverInfo && (
-          <div
-            className={cx(cs.tooltip, this.state.nodeHoverInfo && cs.visible)}
-            style={{
-              left: `${this.state.tooltipX + 20}px`,
-              top: `${this.state.tooltipY + 20}px`
-            }}
-          >
-            <DataTooltip data={this.state.nodeHoverInfo} />
-          </div>
-        )}
-        {this.state.columnMetadataLegend && (
-          <div
-            className={cx(
-              cs.tooltip,
-              this.state.columnMetadataLegend && cs.visible
-            )}
-            style={{
-              left: `${this.state.tooltipX + 20}px`,
-              top: `${this.state.tooltipY + 20}px`
-            }}
-          >
-            {this.renderColumnMetadataLegend(this.state.columnMetadataLegend)}
-          </div>
-        )}
-        {this.state.addMetadataTrigger && (
+        {nodeHoverInfo &&
+          tooltipLocation && (
+            <div
+              className={cx(cs.tooltip, nodeHoverInfo && cs.visible)}
+              style={getTooltipStyle(tooltipLocation, {
+                buffer: 20,
+                below: true
+              })}
+            >
+              <DataTooltip data={nodeHoverInfo} />
+            </div>
+          )}
+        {columnMetadataLegend &&
+          tooltipLocation && (
+            <div
+              className={cx(cs.tooltip, columnMetadataLegend && cs.visible)}
+              style={getTooltipStyle(tooltipLocation, {
+                buffer: 20,
+                below: true
+              })}
+            >
+              {this.renderColumnMetadataLegend(columnMetadataLegend)}
+            </div>
+          )}
+        {addMetadataTrigger && (
           <ContextPlaceholder
             closeOnOutsideClick
-            context={this.state.addMetadataTrigger}
+            context={addMetadataTrigger}
             horizontalOffset={5}
             verticalOffset={10}
             onClose={() => {


### PR DESCRIPTION
Tooltip now opens to the left when near the right side of the window, instead of becoming narrow.
Generalized `getTooltipStyle` a bit for use in heatmap.

<img width="709" alt="Screen Shot 2019-04-30 at 6 21 02 PM" src="https://user-images.githubusercontent.com/837004/57002573-3a00fe00-6b75-11e9-987d-55f2d6fff7c2.png">

Verification steps:
* Tested that tooltips on coverage viz are unaffected.