### PR TITLE
Fix bug for loading '1.0' reports

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -90,7 +90,7 @@ class Sample < ApplicationRecord
 
   def pipeline_run_by_version(pipeline_version)
     # Right now we don't filter for successful pipeline runs. we should do that at some point.
-    prs = if pipeline_version == PipelineRun::PIPELINE_VERSION_WHEN_NULL
+    prs = if pipeline_version.to_f == PipelineRun::PIPELINE_VERSION_WHEN_NULL.to_f
             pipeline_runs.where(pipeline_version: nil)
           else
             pipeline_runs.where(pipeline_version: pipeline_version)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -91,6 +91,7 @@ class Sample < ApplicationRecord
   def pipeline_run_by_version(pipeline_version)
     # Right now we don't filter for successful pipeline runs. we should do that at some point.
     prs = if pipeline_version.to_f == PipelineRun::PIPELINE_VERSION_WHEN_NULL.to_f
+            # Note: change comparator if comparing versions like '3.10' to '3.1'
             pipeline_runs.where(pipeline_version: nil)
           else
             pipeline_runs.where(pipeline_version: pipeline_version)


### PR DESCRIPTION
### Description
In report_helper#select_pipeline_run,
```
pipeline_version = params[:pipeline_version].to_f
if pipeline_version > 0.0
  sample.pipeline_run_by_version(params[:pipeline_version])
```
was changed to 
```
pipeline_version = pipeline_version.to_f
if pipeline_version > 0.0
  sample.pipeline_run_by_version(pipeline_version)
```
so the code was comparing 1.0 == "1.0" and returning false for the 1.0 reports.

### Test and Reproduce
- This was triggered by sample 1405 in prod. I had the same sample locally and reproduced the fix.