### PR TITLE
[Data Discovery] Fix link to project page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'puma', '~> 3.7'
 # gem 'redis', '~> 3.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.5'
+gem 'rails-controller-testing'
 gem 'rake'
 # Worker/Scheduler management
 gem 'resque', '>= 1.27.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -932,6 +932,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.6.2)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -1009,10 +1013,6 @@ GEM
     shortener (0.8.0)
       voight_kampff (~> 1.1.2)
     silencer (1.0.1)
-    simple_token_authentication (1.15.1)
-      actionmailer (>= 3.2.6, < 6)
-      actionpack (>= 3.2.6, < 6)
-      devise (>= 3.2, < 6)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -1113,6 +1113,7 @@ DEPENDENCIES
   rack-host-redirect
   rack-mini-profiler
   rails (~> 5.1.5)
+  rails-controller-testing
   rake
   resque (>= 1.27.4)
   resque-lock
@@ -1122,7 +1123,6 @@ DEPENDENCIES
   selenium-webdriver
   shortener
   silencer
-  simple_token_authentication (~> 1.15, >= 1.15.1)
   sprockets-es6
   stackprof
   thread

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -71,7 +71,8 @@ class DiscoveryView extends React.Component {
   constructor(props) {
     super(props);
 
-    const { project } = this.props;
+    const { projectId } = this.props;
+
     this.urlParser = new UrlQueryParser({
       filters: "object",
       projectId: "number",
@@ -93,8 +94,8 @@ class DiscoveryView extends React.Component {
         loadingSamples: true,
         loadingDimensions: true,
         loadingStats: true,
-        project: project,
-        projectId: project && project.id,
+        project: null,
+        projectId: projectId,
         projectDimensions: [],
         projects: [],
         sampleDimensions: [],
@@ -827,7 +828,7 @@ DiscoveryView.propTypes = {
     DISCOVERY_DOMAIN_MY_DATA,
     DISCOVERY_DOMAIN_PUBLIC
   ]).isRequired,
-  project: PropTypes.object,
+  projectId: PropTypes.number,
   allowedFeatures: PropTypes.arrayOf(PropTypes.string)
 };
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -32,14 +32,15 @@ class HomeController < ApplicationController
     if current_user.allowed_feature_list.include?("data_discovery")
       project_id = params[:project_id]
       project = Project.find(params[:project_id])
-      if project
-        if current_user.owns_project?(project.id)
-          redirect_to action: "my_data", project_id: project_id
-        elsif project.public_access != 0
-          redirect_to action: "public", project_id: project_id
-        else current_user.admin?
-          redirect_to action: "all_data", project_id: project_id
-        end
+
+      redirect_to my_data_path if project.blank?
+
+      if current_user.owns_project?(project.id)
+        redirect_to action: "my_data", project_id: project_id
+      elsif project.public_access != 0
+        redirect_to action: "public", project_id: project_id
+      elsif current_user.admin?
+        redirect_to action: "all_data", project_id: project_id
       else
         redirect_to my_data_path
       end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -30,7 +30,19 @@ class HomeController < ApplicationController
 
   def index
     if current_user.allowed_feature_list.include?("data_discovery")
-      redirect_to my_data_path
+      project_id = params[:project_id]
+      project = Project.find(params[:project_id])
+      if project
+        if current_user.owns_project?(project.id)
+          redirect_to action: "my_data", project_id: project_id
+        elsif project.public_access != 0
+          redirect_to action: "public", project_id: project_id
+        else current_user.admin?
+          redirect_to action: "all_data", project_id: project_id
+        end
+      else
+        redirect_to my_data_path
+      end
     else
       legacy
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,6 +107,10 @@ class User < ApplicationRecord
     name.split[-1]
   end
 
+  def owns_project?(project_id)
+    projects.exists?(project_id)
+  end
+
   # This returns a hash of interesting optional data for Segment user tracking.
   # Make sure you use any reserved names as intended by Segment!
   # See https://segment.com/docs/spec/identify/#traits .

--- a/app/views/home/all_data.html.erb
+++ b/app/views/home/all_data.html.erb
@@ -3,6 +3,7 @@
   <%= javascript_tag do %>
     react_component('DiscoveryView', {
       domain: "all_data",
+      projectId: <%= params[:project_id] || "null" %>,
       allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
     }, 'page_content');
   <% end %>

--- a/app/views/home/my_data.html.erb
+++ b/app/views/home/my_data.html.erb
@@ -3,6 +3,7 @@
   <%= javascript_tag do %>
     react_component('DiscoveryView', {
       domain: "my_data",
+      projectId: <%= params[:project_id] || "null" %>,
       allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
     }, 'page_content');
   <% end %>

--- a/app/views/home/public.html.erb
+++ b/app/views/home/public.html.erb
@@ -3,6 +3,7 @@
   <%= javascript_tag do %>
     react_component('DiscoveryView', {
       domain: "public",
+      projectId: <%= params[:project_id] || "null" %>,
       allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
     }, 'page_content');
   <% end %>

--- a/db/migrate/20190502150040_add_index_tax_id_to_taxon_counts.rb
+++ b/db/migrate/20190502150040_add_index_tax_id_to_taxon_counts.rb
@@ -1,0 +1,5 @@
+class AddIndexTaxIdToTaxonCounts < ActiveRecord::Migration[5.1]
+  def change
+    add_index :taxon_counts, :tax_id
+  end
+end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class HomeControllerTest < ActionDispatch::IntegrationTest
-
   test 'joe redirected to project page in my_data when linking to joe_project with data_discovery' do
     sign_in(:joe_dd)
     @joe_project = projects(:joe_project)

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,7 +1,38 @@
 require 'test_helper'
 
 class HomeControllerTest < ActionDispatch::IntegrationTest
-  test 'the truth' do
-    assert true
+  test 'joe redirect to my_data when seeing joe_project with data_discovery' do
+    sign_in(:joe_dd)
+    @joe_project = projects(:joe_project)
+    get "/home?project_id=#{@joe_project.id}"
+    res = @response.body
+
+    assert_redirect_to(action: my_data, )
+    assert_response :success
+    puts res
   end
+
+  test 'joe redirect to my_data when seeing joe_project with data_discovery' do
+    sign_in(:joe_dd)
+    @joe_project = projects(:joe_project)
+    get "/home?project_id=#{@joe_project.id}"
+    res = @response.body
+
+    assert_redirect_to(action: my_data, )
+    assert_response :success
+    puts res
+  end
+
+  test 'joe redirect to my_data when seeing joe_project with data_discovery' do
+    sign_in(:joe_dd)
+    @joe_project = projects(:joe_project)
+    get "/home?project_id=#{@joe_project.id}"
+    res = @response.body
+
+    assert_redirect_to(action: my_data, )
+    assert_response :success
+    puts res
+  end
+
+  
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,38 +1,69 @@
 require 'test_helper'
 
 class HomeControllerTest < ActionDispatch::IntegrationTest
-  test 'joe redirect to my_data when seeing joe_project with data_discovery' do
+
+  test 'joe redirected to project page in my_data when linking to joe_project with data_discovery' do
     sign_in(:joe_dd)
     @joe_project = projects(:joe_project)
     get "/home?project_id=#{@joe_project.id}"
-    res = @response.body
 
-    assert_redirect_to(action: my_data, )
-    assert_response :success
-    puts res
+    assert_response :redirect
+    assert_redirected_to action: "my_data", controller: "home", project_id: @joe_project.id
   end
 
-  test 'joe redirect to my_data when seeing joe_project with data_discovery' do
+  test 'joe redirected to project page in public when linking to public_project with data_discovery' do
     sign_in(:joe_dd)
+    @public_project = projects(:public_project)
+    get "/home?project_id=#{@public_project.id}"
+
+    assert_response :redirect
+    assert_redirected_to action: "public", controller: "home", project_id: @public_project.id
+  end
+
+  test 'joe redirected to default my_data when linking to some other project with data_discovery' do
+    sign_in(:joe_dd)
+    @not_joe_project = projects(:not_joe_project)
+    get "/home?project_id=#{@not_joe_project.id}"
+
+    assert_response :redirect
+    assert_redirected_to action: "my_data", controller: "home"
+  end
+
+  # test admin can see
+
+  test 'admin redirected to project page in my_data when linking to its admin_project with data_discovery' do
+    sign_in(:admin)
+    @admin_project = projects(:admin_project)
+    get "/home?project_id=#{@admin_project.id}"
+
+    assert_response :redirect
+    assert_redirected_to action: "my_data", controller: "home", project_id: @admin_project.id
+  end
+
+  test 'admin redirected to project page in public when linking to public_project with data_discovery' do
+    sign_in(:admin)
+    @public_project = projects(:public_project)
+    get "/home?project_id=#{@public_project.id}"
+
+    assert_response :redirect
+    assert_redirected_to action: "public", controller: "home", project_id: @public_project.id
+  end
+
+  test 'admin redirected to project page in all_data when linking to other project with data_discovery' do
+    sign_in(:admin)
+    @not_joe_project = projects(:not_joe_project)
+    get "/home?project_id=#{@not_joe_project.id}"
+
+    assert_response :redirect
+    assert_redirected_to action: "all_data", controller: "home", project_id: @not_joe_project.id
+  end
+
+  test 'non-dd user sees legacy home page' do
+    sign_in(:joe)
     @joe_project = projects(:joe_project)
     get "/home?project_id=#{@joe_project.id}"
-    res = @response.body
 
-    assert_redirect_to(action: my_data, )
     assert_response :success
-    puts res
+    assert_template :legacy
   end
-
-  test 'joe redirect to my_data when seeing joe_project with data_discovery' do
-    sign_in(:joe_dd)
-    @joe_project = projects(:joe_project)
-    get "/home?project_id=#{@joe_project.id}"
-    res = @response.body
-
-    assert_redirect_to(action: my_data, )
-    assert_response :success
-    puts res
-  end
-
-  
 end

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -17,7 +17,7 @@ public_project:
 
 joe_project:
   name: Project 3
-  users: [joe]
+  users: [joe, joe_dd]
   metadata_fields: [sample_type, nucleotide_type, age, admission_date, blood_fed, reported_sex, sex]
 
 metadata_validation_project:

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -20,6 +20,15 @@ joe_project:
   users: [joe, joe_dd]
   metadata_fields: [sample_type, nucleotide_type, age, admission_date, blood_fed, reported_sex, sex]
 
+not_joe_project:
+  name: Not Joe's Project
+  public_access: 0
+
+admin_project:
+  name: Project of Admin user
+  public_access: 0
+  users: [admin]
+
 metadata_validation_project:
   name: Metadata Project
   users: [one]

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -27,3 +27,4 @@ admin:
   encrypted_password: <%= Devise::Encryptor.digest(User, "password") %>
   name: Admin User
   role: 1
+  allowed_features: "[\"data_discovery\"]"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -16,6 +16,12 @@ joe:
   encrypted_password: <%= Devise::Encryptor.digest(User, "password") %>
   name: User Three
 
+joe_dd:
+  email: joe_dd@gmail.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, "password") %>
+  name: User Three
+  allowed_features: "[\"data_discovery\"]"
+
 admin:
   email: admin@example.com
   encrypted_password: <%= Devise::Encryptor.digest(User, "password") %>


### PR DESCRIPTION
## Description

* Redirects previous project links to new DD project page
* The project page will load under `my_data`, `public` tabs depending on if the user owns the project or the project is public
* The user will be redirect to default `my_data` if the user has not permissions to see the project.
* backwards compatible with previous links

Note: a future change should replace this by the normal RESTful route `/projects/<project_id>`. To do that, we need to implement the admin features we have for the current project page.

## Test

* Add controller tests user access control
* Load `/home?project_id=<project_id>`, and check if the project opens on the correct tab.