### PR TITLE
Ignore CZI users from perf stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'airbrake', '~> 8.3.2'
-gem 'airbrake-ruby'
+gem 'airbrake', '~> 9.2.2'
+gem 'airbrake-ruby', '~> 4.4'
 gem 'aws-sdk-ecs'
 gem 'aws-sdk-resources'
 gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,9 +43,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    airbrake (8.3.2)
-      airbrake-ruby (~> 4.1)
-    airbrake-ruby (4.2.1)
+    airbrake (9.2.2)
+      airbrake-ruby (~> 4.4)
+    airbrake-ruby (4.4.0)
       rbtree3 (~> 0.5)
     analytics-ruby (2.0.13)
     arel (8.0.0)
@@ -1079,8 +1079,8 @@ DEPENDENCIES
   active_record_query_trace
   activerecord-import
   activesupport
-  airbrake (~> 8.3.2)
-  airbrake-ruby
+  airbrake (~> 9.2.2)
+  airbrake-ruby (~> 4.4)
   analytics-ruby (~> 2.0.0)
   aws-sdk
   aws-sdk-ecs

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -73,6 +73,16 @@ if ENV['AIRBRAKE_PROJECT_ID'] && ENV['AIRBRAKE_PROJECT_KEY']
     end
   end
 
+  # Ignore CZI users from perf stats because they tend to be outliers
+  Airbrake.add_performance_hook do |resource|
+    if resource.stash.key?(:user)
+      email = resource.stash[:user][:email]
+      if email.present? && ["chanzuckerberg.com"].include?(email.split("@").last)
+        resource.ignore!
+      end
+    end
+  end
+
   # If you want to convert your log messages to Airbrake errors, we offer an
   # integration with the Logger class from stdlib.
   # https://github.com/airbrake/airbrake#logger


### PR DESCRIPTION
# Description

Ignore CZI users from perf stats because they tend to be outliers. This is a new feature of airbrake, and it will be useful for us immediately as we focus on web performance. 

# Test and Reproduce

After deployment to staging, check in airbrake that my hits as gdingle@chanzuckerberg.com don't show up. 

https://chanzuckerberg.airbrake.io/projects/158403/performance?dur=90m%2F1m&last_n=60&environment=staging&sortColumn=total.p95&sortDesc=true&page=1