### PR TITLE
Enable coverage_viz UI for all users.

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -787,10 +787,7 @@ class PipelineSampleReport extends React.Component {
       this.sampleId
     }/alignment_viz/nt_${taxLevel}_${taxId}?pipeline_version=${pipelineVersion}`;
 
-    if (
-      (this.admin || this.allowedFeatures.includes("coverage_viz")) &&
-      pipelineVersionHasCoverageViz(pipelineVersion)
-    ) {
+    if (pipelineVersionHasCoverageViz(pipelineVersion)) {
       this.props.onCoverageVizClick({
         taxId,
         taxName,

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -381,7 +381,6 @@ class SampleView extends React.Component {
   };
 
   coverageVizEnabled = () =>
-    (this.props.admin || this.props.allowedFeatures.includes("coverage_viz")) &&
     pipelineVersionHasCoverageViz(
       get("pipeline_version", this.props.reportPageParams)
     );

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -546,7 +546,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal(response.count, 2)
-    assert_equal(response.pluck("id"), @visualizations.pluck(:id))
+    assert_equal(response.pluck("id").sort, @visualizations.pluck(:id).sort)
   end
 
   test 'joe should see own plus public visualizations on all data domain' do


### PR DESCRIPTION
Verified that:
* Non-admin users can now view coverage viz for v3.6+ pipeline runs.
* Non-admin users still see the old alignment viz for v3.5 and before (admin get the same behavior). Page loads correctly with no errors.