### PR TITLE
Fix slow heatmap query

### DIFF
--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -541,9 +541,9 @@ module ReportHelper
 
   def self.fetch_parent_ids(taxon_ids, samples)
     # Get parent (genus,family) ids for the taxon_ids based on the samples
-    pipeline_run_ids = PipelineRun.where(sample_id: samples.pluck(:id)).pluck(:id)
     TaxonCount.select("distinct genus_taxid, family_taxid")
-              .where(pipeline_run_id: pipeline_run_ids)
+              .joins(:pipeline_run)
+              .where(pipeline_runs: { sample: samples })
               .where(tax_id: taxon_ids)
               .map { |u| u.attributes.values.compact }.flatten
   end

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -530,11 +530,13 @@ module ReportHelper
         pr = pipeline_runs_by_id[pipeline_run_id]
         result_hash[pipeline_run_id] = { "pr" => pr, "taxon_counts" => [] }
       end
-      row["rpm"] = row["r"] / ((pr.total_reads - pr.total_ercc_reads.to_i) * pr.subsample_fraction) * 1_000_000.0
-      row["zscore"] = row["stdev"].nil? ? ZSCORE_WHEN_ABSENT_FROM_BACKGROUND : ((row["rpm"] - row["mean"]) / row["stdev"])
-      row["zscore"] = ZSCORE_MAX if row["zscore"] > ZSCORE_MAX && row["zscore"] != ZSCORE_WHEN_ABSENT_FROM_BACKGROUND
-      row["zscore"] = ZSCORE_MIN if row["zscore"] < ZSCORE_MIN
-      result_hash[pipeline_run_id]["taxon_counts"] << row
+      if pr.total_reads
+        row["rpm"] = row["r"] / ((pr.total_reads - pr.total_ercc_reads.to_i) * pr.subsample_fraction) * 1_000_000.0
+        row["zscore"] = row["stdev"].nil? ? ZSCORE_WHEN_ABSENT_FROM_BACKGROUND : ((row["rpm"] - row["mean"]) / row["stdev"])
+        row["zscore"] = ZSCORE_MAX if row["zscore"] > ZSCORE_MAX && row["zscore"] != ZSCORE_WHEN_ABSENT_FROM_BACKGROUND
+        row["zscore"] = ZSCORE_MIN if row["zscore"] < ZSCORE_MIN
+        result_hash[pipeline_run_id]["taxon_counts"] << row
+      end
     end
     result_hash
   end
@@ -609,11 +611,13 @@ module ReportHelper
         pr = pipeline_runs_by_id[pipeline_run_id]
         result_hash[pipeline_run_id] = { "pr" => pr, "taxon_counts" => [] }
       end
-      row["rpm"] = row["r"] / ((pr.total_reads - pr.total_ercc_reads.to_i) * pr.subsample_fraction) * 1_000_000.0
-      row["zscore"] = row["stdev"].nil? ? ZSCORE_WHEN_ABSENT_FROM_BACKGROUND : ((row["rpm"] - row["mean"]) / row["stdev"])
-      row["zscore"] = ZSCORE_MAX if row["zscore"] > ZSCORE_MAX && row["zscore"] != ZSCORE_WHEN_ABSENT_FROM_BACKGROUND
-      row["zscore"] = ZSCORE_MIN if row["zscore"] < ZSCORE_MIN
-      result_hash[pipeline_run_id]["taxon_counts"] << row
+      if pr.total_reads
+        row["rpm"] = row["r"] / ((pr.total_reads - pr.total_ercc_reads.to_i) * pr.subsample_fraction) * 1_000_000.0
+        row["zscore"] = row["stdev"].nil? ? ZSCORE_WHEN_ABSENT_FROM_BACKGROUND : ((row["rpm"] - row["mean"]) / row["stdev"])
+        row["zscore"] = ZSCORE_MAX if row["zscore"] > ZSCORE_MAX && row["zscore"] != ZSCORE_WHEN_ABSENT_FROM_BACKGROUND
+        row["zscore"] = ZSCORE_MIN if row["zscore"] < ZSCORE_MIN
+        result_hash[pipeline_run_id]["taxon_counts"] << row
+      end
     end
 
     result_hash


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/28797/58132432-22e28880-7bd6-11e9-9b61-86204ec2cdab.png)

Profiling showed that one query was taking 50% of the time, 6s, in my test heatmap of all samples in the medical detectives project. Strangely, the query was quite simple, but I consistently reproduced the slowness in isolation in the mysql CLI, both locally and in prod. SQL `EXPLAIN` showed row scan of ~5k rows. 

```
+----+-------------+--------------+-------+--------------------------------------------------------+------------------------------+---------+------+------+----------------------------------------------------------------+
| id | select_type | table        | type  | possible_keys                                          | key                          | key_len | ref  | rows | Extra                                                          |
+----+-------------+--------------+-------+--------------------------------------------------------+------------------------------+---------+------+------+----------------------------------------------------------------+
|  1 | SIMPLE      | taxon_counts | range | index_pr_tax_hit_level_tc,index_taxon_counts_on_tax_id | index_taxon_counts_on_tax_id | 5       | NULL | 5814 | Using index condition; Using where; Using MRR; Using temporary |
+----+-------------+--------------+-------+--------------------------------------------------------+------------------------------+---------+------+------+----------------------------------------------------------------+
```

I noticed that the a previous query in the code could be combined logically with the slow one. After combining, the new query took <1s. I'm not exactly sure why. The `EXPLAIN` shows 1020 rows scanned.

```
+----+-------------+--------------+-------+--------------------------------------------------------+------------------------------+---------+------+------+-----------------------------------------------------+
| id | select_type | table        | type  | possible_keys                                          | key                          | key_len | ref  | rows | Extra                                               |
+----+-------------+--------------+-------+--------------------------------------------------------+------------------------------+---------+------+------+-----------------------------------------------------+
|  1 | SIMPLE      | taxon_counts | range | index_pr_tax_hit_level_tc,index_taxon_counts_on_tax_id | index_taxon_counts_on_tax_id | 5       | NULL | 1020 | Using index condition; Using where; Using temporary |
+----+-------------+--------------+-------+--------------------------------------------------------+------------------------------+---------+------+------+-----------------------------------------------------+
```

Anyway, this improvement should make the heatmaps much more usable. Based on the profiling, the next win would be to cache the JSON response client and-or server side. This would help the next load of a heatmap with particular settings. 

Precaching heatmap info for a pipeline run would be doable but complicated. 

# Test

1. run query before and after in CLI, no SQL caching
2. see time decrease from ~6s to <1s
3. check the row count is the same

---

1. open a heatmap
2. change the query 
3. see the page load time decrease ~5s
4. see the heatmap is itself the same