### PR TITLE
[Data Discovery] Add index to taxon_counts

### DIFF
--- a/db/migrate/20190502150040_add_index_tax_id_to_taxon_counts.rb
+++ b/db/migrate/20190502150040_add_index_tax_id_to_taxon_counts.rb
@@ -1,0 +1,5 @@
+class AddIndexTaxIdToTaxonCounts < ActiveRecord::Migration[5.1]
+  def change
+    add_index :taxon_counts, :tax_id
+  end
+end


### PR DESCRIPTION
## Description

[Optimization] 
Adding an index on `tax_id` field to the `taxon_counts` tables seems to accelerate the query to constrain ElasticSearch results ~x4. This queries are much more restrictive on `tax_id` than `pipeline_run_id`, which makes this new index much more efficient that the previous on which had (`pipeline_run_id`, `tax_id`) as the first two fields.
The proportional impact production might hopefully be greater since it currently scans ~1.5x more sample rows.

`EXPLAIN` of query that constrains taxa by `tax_id` through taxon_counts:
* Before:
<pre>
+----+-------------+---------------+--------+--------------------------------------------------------------------+-----------------------------------+---------+-------------------------------------------+------+---------------------------------------------------------------------+
| id | select_type | table         | type   | possible_keys                                                      | key                               | key_len | ref                                       | <b>rows</b> | Extra                                                               |
+----+-------------+---------------+--------+--------------------------------------------------------------------+-----------------------------------+---------+-------------------------------------------+------+---------------------------------------------------------------------+
|  1 | PRIMARY     | samples       | index  | PRIMARY                                                            | index_samples_on_user_id          | 9       | NULL                                      | <b>9385</b> | Using index; Using temporary                                        |
|  1 | PRIMARY     | pipeline_runs | ref    | PRIMARY,index_pipeline_runs_on_sample_id                           | index_pipeline_runs_on_sample_id  | 9       | idseq_development.samples.id              |    1 | Using where; Using index                                            |
|  1 | PRIMARY     | taxon_counts  | ref    | index_pr_tax_hit_level_tc                                          | index_pr_tax_hit_level_tc         | 9       | idseq_development.pipeline_runs.id        |  <b>141</b> | Using index condition; Using where                                  |
|  2 | SUBQUERY    | pipeline_runs | ref    | index_pipeline_runs_on_sample_id,index_pipeline_runs_on_job_status | index_pipeline_runs_on_job_status | 768     | const                                     | 7545 | Using index condition; Using where; Using temporary; Using filesort |
|  2 | SUBQUERY    | samples       | eq_ref | PRIMARY                                                            | PRIMARY                           | 8       | idseq_development.pipeline_runs.sample_id |    1 | Using index                                                         |
|  2 | SUBQUERY    | samples       | eq_ref | PRIMARY                                                            | PRIMARY                           | 8       | idseq_development.pipeline_runs.sample_id |    1 | Using index                                                         |
+----+-------------+---------------+--------+--------------------------------------------------------------------+-----------------------------------+---------+-------------------------------------------+------+---------------------------------------------------------------------+
</pre>
```
...
11 rows in set (5.51 sec)
```

* After:
<pre>
+----+-------------+---------------+--------+--------------------------------------------------------------------+-----------------------------------+---------+------------------------------------------------+------+---------------------------------------------------------------------+
| id | select_type | table         | type   | possible_keys                                                      | key                               | key_len | ref                                            | <b>rows</b> | Extra                                                               |
+----+-------------+---------------+--------+--------------------------------------------------------------------+-----------------------------------+---------+------------------------------------------------+------+---------------------------------------------------------------------+
|  1 | PRIMARY     | taxon_counts  | range  | index_pr_tax_hit_level_tc,index_tax_id                             | index_tax_id                      | 5       | NULL                                           |  <b>400</b> | Using index condition; Using where; Using temporary                 |
|  1 | PRIMARY     | pipeline_runs | eq_ref | PRIMARY,index_pipeline_runs_on_sample_id                           | PRIMARY                           | 8       | idseq_development.taxon_counts.pipeline_run_id |    1 | Using where                                                         |
|  1 | PRIMARY     | samples       | eq_ref | PRIMARY                                                            | PRIMARY                           | 8       | idseq_development.pipeline_runs.sample_id      |    1 | Using index                                                         |
|  2 | SUBQUERY    | pipeline_runs | ref    | index_pipeline_runs_on_sample_id,index_pipeline_runs_on_job_status | index_pipeline_runs_on_job_status | 768     | const                                          | 7545 | Using index condition; Using where; Using temporary; Using filesort |
|  2 | SUBQUERY    | samples       | eq_ref | PRIMARY                                                            | PRIMARY                           | 8       | idseq_development.pipeline_runs.sample_id      |    1 | Using index                                                         |
|  2 | SUBQUERY    | samples       | eq_ref | PRIMARY                                                            | PRIMARY                           | 8       | idseq_development.pipeline_runs.sample_id      |    1 | Using index                                                         |
+----+-------------+---------------+--------+--------------------------------------------------------------------+-----------------------------------+---------+------------------------------------------------+------+---------------------------------------------------------------------+
</pre>
```
...
11 rows in set (1.47 sec)
```

Note: in the future, indexing and denormalizing these relations in ElasticSearch should help with performance.