### PR TITLE
Switch to more efficient webpack sourcemaps on development.

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,6 +2,6 @@ const merge = require("webpack-merge");
 const commonConfig = require("./webpack.config.common.js");
 
 module.exports = merge(commonConfig, {
-  devtool: "source-map",
+  devtool: "cheap-module-eval-source-map",
   mode: "development"
 });


### PR DESCRIPTION
`cheap-module-eval-source-map` preserves the original source code (same as `source-map`), so the development experience is the same. 
It's much faster, but has a larger bundle size (doesn't matter for dev). 
Start-up build time is still about the same (40 seconds), but incremental build time has gone from around 6s to <1s.
(See https://webpack.js.org/configuration/devtool/ for a great explanation of different sourcemaps.)

We were previously using `source-map` in development. Using SMP, a webpack profiling tool,  (https://github.com/stephencookdev/speed-measure-webpack-plugin/) I found that the source-maps were the primary bottleneck for our incremental build times.

![Screen Shot 2019-05-01 at 6 14 48 PM](https://user-images.githubusercontent.com/837004/57052570-04bfe300-6c3d-11e9-9f5f-9bf88df03abe.png)

The above screenshot indicates that the slowness is NOT due to loaders or plugins, but due to Webpack itself. The culprit turned out to be the choice of sourcemaps.

After the sourcemap change:
![Screen Shot 2019-05-01 at 6 16 06 PM](https://user-images.githubusercontent.com/837004/57052593-33d65480-6c3d-11e9-8a4c-651aed5c7467.png)


