### PR TITLE
[MapPlayground] Add a geosearch location entry demo to the page

### DIFF
--- a/app/assets/src/api/locations.js
+++ b/app/assets/src/api/locations.js
@@ -1,0 +1,6 @@
+import { get } from "./core";
+
+export const getGeoSearchSuggestions = query =>
+  get("/locations/external_search", {
+    params: { query }
+  });

--- a/app/assets/src/components/ui/controls/LiveSearchBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchBox.jsx
@@ -76,12 +76,11 @@ class LiveSearchBox extends React.Component {
   };
 
   render() {
-    const { hasCategories } = this.props;
     const { isLoading, value, results } = this.state;
-    console.log("I want to show: ", results);
+
     return (
       <Search
-        category={hasCategories}
+        category
         className={cs.liveSearchBox}
         loading={isLoading}
         onKeyDown={this.handleKeyDown}
@@ -99,8 +98,7 @@ class LiveSearchBox extends React.Component {
 LiveSearchBox.defaultProps = {
   delayTriggerSearch: 1000,
   initialValue: "",
-  minChars: 2,
-  hasCategories: true
+  minChars: 2
 };
 
 LiveSearchBox.propTypes = {
@@ -109,8 +107,7 @@ LiveSearchBox.propTypes = {
   minChars: PropTypes.number,
   onEnter: PropTypes.func,
   onSearchTriggered: PropTypes.func.isRequired,
-  onResultSelect: PropTypes.func,
-  hasCategories: PropTypes.bool
+  onResultSelect: PropTypes.func
 };
 
 export default LiveSearchBox;

--- a/app/assets/src/components/ui/controls/LiveSearchBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchBox.jsx
@@ -78,7 +78,7 @@ class LiveSearchBox extends React.Component {
   render() {
     const { hasCategories } = this.props;
     const { isLoading, value, results } = this.state;
-
+    console.log("I want to show: ", results);
     return (
       <Search
         category={hasCategories}

--- a/app/assets/src/components/ui/controls/LiveSearchBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchBox.jsx
@@ -76,11 +76,12 @@ class LiveSearchBox extends React.Component {
   };
 
   render() {
+    const { hasCategories } = this.props;
     const { isLoading, value, results } = this.state;
 
     return (
       <Search
-        category
+        category={hasCategories}
         className={cs.liveSearchBox}
         loading={isLoading}
         onKeyDown={this.handleKeyDown}
@@ -98,7 +99,8 @@ class LiveSearchBox extends React.Component {
 LiveSearchBox.defaultProps = {
   delayTriggerSearch: 1000,
   initialValue: "",
-  minChars: 2
+  minChars: 2,
+  hasCategories: true
 };
 
 LiveSearchBox.propTypes = {
@@ -107,7 +109,8 @@ LiveSearchBox.propTypes = {
   minChars: PropTypes.number,
   onEnter: PropTypes.func,
   onSearchTriggered: PropTypes.func.isRequired,
-  onResultSelect: PropTypes.func
+  onResultSelect: PropTypes.func,
+  hasCategories: PropTypes.bool
 };
 
 export default LiveSearchBox;

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -3,9 +3,13 @@ import PropTypes from "prop-types";
 import { Marker } from "react-map-gl";
 import { get } from "lodash/fp";
 
+import { getGeoSearchSuggestions } from "~/api/locations";
+import LiveSearchBox from "~ui/controls/LiveSearchBox";
 import BaseMap from "~/components/views/discovery/mapping/BaseMap";
 import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
 import MapTooltip from "~/components/views/discovery/mapping/MapTooltip";
+
+import cs from "./map_playground.scss";
 
 export const TOOLTIP_TIMEOUT_MS = 1000;
 
@@ -125,17 +129,34 @@ class MapPlayground extends React.Component {
     this.setState({ tooltipShouldClose: false });
   };
 
+  handleSearchTriggered = async query => {
+    const serverSideSuggestions = await getGeoSearchSuggestions(query);
+    console.log(serverSideSuggestions);
+    return serverSideSuggestions;
+  };
+
   render() {
     const { mapTilerKey } = this.props;
     const { locationsToItems, tooltip } = this.state;
 
     return (
-      <BaseMap
-        mapTilerKey={mapTilerKey}
-        updateViewport={this.updateViewport}
-        tooltip={tooltip}
-        markers={Object.entries(locationsToItems).map(this.renderMarker)}
-      />
+      <div>
+        <div className={cs.searchContainer}>
+          <LiveSearchBox
+            onSearchTriggered={this.handleSearchTriggered}
+            // onResultSelect={this.handleSearchResultSelected}
+            // onEnter={this.handleSearchEnterPressed}
+            placeholder="Search"
+            hasCategories={false}
+          />
+        </div>
+        <BaseMap
+          mapTilerKey={mapTilerKey}
+          updateViewport={this.updateViewport}
+          tooltip={tooltip}
+          markers={Object.entries(locationsToItems).map(this.renderMarker)}
+        />
+      </div>
     );
   }
 }

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -132,7 +132,14 @@ class MapPlayground extends React.Component {
   handleSearchTriggered = async query => {
     const serverSideSuggestions = await getGeoSearchSuggestions(query);
     console.log(serverSideSuggestions);
-    return serverSideSuggestions;
+    return {
+      Locations: {
+        name: "Locations",
+        results: serverSideSuggestions.map(r =>
+          Object.assign({}, r, { key: r.description })
+        )
+      }
+    };
   };
 
   render() {
@@ -147,7 +154,7 @@ class MapPlayground extends React.Component {
             // onResultSelect={this.handleSearchResultSelected}
             // onEnter={this.handleSearchEnterPressed}
             placeholder="Search"
-            hasCategories={false}
+            // hasCategories={false}
           />
         </div>
         <BaseMap

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -1,0 +1,3 @@
+.searchContainer {
+  margin: 10px;
+}

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -1,3 +1,10 @@
-.searchContainer {
-  margin: 10px;
+@import "~styles/themes/typography";
+
+.container {
+  margin: 20px;
+
+  .title {
+    @include font-header-m;
+    margin: 5px;
+  }
 }


### PR DESCRIPTION
### Description
- Adds a new location entry geosearch box based on <LiveSearchBox> to the MapPlayground page. It's unrelated to the map but convenient to put there for development before integrating into the full metadata upload flow.
- Next steps: Square styling, keeping the selected result in the box, getting the results dropdown to "pop out" of the modal box in the metadata upload.

### Demo
![Screen Shot 2019-05-08 at 5 46 26 PM](https://user-images.githubusercontent.com/5652739/57419928-a73a1200-71b9-11e9-8b85-c40745fefc03.png)
![May-08-2019 17-48-29](https://user-images.githubusercontent.com/5652739/57419930-a903d580-71b9-11e9-8514-b7d6280667ec.gif)

### Test and Reproduce
- Pull the branch, start with `LOCATION_IQ_API_KEY=key MAPTILER_API_KEY=key docker-compose up web`, go to `http://localhost:3000/locations/map_playground`.
- Type in search queries like California, White House, Uganda, Bangladesh, etc. and test the search box.