### PR TITLE
Fix a Location test

### DIFF
--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -40,6 +40,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
 
   test "user can geosearch and see an error" do
     post user_session_path, params: @user_params
+    ENV["LOCATION_IQ_API_KEY"] = nil
     get external_search_locations_path, params: { query: "UCSF" }
     assert_response :error
     assert_equal LocationsController::GEOSEARCH_ERR_MSG, JSON.parse(@response.body)["message"]


### PR DESCRIPTION
- Bad test writing in relying on ENV["LOCATION_IQ_API_KEY"] == nil to trigger a test error when it could get set by a previous test.

# Test and Reproduce
- Run `docker-compose run web "SEED=36363 rake test"`. It would fail before (on Travis) but now passes.