### PR TITLE
More cache logging

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -746,6 +746,7 @@ class SamplesController < ApplicationController
     response.headers["Last-Modified"] = httpdate
     # This is a custom header for testing and debugging
     response.headers["X-IDseq-Cache"] = 'requested'
+    Rails.logger.info("Requesting report_info #{cache_key}")
 
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
     json = Rails.cache.fetch(cache_key, expires_in: 30.days) do

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1439,7 +1439,7 @@ class PipelineRun < ApplicationRecord
         "/samples/#{sample.id}/report_info",
         params.merge(background_id: background_id)
       )
-      Rails.logger.debug("Precaching #{cache_key} with background #{background_id}")
+      Rails.logger.info("Precaching #{cache_key} with background #{background_id}")
       Rails.cache.fetch(cache_key, expires_in: 30.days) do
         ReportHelper.report_info_json(self, background_id)
       end


### PR DESCRIPTION
# Description

The first few idseq bench runs in prod are not being precached correctly. First open of the report page with defaults still results in a cache miss. 

This adds more logging to see what's going on. 

I also created this dashboard for cache hit rate: https://app.datadoghq.com/dashboard/h6d-92u-nw4?from_ts=1558396311493&to_ts=1558482711493&live=true&tile_size=m

![image](https://user-images.githubusercontent.com/28797/58138667-1ff29280-7bec-11e9-8291-762882d6b3cf.png)

# Test

Load a report 
See no errors


Wait for staging
See logs in datadog