### PR TITLE
[Maps] Add a map toggle + empty map to Data Discovery Samples view

### DIFF
--- a/app/assets/src/components/ui/controls/Menu.jsx
+++ b/app/assets/src/components/ui/controls/Menu.jsx
@@ -1,6 +1,7 @@
 import { Menu as BaseMenu } from "semantic-ui-react";
 import PropTypes from "prop-types";
 import React from "react";
+import cx from "classnames";
 
 class Menu extends React.Component {
   constructor(props) {
@@ -8,8 +9,9 @@ class Menu extends React.Component {
   }
 
   render() {
+    const { className } = this.props;
     return (
-      <BaseMenu className="idseq-ui" {...this.props}>
+      <BaseMenu className={cx("idseq-ui", className)} {...this.props}>
         {this.props.children}
       </BaseMenu>
     );
@@ -17,6 +19,7 @@ class Menu extends React.Component {
 }
 
 Menu.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
@@ -29,8 +32,9 @@ class MenuItem extends React.Component {
   }
 
   render() {
+    const { className } = this.props;
     return (
-      <BaseMenu.Item className="idseq-ui" {...this.props}>
+      <BaseMenu.Item className={cx("idseq-ui", className)} {...this.props}>
         {this.props.children}
       </BaseMenu.Item>
     );
@@ -38,6 +42,7 @@ class MenuItem extends React.Component {
 }
 
 MenuItem.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -84,6 +84,7 @@ class DiscoveryView extends React.Component {
 
     this.state = defaults(
       {
+        currentDisplay: "table",
         currentTab: projectId ? "samples" : "projects",
         filteredProjectDimensions: [],
         filteredSampleDimensions: [],
@@ -663,6 +664,7 @@ class DiscoveryView extends React.Component {
 
   render() {
     const {
+      currentDisplay,
       currentTab,
       filteredProjectDimensions,
       filteredSampleDimensions,
@@ -686,7 +688,7 @@ class DiscoveryView extends React.Component {
       visualizations
     } = this.state;
 
-    const { domain } = this.props;
+    const { domain, allowedFeatures } = this.props;
 
     const tabs = this.computeTabs();
     const dimensions = this.getCurrentDimensions();
@@ -700,9 +702,7 @@ class DiscoveryView extends React.Component {
               project={project || {}}
               fetchedSamples={samples}
               onProjectUpdated={this.handleProjectUpdated}
-              newSampleUpload={this.props.allowedFeatures.includes(
-                "new_sample_upload"
-              )}
+              newSampleUpload={allowedFeatures.includes("new_sample_upload")}
             />
           )}
           <DiscoveryHeader
@@ -766,6 +766,8 @@ class DiscoveryView extends React.Component {
                       selectableIds={sampleIds}
                       onSampleSelected={this.handleSampleSelected}
                       projectId={projectId}
+                      currentDisplay={currentDisplay}
+                      allowedFeatures={allowedFeatures}
                     />
                   </div>
                   {!samples.length &&

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -662,6 +662,10 @@ class DiscoveryView extends React.Component {
     );
   };
 
+  handleDisplaySwitch = currentDisplay => {
+    this.setState({ currentDisplay });
+  };
+
   render() {
     const {
       currentDisplay,
@@ -768,6 +772,7 @@ class DiscoveryView extends React.Component {
                       projectId={projectId}
                       currentDisplay={currentDisplay}
                       allowedFeatures={allowedFeatures}
+                      onDisplaySwitch={this.handleDisplaySwitch}
                     />
                   </div>
                   {!samples.length &&

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -692,7 +692,7 @@ class DiscoveryView extends React.Component {
       visualizations
     } = this.state;
 
-    const { domain, allowedFeatures } = this.props;
+    const { domain, allowedFeatures, mapTilerKey } = this.props;
 
     const tabs = this.computeTabs();
     const dimensions = this.getCurrentDimensions();
@@ -773,6 +773,7 @@ class DiscoveryView extends React.Component {
                       currentDisplay={currentDisplay}
                       allowedFeatures={allowedFeatures}
                       onDisplaySwitch={this.handleDisplaySwitch}
+                      mapTilerKey={mapTilerKey}
                     />
                   </div>
                   {!samples.length &&
@@ -836,7 +837,8 @@ DiscoveryView.propTypes = {
     DISCOVERY_DOMAIN_PUBLIC
   ]).isRequired,
   projectId: PropTypes.number,
-  allowedFeatures: PropTypes.arrayOf(PropTypes.string)
+  allowedFeatures: PropTypes.arrayOf(PropTypes.string),
+  mapTilerKey: PropTypes.string
 };
 
 export default DiscoveryView;

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -25,7 +25,7 @@ class BaseMap extends React.Component {
   }
 
   updateViewport = viewport => {
-    const { updateViewport, viewBounds } = this.props;
+    const { updateViewport, viewBounds, width, height } = this.props;
 
     viewport.latitude = limitToRange(
       viewport.latitude,
@@ -43,7 +43,7 @@ class BaseMap extends React.Component {
       viewBounds.maxZoom
     );
 
-    this.setState({ viewport });
+    this.setState({ viewport, width, height });
     updateViewport && updateViewport(viewport);
   };
 
@@ -77,8 +77,8 @@ class BaseMap extends React.Component {
 BaseMap.propTypes = {
   mapTilerKey: PropTypes.string.isRequired,
   updateViewport: PropTypes.func,
-  width: PropTypes.number,
-  height: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   latitude: PropTypes.number,
   longitude: PropTypes.number,
   zoom: PropTypes.number,
@@ -89,8 +89,8 @@ BaseMap.propTypes = {
 };
 
 BaseMap.defaultProps = {
-  width: 1250,
-  height: 1000,
+  width: "100%",
+  height: "100%",
   // United States framed
   latitude: 40,
   longitude: -98,

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -27,6 +27,9 @@ class BaseMap extends React.Component {
   updateViewport = viewport => {
     const { updateViewport, viewBounds, width, height } = this.props;
 
+    // Let width/height update on resize
+    viewport.width = width;
+    viewport.height = height;
     viewport.latitude = limitToRange(
       viewport.latitude,
       viewBounds.minLatitude,
@@ -43,7 +46,7 @@ class BaseMap extends React.Component {
       viewBounds.maxZoom
     );
 
-    this.setState({ viewport, width, height });
+    this.setState({ viewport });
     updateViewport && updateViewport(viewport);
   };
 

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Marker } from "react-map-gl";
 import { get } from "lodash/fp";
+import cx from "classnames";
 
 import BaseMap from "~/components/views/discovery/mapping/BaseMap";
 import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
@@ -124,7 +125,7 @@ class MapPlayground extends React.Component {
           <GeoSearchInputBox onResultSelect={this.handleSearchResultSelected} />
           {searchResult && `Selected: ${JSON.stringify(searchResult)}`}
         </div>
-        <div className={cs.container}>
+        <div className={cx(cs.container, cs.mapDemo)}>
           <div className={cs.title}>Map display demo:</div>
           <BaseMap
             mapTilerKey={mapTilerKey}

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Marker } from "react-map-gl";
 import { get } from "lodash/fp";
-import cx from "classnames";
 
 import BaseMap from "~/components/views/discovery/mapping/BaseMap";
 import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
@@ -125,13 +124,15 @@ class MapPlayground extends React.Component {
           <GeoSearchInputBox onResultSelect={this.handleSearchResultSelected} />
           {searchResult && `Selected: ${JSON.stringify(searchResult)}`}
         </div>
-        <div className={cx(cs.container, cs.mapDemo)}>
+        <div className={cs.container}>
           <div className={cs.title}>Map display demo:</div>
           <BaseMap
             mapTilerKey={mapTilerKey}
             updateViewport={this.updateViewport}
             tooltip={tooltip}
             markers={Object.entries(locationsToItems).map(this.renderMarker)}
+            width={1250}
+            height={1000}
           />
         </div>
       </div>

--- a/app/assets/src/components/views/discovery/mapping/base_map.scss
+++ b/app/assets/src/components/views/discovery/mapping/base_map.scss
@@ -2,8 +2,10 @@
 @import "~styles/themes/colors";
 
 .mapContainer {
-  display: inline-block;
-  border: 1px solid $dark-grey;
+  display: block;
+  position: relative;
+  flex: 1 0 auto;
+  flex-direction: column;
 
   .zoomControl {
     position: absolute;

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -8,3 +8,9 @@
     margin: 5px;
   }
 }
+
+.mapDemo {
+  position: absolute;
+  width: 1000px;
+  height: 1000px;
+}

--- a/app/assets/src/components/views/discovery/mapping/map_playground.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_playground.scss
@@ -8,9 +8,3 @@
     margin: 5px;
   }
 }
-
-.mapDemo {
-  position: absolute;
-  width: 1000px;
-  height: 1000px;
-}

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -421,12 +421,7 @@ class SamplesView extends React.Component {
     const { mapTilerKey } = this.props;
     return (
       <div className={cs.map}>
-        <BaseMap
-          mapTilerKey={mapTilerKey}
-          // updateViewport={this.updateViewport}
-          // tooltip={tooltip}
-          // markers={Object.entries(locationsToItems).map(this.renderMarker)}
-        />
+        <BaseMap mapTilerKey={mapTilerKey} />
       </div>
     );
   };

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -322,32 +322,7 @@ class SamplesView extends React.Component {
     const { selectedSampleIds } = this.state;
     return (
       <div className={cs.samplesToolbar}>
-        <div className={cs.displaySwitcher}>
-          <Menu compact className={cs.switcherMenu}>
-            <MenuItem
-              className={cs.menuItem}
-              // active={this.state.localUploadMode}
-              // onClick={withAnalytics(
-              //   () => this.setState({ localUploadMode: true }),
-              //   "SampleUpload_upload-local_clicked"
-              // )}
-              // disabled={this.state.submitting}
-            >
-              <i className={cx("fa fa-list-ul", cs.icon)} />
-            </MenuItem>
-            <MenuItem
-              className={cs.menuItem}
-              // active={!this.state.localUploadMode}
-              // onClick={withAnalytics(
-              //   () => this.setState({ localUploadMode: false }),
-              //   "SampleUpload_upload-remote_clicked"
-              // )}
-              // disabled={this.state.submitting}
-            >
-              <i className={cx("fa fa-globe", cs.icon)} />
-            </MenuItem>
-          </Menu>
-        </div>
+        <div className={cs.displaySwitcher}>{this.renderDisplaySwitcher()}</div>
         <div className={cs.fluidBlank} />
         <div className={cs.counterContainer}>
           <Label
@@ -373,6 +348,34 @@ class SamplesView extends React.Component {
           <div className={cs.action}>{this.renderDownloadTrigger()}</div>
         </div>
       </div>
+    );
+  };
+
+  renderDisplaySwitcher = () => {
+    const { currentDisplay } = this.props;
+    return (
+      <Menu compact className={cs.switcherMenu}>
+        <MenuItem
+          className={cs.menuItem}
+          active={currentDisplay === "table"}
+          // onClick={withAnalytics(
+          //   () => this.setState({ localUploadMode: true }),
+          //   "SampleUpload_upload-local_clicked"
+          // )}
+        >
+          <i className={cx("fa fa-list-ul", cs.icon)} />
+        </MenuItem>
+        <MenuItem
+          className={cs.menuItem}
+          active={currentDisplay === "map"}
+          // onClick={withAnalytics(
+          //   () => this.setState({ localUploadMode: false }),
+          //   "SampleUpload_upload-remote_clicked"
+          // )}
+        >
+          <i className={cx("fa fa-globe", cs.icon)} />
+        </MenuItem>
+      </Menu>
     );
   };
 
@@ -460,7 +463,9 @@ SamplesView.propTypes = {
   protectedColumns: PropTypes.array,
   samples: PropTypes.array,
   selectableIds: PropTypes.array.isRequired,
-  onSampleSelected: PropTypes.func
+  onSampleSelected: PropTypes.func,
+  currentDisplay: PropTypes.string,
+  allowedFeatures: PropTypes.arrayOf(PropTypes.string)
 };
 
 export default SamplesView;

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -16,7 +16,7 @@ import PhyloTreeCreationModal from "~/components/views/phylo_tree/PhyloTreeCreat
 import { DownloadIconDropdown } from "~ui/controls/dropdowns";
 import BasicPopup from "~/components/BasicPopup";
 import TableRenderers from "~/components/views/discovery/TableRenderers";
-import Tabs from "~/components/ui/controls/Tabs";
+import { Menu, MenuItem } from "~ui/controls/Menu";
 
 import ReportsDownloader from "./ReportsDownloader";
 import CollectionModal from "./CollectionModal";
@@ -322,12 +322,32 @@ class SamplesView extends React.Component {
     const { selectedSampleIds } = this.state;
     return (
       <div className={cs.samplesToolbar}>
-        <Tabs
-          // className={cs.tabs}
-          tabs={["A", "B"]}
-          // value={this.state.currentTab}
-          // onChange={this.onTabChange}
-        />
+        <div className={cs.displaySwitcher}>
+          <Menu compact className={cs.switcherMenu}>
+            <MenuItem
+              className={cs.menuItem}
+              // active={this.state.localUploadMode}
+              // onClick={withAnalytics(
+              //   () => this.setState({ localUploadMode: true }),
+              //   "SampleUpload_upload-local_clicked"
+              // )}
+              // disabled={this.state.submitting}
+            >
+              <i className={cx("fa fa-list-ul", cs.icon)} />
+            </MenuItem>
+            <MenuItem
+              className={cs.menuItem}
+              // active={!this.state.localUploadMode}
+              // onClick={withAnalytics(
+              //   () => this.setState({ localUploadMode: false }),
+              //   "SampleUpload_upload-remote_clicked"
+              // )}
+              // disabled={this.state.submitting}
+            >
+              <i className={cx("fa fa-globe", cs.icon)} />
+            </MenuItem>
+          </Menu>
+        </div>
         <div className={cs.fluidBlank} />
         <div className={cs.counterContainer}>
           <Label

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -17,6 +17,7 @@ import { DownloadIconDropdown } from "~ui/controls/dropdowns";
 import BasicPopup from "~/components/BasicPopup";
 import TableRenderers from "~/components/views/discovery/TableRenderers";
 import { Menu, MenuItem } from "~ui/controls/Menu";
+import BaseMap from "~/components/views/discovery/mapping/BaseMap";
 
 import ReportsDownloader from "./ReportsDownloader";
 import CollectionModal from "./CollectionModal";
@@ -326,11 +327,8 @@ class SamplesView extends React.Component {
     return (
       <div className={cs.samplesToolbar}>
         {allowedFeatures &&
-          allowedFeatures.includes("maps") && (
-            <div className={cs.displaySwitcher}>
-              {this.renderDisplaySwitcher()}
-            </div>
-          )}
+          allowedFeatures.includes("maps") &&
+          this.renderDisplaySwitcher()}
         <div className={cs.fluidBlank} />
         <div className={cs.counterContainer}>
           <Label
@@ -359,29 +357,77 @@ class SamplesView extends React.Component {
     );
   };
 
+  renderTable = () => {
+    const { activeColumns, onLoadRows, protectedColumns } = this.props;
+    const { selectedSampleIds } = this.state;
+
+    // TODO(tiago): replace by automated cell height computing
+    const rowHeight = 66;
+    const selectAllChecked = this.isSelectAllChecked();
+    return (
+      <div className={cs.table}>
+        <InfiniteTable
+          ref={infiniteTable => (this.infiniteTable = infiniteTable)}
+          columns={this.columns}
+          defaultRowHeight={rowHeight}
+          initialActiveColumns={activeColumns}
+          loadingClassName={cs.loading}
+          onLoadRows={onLoadRows}
+          onSelectAllRows={withAnalytics(
+            this.handleSelectAllRows,
+            "SamplesView_select-all-rows_clicked"
+          )}
+          onSelectRow={this.handleSelectRow}
+          onRowClick={this.handleRowClick}
+          protectedColumns={protectedColumns}
+          rowClassName={cs.tableDataRow}
+          selectableKey="id"
+          selected={selectedSampleIds}
+          selectAllChecked={selectAllChecked}
+        />
+      </div>
+    );
+  };
+
   renderDisplaySwitcher = () => {
     const { currentDisplay, onDisplaySwitch } = this.props;
     return (
-      <Menu compact className={cs.switcherMenu}>
-        {DISPLAYS.map(display => (
-          <MenuItem
-            className={cs.menuItem}
-            active={currentDisplay === display}
-            onClick={withAnalytics(
-              () => onDisplaySwitch(display),
-              `SamplesView_${display}-switch_clicked`
-            )}
-          >
-            <i
-              className={cx(
-                "fa",
-                display === "map" ? "fa-globe" : "fa-list-ul",
-                cs.icon
+      <div className={cs.displaySwitcher}>
+        <Menu compact className={cs.switcherMenu}>
+          {DISPLAYS.map(display => (
+            <MenuItem
+              className={cs.menuItem}
+              active={currentDisplay === display}
+              onClick={withAnalytics(
+                () => onDisplaySwitch(display),
+                `SamplesView_${display}-switch_clicked`
               )}
-            />
-          </MenuItem>
-        ))}
-      </Menu>
+            >
+              <i
+                className={cx(
+                  "fa",
+                  display === "map" ? "fa-globe" : "fa-list-ul",
+                  cs.icon
+                )}
+              />
+            </MenuItem>
+          ))}
+        </Menu>
+      </div>
+    );
+  };
+
+  renderMap = () => {
+    const { mapTilerKey } = this.props;
+    return (
+      <div className={cs.map}>
+        <BaseMap
+          mapTilerKey={mapTilerKey}
+          // updateViewport={this.updateViewport}
+          // tooltip={tooltip}
+          // markers={Object.entries(locationsToItems).map(this.renderMarker)}
+        />
+      </div>
     );
   };
 
@@ -404,37 +450,12 @@ class SamplesView extends React.Component {
   };
 
   render() {
-    const { activeColumns, onLoadRows, protectedColumns } = this.props;
-    const { phyloTreeCreationModalOpen, selectedSampleIds } = this.state;
-
-    // TODO(tiago): replace by automated cell height computing
-    const rowHeight = 66;
-
-    const selectAllChecked = this.isSelectAllChecked();
+    const { currentDisplay } = this.props;
+    const { phyloTreeCreationModalOpen } = this.state;
     return (
       <div className={cs.container}>
         {this.renderToolbar()}
-        <div className={cs.table}>
-          <InfiniteTable
-            ref={infiniteTable => (this.infiniteTable = infiniteTable)}
-            columns={this.columns}
-            defaultRowHeight={rowHeight}
-            initialActiveColumns={activeColumns}
-            loadingClassName={cs.loading}
-            onLoadRows={onLoadRows}
-            onSelectAllRows={withAnalytics(
-              this.handleSelectAllRows,
-              "SamplesView_select-all-rows_clicked"
-            )}
-            onSelectRow={this.handleSelectRow}
-            onRowClick={this.handleRowClick}
-            protectedColumns={protectedColumns}
-            rowClassName={cs.tableDataRow}
-            selectableKey="id"
-            selected={selectedSampleIds}
-            selectAllChecked={selectAllChecked}
-          />
-        </div>
+        {currentDisplay === "table" ? this.renderTable() : this.renderMap()}
         {phyloTreeCreationModalOpen && (
           <PhyloTreeCreationModal
             // TODO(tiago): migrate phylo tree to use api (or read csrf from context) and remove this
@@ -459,7 +480,8 @@ SamplesView.defaultProps = {
     "nonHostReads",
     "qcPercent"
   ],
-  protectedColumns: ["sample"]
+  protectedColumns: ["sample"],
+  currentDisplay: "table"
 };
 
 SamplesView.propTypes = {
@@ -470,9 +492,10 @@ SamplesView.propTypes = {
   samples: PropTypes.array,
   selectableIds: PropTypes.array.isRequired,
   onSampleSelected: PropTypes.func,
-  currentDisplay: PropTypes.string,
+  currentDisplay: PropTypes.string.isRequired,
   allowedFeatures: PropTypes.arrayOf(PropTypes.string),
-  onDisplaySwitch: PropTypes.func
+  onDisplaySwitch: PropTypes.func,
+  mapTilerKey: PropTypes.string
 };
 
 export default SamplesView;

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -22,6 +22,8 @@ import ReportsDownloader from "./ReportsDownloader";
 import CollectionModal from "./CollectionModal";
 import cs from "./samples_view.scss";
 
+const DISPLAYS = ["table", "map"];
+
 class SamplesView extends React.Component {
   constructor(props) {
     super(props);
@@ -319,10 +321,16 @@ class SamplesView extends React.Component {
   };
 
   renderToolbar = () => {
+    const { allowedFeatures } = this.props;
     const { selectedSampleIds } = this.state;
     return (
       <div className={cs.samplesToolbar}>
-        <div className={cs.displaySwitcher}>{this.renderDisplaySwitcher()}</div>
+        {allowedFeatures &&
+          allowedFeatures.includes("maps") && (
+            <div className={cs.displaySwitcher}>
+              {this.renderDisplaySwitcher()}
+            </div>
+          )}
         <div className={cs.fluidBlank} />
         <div className={cs.counterContainer}>
           <Label
@@ -352,29 +360,27 @@ class SamplesView extends React.Component {
   };
 
   renderDisplaySwitcher = () => {
-    const { currentDisplay } = this.props;
+    const { currentDisplay, onDisplaySwitch } = this.props;
     return (
       <Menu compact className={cs.switcherMenu}>
-        <MenuItem
-          className={cs.menuItem}
-          active={currentDisplay === "table"}
-          // onClick={withAnalytics(
-          //   () => this.setState({ localUploadMode: true }),
-          //   "SampleUpload_upload-local_clicked"
-          // )}
-        >
-          <i className={cx("fa fa-list-ul", cs.icon)} />
-        </MenuItem>
-        <MenuItem
-          className={cs.menuItem}
-          active={currentDisplay === "map"}
-          // onClick={withAnalytics(
-          //   () => this.setState({ localUploadMode: false }),
-          //   "SampleUpload_upload-remote_clicked"
-          // )}
-        >
-          <i className={cx("fa fa-globe", cs.icon)} />
-        </MenuItem>
+        {DISPLAYS.map(display => (
+          <MenuItem
+            className={cs.menuItem}
+            active={currentDisplay === display}
+            onClick={withAnalytics(
+              () => onDisplaySwitch(display),
+              `SamplesView_${display}-switch_clicked`
+            )}
+          >
+            <i
+              className={cx(
+                "fa",
+                display === "map" ? "fa-globe" : "fa-list-ul",
+                cs.icon
+              )}
+            />
+          </MenuItem>
+        ))}
       </Menu>
     );
   };
@@ -465,7 +471,8 @@ SamplesView.propTypes = {
   selectableIds: PropTypes.array.isRequired,
   onSampleSelected: PropTypes.func,
   currentDisplay: PropTypes.string,
-  allowedFeatures: PropTypes.arrayOf(PropTypes.string)
+  allowedFeatures: PropTypes.arrayOf(PropTypes.string),
+  onDisplaySwitch: PropTypes.func
 };
 
 export default SamplesView;

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -16,6 +16,7 @@ import PhyloTreeCreationModal from "~/components/views/phylo_tree/PhyloTreeCreat
 import { DownloadIconDropdown } from "~ui/controls/dropdowns";
 import BasicPopup from "~/components/BasicPopup";
 import TableRenderers from "~/components/views/discovery/TableRenderers";
+import Tabs from "~/components/ui/controls/Tabs";
 
 import ReportsDownloader from "./ReportsDownloader";
 import CollectionModal from "./CollectionModal";
@@ -321,6 +322,12 @@ class SamplesView extends React.Component {
     const { selectedSampleIds } = this.state;
     return (
       <div className={cs.samplesToolbar}>
+        <Tabs
+          // className={cs.tabs}
+          tabs={["A", "B"]}
+          // value={this.state.currentTab}
+          // onChange={this.onTabChange}
+        />
         <div className={cs.fluidBlank} />
         <div className={cs.counterContainer}>
           <Label

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -105,16 +105,17 @@
       margin: 0;
       min-height: 25px;
       border-radius: 10px;
+      box-shadow: none;
 
       .menuItem {
         padding: 5px 20px;
 
         .icon {
           font-size: 15px;
+        }
 
-          &.active {
-            fill: $primary-light;
-          }
+        &:global(.active) {
+          color: $primary-light;
         }
       }
     }

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -8,7 +8,8 @@
   height: 100%;
   flex: 1 0 auto;
 
-  .table {
+  .table,
+  .map {
     flex: 1 0 auto;
     display: flex;
     flex-direction: column;

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -115,7 +115,8 @@
         }
 
         &:global(.active) {
-          color: $primary-light;
+          // Important due to a { color: inherit !important; } in header.scss.
+          color: $primary-light !important;
         }
       }
     }

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -97,6 +97,28 @@
       }
     }
   }
+
+  .displaySwitcher {
+    margin-left: 15px;
+
+    .switcherMenu {
+      margin: 0;
+      min-height: 25px;
+      border-radius: 10px;
+
+      .menuItem {
+        padding: 5px 20px;
+
+        .icon {
+          font-size: 15px;
+
+          &.active {
+            fill: $primary-light;
+          }
+        }
+      }
+    }
+  }
 }
 
 .sampleHeader {

--- a/app/views/home/all_data.html.erb
+++ b/app/views/home/all_data.html.erb
@@ -5,6 +5,7 @@
       domain: "all_data",
       projectId: <%= params[:project_id] || "null" %>,
       allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
+      mapTilerKey: '<%= ENV["MAPTILER_API_KEY"] %>',
     }, 'page_content');
   <% end %>
 

--- a/app/views/home/my_data.html.erb
+++ b/app/views/home/my_data.html.erb
@@ -5,6 +5,7 @@
       domain: "my_data",
       projectId: <%= params[:project_id] || "null" %>,
       allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
+      mapTilerKey: '<%= ENV["MAPTILER_API_KEY"] %>',
     }, 'page_content');
   <% end %>
 

--- a/app/views/home/public.html.erb
+++ b/app/views/home/public.html.erb
@@ -5,6 +5,7 @@
       domain: "public",
       projectId: <%= params[:project_id] || "null" %>,
       allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
+      mapTilerKey: '<%= ENV["MAPTILER_API_KEY"] %>',
     }, 'page_content');
   <% end %>
 


### PR DESCRIPTION
### Description
- Adapts SamplesView in data discovery to have a map display mode in addition to a table display mode. currentDisplay is stored in DiscoveryView so that the DiscoverySidebar can also adapt to map mode.
- Will just show a plain map with no markers for now. Map resizes with window resizes.
- Map toggle is feature flagged and has withAnalytics
- renderTable() is moved code
- Next up: figuring out the non-paginated location loading and adding markers

### Demo
![Screen Shot 2019-05-22 at 5 52 12 PM](https://user-images.githubusercontent.com/5652739/58218428-b04bd880-7cbb-11e9-83bd-4ce63b546d90.png)
![Screen Shot 2019-05-22 at 6 00 16 PM](https://user-images.githubusercontent.com/5652739/58218433-b2ae3280-7cbb-11e9-8ea3-67d11d58efad.png)

### Test and Reproduce
- Start with map key, add "maps" to your allowed_features, go to http://localhost:3000/my_data?currentTab=samples, see the map toggle, click and see the map.