### PR TITLE
[Maps] Add location_v2 loading to data discovery map display

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -305,7 +305,7 @@ const getContigsSequencesByByteranges = (
 
 const getPhyloTree = id => get(`/phylo_trees/${id}/show.json`);
 
-const getLocations = ({ domain, sampleIds }) =>
+const getSamplesLocations = ({ domain, sampleIds }) =>
   get("/locations/samples_locations.json", {
     params: {
       domain,
@@ -322,7 +322,7 @@ export {
   deleteSample,
   getAlignmentData,
   getAllHostGenomes,
-  getLocations,
+  getSamplesLocations,
   getProjectDimensions,
   getProjects,
   getSampleDimensions,

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -306,7 +306,7 @@ const getContigsSequencesByByteranges = (
 const getPhyloTree = id => get(`/phylo_trees/${id}/show.json`);
 
 const getSamplesLocations = ({ domain, sampleIds }) =>
-  get("/locations/sample_locations.json", {
+  postWithCSRF("/locations/sample_locations.json", {
     params: { domain },
     // Put in data because it can be too long for URL params
     data: { sampleIds }

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -305,11 +305,14 @@ const getContigsSequencesByByteranges = (
 
 const getPhyloTree = id => get(`/phylo_trees/${id}/show.json`);
 
-const getSamplesLocations = ({ domain, sampleIds }) =>
-  postWithCSRF("/locations/sample_locations.json", {
-    params: { domain },
-    // Put in data because it can be too long for URL params
-    data: { sampleIds }
+const getSamplesLocations = ({ domain, filters, projectId, search }) =>
+  get("/locations/sample_locations.json", {
+    params: {
+      domain,
+      search,
+      projectId,
+      ...filters
+    }
   });
 
 export {

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -305,6 +305,14 @@ const getContigsSequencesByByteranges = (
 
 const getPhyloTree = id => get(`/phylo_trees/${id}/show.json`);
 
+const getLocations = ({ domain, sampleIds }) =>
+  get("/locations/samples_locations.json", {
+    params: {
+      domain,
+      sampleIds
+    }
+  });
+
 export {
   bulkImportRemoteSamples,
   bulkUploadRemoteSamples,
@@ -314,6 +322,7 @@ export {
   deleteSample,
   getAlignmentData,
   getAllHostGenomes,
+  getLocations,
   getProjectDimensions,
   getProjects,
   getSampleDimensions,

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -306,11 +306,10 @@ const getContigsSequencesByByteranges = (
 const getPhyloTree = id => get(`/phylo_trees/${id}/show.json`);
 
 const getSamplesLocations = ({ domain, sampleIds }) =>
-  get("/locations/samples_locations.json", {
-    params: {
-      domain,
-      sampleIds
-    }
+  get("/locations/sample_locations.json", {
+    params: { domain },
+    // Put in data because it can be too long for URL params
+    data: { sampleIds }
   });
 
 export {

--- a/app/assets/src/components/utils/propTypes.js
+++ b/app/assets/src/components/utils/propTypes.js
@@ -91,6 +91,19 @@ const HostGenome = PropTypes.shape({
   name: PropTypes.string
 });
 
+const Location = PropTypes.shape({
+  city_name: PropTypes.string,
+  country_name: PropTypes.string,
+  geo_level: PropTypes.string,
+  id: PropTypes.number,
+  lat: PropTypes.string, // Rails returns Decimal as string to avoid fp issues
+  lng: PropTypes.string,
+  name: PropTypes.string,
+  sample_ids: PropTypes.arrayOf(PropTypes.number),
+  state_name: PropTypes.string,
+  subdivision_name: PropTypes.string
+});
+
 export default {
   ReportDetails,
   Taxon,
@@ -102,5 +115,6 @@ export default {
   Project,
   SummaryStats,
   HostGenome,
+  Location,
   ...PropTypes
 };

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -96,6 +96,7 @@ class DiscoveryView extends React.Component {
         loadingSamples: true,
         loadingDimensions: true,
         loadingStats: true,
+        mapLocationData: {},
         project: null,
         projectId: projectId,
         projectDimensions: [],
@@ -666,17 +667,17 @@ class DiscoveryView extends React.Component {
   handleDisplaySwitch = currentDisplay => {
     this.setState({ currentDisplay });
     if (currentDisplay === "map") {
-      this.handleMapLoad().then(res => console.log(res));
+      this.handleLoadSampleLocations().then(res => {
+        console.log(res);
+        this.setState({ mapLocationData: res });
+      });
     }
   };
 
-  handleMapLoad = async () => {
+  handleLoadSampleLocations = async () => {
     const { domain } = this.props;
     const { sampleIds } = this.state;
-
-    let results = await getDiscoveryLocations({ domain, sampleIds });
-    console.log("foobar 1:48pm results: ", results);
-    return results;
+    return await getDiscoveryLocations({ domain, sampleIds });
   };
 
   render() {
@@ -706,6 +707,7 @@ class DiscoveryView extends React.Component {
     } = this.state;
 
     const { domain, allowedFeatures, mapTilerKey } = this.props;
+    const { mapLocationData } = this.state;
 
     const tabs = this.computeTabs();
     const dimensions = this.getCurrentDimensions();
@@ -787,6 +789,7 @@ class DiscoveryView extends React.Component {
                       allowedFeatures={allowedFeatures}
                       onDisplaySwitch={this.handleDisplaySwitch}
                       mapTilerKey={mapTilerKey}
+                      mapLocationData={mapLocationData}
                     />
                   </div>
                   {!samples.length &&

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -43,6 +43,7 @@ import {
   getDiscoveryDimensions,
   getDiscoveryStats,
   getDiscoverySamples,
+  getDiscoveryLocations,
   DISCOVERY_DOMAIN_ALL_DATA,
   DISCOVERY_DOMAIN_MY_DATA,
   DISCOVERY_DOMAIN_PUBLIC
@@ -664,9 +665,19 @@ class DiscoveryView extends React.Component {
 
   handleDisplaySwitch = currentDisplay => {
     this.setState({ currentDisplay });
+    if (currentDisplay === "map") {
+      this.handleMapLoad().then(res => console.log(res));
+    }
   };
 
-  getLocationData = async sampleIds => {};
+  handleMapLoad = async () => {
+    const { domain } = this.props;
+    const { sampleIds } = this.state;
+
+    let results = await getDiscoveryLocations({ domain, sampleIds });
+    console.log("foobar 1:48pm results: ", results);
+    return results;
+  };
 
   render() {
     const {

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -11,7 +11,6 @@ import {
   escapeRegExp,
   find,
   findIndex,
-  isEmpty,
   keyBy,
   map,
   mapKeys,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -92,15 +92,16 @@ class DiscoveryView extends React.Component {
         filteredSampleDimensions: [],
         filteredSampleStats: {},
         filters: {},
-        loadingProjects: true,
-        loadingVisualizations: true,
-        loadingSamples: true,
         loadingDimensions: true,
+        loadingLocations: true,
+        loadingProjects: true,
+        loadingSamples: true,
         loadingStats: true,
+        loadingVisualizations: true,
         mapLocationData: {},
         project: null,
-        projectId: projectId,
         projectDimensions: [],
+        projectId: projectId,
         projects: [],
         sampleDimensions: [],
         sampleIds: [],
@@ -223,9 +224,10 @@ class DiscoveryView extends React.Component {
     this.resetData({
       callback: () => {
         // * Initial load:
-        //   - load (A) non-filtered dimensions, (C) filtered stats and (D) synchronous table data
+        //   - load (A) non-filtered dimensions, (C) filtered stats, (D) filtered locations, and (E) synchronous table data
         this.refreshDimensions();
         this.refreshFilteredStats();
+        this.refreshFilteredLocations();
         this.refreshSynchronousData();
         //   * if filter or project is set
         //     - load (B) filtered dimensions
@@ -239,11 +241,12 @@ class DiscoveryView extends React.Component {
     this.resetData({
       callback: () => {
         // * On filter change:
-        //   - load (B) filtered dimensions, (C) filtered stats
+        //   - load (B) filtered dimensions, (C) filtered stats, (D) filtered locations
         this.refreshFilteredDimensions();
         this.refreshFilteredStats();
+        this.refreshFilteredLocations();
         //  * if project not set
-        //       load (D) synchronous table data
+        //       load (E) synchronous table data
         !project && this.refreshSynchronousData();
       }
     });
@@ -258,6 +261,7 @@ class DiscoveryView extends React.Component {
         this.refreshDimensions();
         this.refreshFilteredDimensions();
         this.refreshFilteredStats();
+        this.refreshFilteredLocations();
       }
     });
   };
@@ -355,6 +359,24 @@ class DiscoveryView extends React.Component {
       filteredSampleDimensions,
       loadingDimensions: false
     });
+  };
+
+  refreshFilteredLocations = async () => {
+    const { domain } = this.props;
+    const { projectId, search } = this.state;
+
+    this.setState({
+      loadingLocations: true
+    });
+
+    const mapLocationData = await getDiscoveryLocations({
+      domain,
+      projectId,
+      filters: this.preparedFilters(),
+      search
+    });
+
+    this.setState({ mapLocationData, loadingLocations: false });
   };
 
   computeTabs = () => {
@@ -667,17 +689,6 @@ class DiscoveryView extends React.Component {
 
   handleDisplaySwitch = currentDisplay => {
     this.setState({ currentDisplay });
-    if (currentDisplay === "map") this.handleDisplaySwitchToMap();
-  };
-
-  handleDisplaySwitchToMap = async () => {
-    const { domain } = this.props;
-    const { sampleIds, mapLocationData } = this.state;
-
-    if (isEmpty(mapLocationData)) {
-      const results = await getDiscoveryLocations({ domain, sampleIds });
-      this.setState({ mapLocationData: results });
-    }
   };
 
   render() {

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -666,6 +666,8 @@ class DiscoveryView extends React.Component {
     this.setState({ currentDisplay });
   };
 
+  getLocationData = async sampleIds => {};
+
   render() {
     const {
       currentDisplay,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -11,6 +11,7 @@ import {
   escapeRegExp,
   find,
   findIndex,
+  isEmpty,
   keyBy,
   map,
   mapKeys,
@@ -666,18 +667,17 @@ class DiscoveryView extends React.Component {
 
   handleDisplaySwitch = currentDisplay => {
     this.setState({ currentDisplay });
-    if (currentDisplay === "map") {
-      this.handleLoadSampleLocations().then(res => {
-        console.log(res);
-        this.setState({ mapLocationData: res });
-      });
-    }
+    if (currentDisplay === "map") this.handleDisplaySwitchToMap();
   };
 
-  handleLoadSampleLocations = async () => {
+  handleDisplaySwitchToMap = async () => {
     const { domain } = this.props;
-    const { sampleIds } = this.state;
-    return await getDiscoveryLocations({ domain, sampleIds });
+    const { sampleIds, mapLocationData } = this.state;
+
+    if (isEmpty(mapLocationData)) {
+      const results = await getDiscoveryLocations({ domain, sampleIds });
+      this.setState({ mapLocationData: results });
+    }
   };
 
   render() {

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -1,12 +1,12 @@
 import { get, map } from "lodash/fp";
 import {
-  getProjects,
-  getSamples,
   getProjectDimensions,
+  getProjects,
   getSampleDimensions,
   getSampleStats,
-  getVisualizations,
-  getSamplesLocations
+  getSamples,
+  getSamplesLocations,
+  getVisualizations
 } from "~/api";
 
 const DISCOVERY_DOMAIN_MY_DATA = "my_data";
@@ -169,9 +169,9 @@ export {
   DISCOVERY_DOMAIN_MY_DATA,
   DISCOVERY_DOMAIN_ALL_DATA,
   DISCOVERY_DOMAIN_PUBLIC,
-  getDiscoverySyncData,
   getDiscoveryDimensions,
-  getDiscoveryStats,
+  getDiscoveryLocations,
   getDiscoverySamples,
-  getDiscoveryLocations
+  getDiscoveryStats,
+  getDiscoverySyncData
 };

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -5,7 +5,8 @@ import {
   getProjectDimensions,
   getSampleDimensions,
   getSampleStats,
-  getVisualizations
+  getVisualizations,
+  getLocations
 } from "~/api";
 
 const DISCOVERY_DOMAIN_MY_DATA = "my_data";
@@ -144,6 +145,20 @@ const getDiscoverySamples = async ({
   };
 };
 
+const getDiscoveryLocations = async ({ domain, sampleIds }) => {
+  try {
+    const result = await getLocations({
+      domain,
+      sampleIds
+    });
+    return result;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    return {};
+  }
+};
+
 export {
   DISCOVERY_DOMAIN_MY_DATA,
   DISCOVERY_DOMAIN_ALL_DATA,
@@ -151,5 +166,6 @@ export {
   getDiscoverySyncData,
   getDiscoveryDimensions,
   getDiscoveryStats,
-  getDiscoverySamples
+  getDiscoverySamples,
+  getDiscoveryLocations
 };

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -145,11 +145,18 @@ const getDiscoverySamples = async ({
   };
 };
 
-const getDiscoveryLocations = async ({ domain, sampleIds }) => {
+const getDiscoveryLocations = async ({
+  domain,
+  filters,
+  projectId,
+  search
+}) => {
   try {
     return await getSamplesLocations({
       domain,
-      sampleIds
+      filters,
+      projectId,
+      search
     });
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -147,11 +147,10 @@ const getDiscoverySamples = async ({
 
 const getDiscoveryLocations = async ({ domain, sampleIds }) => {
   try {
-    const result = await getSamplesLocations({
+    return await getSamplesLocations({
       domain,
       sampleIds
     });
-    return result;
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -6,7 +6,7 @@ import {
   getSampleDimensions,
   getSampleStats,
   getVisualizations,
-  getLocations
+  getSamplesLocations
 } from "~/api";
 
 const DISCOVERY_DOMAIN_MY_DATA = "my_data";
@@ -147,7 +147,7 @@ const getDiscoverySamples = async ({
 
 const getDiscoveryLocations = async ({ domain, sampleIds }) => {
   try {
-    const result = await getLocations({
+    const result = await getSamplesLocations({
       domain,
       sampleIds
     });

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -1,13 +1,60 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Marker } from "react-map-gl";
+import { get } from "lodash/fp";
 
 import BaseMap from "~/components/views/discovery/mapping/BaseMap";
 import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
+import MapTooltip from "~/components/views/discovery/mapping/MapTooltip";
+
+export const TOOLTIP_TIMEOUT_MS = 1000;
 
 class DiscoveryMap extends React.Component {
-  renderMapMarker = markerData => {
-    console.log(markerData);
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tooltip: null,
+      tooltipShouldClose: false
+    };
+  }
+
+  updateViewport = viewport => {
+    this.setState({ viewport });
+  };
+
+  handleMarkerMouseEnter = hoverInfo => {
+    const title = `${hoverInfo.pointCount} Sample${
+      hoverInfo.pointCount > 1 ? "s" : ""
+    }`;
+    const tooltip = (
+      <MapTooltip
+        lat={hoverInfo.lat}
+        lng={hoverInfo.lng}
+        title={title}
+        body={hoverInfo.name}
+        onMouseEnter={this.handleTooltipMouseEnter}
+        onMouseLeave={this.handleMarkerMouseLeave}
+      />
+    );
+    this.setState({ tooltip, tooltipShouldClose: false });
+  };
+
+  handleMarkerMouseLeave = () => {
+    // Flag the tooltip to close after a timeout, which could be unflagged by another event (entering a marker or tooltip).
+    this.setState({ tooltipShouldClose: true });
+    setTimeout(() => {
+      const { tooltipShouldClose } = this.state;
+      tooltipShouldClose && this.setState({ tooltip: null });
+    }, TOOLTIP_TIMEOUT_MS);
+  };
+
+  handleTooltipMouseEnter = () => {
+    this.setState({ tooltipShouldClose: false });
+  };
+
+  renderMarker = markerData => {
+    const { viewport } = this.state;
     const name = markerData.name;
     const lat = parseFloat(markerData.lat);
     const lng = parseFloat(markerData.lng);
@@ -15,19 +62,19 @@ class DiscoveryMap extends React.Component {
     const minSize = 12;
     // Scale based on the zoom and point count (zoomed-in = higher zoom)
     // Log1.5 of the count looked nice visually for not getting too large with many points.
-    // const markerSize = Math.max(
-    //   Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
-    //   minSize
-    // );
+    const markerSize = Math.max(
+      Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
+      minSize
+    );
 
     return (
       <Marker key={`marker-${markerData.id}`} latitude={lat} longitude={lng}>
         <CircleMarker
-          size={20}
-          // onMouseEnter={() =>
-          //   this.handleMarkerMouseEnter({ lat, lng, name, pointCount })
-          // }
-          // onMouseLeave={this.handleMarkerMouseLeave}
+          size={markerSize}
+          onMouseEnter={() =>
+            this.handleMarkerMouseEnter({ lat, lng, name, pointCount })
+          }
+          onMouseLeave={this.handleMarkerMouseLeave}
         />
       </Marker>
     );
@@ -35,11 +82,14 @@ class DiscoveryMap extends React.Component {
 
   render() {
     const { mapTilerKey, mapLocationData } = this.props;
+    const { tooltip } = this.state;
 
     return (
       <BaseMap
         mapTilerKey={mapTilerKey}
-        markers={Object.values(mapLocationData).map(this.renderMapMarker)}
+        updateViewport={this.updateViewport}
+        markers={Object.values(mapLocationData).map(this.renderMarker)}
+        tooltip={tooltip}
       />
     );
   }

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Marker } from "react-map-gl";
+
+import BaseMap from "~/components/views/discovery/mapping/BaseMap";
+import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
+
+class DiscoveryMap extends React.Component {
+  renderMapMarker = markerData => {
+    console.log(markerData);
+    const name = markerData.name;
+    const lat = parseFloat(markerData.lat);
+    const lng = parseFloat(markerData.lng);
+    const pointCount = markerData.sample_ids.length;
+    const minSize = 12;
+    // Scale based on the zoom and point count (zoomed-in = higher zoom)
+    // Log1.5 of the count looked nice visually for not getting too large with many points.
+    // const markerSize = Math.max(
+    //   Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
+    //   minSize
+    // );
+
+    return (
+      <Marker key={`marker-${markerData.id}`} latitude={lat} longitude={lng}>
+        <CircleMarker
+          size={20}
+          // onMouseEnter={() =>
+          //   this.handleMarkerMouseEnter({ lat, lng, name, pointCount })
+          // }
+          // onMouseLeave={this.handleMarkerMouseLeave}
+        />
+      </Marker>
+    );
+  };
+
+  render() {
+    const { mapTilerKey, mapLocationData } = this.props;
+
+    return (
+      <BaseMap
+        mapTilerKey={mapTilerKey}
+        markers={Object.values(mapLocationData).map(this.renderMapMarker)}
+      />
+    );
+  }
+}
+
+DiscoveryMap.propTypes = {
+  mapTilerKey: PropTypes.string,
+  mapLocationData: PropTypes.object
+};
+
+export default DiscoveryMap;

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -1,8 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Marker } from "react-map-gl";
 import { get } from "lodash/fp";
 
+import PropTypes from "~/components/utils/propTypes";
 import BaseMap from "~/components/views/discovery/mapping/BaseMap";
 import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
 import MapTooltip from "~/components/views/discovery/mapping/MapTooltip";
@@ -97,7 +97,7 @@ class DiscoveryMap extends React.Component {
 
 DiscoveryMap.propTypes = {
   mapTilerKey: PropTypes.string,
-  mapLocationData: PropTypes.object
+  mapLocationData: PropTypes.objectOf(PropTypes.Location)
 };
 
 export default DiscoveryMap;

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { difference, find, get, isEmpty, union } from "lodash/fp";
+import { difference, find, isEmpty, union } from "lodash/fp";
 import cx from "classnames";
-import { Marker } from "react-map-gl";
 
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
@@ -18,8 +17,7 @@ import { DownloadIconDropdown } from "~ui/controls/dropdowns";
 import BasicPopup from "~/components/BasicPopup";
 import TableRenderers from "~/components/views/discovery/TableRenderers";
 import { Menu, MenuItem } from "~ui/controls/Menu";
-import BaseMap from "~/components/views/discovery/mapping/BaseMap";
-import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
+import DiscoveryMap from "~/components/views/discovery/mapping/DiscoveryMap";
 
 import ReportsDownloader from "./ReportsDownloader";
 import CollectionModal from "./CollectionModal";
@@ -422,40 +420,13 @@ class SamplesView extends React.Component {
     );
   };
 
-  renderMapMarker = markerData => {
-    console.log(markerData);
-    const name = markerData.name;
-    const lat = parseFloat(markerData.lat);
-    const lng = parseFloat(markerData.lng);
-    const pointCount = markerData.sample_ids.length;
-    const minSize = 12;
-    // Scale based on the zoom and point count (zoomed-in = higher zoom)
-    // Log1.5 of the count looked nice visually for not getting too large with many points.
-    // const markerSize = Math.max(
-    //   Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
-    //   minSize
-    // );
-
-    return (
-      <Marker key={`marker-${markerData.id}`} latitude={lat} longitude={lng}>
-        <CircleMarker
-          size={20}
-          // onMouseEnter={() =>
-          //   this.handleMarkerMouseEnter({ lat, lng, name, pointCount })
-          // }
-          // onMouseLeave={this.handleMarkerMouseLeave}
-        />
-      </Marker>
-    );
-  };
-
   renderMap = () => {
     const { mapTilerKey, mapLocationData } = this.props;
     return (
       <div className={cs.map}>
-        <BaseMap
+        <DiscoveryMap
           mapTilerKey={mapTilerKey}
-          markers={Object.values(mapLocationData).map(this.renderMapMarker)}
+          mapLocationData={mapLocationData}
         />
       </div>
     );

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -246,7 +246,8 @@ class SamplesView extends React.Component {
   };
 
   reset = () => {
-    this.infiniteTable.reset();
+    const { currentDisplay } = this.state;
+    if (currentDisplay === "table") this.infiniteTable.reset();
   };
 
   renderHeatmapTrigger = () => {

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { difference, find, isEmpty, union } from "lodash/fp";
+import { difference, find, get, isEmpty, union } from "lodash/fp";
 import cx from "classnames";
+import { Marker } from "react-map-gl";
 
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
@@ -18,6 +19,7 @@ import BasicPopup from "~/components/BasicPopup";
 import TableRenderers from "~/components/views/discovery/TableRenderers";
 import { Menu, MenuItem } from "~ui/controls/Menu";
 import BaseMap from "~/components/views/discovery/mapping/BaseMap";
+import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
 
 import ReportsDownloader from "./ReportsDownloader";
 import CollectionModal from "./CollectionModal";
@@ -420,11 +422,41 @@ class SamplesView extends React.Component {
     );
   };
 
+  renderMapMarker = markerData => {
+    console.log(markerData);
+    const name = markerData.name;
+    const lat = parseFloat(markerData.lat);
+    const lng = parseFloat(markerData.lng);
+    const pointCount = markerData.sample_ids.length;
+    const minSize = 12;
+    // Scale based on the zoom and point count (zoomed-in = higher zoom)
+    // Log1.5 of the count looked nice visually for not getting too large with many points.
+    // const markerSize = Math.max(
+    //   Math.log(pointCount) / Math.log(1.5) * (get("zoom", viewport) || 3),
+    //   minSize
+    // );
+
+    return (
+      <Marker key={`marker-${markerData.id}`} latitude={lat} longitude={lng}>
+        <CircleMarker
+          size={20}
+          // onMouseEnter={() =>
+          //   this.handleMarkerMouseEnter({ lat, lng, name, pointCount })
+          // }
+          // onMouseLeave={this.handleMarkerMouseLeave}
+        />
+      </Marker>
+    );
+  };
+
   renderMap = () => {
-    const { mapTilerKey } = this.props;
+    const { mapTilerKey, mapLocationData } = this.props;
     return (
       <div className={cs.map}>
-        <BaseMap mapTilerKey={mapTilerKey} />
+        <BaseMap
+          mapTilerKey={mapTilerKey}
+          markers={Object.values(mapLocationData).map(this.renderMapMarker)}
+        />
       </div>
     );
   };
@@ -493,7 +525,8 @@ SamplesView.propTypes = {
   currentDisplay: PropTypes.string.isRequired,
   allowedFeatures: PropTypes.arrayOf(PropTypes.string),
   onDisplaySwitch: PropTypes.func,
-  mapTilerKey: PropTypes.string
+  mapTilerKey: PropTypes.string,
+  mapLocationData: PropTypes.object
 };
 
 export default SamplesView;

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,8 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { difference, find, isEmpty, union } from "lodash/fp";
 import cx from "classnames";
 
+import PropTypes from "~/components/utils/propTypes";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 import Label from "~ui/labels/Label";
@@ -498,7 +498,7 @@ SamplesView.propTypes = {
   allowedFeatures: PropTypes.arrayOf(PropTypes.string),
   onDisplaySwitch: PropTypes.func,
   mapTilerKey: PropTypes.string,
-  mapLocationData: PropTypes.object
+  mapLocationData: PropTypes.objectOf(PropTypes.Location)
 };
 
 export default SamplesView;

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -100,8 +100,6 @@
   }
 
   .displaySwitcher {
-    margin-left: 15px;
-
     .switcherMenu {
       margin: 0;
       min-height: 25px;

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -61,12 +61,13 @@ class LocationsController < ApplicationController
     }, status: :internal_server_error
   end
 
+  # GET /locations/sample_locations.json
+  # Get location data for a list of sample ids
   def sample_locations
+    # Get samples with domain and access control
     domain = location_params[:domain]
     param_sample_ids = (location_params[:sampleIds] || []).map(&:to_i)
-
-    # Access control enforced within samples_by_domain
-    samples = samples_by_domain(domain)
+    samples = samples_by_domain(domain) # access controlled
     unless param_sample_ids.empty?
       samples = samples.where(id: param_sample_ids)
     end
@@ -81,7 +82,7 @@ class LocationsController < ApplicationController
 
     # Get all the location attributes
     location_ids = sample_info.map(&:first).uniq
-    fields = [:id, :name, :geo_level, :country_name, :state_name, :subdivision_name, :city_name, :lat, :lng]
+    fields = [:id, :name, :geo_level, :country_name, :state_name, :subdivision_name, :city_name, :lat, :lng] # pluck for efficiency
     location_data = Location.where(id: location_ids).pluck(*fields).map { |p| fields.zip(p).to_h }.index_by { |loc| loc[:id] }
 
     # Add list of sample_ids to each location

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -106,9 +106,9 @@ class LocationsController < ApplicationController
     end
   rescue => err
     render json: {
-        status: "failed",
-        message: LOCATION_LOAD_ERR_MSG,
-        errors: [err]
+      status: "failed",
+      message: LOCATION_LOAD_ERR_MSG,
+      errors: [err]
     }, status: :internal_server_error
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -64,17 +64,10 @@ class LocationsController < ApplicationController
   # GET /locations/sample_locations.json
   # Get location data for a set of samples with filters
   def sample_locations
-    # Get samples with domain and access control
-    domain = location_params[:domain]
-    data = request.body.read
-    puts "foobar 8:38pm", data["data"]
-    data = data["data"]["sampleIds"]
-    param_sample_ids = data
-    # param_sample_ids = (location_params[:sampleIds] || []).map(&:to_i)
+    # Get the samples
+    domain = params[:domain]
     samples = samples_by_domain(domain) # access controlled
-    unless param_sample_ids.empty?
-      samples = samples.where(id: param_sample_ids)
-    end
+    samples = filter_samples(samples, params)
 
     # Get the relevant location_ids and sample_ids
     field_id = MetadataField.find_by(name: "collection_location_v2").id

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -62,11 +62,15 @@ class LocationsController < ApplicationController
   end
 
   # GET /locations/sample_locations.json
-  # Get location data for a list of sample ids
+  # Get location data for a set of samples with filters
   def sample_locations
     # Get samples with domain and access control
     domain = location_params[:domain]
-    param_sample_ids = (location_params[:sampleIds] || []).map(&:to_i)
+    data = request.body.read
+    puts "foobar 8:38pm", data["data"]
+    data = data["data"]["sampleIds"]
+    param_sample_ids = data
+    # param_sample_ids = (location_params[:sampleIds] || []).map(&:to_i)
     samples = samples_by_domain(domain) # access controlled
     unless param_sample_ids.empty?
       samples = samples.where(id: param_sample_ids)
@@ -100,6 +104,12 @@ class LocationsController < ApplicationController
         render json: location_data
       end
     end
+  rescue => err
+    render json: {
+        status: "failed",
+        message: LOCATION_LOAD_ERR_MSG,
+        errors: [err]
+    }, status: :internal_server_error
   end
 
   private

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -61,7 +61,7 @@ class LocationsController < ApplicationController
     }, status: :internal_server_error
   end
 
-  def samples_locations
+  def sample_locations
     domain = location_params[:domain]
     param_sample_ids = (location_params[:sampleIds] || []).map(&:to_i)
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -84,7 +84,7 @@ class LocationsController < ApplicationController
                   .where.not(metadata: { location_id: nil })
                   .pluck(:location_id, :id)
 
-    # Get all the location attributes
+    # Get all the location attributes. Key by location_id for lookups.
     location_ids = sample_info.map(&:first).uniq
     fields = [:id, :name, :geo_level, :country_name, :state_name, :subdivision_name, :city_name, :lat, :lng] # pluck for performance
     location_data = Location.where(id: location_ids).pluck(*fields).map { |p| fields.zip(p).to_h }.index_by { |loc| loc[:id] }

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -15,7 +15,7 @@ class Metadatum < ApplicationRecord
   # ActiveRecord related
   belongs_to :sample
   belongs_to :metadata_field
-  belongs_to :location
+  belongs_to :location, optional: true
   STRING_TYPE = 0
   NUMBER_TYPE = 1
   DATE_TYPE = 2

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -15,6 +15,7 @@ class Metadatum < ApplicationRecord
   # ActiveRecord related
   belongs_to :sample
   belongs_to :metadata_field
+  belongs_to :location
   STRING_TYPE = 0
   NUMBER_TYPE = 1
   DATE_TYPE = 2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,6 +124,7 @@ Rails.application.routes.draw do
   resource :locations do
     get :external_search, on: :collection
     get :map_playground, on: :collection
+    get :samples_locations, on: :collection
   end
 
   authenticate :user, ->(u) { u.admin? } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,7 @@ Rails.application.routes.draw do
   resource :locations do
     get :external_search, on: :collection
     get :map_playground, on: :collection
-    get :sample_locations, on: :collection
+    post :sample_locations, on: :collection
   end
 
   authenticate :user, ->(u) { u.admin? } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,7 @@ Rails.application.routes.draw do
   resource :locations do
     get :external_search, on: :collection
     get :map_playground, on: :collection
-    get :samples_locations, on: :collection
+    get :sample_locations, on: :collection
   end
 
   authenticate :user, ->(u) { u.admin? } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,7 @@ Rails.application.routes.draw do
   resource :locations do
     get :external_search, on: :collection
     get :map_playground, on: :collection
-    post :sample_locations, on: :collection
+    get :sample_locations, on: :collection
   end
 
   authenticate :user, ->(u) { u.admin? } do

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -81,16 +81,6 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal actual_object, expected_object
   end
 
-  test "user can see a map location data load error" do
-    post user_session_path, params: @user_params
-
-    MetadataField.stub :find_by, nil do
-      get sample_locations_locations_path, as: :json
-      assert_response :error
-      assert_equal LocationsController::LOCATION_LOAD_ERR_MSG, JSON.parse(@response.body)["message"]
-    end
-  end
-
   test "disallowed users cannot access sample_locations" do
     post user_session_path, params: @non_admin_user_params
     get sample_locations_locations_path, as: :json

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -5,8 +5,8 @@ require "test_helpers/location_test_helper"
 class LocationsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:admin) # Change to non-admin user once released
-    @user_params = {"user[email]" => @user.email, "user[password]" => "password"}
-    @non_admin_user = {"user[email]" => users(:joe).email, "user[password]" => "password"}
+    @user_params = { "user[email]" => @user.email, "user[password]" => "password" }
+    @non_admin_user = { "user[email]" => users(:joe).email, "user[password]" => "password" }
     @api_response = true, LocationTestHelper::API_GEOSEARCH_RESPONSE
     @our_results = LocationTestHelper::FORMATTED_GEOSEARCH_RESPONSE
   end
@@ -15,7 +15,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     post user_session_path, params: @user_params
 
     Location.stub :geosearch, @api_response do
-      get external_search_locations_path, params: {query: "UCSF"}
+      get external_search_locations_path, params: { query: "UCSF" }
       assert_response :success
       assert_equal JSON.dump(@our_results), @response.body
     end
@@ -25,11 +25,11 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     post user_session_path, params: @user_params
 
     Location.stub :geosearch, [true, []] do
-      get external_search_locations_path, params: {query: "ahsdlfkjasfk"}
+      get external_search_locations_path, params: { query: "ahsdlfkjasfk" }
       assert_response :success
       assert_equal "[]", @response.body
 
-      get external_search_locations_path, params: {query: ""}
+      get external_search_locations_path, params: { query: "" }
       assert_response :success
       assert_equal "[]", @response.body
 
@@ -42,7 +42,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   test "user can geosearch and see an error" do
     post user_session_path, params: @user_params
     ENV["LOCATION_IQ_API_KEY"] = nil
-    get external_search_locations_path, params: {query: "UCSF"}
+    get external_search_locations_path, params: { query: "UCSF" }
     assert_response :error
     assert_equal LocationsController::GEOSEARCH_ERR_MSG, JSON.parse(@response.body)["message"]
   end
@@ -76,7 +76,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     results = JSON.parse(@response.body)
     loc = locations(:swamp)
     actual_object = results[loc.id.to_s]
-    expected_object = {"id" => loc.id, "name" => loc.name, "geo_level" => loc.geo_level, "country_name" => loc.country_name, "state_name" => loc.state_name, "subdivision_name" => loc.subdivision_name, "city_name" => loc.city_name, "lat" => loc.lat.to_s, "lng" => loc.lng.to_s, "sample_ids" => [samples(:joe_project_sample_mosquito).id]}
+    expected_object = { "id" => loc.id, "name" => loc.name, "geo_level" => loc.geo_level, "country_name" => loc.country_name, "state_name" => loc.state_name, "subdivision_name" => loc.subdivision_name, "city_name" => loc.city_name, "lat" => loc.lat.to_s, "lng" => loc.lng.to_s, "sample_ids" => [samples(:joe_project_sample_mosquito).id] }
 
     assert_equal actual_object, expected_object
   end
@@ -92,7 +92,6 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "non-admin users cannot access sample_locations" do
-
   end
 
   # TODO: Uncomment and use non-admin user once released

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -6,7 +6,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:admin) # Change to non-admin user once released
     @user_params = { "user[email]" => @user.email, "user[password]" => "password" }
-    @non_admin_user = { "user[email]" => users(:joe).email, "user[password]" => "password" }
+    @non_admin_user_params = { "user[email]" => users(:joe).email, "user[password]" => "password" }
     @api_response = true, LocationTestHelper::API_GEOSEARCH_RESPONSE
     @our_results = LocationTestHelper::FORMATTED_GEOSEARCH_RESPONSE
   end
@@ -91,7 +91,10 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "non-admin users cannot access sample_locations" do
+  test "disallowed users cannot access sample_locations" do
+    post user_session_path, params: @non_admin_user_params
+    get sample_locations_locations_path, as: :json
+    assert_response 401
   end
 
   # TODO: Uncomment and use non-admin user once released

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -5,3 +5,10 @@ ucsf:
 swamp:
   name: "Swamp of Mosquitos"
   id: 1
+  geo_level: "city"
+  country_name: "USA"
+  state_name: "California"
+  subdivision_name: "San Mateo County"
+  city_name: "Redwood City"
+  lat: "37.49"
+  lng: "-122.23"


### PR DESCRIPTION
### Description
- This completes the flow and add location_v2 loading to the map display.
- Matches the patterns for stats/dimensions and the left filtering sidebar still works as expected.
- Location endpoint returns the location info keyed by location_id for frontend lookups along with the list of sample_ids at that point. The main interaction (coming next) will be clicking a bubble -> seeing just those samples in the right sidebar.
- Most of the DiscoveryMap code was copied from MapPlayground.

### Demo
![May-28-2019 10-06-44](https://user-images.githubusercontent.com/5652739/58497252-65edb000-8130-11e9-812a-dda10b5a3591.gif)

### Test and Reproduce
- Load the branch with map keys, go to Data Discovery samples tab, click the map toggle, play around with the map and filters.
- See endpoint tests.