### PR TITLE
[MapPlayground] Add limits on the viewport (zoom and latitude)

### DIFF
--- a/app/assets/src/components/utils/format.js
+++ b/app/assets/src/components/utils/format.js
@@ -1,1 +1,4 @@
 export const formatPercent = number => `${(100 * number).toFixed(1)}%`;
+
+export const limitToRange = (number, min, max) =>
+  Math.min(max, Math.max(min, number));

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -58,7 +58,6 @@ class BaseMap extends React.Component {
           {...viewport}
           onViewportChange={this.updateViewport}
           mapStyle={styleURL}
-          // mapOptions={{ maxBounds: bounds }}
         >
           {tooltip}
           {markers}

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -27,11 +27,6 @@ class BaseMap extends React.Component {
   updateViewport = viewport => {
     const { updateViewport, viewBounds } = this.props;
 
-    viewport.zoom = limitToRange(
-      viewport.zoom,
-      viewBounds.minZoom,
-      viewBounds.maxZoom
-    );
     viewport.latitude = limitToRange(
       viewport.latitude,
       viewBounds.minLatitude,
@@ -41,6 +36,11 @@ class BaseMap extends React.Component {
       viewport.longitude,
       viewBounds.minLongitude,
       viewBounds.maxLongitude
+    );
+    viewport.zoom = limitToRange(
+      viewport.zoom,
+      viewBounds.minZoom,
+      viewBounds.maxZoom
     );
 
     this.setState({ viewport });
@@ -95,7 +95,7 @@ BaseMap.defaultProps = {
   latitude: 40,
   longitude: -98,
   zoom: 3,
-  // These bounds prevent panning too far north or south, although you will still see those regions at the widest zoom levels.
+  // These bounds prevent panning too far north or south, although you will still see those regions at the widest zoom levels. minZoom level frames most of the world. maxZoom level keeps you at an area about the size of a metropolitan area.
   viewBounds: {
     minLatitude: -60,
     maxLatitude: 60,

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -24,7 +24,16 @@ class BaseMap extends React.Component {
   }
 
   updateViewport = viewport => {
-    const { updateViewport } = this.props;
+    const { updateViewport, panBounds } = this.props;
+    console.log("Before: ", viewport.latitude, viewport.longitude);
+    viewport.zoom = Math.max(1.3, viewport.zoom);
+    viewport.latitude = Math.min(50, Math.max(-40, viewport.latitude));
+    viewport.longitude = Math.min(
+      panBounds.maxLongitude,
+      Math.max(panBounds.minLongitude, viewport.longitude)
+    );
+    console.log(viewport);
+    console.log(viewport.latitude, viewport.longitude);
     this.setState({ viewport });
     updateViewport && updateViewport(viewport);
   };
@@ -34,12 +43,17 @@ class BaseMap extends React.Component {
     const { viewport } = this.state;
 
     const styleURL = `https://api.maptiler.com/maps/${MAP_STYLE_ID}/style.json?key=${mapTilerKey}`;
+    const bounds = [
+      [-180, -70], // Southwest coordinates
+      [180, 75] // Northeast coordinates
+    ];
     return (
       <div className={cs.mapContainer}>
         <MapGL
           {...viewport}
           onViewportChange={this.updateViewport}
           mapStyle={styleURL}
+          // mapOptions={{ maxBounds: bounds }}
         >
           {tooltip}
           {markers}
@@ -64,18 +78,25 @@ BaseMap.propTypes = {
   latitude: PropTypes.number,
   longitude: PropTypes.number,
   zoom: PropTypes.number,
+  panBounds: PropTypes.objectOf(PropTypes.number),
   tooltip: PropTypes.node,
   markers: PropTypes.array,
   popups: PropTypes.array
 };
 
 BaseMap.defaultProps = {
-  width: 1000,
+  width: 1250,
   height: 1000,
   // United States framed
   latitude: 40,
   longitude: -98,
-  zoom: 3
+  zoom: 3,
+  panBounds: {
+    minLatitude: -70,
+    maxLatitude: 75,
+    minLongitude: -180,
+    maxLongitude: 180
+  }
 };
 
 export default BaseMap;


### PR DESCRIPTION
### Description
- Add limits to the viewport lat/lng/zoom so you don't see as much of Greenland/Antarctica. It's not perfect because the lat/lng corresponds to the center of the viewport and you can still zoom out to see more, but it does look better.
- Also changes the playground size to 1250x1000 to get closer to the rectangular shape it will take in Data Discovery.

### Demo
- Northbound:
![Screen Shot 2019-05-08 at 2 25 20 PM](https://user-images.githubusercontent.com/5652739/57409545-66340480-719d-11e9-89c4-17451c79e69f.png)

- Southbound:
![Screen Shot 2019-05-08 at 2 26 04 PM](https://user-images.githubusercontent.com/5652739/57409549-692ef500-719d-11e9-9f5e-5316420a20ff.png)

### Test and Reproduce
- Pull the branch, start with `MAPTILER_API_KEY=key docker-compose up web`, go to `http://localhost:3000/locations/map_playground`, and pan around the map.