### PR TITLE
[MapPlayground] Switchover to new Locations to display

### DIFF
--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Marker } from "react-map-gl";
-import { get, isString } from "lodash/fp";
+import { get } from "lodash/fp";
 
 import BaseMap from "~/components/views/discovery/mapping/BaseMap";
 import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -40,12 +40,13 @@ class LocationsController < ApplicationController
     end
 
     # Show all viewable locations in a demo format
-    field_id = MetadataField.find_by(name: "collection_location").id
+    field_id = MetadataField.find_by(name: "new_collection_location").id
     sample_info = current_power.samples
                                .includes(metadata: :metadata_field)
                                .where(metadata: { metadata_field_id: field_id })
-                               .pluck(:id, :name, :string_validated_value)
-    @results = sample_info.map { |s| { id: s[0], name: s[1], location: s[2] } }
+                               .where.not(metadata: { location_id: nil })
+                               .pluck(:id, :name, :location_id)
+    @results = sample_info.map { |s| { id: s[0], name: s[1], location_validated_value: Location.find(s[2]).attributes } }
 
     respond_to do |format|
       format.html { render :map_playground }

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -40,7 +40,7 @@ class LocationsController < ApplicationController
     end
 
     # Show all viewable locations in a demo format
-    field_id = MetadataField.find_by(name: "new_collection_location").id
+    field_id = MetadataField.find_by(name: "collection_location_v2").id
     sample_info = current_power.samples
                                .includes(metadata: :metadata_field)
                                .where(metadata: { metadata_field_id: field_id })

--- a/db/migrate/20190522175035_rename_new_location.rb
+++ b/db/migrate/20190522175035_rename_new_location.rb
@@ -1,0 +1,15 @@
+class RenameNewLocation < ActiveRecord::Migration[5.1]
+  def up
+    existing = MetadataField.find_by(name: "new_collection_location")
+    if existing
+      existing.update(name: "collection_location_v2", display_name: "Collection Location v2")
+    end
+  end
+
+  def down
+    existing = MetadataField.find_by(name: "collection_location_v2")
+    if existing
+      existing.update(name: "new_collection_location", display_name: "New Collection Location")
+    end
+  end
+end

--- a/db/migrate/20190522175035_rename_new_location.rb
+++ b/db/migrate/20190522175035_rename_new_location.rb
@@ -4,6 +4,7 @@ class RenameNewLocation < ActiveRecord::Migration[5.1]
     if existing
       existing.update(name: "collection_location_v2", display_name: "Collection Location v2")
     end
+    Metadatum.where(key: "new_collection_location").update_all(key: "collection_location_v2") # rubocop:disable SkipsModelValidations
   end
 
   def down
@@ -11,5 +12,6 @@ class RenameNewLocation < ActiveRecord::Migration[5.1]
     if existing
       existing.update(name: "new_collection_location", display_name: "New Collection Location")
     end
+    Metadatum.where(key: "collection_location_v2").update_all(key: "new_collection_location") # rubocop:disable SkipsModelValidations
   end
 end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -53,8 +53,8 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     results = JSON.parse(@response.body)
-    assert results.count == 2
-    assert_includes results.pluck("location"), metadata(:sample_joe_collection_location).string_validated_value
+    assert_equal 1, results.count
+    assert_includes @response.body, locations(:swamp).name
   end
 
   test "user can see a map playground error" do

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -1,3 +1,7 @@
 ucsf:
   name: "University of California, San Francisco, Parnassus Avenue, Inner Sunset, San Francisco, San Francisco City and County, California, 94131, USA"
   geo_level: "city"
+
+swamp:
+  name: "Swamp of Mosquitos"
+  id: 1

--- a/test/fixtures/metadata.yml
+++ b/test/fixtures/metadata.yml
@@ -72,7 +72,7 @@ sample_human_expired_age:
   sample: sample_human_existing_metadata_expired
   metadata_field: age
 
-sample_new_collection_location:
-  key: "new_collection_location"
+sample_collection_location_v2:
+  key: "collection_location_v2"
   raw_value: "{\"locationiq_id\":\"123\",\"osm_id\":\"321\",\"osm_type\":\"Way\"}"
-  metadata_field: new_collection_location
+  metadata_field: collection_location_v2

--- a/test/fixtures/metadata.yml
+++ b/test/fixtures/metadata.yml
@@ -76,3 +76,5 @@ sample_collection_location_v2:
   key: "collection_location_v2"
   raw_value: "{\"locationiq_id\":\"123\",\"osm_id\":\"321\",\"osm_type\":\"Way\"}"
   metadata_field: collection_location_v2
+  location_id: 1
+  sample: joe_project_sample_mosquito

--- a/test/fixtures/metadata_fields.yml
+++ b/test/fixtures/metadata_fields.yml
@@ -57,7 +57,7 @@ collection_location:
   display_name: "Collection Location"
   base_type: 0
 
-new_collection_location:
-  name: "new_collection_location"
-  display_name: "New Collection Location"
+collection_location_v2:
+  name: "collection_location_v2"
+  display_name: "Collection Location v2"
   base_type: 3

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -6,7 +6,7 @@ class MetadatumTest < ActiveSupport::TestCase
 
   test "should check and set Location Metadatum types" do
     mock_create = MiniTest::Mock.new
-    loc = metadata(:sample_new_collection_location)
+    loc = metadata(:sample_collection_location_v2)
     fields = JSON.parse(loc.raw_value, symbolize_names: true)
     mock_create.expect(:call, locations(:ucsf), [fields[:locationiq_id], fields[:osm_id], fields[:osm_type]])
 
@@ -18,7 +18,7 @@ class MetadatumTest < ActiveSupport::TestCase
   end
 
   test "should raise Location validation/setting errors" do
-    loc = metadata(:sample_new_collection_location)
+    loc = metadata(:sample_collection_location_v2)
     loc.raw_value = "{\"locationiq_id\":\"123\"}"
     loc.check_and_set_location_type
     assert_match MetadataValidationErrors::INVALID_LOCATION, loc.errors.full_messages[0]


### PR DESCRIPTION
### Description
- Updates the MapPlayground to use the new Locations model. Now it will only display 'resolved' locations since parsing lat/lon name strings was a temporary demo.
- Now you can test out a whole flow by going to a sample in project "CI", adding a New Collection Location in the sidebar, picking a location, and then seeing it in /locations/map_playground !

### Demo
![Screen Shot 2019-05-22 at 10 40 17 AM](https://user-images.githubusercontent.com/5652739/58195946-069a2680-7c7e-11e9-8ddd-b46157fdd871.png)

### Test and Reproduce
- Start with map keys loaded, go to /locations/map_playground, see new_collection_locations displayed. Add locations as described above.