### PR TITLE
staging only:   test python 3.7 in idseq_dag

### DIFF
--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -57,7 +57,7 @@ module PipelineRunsHelper
                                  memory: Sample::DEFAULT_MEMORY_IN_MB,
                                  vcpus: Sample::DEFAULT_VCPUS,
                                  job_queue: Sample::DEFAULT_QUEUE,
-                                 docker_image: "idseq_dag")
+                                 docker_image: (Rails.env == 'staging' ? 'idseq_dag_boris_test_2020_05_23' : 'idseq_dag'))
     command = "aegea batch submit --command=\"#{base_command}\" "
     command += " --storage /mnt=#{Sample::DEFAULT_STORAGE_IN_GB} --volume-type gp2 --ecr-image #{docker_image} --memory #{memory} --queue #{job_queue} --vcpus #{vcpus} --job-role idseq-pipeline "
     command


### PR DESCRIPTION
Created a test ECR repository for testing the docker image based on idseq-dag branch dag_playground_2020_05_23.    It generates different aegea command based on environment.

The steps taken to upload the image to ECR are:
```
aws --profile idseq ecr create-repository --repository-name idseq_dag_boris_test_2020_05_23
{
    "repository": {
        "repositoryArn": "arn:aws:ecr:us-west-2:732052188396:repository/idseq_dag_boris_test_2020_05_23",
        "registryId": "732052188396",
        "repositoryName": "idseq_dag_boris_test_2020_05_23",
        "repositoryUri": "732052188396.dkr.ecr.us-west-2.amazonaws.com/idseq_dag_boris_test_2020_05_23",
        "createdAt": 1558646190.0
    }
}

https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_AWSCLI.html
```