### PR TITLE
Precache report info on success of pipeline run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,10 @@ gem 'shortener'
 # Explicit load to avoid an "unable to load" warning
 gem 'http-2'
 
+# Caching for action responses. Added for slow pages such sample report.
+# See https://github.com/rails/actionpack-action_caching .
+gem 'actionpack-action_caching'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'bundler-audit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionpack-action_caching (1.2.0)
+      actionpack (>= 4.0.0, < 6)
     actionview (5.1.6.2)
       activesupport (= 5.1.6.2)
       builder (~> 3.1)
@@ -1009,10 +1011,6 @@ GEM
     shortener (0.8.0)
       voight_kampff (~> 1.1.2)
     silencer (1.0.1)
-    simple_token_authentication (1.15.1)
-      actionmailer (>= 3.2.6, < 6)
-      actionpack (>= 3.2.6, < 6)
-      devise (>= 3.2, < 6)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -1076,6 +1074,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-action_caching
   active_record_query_trace
   activerecord-import
   activesupport
@@ -1122,7 +1121,6 @@ DEPENDENCIES
   selenium-webdriver
   shortener
   silencer
-  simple_token_authentication (~> 1.15, >= 1.15.1)
   sprockets-es6
   stackprof
   thread

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -214,7 +214,7 @@ class PipelineSampleReport extends React.Component {
     });
     let params = `?${window.location.search.replace("?", "")}&report_ts=${
       this.report_ts
-    }&version=${this.gitVersion}`;
+    }&git_version=${this.gitVersion}&format=json`;
 
     const [sampleReportInfo, summaryContigCounts] = await Promise.all([
       getSampleReportInfo(this.sampleId, params),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,6 +85,17 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # This provides IP whitelisting on top of token authentication for added security.
+  def authenticate_internal_user_from_token!
+    if request.remote_ip == "127.0.0.1"
+      authenticate_user_from_token!
+    else
+      Rails.logger.warn(
+        "Attempted to authenticate a non-internal user from IP #{request.remote_ip}"
+      )
+    end
+  end
+
   def check_browser
     browser = UserAgent.parse(request.user_agent).browser
     @browser_info = {

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -61,6 +61,9 @@ class SamplesController < ApplicationController
     MetricUtil.put_metric_now("samples.cache.requested", 1)
 
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
+    if pipeline_run.nil?
+      raise "Pipeline run not found for sample #{@sample.id}"
+    end
     report_info_params = pipeline_run.report_info_params
 
     # This allows 304 Not Modified to be returned so that the client can use its
@@ -70,7 +73,7 @@ class SamplesController < ApplicationController
 
     cache_keys = params.permit(report_info_params.keys)
     # Set background_id to a viewable background, same behavior as in report_info itself
-    cache_keys[:background_id] = get_background_id(params[:background_id])
+    cache_keys[:background_id] = get_background_id(@sample)
     cache_keys
   end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -60,7 +60,10 @@ class SamplesController < ApplicationController
   # rubocop:disable Style/Lambda
   caches_action :report_info, expires_in: REPORT_INFO_CACHE_EXPIRES, cache_path: -> do
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
-    params.permit(pipeline_run.report_info_params.keys)
+    cache_keys = params.permit(pipeline_run.report_info_params.keys)
+    # Set background_id to a viewable background, same behavior as in report_info itself
+    cache_keys[:background_id] = get_background_id(params[:background_id])
+    cache_keys
   end
 
   # GET /samples

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -58,6 +58,8 @@ class SamplesController < ApplicationController
   # when serving from the cache.
   # rubocop:disable Style/Lambda
   caches_action :report_info, cache_path: -> do
+    MetricUtil.put_metric_now("samples.cache.requested", 1)
+
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
     report_info_params = pipeline_run.report_info_params
 
@@ -742,6 +744,8 @@ class SamplesController < ApplicationController
   end
 
   def report_info
+    MetricUtil.put_metric_now("samples.cache.miss", 1)
+
     @pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
 
     ##################################################

--- a/app/jobs/precache_report_info.rb
+++ b/app/jobs/precache_report_info.rb
@@ -1,0 +1,13 @@
+class PrecacheReportInfo
+  @queue = :q03_pipeline_run
+
+  def self.perform(pipeline_run_id)
+    pr = PipelineRun.find(pipeline_run_id)
+    pr.precache_report_info!
+  rescue => err
+    LogUtil.log_err_and_airbrake(
+      "PipelineRun #{pipeline_run_id} failed to precache report_info"
+    )
+    LogUtil.log_backtrace(err)
+  end
+end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1419,6 +1419,7 @@ class PipelineRun < ApplicationRecord
 
   # This precaches reports for *all* backgrounds.
   # TODO: (gdingle): narrow to most likely to be hit, narrow to constant sized set.
+  # TODO: (gdingle): move to resque
   def precache_report_info!
     params = report_info_params
     Background.where(ready: 1).pluck(:id).each do |background_id|

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1407,9 +1407,9 @@ class PipelineRun < ApplicationRecord
       sort_by: "nt_aggregatescore",
       # For invalidation when data or config changes
       report_ts: [
-        updated_at.to_i,
-        sample.updated_at.to_i,
-        alignment_config.updated_at.to_i
+        updated_at.utc.to_i,
+        sample.updated_at.utc.to_i,
+        alignment_config.updated_at.utc.to_i
       ].max,
       # For invalidation when code changes
       git_version: ENV['GIT_VERSION'] || "",

--- a/app/views/samples/show.html.erb
+++ b/app/views/samples/show.html.erb
@@ -14,7 +14,6 @@
       summaryStats: JSON.parse('<%= raw escape_json(@summary_stats) %>'),
       reportPresent: <%= !!@report_present %>,
       reportTime: '<%=@report_ts%>',
-
       allCategories: JSON.parse('<%= raw escape_json(@all_categories)%>'),
       reportDetails: JSON.parse('<%= raw escape_json(@report_details)%>'),
       reportPageParams: JSON.parse('<%= raw escape_json(@report_page_params) %>'),

--- a/app/views/samples/show.html.erb
+++ b/app/views/samples/show.html.erb
@@ -14,6 +14,7 @@
       summaryStats: JSON.parse('<%= raw escape_json(@summary_stats) %>'),
       reportPresent: <%= !!@report_present %>,
       reportTime: '<%=@report_ts%>',
+
       allCategories: JSON.parse('<%= raw escape_json(@all_categories)%>'),
       reportDetails: JSON.parse('<%= raw escape_json(@report_details)%>'),
       reportPageParams: JSON.parse('<%= raw escape_json(@report_page_params) %>'),

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,8 +15,7 @@ Rails.application.configure do
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
-
-    config.cache_store = :memory_store
+    config.cache_store = :file_store, "/tmp/rails_cache_store"
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
     }
@@ -68,6 +67,9 @@ Rails.application.configure do
   config.action_controller.asset_host = proc { |source|
     "http://localhost:8080" if source =~ /wp_bundle\.js$/i
   }
+
+  # Custom for precaching by hitting URLs internally
+  config.idseq_precache_base_url = "http://localhost:3000"
 
   ActiveRecordQueryTrace.enabled = true
 

--- a/config/environments/prod.rb
+++ b/config/environments/prod.rb
@@ -13,6 +13,7 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
+  config.cache_store = :file_store, "/tmp/rails_cache_store"
 
   # Attempt to read encrypted secrets from `config/secrets.yml.enc`.
   # Requires an encryption key in `ENV["RAILS_MASTER_KEY"]` or
@@ -82,6 +83,9 @@ Rails.application.configure do
 
   config.action_controller.asset_host = 'idseq.net'
   config.middleware.use Rack::HostRedirect, 'www.idseq.net' => 'idseq.net'
+
+  # Custom for precaching by hitting URLs internally
+  config.idseq_precache_base_url = "https://idseq.net"
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -13,6 +13,7 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
+  config.cache_store = :file_store, "/tmp/rails_cache_store"
 
   # Attempt to read encrypted secrets from `config/secrets.yml.enc`.
   # Requires an encryption key in `ENV["RAILS_MASTER_KEY"]` or
@@ -80,6 +81,9 @@ Rails.application.configure do
 
   config.action_controller.asset_host = 'staging.idseq.net'
   config.middleware.use Rack::HostRedirect, 'www.staging.idseq.net' => 'staging.idseq.net'
+
+  # Custom for precaching by hitting URLs internally
+  config.idseq_precache_base_url = "https://staging.idseq.net"
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,8 +23,6 @@ Rails.application.configure do
   # config.action_controller.perform_caching = false
 
   # Configure caching to be the same as development
-  # TODO: (gdingle): fix me
-  # see https://makandracards.com/makandra/46189-how-to-rails-cache-for-individual-rspec-tests
   config.action_controller.perform_caching = true
   config.cache_store = :file_store, "/tmp/rails_cache_store"
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,14 +20,19 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  # config.action_controller.perform_caching = false
+
+  # Configure caching to be the same as development
+  # TODO: (gdingle): fix me
+  # see https://makandracards.com/makandra/46189-how-to-rails-cache-for-individual-rspec-tests
+  config.action_controller.perform_caching = true
+  config.cache_store = :file_store, "/tmp/rails_cache_store"
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
-  config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_426_002_714) do
+ActiveRecord::Schema.define(version: 20_190_502_150_040) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", null: false
+    t.string "name"
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type", null: false
+    t.string "source_type"
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -161,7 +161,7 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
   end
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "key", null: false
+    t.string "key", null: false, collation: "latin1_swedish_ci"
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9
@@ -313,7 +313,7 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1
+    t.integer "public_access", limit: 1, default: 0
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -431,14 +431,15 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
     t.integer "family_taxid", default: -300, null: false
     t.integer "is_phage", limit: 1, default: 0, null: false
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
+    t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
   end
 
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
     t.string "title"
-    t.text "summary"
-    t.text "description"
+    t.text "summary", limit: 16_777_215
+    t.text "description", limit: 16_777_215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -528,11 +529,11 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email", default: "", null: false
+    t.string "email"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password", default: "", null: false
+    t.string "encrypted_password"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -545,6 +546,7 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
     t.integer "role"
     t.text "allowed_features"
     t.string "institution", limit: 100
+    t.integer "projects_count", default: 0, null: false
     t.integer "samples_count", default: 0, null: false
     t.integer "favorite_projects_count", default: 0, null: false
     t.integer "favorites_count", default: 0, null: false
@@ -565,4 +567,6 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
     t.string "name"
     t.index ["user_id"], name: "index_visualizations_on_user_id"
   end
+
+  add_foreign_key "visualizations", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_502_150_040) do
+ActiveRecord::Schema.define(version: 20_190_426_002_714) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20_190_502_150_040) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define(version: 20_190_502_150_040) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 20_190_502_150_040) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type"
+    t.string "source_type", null: false
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -161,7 +161,7 @@ ActiveRecord::Schema.define(version: 20_190_502_150_040) do
   end
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "key", null: false, collation: "latin1_swedish_ci"
+    t.string "key", null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9
@@ -313,7 +313,7 @@ ActiveRecord::Schema.define(version: 20_190_502_150_040) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1, default: 0
+    t.integer "public_access", limit: 1
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -431,15 +431,14 @@ ActiveRecord::Schema.define(version: 20_190_502_150_040) do
     t.integer "family_taxid", default: -300, null: false
     t.integer "is_phage", limit: 1, default: 0, null: false
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
-    t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
   end
 
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
     t.string "title"
-    t.text "summary", limit: 16_777_215
-    t.text "description", limit: 16_777_215
+    t.text "summary"
+    t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -529,11 +528,11 @@ ActiveRecord::Schema.define(version: 20_190_502_150_040) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email"
+    t.string "email", default: "", null: false
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password"
+    t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -546,7 +545,6 @@ ActiveRecord::Schema.define(version: 20_190_502_150_040) do
     t.integer "role"
     t.text "allowed_features"
     t.string "institution", limit: 100
-    t.integer "projects_count", default: 0, null: false
     t.integer "samples_count", default: 0, null: false
     t.integer "favorite_projects_count", default: 0, null: false
     t.integer "favorites_count", default: 0, null: false
@@ -567,6 +565,4 @@ ActiveRecord::Schema.define(version: 20_190_502_150_040) do
     t.string "name"
     t.index ["user_id"], name: "index_visualizations_on_user_id"
   end
-
-  add_foreign_key "visualizations", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_426_002_714) do
+ActiveRecord::Schema.define(version: 20_190_502_150_040) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -431,6 +431,7 @@ ActiveRecord::Schema.define(version: 20_190_426_002_714) do
     t.integer "family_taxid", default: -300, null: false
     t.integer "is_phage", limit: 1, default: 0, null: false
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
+    t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
   end
 
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -349,4 +349,25 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
       }
     end
   end
+
+  test 'report_info should return cached copy on second request' do
+  end
+
+  test 'report_info should override background when background is not viewable' do
+  end
+
+  test 'report_info should return max-age 365 days on first request' do
+  end
+
+  test 'report_info should return max-age 365 days on second request' do
+  end
+
+  test 'report_info cache should invalidate on change of relevant params' do
+  end
+
+  test 'report_info cache should remain on change of irrelevant params' do
+  end
+
+  test 'report_info cache should not return if sample is not visible' do
+  end
 end

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -399,6 +399,16 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
   test 'report_info cache should invalidate on change of relevant params' do
     post user_session_path, params: @user_params
 
+    test_miss("background_id")
+    test_miss("scoring_model")
+    test_miss("sort_by")
+    test_miss("report_ts")
+    test_miss("git_version")
+  end
+
+  test 'report_info cache should remain on change of irrelevant params' do
+    post user_session_path, params: @user_params
+
     url = report_info_url
     get(url)
     assert_response :success
@@ -410,9 +420,6 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     cache_header = @response.headers["X-IDseq-Cache"]
     assert_equal "requested", cache_header
-  end
-
-  test 'report_info cache should remain on change of irrelevant params' do
   end
 
   private
@@ -431,5 +438,13 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
 
     path = "/samples/#{samples(sample_name).id}/report_info"
     path + "?" + query
+  end
+
+  def test_miss(key)
+    url = report_info_url(key => rand(10**10).to_s)
+    get(url)
+    assert_response :success
+    cache_header = @response.headers["X-IDseq-Cache"]
+    assert_equal "missed", cache_header
   end
 end

--- a/test/fixtures/backgrounds.yml
+++ b/test/fixtures/backgrounds.yml
@@ -2,7 +2,7 @@
 
 one:
   name: default
-  pipeline_runs: [three, four]
+  pipeline_runs: [three, four, six]
   ready: 1
 
 two:

--- a/test/fixtures/pipeline_runs.yml
+++ b/test/fixtures/pipeline_runs.yml
@@ -39,6 +39,7 @@ six:
   adjusted_remaining_reads: 316
   subsample: 1000000
   alignment_config: one
+  pipeline_version: '1.0'
 public_project_sampleA_run:
   sample: public_project_sampleA
   job_id: 'public_project_sampleA_job'

--- a/test/fixtures/pipeline_runs.yml
+++ b/test/fixtures/pipeline_runs.yml
@@ -40,6 +40,15 @@ six:
   subsample: 1000000
   alignment_config: one
   pipeline_version: '1.0'
+joe_sample_run:
+  sample: joe_sample
+  job_status: "CHECKED"
+  finalized: 1
+  total_reads: 1122
+  adjusted_remaining_reads: 316
+  subsample: 1000000
+  alignment_config: one
+  pipeline_version: '1.0'
 public_project_sampleA_run:
   sample: public_project_sampleA
   job_id: 'public_project_sampleA_job'


### PR DESCRIPTION
# Description

This fixes the bad perf of the sample report page by caching the http response as a file on disk by using the Rails standard action caching. The browser HTTP client-side caching behavior is preserved in prod, and enabled in dev.

My tests of a large sample show 
1) report_info time decreased from 8s to 1s by server side caching
2) report_info time decreased to less than 1s by client side caching

I refactored some of the `report_info` and child methods to make the param dependencies more clear.

I still have some questions about the correct defaults for params like `background_id` which will affect the cache hit rate. Note we can always precache with more param values. 

NOTE: the choice of cache keys means that the server cache of a report will be invalidated on 
* new pipeline run
* any update of sample object
* new code push

# Test and Reproduce

Test caching
1. Open a report such as http://localhost:3000/samples/12303
2. See SQL queries in rails log 
3. Reload the report 
4. See cache line in rails log such as 

```
ActiveSupport::Cache::FileStore : Cache read: /tmp/rails_cache_store/BD7/1E3/views%2Flocalhost%3A3000%2Fsamples%2F10399%2Freport_info.json%3Fbackground_id%3D29%26git_version%3D%26pipeline_version%3D3.3%26report_ts%3D1548725583%26sort_by%3Dnt_aggregatescore ({:expires_in=>365 days})
```

5. Verify that the decoded URL is correctly unique in param values
```/tmp/rails_cache_store/BD7/1E3/views/localhost:3000/samples/10399/report_info.json?background_id=29&git_version=&pipeline_version=3.3&report_ts=1548725583&sort_by=nt_aggregatescore```

6. Verify cache on further reloads of report page

7. Verify cache miss on changing background


Test precaching:

1.  In `rails console`, load a pipeline run
2. Precache  method and see the following:

```
irb(main):002:0> PipelineRun.find(18660).precache_report_info!
...
[2019-05-07T19:28:38] DEBUG Rails : Precaching URL http://localhost:3000/samples/12295/report_info?background_id=93&format=json&git_version=&pipeline_version=3.3&report_ts=1549325153&scoring_model=aggregate_score&sort_by=nt_aggregatescore
=> #<Tempfile:/tmp/open-uri20190507-144-u0xcg3>
```
3. Run it again and see a cache hit in the rails logs


Overall perf testing:

I'll review the stats before and after launch to prod in the airbrake dashboard. 