### PR TITLE
[Location] Restrict playground access to admins

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,4 +1,6 @@
 class LocationsController < ApplicationController
+  before_action :admin_required
+
   GEOSEARCH_ERR_MSG = "Unable to perform geosearch".freeze
   LOCATION_LOAD_ERR_MSG = "Unable to load sample locations".freeze
 

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -87,13 +87,13 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "joe cannot see someone else's private map playground results" do
-    # TODO: Uncomment and use non-admin user once released
-    # post user_session_path, params: @user_params
-    # get map_playground_locations_path, as: :json
-    #
-    # assert_response :success
-    # results = JSON.parse(@response.body).map { |r| r["location"] }
-    # assert_not results.include?(metadata(:sample_collection_location).string_validated_value)
-  end
+  # TODO: Uncomment and use non-admin user once released
+  # test "joe cannot see someone else's private map playground results" do
+  #   post user_session_path, params: @user_params
+  #   get map_playground_locations_path, as: :json
+  #
+  #   assert_response :success
+  #   results = JSON.parse(@response.body).map { |r| r["location"] }
+  #   assert_not results.include?(metadata(:sample_collection_location).string_validated_value)
+  # end
 end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -3,7 +3,7 @@ require "minitest/mock"
 
 class LocationsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:joe)
+    @user = users(:admin) # Change to non-admin user once released
     @user_params = { "user[email]" => @user.email, "user[password]" => "password" }
     @api_response = true, [
       {
@@ -68,13 +68,14 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "user can see their map playground results" do
+    # TODO: Use non-admin user once released
     post user_session_path, params: @user_params
     get map_playground_locations_path, as: :json
 
     assert_response :success
     results = JSON.parse(@response.body)
-    assert results.count == 1
-    assert_equal metadata(:sample_joe_collection_location).string_validated_value, results[0]["location"]
+    assert results.count == 2
+    assert_includes results.pluck("location"), metadata(:sample_joe_collection_location).string_validated_value
   end
 
   test "user can see a map playground error" do
@@ -87,11 +88,12 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "joe cannot see someone else's private map playground results" do
-    post user_session_path, params: @user_params
-    get map_playground_locations_path, as: :json
-
-    assert_response :success
-    results = JSON.parse(@response.body).map { |r| r["location"] }
-    assert_not results.include?(metadata(:sample_collection_location).string_validated_value)
+    # TODO: Uncomment and use non-admin user once released
+    # post user_session_path, params: @user_params
+    # get map_playground_locations_path, as: :json
+    #
+    # assert_response :success
+    # results = JSON.parse(@response.body).map { |r| r["location"] }
+    # assert_not results.include?(metadata(:sample_collection_location).string_validated_value)
   end
 end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -3,7 +3,7 @@ require "minitest/mock"
 
 class LocationsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:joe)
+    @user = users(:admin) # Change to non-admin user once released
     @user_params = { "user[email]" => @user.email, "user[password]" => "password" }
     @api_response = true, [
       {
@@ -68,13 +68,14 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "user can see their map playground results" do
+    # TODO: Use non-admin user once released
     post user_session_path, params: @user_params
     get map_playground_locations_path, as: :json
 
     assert_response :success
     results = JSON.parse(@response.body)
-    assert results.count == 1
-    assert_equal metadata(:sample_joe_collection_location).string_validated_value, results[0]["location"]
+    assert results.count == 2
+    assert_includes results.pluck("location"), metadata(:sample_joe_collection_location).string_validated_value
   end
 
   test "user can see a map playground error" do
@@ -86,12 +87,13 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "joe cannot see someone else's private map playground results" do
-    post user_session_path, params: @user_params
-    get map_playground_locations_path, as: :json
-
-    assert_response :success
-    results = JSON.parse(@response.body).map { |r| r["location"] }
-    assert_not results.include?(metadata(:sample_collection_location).string_validated_value)
-  end
+  # TODO: Uncomment and use non-admin user once released
+  # test "joe cannot see someone else's private map playground results" do
+  #   post user_session_path, params: @user_params
+  #   get map_playground_locations_path, as: :json
+  #
+  #   assert_response :success
+  #   results = JSON.parse(@response.body).map { |r| r["location"] }
+  #   assert_not results.include?(metadata(:sample_collection_location).string_validated_value)
+  # end
 end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -3,7 +3,7 @@ require "minitest/mock"
 
 class LocationsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:admin) # Change to non-admin user once released
+    @user = users(:joe)
     @user_params = { "user[email]" => @user.email, "user[password]" => "password" }
     @api_response = true, [
       {
@@ -68,14 +68,13 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "user can see their map playground results" do
-    # TODO: Use non-admin user once released
     post user_session_path, params: @user_params
     get map_playground_locations_path, as: :json
 
     assert_response :success
     results = JSON.parse(@response.body)
-    assert results.count == 2
-    assert_includes results.pluck("location"), metadata(:sample_joe_collection_location).string_validated_value
+    assert results.count == 1
+    assert_equal metadata(:sample_joe_collection_location).string_validated_value, results[0]["location"]
   end
 
   test "user can see a map playground error" do
@@ -87,13 +86,12 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  # TODO: Uncomment and use non-admin user once released
-  # test "joe cannot see someone else's private map playground results" do
-  #   post user_session_path, params: @user_params
-  #   get map_playground_locations_path, as: :json
-  #
-  #   assert_response :success
-  #   results = JSON.parse(@response.body).map { |r| r["location"] }
-  #   assert_not results.include?(metadata(:sample_collection_location).string_validated_value)
-  # end
+  test "joe cannot see someone else's private map playground results" do
+    post user_session_path, params: @user_params
+    get map_playground_locations_path, as: :json
+
+    assert_response :success
+    results = JSON.parse(@response.body).map { |r| r["location"] }
+    assert_not results.include?(metadata(:sample_collection_location).string_validated_value)
+  end
 end


### PR DESCRIPTION
### Description
- I left this off before to decrease release friction but was asked to add an admin_required flag to the LocationsController endpoints

### Test and Reproduce
- Pull the branch, log in as a non-admin, try to visit http://localhost:3000/locations/map_playground or localhost:3000/locations/external_search?query=Uganda and get redirected to the home page.