### PR TITLE
[Upload Page] Fix 'More Info' links

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
@@ -68,9 +68,11 @@ class LocalSampleFileUpload extends React.Component {
       {
         showInfo: !this.state.showInfo
       },
-      logAnalyticsEvent("LocalSampleFileUpload_more-info-toggle_clicked", {
-        showInfo: this.state.showInfo
-      })
+      () => {
+        logAnalyticsEvent("LocalSampleFileUpload_more-info-toggle_clicked", {
+          showInfo: this.state.showInfo
+        });
+      }
     );
   };
 

--- a/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
@@ -21,10 +21,11 @@ class RemoteSampleFileUpload extends React.Component {
       {
         showInfo: !this.state.showInfo
       },
-
-      logAnalyticsEvent("RemoteSampleFileUpload_more-info-toggle_clicked", {
-        showInfo: this.state.showInfo
-      })
+      () => {
+        logAnalyticsEvent("RemoteSampleFileUpload_more-info-toggle_clicked", {
+          showInfo: this.state.showInfo
+        });
+      }
     );
   };
 


### PR DESCRIPTION
### Description
- There was a bug in the setState calls so the page would crash when they try to view upload info
![Screen Shot 2019-05-09 at 10 26 49 AM](https://user-images.githubusercontent.com/5652739/57473672-3809ff80-7245-11e9-80e0-36cd4eeac481.png)

### Test and Reproduce
- Pull the branch, go to http://localhost:3000/samples/upload and toggle "More Info" in the "upload from your computer" and "upload from S3".