### PR TITLE
Add Privacy Update Notification.

### DIFF
--- a/app/assets/src/components/common/header.scss
+++ b/app/assets/src/components/common/header.scss
@@ -66,3 +66,7 @@
     }
   }
 }
+
+.notificationLink {
+  text-decoration: underline;
+}

--- a/app/assets/src/components/views/support/FAQPage.jsx
+++ b/app/assets/src/components/views/support/FAQPage.jsx
@@ -9,7 +9,6 @@ export default class FAQPage extends React.Component {
         <div className={cs.title}>
           <h1>Frequently Asked Questions</h1>
         </div>
-        <h2>Privacy, Security, and Research</h2>
         <Accordion
           className={cs.question}
           header={<h3>Does IDseq own any of the data I upload to the tool?</h3>}

--- a/app/assets/src/components/views/support/PrivacyPolicy.jsx
+++ b/app/assets/src/components/views/support/PrivacyPolicy.jsx
@@ -10,7 +10,7 @@ export default class PrivacyPolicy extends React.Component {
           <h1>IDseq Data Privacy Notice</h1>
           <h4 className={cs.subtitle}>
             Last Updated: May 13, 2019.{" "}
-            <a href="/terms_changes">Recent Changes</a>. <a href="/faqs">FAQ</a>.
+            <a href="/terms_changes">See Recent Changes</a>
           </h4>
         </div>
         <p className={cs.large}>
@@ -302,11 +302,12 @@ export default class PrivacyPolicy extends React.Component {
         <p className={cs.large}>
           We (along with CZI (defined below)) have a legitimate interest in
           using personal data within Visitor Data and User Data in the ways
-          described in this Privacy Policy to provide, protect, and improve
-          IDseq. This allows us to improve the service that we provide to Users
-          which, in turn, supports research regarding the study of infectious
-          disease with the potential to benefit global public health. You can
-          contact us at <a href="mailto:privacy@idseq.net">privacy@idseq.net</a>.
+          described in this <a href="/privacy">Privacy Policy</a> to provide,
+          protect, and improve IDseq. This allows us to improve the service that
+          we provide to Users which, in turn, supports research regarding the
+          study of infectious disease with the potential to benefit global
+          public health. You can contact us at{" "}
+          <a href="mailto:privacy@idseq.net">privacy@idseq.net</a>.
         </p>
         <h2>
           <span className={cs.number}>4.</span>Vendors, and Other Third Parties.

--- a/app/assets/src/components/views/support/TermsChanges.jsx
+++ b/app/assets/src/components/views/support/TermsChanges.jsx
@@ -20,7 +20,7 @@ export default class TermsChanges extends React.Component {
         {/*TODO: Fill in a specific date*/}
         <p className={cs.large}>
           We are planning to update our Terms of Use and Data Privacy Notice for
-          the IDseq service to be effective on June XX, 2019. We encourage our
+          the IDseq service to be effective on June 24, 2019. We encourage our
           Users to read the revised <a href="/terms">Terms</a> and{" "}
           <a href="/privacy">Privacy Notice</a>. We have also provided more
           information about our updates through a new{" "}
@@ -211,7 +211,8 @@ export default class TermsChanges extends React.Component {
         <h2>IDseq Data Privacy Notice</h2>
         <p className={cs.large}>
           This summary is intended to help you better understand the most recent
-          changes to the IDseq Data Privacy Notice and how they may impact you.
+          changes to the <a href="/privacy">IDseq Data Privacy Notice</a> and
+          how they may impact you.
         </p>
         <h3>Introduction Section.</h3>
         <ul>

--- a/app/assets/src/components/views/support/TermsOfUse.jsx
+++ b/app/assets/src/components/views/support/TermsOfUse.jsx
@@ -9,9 +9,8 @@ export default class TermsOfUse extends React.Component {
         <div className={cs.title}>
           <h1>IDseq Terms of Use</h1>
           <h4 className={cs.subtitle}>
-            {/*TODO: Link to recent changes here*/}
             Last Updated: May 13, 2019.{" "}
-            <a href="/terms_changes">Recent Changes</a>. <a href="/faqs">FAQ</a>.
+            <a href="/terms_changes">See Recent Changes</a>
           </h4>
         </div>
         <p className={cs.large}>
@@ -100,7 +99,9 @@ export default class TermsOfUse extends React.Component {
         <p className={cs.large}>
           “<b>Database</b>” refers to both the data and database(s) of IDseq.
         </p>
-        <h3>Summary of Key Things to Know (see FAQ for more)</h3>
+        <h3>
+          Summary of Key Things to Know (see <a href="/faqs">FAQ</a> for more)
+        </h3>
         <ul>
           <li>
             <span className={cs.listItemLabel}>
@@ -128,7 +129,8 @@ export default class TermsOfUse extends React.Component {
             You represent that you have obtained, and will maintain, all
             consents, permissions, and authorizations needed to collect, share,
             and export Upload Data with IDseq, and for IDseq to use and share
-            the information as described in its Privacy Notice.
+            the information as described in its{" "}
+            <a href="/privacy">Privacy Notice</a>.
           </li>
           <li>
             <span className={cs.listItemLabel}>
@@ -328,8 +330,8 @@ export default class TermsOfUse extends React.Component {
             You agree to keep your Account Information accurate and up-to-date.
             You agree that we may send to the e-mail address you provide us or
             otherwise electronically deliver notices or communications regarding
-            IDseq, including notices of updates to these terms and the Privacy
-            Notice.
+            IDseq, including notices of updates to these terms and the{" "}
+            <a href="/privacy">Privacy Notice</a>.
           </li>
         </ul>
         <h2>
@@ -382,7 +384,7 @@ export default class TermsOfUse extends React.Component {
           </li>
           <li>
             <span className={cs.listItemLabel}>6.2 Feedback.</span>
-            We’d love your feedback about how to improve IDseq at
+            We’d love your feedback about how to improve IDseq at{" "}
             <a href="mailto:help@idseq.net">help@idseq.net</a>. That said, by
             giving us feedback, you agree that we can use and share it for any
             purpose without compensation to you. You agree that we are not
@@ -550,10 +552,10 @@ export default class TermsOfUse extends React.Component {
           </li>
           <li>
             <span className={cs.listItemLabel}>9.4 Entire Agreement.</span>
-            These Terms (along with the Privacy Notice) constitute the entire
-            agreement between you and us regarding IDseq. If you wish to modify
-            these Terms, any amendment must be provided to us in writing and
-            signed by our authorized representative.
+            These Terms (along with the <a href="/privacy">Privacy Notice</a>)
+            constitute the entire agreement between you and us regarding IDseq.
+            If you wish to modify these Terms, any amendment must be provided to
+            us in writing and signed by our authorized representative.
           </li>
         </ul>
         <h2>
@@ -563,7 +565,7 @@ export default class TermsOfUse extends React.Component {
           <li>
             If you have any questions, comments, or concerns with Terms, you may
             contact us at <a href="mailto:help@idseq.net">help@idseq.net</a> or
-            by physical mail at the addresses in the FAQ.
+            by physical mail at the addresses in the <a href="/faqs">FAQ</a>.
           </li>
         </ul>
       </NarrowContainer>


### PR DESCRIPTION
Also small tweaks to Terms and Privacy page.
For example, linking to the FAQ page when we mention FAQ.

Verified that:
* Non-logged-in users don't see this notice.
* Logged-in users only see the notice once.
* Once the user clicks dismiss or clicks on the link, the notice goes away.
* Logging out and back in doesn't re-trigger the message. (But signing on on incognito does, as expected)

![Screen Shot 2019-05-20 at 4 46 21 PM](https://user-images.githubusercontent.com/837004/58058796-2f57da00-7b1f-11e9-99c9-a477389958ef.png)
