### PR TITLE
Fix heatmap perf part 2

### DIFF
--- a/.byebugrc
+++ b/.byebugrc
@@ -1,0 +1,2 @@
+# because of docker read-only volume
+set noautosave

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -30,7 +30,6 @@ class SamplesHeatmapVis extends React.Component {
 
     // TODO: yet another metric name conversion to remove
     this.metrics = [
-      { key: "NT.aggregatescore", label: "Score" },
       { key: "NT.zscore", label: "NT Z Score" },
       { key: "NT.rpm", label: "NT rPM" },
       { key: "NT.r", label: "NT r (total reads)" },

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -136,7 +136,6 @@ class VisualizationsController < ApplicationController
         Viruses: ["Phage"]
       },
       metrics: [
-        { text: "Aggregate Score", value: "NT.aggregatescore" },
         { text: "NT Z Score", value: "NT.zscore" },
         { text: "NT rPM", value: "NT.rpm" },
         { text: "NT r (total reads)", value: "NT.r" },
@@ -149,7 +148,6 @@ class VisualizationsController < ApplicationController
       end,
       thresholdFilters: {
         targets: [
-          { text: "Aggregate Score", value: "NT_aggregatescore" },
           { text: "NT Z Score", value: "NT_zscore" },
           { text: "NT rPM", value: "NT_rpm" },
           { text: "NT r (total reads)", value: "NT_r" },

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -136,12 +136,12 @@ class VisualizationsController < ApplicationController
         Viruses: ["Phage"]
       },
       metrics: [
-        { text: "NT Z Score", value: "NT.zscore" },
         { text: "NT rPM", value: "NT.rpm" },
+        { text: "NT Z Score", value: "NT.zscore" },
         { text: "NT r (total reads)", value: "NT.r" },
+        { text: "NR rPM", value: "NR.rpm" },
         { text: "NR Z Score", value: "NR.zscore" },
-        { text: "NR r (total reads)", value: "NR.r" },
-        { text: "NR rPM", value: "NR.rpm" }
+        { text: "NR r (total reads)", value: "NR.r" }
       ],
       backgrounds: current_power.backgrounds.map do |background|
         { name: background.name, value: background.id }

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -126,9 +126,69 @@ class VisualizationsController < ApplicationController
     }, status: :internal_server_error
   end
 
+  # START OF HEATMAP METHODS
+
+  def heatmap
+    {
+      taxonLevels: %w[Genus Species],
+      categories: ReportHelper::ALL_CATEGORIES.pluck('name'),
+      subcategories: {
+        Viruses: ["Phage"]
+      },
+      metrics: [
+        { text: "Aggregate Score", value: "NT.aggregatescore" },
+        { text: "NT Z Score", value: "NT.zscore" },
+        { text: "NT rPM", value: "NT.rpm" },
+        { text: "NT r (total reads)", value: "NT.r" },
+        { text: "NR Z Score", value: "NR.zscore" },
+        { text: "NR r (total reads)", value: "NR.r" },
+        { text: "NR rPM", value: "NR.rpm" }
+      ],
+      backgrounds: current_power.backgrounds.map do |background|
+        { name: background.name, value: background.id }
+      end,
+      thresholdFilters: {
+        targets: [
+          { text: "Aggregate Score", value: "NT_aggregatescore" },
+          { text: "NT Z Score", value: "NT_zscore" },
+          { text: "NT rPM", value: "NT_rpm" },
+          { text: "NT r (total reads)", value: "NT_r" },
+          { text: "NT %id", value: "NT_percentidentity" },
+          { text: "NT L (alignment length in bp)", value: "NT_alignmentlength" },
+          { text: "NT log(1/e)", value: "NT_neglogevalue" },
+          { text: "NR Z Score", value: "NR_zscore" },
+          { text: "NR r (total reads)", value: "NR_r" },
+          { text: "NR rPM", value: "NR_rpm" },
+          { text: "NR %id", value: "NR_percentidentity" },
+          { text: "NR L (alignment length in bp)", value: "NR_alignmentlength" },
+          { text: "R log(1/e)", value: "NR_neglogevalue" }
+        ],
+        operators: [">=", "<="]
+      },
+      allowedFeatures: current_user.allowed_feature_list
+    }
+  end
+
+  def download_heatmap
+    @sample_taxons_dict = HeatmapHelper.sample_taxons_dict(params, samples_for_heatmap)
+    output_csv = generate_heatmap_csv(@sample_taxons_dict)
+    send_data output_csv, filename: 'heatmap.csv'
+  end
+
+  def samples_taxons
+    @sample_taxons_dict = HeatmapHelper.sample_taxons_dict(params, samples_for_heatmap)
+    render json: @sample_taxons_dict
+  end
+
   private
 
   def visualization_params
     params.permit(:domain, :type, :id, :url, :search, data: {})
+  end
+
+  def samples_for_heatmap
+    current_power.samples
+                 .where(id: params[:sampleIds])
+                 .includes([:host_genome, :pipeline_runs, metadata: [:metadata_field]])
   end
 end

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -107,17 +107,19 @@ module HeatmapHelper
       sample_id = pr.sample_id
 
       tax_2d = ReportHelper.taxon_counts_cleanup(taxon_counts)
-      ReportHelper.only_species_or_genus_counts!(tax_2d, species_selected)
+      HeatmapHelper.only_species_or_genus_counts!(tax_2d, species_selected)
 
       rows = []
       tax_2d.each do |_tax_id, tax_info|
         rows << tax_info
       end
 
-      ReportHelper.compute_aggregate_scores_v2!(rows)
+      HeatmapHelper.compute_aggregate_scores_v2!(rows)
       rows = rows.select do |row|
         row["NT"]["maxzscore"] >= MINIMUM_ZSCORE_THRESHOLD &&
-          ReportHelper.check_custom_filters(row, threshold_filters)
+          # Note: these are applied *after* SQL filters, so results may not be
+          # 100% as expected .
+          HeatmapHelper.check_custom_filters(row, threshold_filters)
       end
 
       # Get the top N for each sample. This re-sorts on the same metric as in
@@ -151,8 +153,6 @@ module HeatmapHelper
     min_reads = MINIMUM_READ_THRESHOLD,
     sort_by = DEFAULT_TAXON_SORT_PARAM
   )
-    pipeline_run_ids = samples.map { |s| s.first_pipeline_run ? s.first_pipeline_run.id : nil }.compact
-
     categories_map = ReportHelper::CATEGORIES_TAXID_BY_NAME
     categories_clause = ""
     if categories.present?
@@ -214,7 +214,12 @@ module HeatmapHelper
       taxon_counts.tax_level  = taxon_summaries.tax_level       AND
       taxon_counts.tax_id     = taxon_summaries.tax_id
     WHERE
-      pipeline_run_id in (#{pipeline_run_ids.join(',')})
+      pipeline_run_id IN (
+        SELECT MAX(id)
+        FROM pipeline_runs
+        WHERE sample_id IN (#{samples.pluck(:id).join(',')})
+        GROUP BY sample_id
+      )
       AND genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}
       AND count >= #{min_reads}
       -- We need both types of counts for threshold filters
@@ -290,21 +295,21 @@ module HeatmapHelper
     unless taxon_ids.empty?
       samples_by_id = Hash[samples.map { |s| [s.id, s] }]
       parent_ids = ReportHelper.fetch_parent_ids(taxon_ids, samples)
-      results_by_pr = ReportHelper.fetch_samples_taxons_counts(samples, taxon_ids, parent_ids, background_id)
+      results_by_pr = HeatmapHelper.fetch_samples_taxons_counts(samples, taxon_ids, parent_ids, background_id)
       results_by_pr.each do |_pr_id, res|
         pr = res["pr"]
         taxon_counts = res["taxon_counts"]
         sample_id = pr.sample_id
         tax_2d = ReportHelper.taxon_counts_cleanup(taxon_counts)
-        ReportHelper.only_species_or_genus_counts!(tax_2d, species_selected)
+        HeatmapHelper.only_species_or_genus_counts!(tax_2d, species_selected)
 
         rows = []
         tax_2d.each { |_tax_id, tax_info| rows << tax_info }
-        ReportHelper.compute_aggregate_scores_v2!(rows)
+        HeatmapHelper.compute_aggregate_scores_v2!(rows)
 
         filtered_rows = rows
                         .select { |row| taxon_ids.include?(row["tax_id"]) }
-                        .each { |row| row[:filtered] = ReportHelper.check_custom_filters(row, threshold_filters) }
+                        .each { |row| row[:filtered] = HeatmapHelper.check_custom_filters(row, threshold_filters) }
 
         results[sample_id] = {
           sample_id: sample_id,
@@ -330,5 +335,130 @@ module HeatmapHelper
 
     # Flatten the hash
     results.values
+  end
+
+  def self.fetch_samples_taxons_counts(samples, taxon_ids, parent_ids, background_id)
+    parent_ids = parent_ids.to_a
+    parent_ids_clause = parent_ids.empty? ? "" : " OR taxon_counts.tax_id in (#{parent_ids.join(',')}) "
+
+    # Note: subsample_fraction is of type 'float' so adjusted_total_reads is too
+    # Note: stdev is never 0
+    # Note: connection.select_all is TWICE faster than TaxonCount.select
+    # (I/O latency goes from 2 seconds -> 0.8 seconds)
+    # Had to derive rpm and zscore for each sample
+    sql_results = TaxonCount.connection.select_all("
+      SELECT
+        taxon_counts.pipeline_run_id     AS  pipeline_run_id,
+        taxon_counts.tax_id              AS  tax_id,
+        taxon_counts.count_type          AS  count_type,
+        taxon_counts.tax_level           AS  tax_level,
+        taxon_counts.genus_taxid         AS  genus_taxid,
+        taxon_counts.family_taxid        AS  family_taxid,
+        taxon_counts.name                AS  name,
+        taxon_counts.superkingdom_taxid  AS  superkingdom_taxid,
+        taxon_counts.is_phage            AS  is_phage,
+        taxon_counts.count               AS  r,
+        taxon_summaries.stdev            AS stdev,
+        taxon_summaries.mean             AS mean,
+        taxon_counts.percent_identity    AS  percentidentity,
+        taxon_counts.alignment_length    AS  alignmentlength,
+        IF(
+          taxon_counts.e_value IS NOT NULL,
+          (0.0 - taxon_counts.e_value),
+          #{ReportHelper::DEFAULT_SAMPLE_NEGLOGEVALUE}
+        )                                AS  neglogevalue,
+        taxon_counts.percent_concordant  AS  percentconcordant
+      FROM taxon_counts
+      LEFT OUTER JOIN taxon_summaries ON
+        #{background_id.to_i}   = taxon_summaries.background_id   AND
+        taxon_counts.count_type = taxon_summaries.count_type      AND
+        taxon_counts.tax_level  = taxon_summaries.tax_level       AND
+        taxon_counts.tax_id     = taxon_summaries.tax_id
+      WHERE
+        pipeline_run_id IN (
+          SELECT MAX(id)
+          FROM pipeline_runs
+          WHERE sample_id IN (#{samples.pluck(:id).join(',')})
+          GROUP BY sample_id
+        )
+        AND taxon_counts.genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}
+        AND taxon_counts.count_type IN ('NT', 'NR')
+        AND (taxon_counts.tax_id IN (#{taxon_ids.join(',')})
+         #{parent_ids_clause}
+         OR taxon_counts.genus_taxid IN (#{taxon_ids.join(',')}))").to_hash
+
+    # calculating rpm and zscore, organizing the results by pipeline_run_id
+    result_hash = {}
+
+    pipeline_run_ids = sql_results.map { |x| x['pipeline_run_id'] }
+    pipeline_runs = PipelineRun.where(id: pipeline_run_ids.uniq).includes([:sample])
+    pipeline_runs_by_id = Hash[pipeline_runs.map { |x| [x.id, x] }]
+
+    sql_results.each do |row|
+      pipeline_run_id = row["pipeline_run_id"]
+      if result_hash[pipeline_run_id]
+        pr = result_hash[pipeline_run_id]["pr"]
+      else
+        pr = pipeline_runs_by_id[pipeline_run_id]
+        result_hash[pipeline_run_id] = { "pr" => pr, "taxon_counts" => [] }
+      end
+      if pr.total_reads
+        z_max = ReportHelper::ZSCORE_MAX
+        z_min = ReportHelper::ZSCORE_MIN
+        z_default = ReportHelper::ZSCORE_WHEN_ABSENT_FROM_BACKGROUND
+        row["rpm"] = pr.rpm(row["r"])
+        row["zscore"] = row["stdev"].nil? ? z_default : ((row["rpm"] - row["mean"]) / row["stdev"])
+        row["zscore"] = z_max if row["zscore"] > z_max && row["zscore"] != z_default
+        row["zscore"] = z_min if row["zscore"] < z_min
+        result_hash[pipeline_run_id]["taxon_counts"] << row
+      end
+    end
+
+    result_hash
+  end
+
+  def self.only_species_or_genus_counts!(tax_2d, species_selected)
+    if species_selected # Species selected
+      only_species_level_counts!(tax_2d)
+    else # Genus selected
+      only_genus_level_counts!(tax_2d)
+    end
+    tax_2d
+  end
+
+  def self.compute_aggregate_scores_v2!(rows)
+    rows.each do |taxon_info|
+      # NT and NR zscore are set to the same
+      taxon_info['NT']['maxzscore'] = [taxon_info['NT']['zscore'], taxon_info['NR']['zscore']].max
+      taxon_info['NR']['maxzscore'] = taxon_info['NT']['maxzscore']
+    end
+  end
+
+  def self.check_custom_filters(row, threshold_filters)
+    threshold_filters.each do |filter|
+      count_type, metric = filter["metric"].split("_")
+      begin
+        value = Float(filter["value"])
+      rescue
+        Rails.logger.warn "Bad threshold filter value."
+      else
+        if filter["operator"] == ">="
+          if row[count_type][metric] < value
+            return false
+          end
+        elsif row[count_type][metric] > value
+          return false
+        end
+      end
+    end
+    true
+  end
+
+  def self.only_species_level_counts!(taxon_counts_2d)
+    taxon_counts_2d.keep_if { |_tax_id, tax_info| tax_info['tax_level'] == TaxonCount::TAX_LEVEL_SPECIES }
+  end
+
+  def self.only_genus_level_counts!(taxon_counts_2d)
+    taxon_counts_2d.keep_if { |_tax_id, tax_info| tax_info['tax_level'] == TaxonCount::TAX_LEVEL_GENUS }
   end
 end

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -1,6 +1,9 @@
 module HeatmapHelper
   DEFAULT_MAX_NUM_TAXONS = 30
 
+  MINIMUM_READ_THRESHOLD = 5
+  MINIMUM_ZSCORE_THRESHOLD = 1.7
+
   def heatmap
     {
       taxonLevels: %w[Genus Species],
@@ -87,9 +90,149 @@ module HeatmapHelper
     first_sample = samples.first
     background_id = params[:background] ? params[:background].to_i : get_background_id(first_sample)
 
-    taxon_ids = ReportHelper.top_taxons_details(samples, background_id, num_results, sort_by, species_selected, categories, threshold_filters, read_specificity, include_phage).pluck("tax_id")
+    taxon_ids = HeatmapHelper.top_taxons_details(samples, background_id, num_results, sort_by, species_selected, categories, threshold_filters, read_specificity, include_phage).pluck("tax_id")
     taxon_ids -= removed_taxon_ids
 
     samples_taxons_details(samples, taxon_ids, background_id, species_selected, threshold_filters)
+  end
+
+  # All the methods below should be considered private, but I don't know enough
+  # about ruby to actually make a class method private and call it.
+  # private
+
+  def self.top_taxons_details(samples, background_id, num_results, sort_by_key, species_selected, categories, threshold_filters = {}, read_specificity = false, include_phage = false)
+    # return top taxons
+    results_by_pr = fetch_top_taxons(samples, background_id, categories, read_specificity, include_phage, num_results)
+
+    sort_by = ReportHelper.decode_sort_by(sort_by_key)
+    count_type = sort_by[:count_type]
+    metric = sort_by[:metric]
+    candidate_taxons = {}
+    results_by_pr.each do |_pr_id, res|
+      pr = res["pr"]
+      taxon_counts = res["taxon_counts"]
+      sample_id = pr.sample_id
+
+      tax_2d = ReportHelper.taxon_counts_cleanup(taxon_counts)
+      ReportHelper.only_species_or_genus_counts!(tax_2d, species_selected)
+
+      rows = []
+      tax_2d.each do |_tax_id, tax_info|
+        rows << tax_info
+      end
+
+      ReportHelper.compute_aggregate_scores_v2!(rows)
+      rows = rows.select do |row|
+        row["NT"]["maxzscore"] >= MINIMUM_ZSCORE_THRESHOLD && ReportHelper.check_custom_filters(row, threshold_filters)
+      end
+
+      rows.sort_by! { |tax_info| ((tax_info[count_type] || {})[metric] || 0.0) * -1.0 }
+      count = 1
+      # get the top N for each sample
+      rows.each do |row|
+        taxon = if candidate_taxons[row["tax_id"]]
+                  candidate_taxons[row["tax_id"]]
+                else
+                  { "tax_id" => row["tax_id"], "samples" => {} }
+                end
+        taxon["max_aggregate_score"] = row[sort_by[:count_type]][sort_by[:metric]] if taxon["max_aggregate_score"].to_f < row[sort_by[:count_type]][sort_by[:metric]].to_f
+        taxon["samples"][sample_id] = [count, row["tax_level"], row["NT"]["zscore"], row["NR"]["zscore"]]
+        candidate_taxons[row["tax_id"]] = taxon
+        break if count >= num_results
+        count += 1
+      end
+    end
+
+    candidate_taxons.values.sort_by { |taxon| -1.0 * taxon["max_aggregate_score"].to_f }
+  end
+
+  def self.fetch_top_taxons(samples, background_id, categories, read_specificity = false, include_phage = false, num_results = 1_000_000)
+    pipeline_run_ids = samples.map { |s| s.first_pipeline_run ? s.first_pipeline_run.id : nil }.compact
+
+    categories_clause = ""
+    if categories.present?
+      categories_clause = " AND taxon_counts.superkingdom_taxid IN (#{categories.map { |category| CATEGORIES_TAXID_BY_NAME[category] }.compact.join(',')})"
+    elsif include_phage
+      categories_clause = " AND taxon_counts.superkingdom_taxid = #{CATEGORIES_TAXID_BY_NAME['Viruses']}"
+    end
+
+    read_specificity_clause = ""
+    if read_specificity
+      read_specificity_clause = " AND taxon_counts.tax_id > 0"
+    end
+
+    if !include_phage && categories.present?
+      phage_clause = " AND taxon_counts.is_phage != 1"
+    elsif include_phage && categories.blank?
+      phage_clause = " AND taxon_counts.is_phage = 1"
+    end
+
+    query = "
+    SELECT
+      taxon_counts.pipeline_run_id     AS  pipeline_run_id,
+      taxon_counts.tax_id              AS  tax_id,
+      taxon_counts.count_type          AS  count_type,
+      taxon_counts.tax_level           AS  tax_level,
+      taxon_counts.genus_taxid         AS  genus_taxid,
+      taxon_counts.family_taxid        AS  family_taxid,
+      taxon_counts.name                AS  name,
+      taxon_counts.superkingdom_taxid  AS  superkingdom_taxid,
+      taxon_counts.is_phage            AS  is_phage,
+      taxon_counts.count               AS  r,
+      taxon_summaries.stdev            AS stdev,
+      taxon_summaries.mean             AS mean,
+      taxon_counts.percent_identity    AS  percentidentity,
+      taxon_counts.alignment_length    AS  alignmentlength,
+      IF(
+        taxon_counts.e_value IS NOT NULL,
+        (0.0 - taxon_counts.e_value),
+        #{ReportHelper::DEFAULT_SAMPLE_NEGLOGEVALUE}
+      )                                AS  neglogevalue,
+      taxon_counts.percent_concordant  AS  percentconcordant
+    FROM taxon_counts
+    LEFT OUTER JOIN taxon_summaries ON
+      #{background_id.to_i}   = taxon_summaries.background_id   AND
+      taxon_counts.count_type = taxon_summaries.count_type      AND
+      taxon_counts.tax_level  = taxon_summaries.tax_level       AND
+      taxon_counts.tax_id     = taxon_summaries.tax_id
+    WHERE
+      pipeline_run_id in (#{pipeline_run_ids.join(',')})
+      AND taxon_counts.genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}
+      AND taxon_counts.count >= #{MINIMUM_READ_THRESHOLD}
+      AND taxon_counts.count_type IN ('NT', 'NR')
+      #{categories_clause}
+      #{read_specificity_clause}
+      #{phage_clause}
+    LIMIT #{num_results}
+     "
+    sql_results = TaxonCount.connection.select_all(query).to_hash
+
+    # calculating rpm and zscore, organizing the results by pipeline_run_id
+    result_hash = {}
+
+    pipeline_run_ids = sql_results.map { |x| x['pipeline_run_id'] }
+    pipeline_runs = PipelineRun.where(id: pipeline_run_ids.uniq).includes([:sample])
+    pipeline_runs_by_id = Hash[pipeline_runs.map { |x| [x.id, x] }]
+
+    sql_results.each do |row|
+      pipeline_run_id = row["pipeline_run_id"]
+      if result_hash[pipeline_run_id]
+        pr = result_hash[pipeline_run_id]["pr"]
+      else
+        pr = pipeline_runs_by_id[pipeline_run_id]
+        result_hash[pipeline_run_id] = { "pr" => pr, "taxon_counts" => [] }
+      end
+      if pr.total_reads
+        z_max = ReportHelper::ZSCORE_MAX
+        z_min = ReportHelper::ZSCORE_MIN
+        z_default = ReportHelper::ZSCORE_WHEN_ABSENT_FROM_BACKGROUND
+        row["rpm"] = row["r"] / ((pr.total_reads - pr.total_ercc_reads.to_i) * pr.subsample_fraction) * 1_000_000.0
+        row["zscore"] = row["stdev"].nil? ? z_default : ((row["rpm"] - row["mean"]) / row["stdev"])
+        row["zscore"] = z_max if row["zscore"] > z_max && row["zscore"] != z_default
+        row["zscore"] = z_min if row["zscore"] < z_min
+        result_hash[pipeline_run_id]["taxon_counts"] << row
+      end
+    end
+    result_hash
   end
 end

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -1,11 +1,17 @@
 # This is a class of static helper methods for generating data for the heatmap
 # visualization. See HeatmapHelperTest.
+# See selectedOptions in SamplesHeatmapView for client-side defaults.
 module HeatmapHelper
   DEFAULT_MAX_NUM_TAXONS = 30
   # Zscore is best for heatmaps because it weighs the frequency against the background
   DEFAULT_TAXON_SORT_PARAM = 'highest_nt_zscore'.freeze
-
+  READ_SPECIFICITY = true
   MINIMUM_READ_THRESHOLD = 5
+  # Note: this is activated from the heatmap page by selecting "Viruses -
+  # Phages". The default categories are all BUT phages, though the UI does not
+  # indicate this.
+  INCLUDE_PHAGE = false
+
   MINIMUM_ZSCORE_THRESHOLD = 1.7
 
   def self.sample_taxons_dict(params, samples)
@@ -36,7 +42,6 @@ module HeatmapHelper
     read_specificity = params[:readSpecificity] ? params[:readSpecificity].to_i == 1 : false
 
     # TODO: should fail if field is not well formatted and return proper error to client
-    # TODO: (gdingle): change this to
     sort_by = params[:sortBy] || HeatmapHelper::DEFAULT_TAXON_SORT_PARAM
     species_selected = params[:species] ? params[:species].to_i == 1 : false # Otherwise genus selected
 
@@ -75,8 +80,8 @@ module HeatmapHelper
     species_selected,
     categories,
     threshold_filters = {},
-    read_specificity = false,
-    include_phage = false,
+    read_specificity = READ_SPECIFICITY,
+    include_phage = INCLUDE_PHAGE,
     min_reads = MINIMUM_READ_THRESHOLD
   )
     # return top taxons
@@ -132,7 +137,15 @@ module HeatmapHelper
     candidate_taxons.values.sort_by { |taxon| -1.0 * taxon["max_aggregate_score"].to_f }
   end
 
-  def self.fetch_top_taxons(samples, background_id, categories, read_specificity = false, include_phage = false, num_results = 1_000_000, min_reads = MINIMUM_READ_THRESHOLD)
+  def self.fetch_top_taxons(
+    samples,
+    background_id,
+    categories,
+    read_specificity = READ_SPECIFICITY,
+    include_phage = INCLUDE_PHAGE,
+    num_results = 1_000_000,
+    min_reads = MINIMUM_READ_THRESHOLD
+  )
     pipeline_run_ids = samples.map { |s| s.first_pipeline_run ? s.first_pipeline_run.id : nil }.compact
 
     categories_map = ReportHelper::CATEGORIES_TAXID_BY_NAME

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -210,7 +210,8 @@ module HeatmapHelper
       #{rpm_sql} AS rpm,
       #{zscore_sql} AS zscore
     FROM taxon_counts
-    JOIN pipeline_runs pr ON pipeline_run_id = pr.id
+    -- warning!!! pipeline_runs may be missing!!!
+    LEFT OUTER JOIN pipeline_runs pr ON pipeline_run_id = pr.id
     LEFT OUTER JOIN taxon_summaries ON
       #{background_id.to_i}   = taxon_summaries.background_id   AND
       taxon_counts.count_type = taxon_summaries.count_type      AND
@@ -221,7 +222,6 @@ module HeatmapHelper
         SELECT MAX(id)
         FROM pipeline_runs
         WHERE sample_id IN (#{samples.pluck(:id).join(',')})
-          AND job_status = '#{PipelineRun::STATUS_CHECKED}'
         GROUP BY sample_id
       )
       AND genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}
@@ -383,7 +383,6 @@ module HeatmapHelper
           SELECT MAX(id)
           FROM pipeline_runs
           WHERE sample_id IN (#{samples.pluck(:id).join(',')})
-            AND job_status = '#{PipelineRun::STATUS_CHECKED}'
           GROUP BY sample_id
         )
         AND taxon_counts.genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -221,6 +221,7 @@ module HeatmapHelper
         SELECT MAX(id)
         FROM pipeline_runs
         WHERE sample_id IN (#{samples.pluck(:id).join(',')})
+          AND job_status = '#{PipelineRun::STATUS_CHECKED}'
         GROUP BY sample_id
       )
       AND genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}
@@ -382,6 +383,7 @@ module HeatmapHelper
           SELECT MAX(id)
           FROM pipeline_runs
           WHERE sample_id IN (#{samples.pluck(:id).join(',')})
+            AND job_status = '#{PipelineRun::STATUS_CHECKED}'
           GROUP BY sample_id
         )
         AND taxon_counts.genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -42,7 +42,19 @@ module HeatmapHelper
     first_sample = samples.first
     background_id = params[:background] ? params[:background].to_i : get_background_id(first_sample)
 
-    taxon_ids = HeatmapHelper.top_taxons_details(samples, background_id, num_results, sort_by, species_selected, categories, threshold_filters, read_specificity, include_phage).pluck("tax_id")
+    taxon_ids = HeatmapHelper.top_taxons_details(
+      samples,
+      background_id,
+      num_results,
+      sort_by,
+      species_selected,
+      categories,
+      threshold_filters,
+      read_specificity,
+      include_phage
+    )
+                             .pluck('tax_id')
+
     taxon_ids -= removed_taxon_ids
 
     HeatmapHelper.samples_taxons_details(samples, taxon_ids, background_id, species_selected, threshold_filters)

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -116,13 +116,14 @@ module HeatmapHelper
 
       ReportHelper.compute_aggregate_scores_v2!(rows)
       rows = rows.select do |row|
-        row["NT"]["maxzscore"] >= MINIMUM_ZSCORE_THRESHOLD && ReportHelper.check_custom_filters(row, threshold_filters)
+        row["NT"]["maxzscore"] >= MINIMUM_ZSCORE_THRESHOLD &&
+          ReportHelper.check_custom_filters(row, threshold_filters)
       end
 
+      # Get the top N for each sample. This re-sorts on the same metric as in
+      # fetch_top_taxons SQL. We sort there first for performance.
       rows.sort_by! { |tax_info| ((tax_info[count_type] || {})[metric] || 0.0) * -1.0 }
       count = 1
-
-      # get the top N for each sample
       rows.each do |row|
         taxon = if candidate_taxons[row["tax_id"]]
                   candidate_taxons[row["tax_id"]]
@@ -180,6 +181,10 @@ module HeatmapHelper
           COALESCE(fraction_subsampled, 1.0)
         ) * 1000 * 1000"
 
+    zscore_sql = "COALESCE(
+        (#{rpm_sql} - mean) / stdev,
+        #{ReportHelper::ZSCORE_WHEN_ABSENT_FROM_BACKGROUND})"
+
     query = "
     SELECT
       pipeline_run_id,
@@ -200,10 +205,7 @@ module HeatmapHelper
       percent_concordant  AS  percentconcordant,
       -- First pass of ranking in SQL. Second pass in Ruby.
       #{rpm_sql} AS rpm,
-      COALESCE(
-        (#{rpm_sql} - mean) / stdev,
-        #{ReportHelper::ZSCORE_WHEN_ABSENT_FROM_BACKGROUND}
-      ) AS zscore
+      #{zscore_sql} AS zscore
     FROM taxon_counts
     JOIN pipeline_runs pr ON pipeline_run_id = pr.id
     LEFT OUTER JOIN taxon_summaries ON
@@ -215,12 +217,12 @@ module HeatmapHelper
       pipeline_run_id in (#{pipeline_run_ids.join(',')})
       AND genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}
       AND count >= #{min_reads}
-      -- AND taxon_counts.count_type = '#{sort[:count_type]}'
+      -- We need both types of counts for threshold filters
       AND taxon_counts.count_type IN ('NT', 'NR')
       #{categories_clause}
       #{read_specificity_clause}
-      #{phage_clause}"
-    # TODO: (gdingle): why select both types of count here?
+      #{phage_clause}
+      AND #{zscore_sql} >= #{MINIMUM_ZSCORE_THRESHOLD}"
 
     # This query:
     # 1) assigns a rank to each row within a pipeline run
@@ -238,11 +240,12 @@ module HeatmapHelper
         ) a
         ORDER BY
           pipeline_run_id,
+          count_type = '#{sort[:count_type]}' DESC,
           #{sort[:metric]} #{sort[:direction] == 'highest' ? 'DESC' : 'ASC'}
       ) b
-      WHERE rank <= #{num_results * 16};
+      -- Overfetch by a factor of 4 to allow for post-SQL threshold filters
+      WHERE rank <= #{num_results * 4};
     "
-    # TODO: (gdingle): do we still need to overfetch???
 
     # TODO: (gdingle): how do we protect against SQL injection?
     sql_results = TaxonCount.connection.select_all(top_n_query).to_hash

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -132,7 +132,8 @@ module HeatmapHelper
                 else
                   { "tax_id" => row["tax_id"], "samples" => {} }
                 end
-        taxon["max_aggregate_score"] = row[sort[:count_type]][sort[:metric]] if taxon["max_aggregate_score"].to_f < row[sort[:count_type]][sort[:metric]].to_f
+        taxon["max_aggregate_score"] = row[sort[:count_type]][sort[:metric]] if
+          taxon["max_aggregate_score"].to_f < row[sort[:count_type]][sort[:metric]].to_f
         taxon["samples"][sample_id] = [count, row["tax_level"], row["NT"]["zscore"], row["NR"]["zscore"]]
         candidate_taxons[row["tax_id"]] = taxon
         break if count >= num_results
@@ -182,7 +183,9 @@ module HeatmapHelper
         ) * 1000 * 1000"
 
     zscore_sql = "COALESCE(
-        (#{rpm_sql} - mean) / stdev,
+        GREATEST(#{ReportHelper::ZSCORE_MIN}, LEAST(#{ReportHelper::ZSCORE_MAX},
+          (#{rpm_sql} - mean) / stdev
+        )),
         #{ReportHelper::ZSCORE_WHEN_ABSENT_FROM_BACKGROUND})"
 
     query = "

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -12,6 +12,7 @@ module HeatmapHelper
     return {} if samples.empty?
 
     num_results = params[:taxonsPerSample] ? params[:taxonsPerSample].to_i : DEFAULT_MAX_NUM_TAXONS
+    min_reads = params[:minReads] ? params[:minReads].to_i : MINIMUM_READ_THRESHOLD
     removed_taxon_ids = (params[:removedTaxonIds] || []).map do |x|
       begin
         Integer(x)
@@ -51,18 +52,43 @@ module HeatmapHelper
       categories,
       threshold_filters,
       read_specificity,
-      include_phage
-    )
-                             .pluck('tax_id')
+      include_phage,
+      min_reads
+    ).pluck('tax_id')
 
     taxon_ids -= removed_taxon_ids
 
-    HeatmapHelper.samples_taxons_details(samples, taxon_ids, background_id, species_selected, threshold_filters)
+    HeatmapHelper.samples_taxons_details(
+      samples,
+      taxon_ids,
+      background_id,
+      species_selected,
+      threshold_filters
+    )
   end
 
-  def self.top_taxons_details(samples, background_id, num_results, sort_by, species_selected, categories, threshold_filters = {}, read_specificity = false, include_phage = false)
+  def self.top_taxons_details(
+    samples,
+    background_id,
+    num_results,
+    sort_by,
+    species_selected,
+    categories,
+    threshold_filters = {},
+    read_specificity = false,
+    include_phage = false,
+    min_reads = MINIMUM_READ_THRESHOLD
+  )
     # return top taxons
-    results_by_pr = fetch_top_taxons(samples, background_id, categories, read_specificity, include_phage, num_results)
+    results_by_pr = fetch_top_taxons(
+      samples,
+      background_id,
+      categories,
+      read_specificity,
+      include_phage,
+      num_results,
+      min_reads
+    )
 
     sort = ReportHelper.decode_sort_by(sort_by)
     count_type = sort[:count_type]
@@ -106,7 +132,7 @@ module HeatmapHelper
     candidate_taxons.values.sort_by { |taxon| -1.0 * taxon["max_aggregate_score"].to_f }
   end
 
-  def self.fetch_top_taxons(samples, background_id, categories, read_specificity = false, include_phage = false, num_results = 1_000_000)
+  def self.fetch_top_taxons(samples, background_id, categories, read_specificity = false, include_phage = false, num_results = 1_000_000, min_reads = MINIMUM_READ_THRESHOLD)
     pipeline_run_ids = samples.map { |s| s.first_pipeline_run ? s.first_pipeline_run.id : nil }.compact
 
     categories_map = ReportHelper::CATEGORIES_TAXID_BY_NAME
@@ -159,7 +185,7 @@ module HeatmapHelper
     WHERE
       pipeline_run_id in (#{pipeline_run_ids.join(',')})
       AND taxon_counts.genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}
-      AND taxon_counts.count >= #{MINIMUM_READ_THRESHOLD}
+      AND taxon_counts.count >= #{min_reads}
       AND taxon_counts.count_type IN ('NT', 'NR')
       #{categories_clause}
       #{read_specificity_clause}
@@ -197,7 +223,13 @@ module HeatmapHelper
     result_hash
   end
 
-  def self.samples_taxons_details(samples, taxon_ids, background_id, species_selected, threshold_filters)
+  def self.samples_taxons_details(
+    samples,
+    taxon_ids,
+    background_id,
+    species_selected,
+    threshold_filters
+  )
     results = {}
 
     # Get sample results for the taxon ids

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -1,12 +1,10 @@
+# This is a class of static helper methods for generating data for the heatmap
+# visualization. See HeatmapHelperTest.
 module HeatmapHelper
   DEFAULT_MAX_NUM_TAXONS = 30
 
   MINIMUM_READ_THRESHOLD = 5
   MINIMUM_ZSCORE_THRESHOLD = 1.7
-
-  # All the methods below should be considered private, but I don't know enough
-  # about ruby to actually make a class method private and call it.
-  # private
 
   def self.sample_taxons_dict(params, samples)
     return {} if samples.empty?

--- a/app/helpers/heatmap_helper_test.rb
+++ b/app/helpers/heatmap_helper_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class HeatmapHelperTest < ActiveSupport::TestCase
   setup do
-    @samples = [samples(:one), samples(:two)]
+    @samples = [samples(:one), samples(:two), samples(:six)]
     @background = backgrounds(:real_background)
     @min_reads = 1 # different from default to allow fewer fixtures
 
@@ -25,9 +25,7 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       minReads: 1
     }
 
-    @top_taxons_details = [{ 'tax_id' => 1,
-                             'samples' => { @samples[0].id => [1, 1, 100, -100], @samples[1].id => [1, 1, 100, -100] },
-                             'max_aggregate_score' => 100 }]
+    @top_taxons_details = [{ "tax_id" => 573, "samples" => { 51_848_956 => [1, 1, 100.0, 100.0] }, "max_aggregate_score" => 100.0 }, { "tax_id" => 28_037, "samples" => { 51_848_956 => [2, 1, 100.0, -100] }, "max_aggregate_score" => 100.0 }, { "tax_id" => 1, "samples" => { 980_190_962 => [1, 1, 100.0, -100], 298_486_374 => [1, 1, 100.0, -100] }, "max_aggregate_score" => 100.0 }, { "tax_id" => 1313, "samples" => { 51_848_956 => [3, 1, -100, 100.0] } }]
   end
 
   test "sample_taxons_dict defaults" do
@@ -35,14 +33,14 @@ class HeatmapHelperTest < ActiveSupport::TestCase
 
     assert_equal @samples.length, dicts.length
     dict = dicts[0]
-    assert_equal 1, dict[:taxons].length
+    assert_equal 3, dict[:taxons].length
     taxon = dict[:taxons][0]
     assert_equal 10, taxon["NT"].length
     assert_equal 10, taxon["NR"].length
-    assert_equal 100, taxon["NT"]["zscore"]
-    assert_equal 100 * -1, taxon["NR"]["zscore"]
-    assert_equal "some species", taxon["name"]
-    assert_equal "Uncategorized", taxon["category_name"]
+    assert_equal 99, taxon["NT"]["zscore"]
+    assert_equal 99, taxon["NR"]["zscore"]
+    assert_equal "Klebsiella pneumoniae", taxon["name"]
+    assert_equal "Bacteria", taxon["category_name"]
   end
 
   test "top_taxons_details defaults" do
@@ -58,7 +56,7 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @include_phage,
       @min_reads
     )
-    assert_equal 1, details.length
+    assert_equal 4, details.length
     assert_equal 100, details[0]["max_aggregate_score"]
     assert_equal @top_taxons_details, details
   end
@@ -108,12 +106,10 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @include_phage,
       @min_reads
     )
-    # TODO: (gdingle): where does this constant come from? not in codebase...?
-    assert_equal 1_900_000_001 * -1, details[0]["tax_id"]
+    assert_equal 570, details[0]["tax_id"]
   end
 
   test "fetch_top_taxons defaults" do
-    # TODO: (gdingle): num_results, sort
     top_taxons = HeatmapHelper.fetch_top_taxons(
       @samples,
       @background.id,
@@ -121,9 +117,10 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @read_specificity,
       @include_phage,
       @num_results,
-      @min_reads
+      @min_reads,
+      @sort_by
     )
-    assert_equal 2, top_taxons.length
+    assert_equal 3, top_taxons.length
     top_taxon = top_taxons[@samples[0].pipeline_runs[0].id]
     taxon_counts = top_taxon["taxon_counts"]
     assert_equal 1, taxon_counts.length
@@ -131,6 +128,52 @@ class HeatmapHelperTest < ActiveSupport::TestCase
     assert_equal "some species", taxon_count["name"]
     assert_equal 100, taxon_count["zscore"]
     assert_equal 1_000_000, taxon_count["rpm"]
+  end
+
+  test "fetch_top_taxons num_results" do
+    top_taxons = HeatmapHelper.fetch_top_taxons(
+      @samples,
+      @background.id,
+      @categories,
+      @read_specificity,
+      @include_phage,
+      0,
+      @min_reads,
+      @sort_by
+    )
+    assert_equal 0, top_taxons.length
+  end
+
+  test "fetch_top_taxons sort_by" do
+    top_taxons = HeatmapHelper.fetch_top_taxons(
+      @samples,
+      @background.id,
+      @categories,
+      @read_specificity,
+      @include_phage,
+      @num_results,
+      @min_reads,
+      "highest_nt_r"
+    )
+    top_taxon = top_taxons.first[1]
+    taxon_count = top_taxon["taxon_counts"][0]
+    assert_equal "Klebsiella", taxon_count["name"]
+    assert_equal 217, taxon_count["r"]
+
+    top_taxons = HeatmapHelper.fetch_top_taxons(
+      @samples,
+      @background.id,
+      @categories,
+      @read_specificity,
+      @include_phage,
+      @num_results,
+      @min_reads,
+      "lowest_nt_r"
+    )
+    top_taxon = top_taxons.first[1]
+    taxon_count = top_taxon["taxon_counts"][0]
+    assert_equal "Streptococcus", taxon_count["name"]
+    assert_equal 4, taxon_count["r"]
   end
 
   test "fetch_top_taxons include_phage" do
@@ -141,7 +184,8 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @read_specificity,
       true,
       @num_results,
-      @min_reads
+      @min_reads,
+      @sort_by
     )
     assert_equal 0, top_taxons.length
   end
@@ -154,7 +198,8 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @read_specificity,
       @include_phage,
       @num_results,
-      @min_reads
+      @min_reads,
+      @sort_by
     )
     assert_equal 2, top_taxons.length
 
@@ -165,9 +210,10 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @read_specificity,
       @include_phage,
       @num_results,
-      @min_reads
+      @min_reads,
+      @sort_by
     )
-    assert_equal 0, top_taxons.length
+    assert_equal 1, top_taxons.length
   end
 
   test "samples_taxons_details defaults" do
@@ -181,12 +227,12 @@ class HeatmapHelperTest < ActiveSupport::TestCase
     )
 
     dict = dicts[0]
-    assert_equal 1, dict[:taxons].length
+    assert_equal 3, dict[:taxons].length
     taxon = dict[:taxons][0]
     assert_equal 10, taxon["NT"].length
     assert_equal 10, taxon["NR"].length
-    assert_equal 100, taxon["NT"]["zscore"]
-    assert_equal 100 * -1, taxon["NR"]["zscore"]
+    assert_equal 99, taxon["NT"]["zscore"]
+    assert_equal 99, taxon["NR"]["zscore"]
   end
 
   test "samples_taxons_details species_selected false" do

--- a/app/helpers/heatmap_helper_test.rb
+++ b/app/helpers/heatmap_helper_test.rb
@@ -1,57 +1,73 @@
-# TODO: (gdingle): store inputs and outputs from for known good values
-class HeatmapHelper < ActiveSupport::TestCase
-  setup do
-    @samples = "TODO"
-    @background_id = "TODO"
-    @num_results = "TODO"
-    @categories = "TODO"
-    @threshold_filters = "TODO"
-    @read_specificity = "TODO"
-    @include_phage = "TODO"
-    @species_selected = "TODO"
+require 'test_helper'
 
-    @sort_by_key = "TODO"
+# TODO: (gdingle): store inputs and outputs from for known good values
+class HeatmapHelperTest < ActiveSupport::TestCase
+  setup do
+    @samples = [samples(:one), samples(:two)]
+    @background = backgrounds(:one)
+    @num_results = 30 # default in UI
+    @sort_by = "highest_nt_zscore"
+
+    # @categories = ReportHelper::ALL_CATEGORIES.map { |category| category['name'] }
+    # TODO: (gdingle): vary these
+    @categories = []
+    @threshold_filters = []
+    @read_specificity = false
+    @include_phage = false
+    @species_selected = true
+
+    @params = {
+      background: @background.id,
+      sortBy: @sort_by,
+      taxonsPerSample: @num_results,
+      readSpecificity: 1,
+      species: 1,
+      subcategories: {}
+    }
   end
 
   test "sample_taxons_dict works" do
-    HeatmapHelper.sample_taxons_dict(params,
-                                     @samples)
+    dict = HeatmapHelper.sample_taxons_dict(@params, @samples)
+    assert_equal [
+      { sample_id: 980_190_962, name: "sample1", metadata: [], host_genome_name: nil },
+      { sample_id: 298_486_374, name: "sample2", metadata: [], host_genome_name: nil }
+    ], dict
   end
 
-  test "top_taxons_details works" do
-    HeatmapHelper.top_taxons_details(
-      @samples,
-      @background_id,
-      @num_results,
-      @sort_by_key,
-      @species_selected,
-      @categories,
-      @threshold_filters = {},
-      @read_specificity = false,
-      @include_phage = false
-    )
-  end
+  # test "top_taxons_details works" do
+  #   HeatmapHelper.top_taxons_details(
+  #     @samples,
+  #     @background_id,
+  #     @num_results,
+  #     @sort_by,
+  #     @species_selected,
+  #     @categories,
+  #     @threshold_filters = {},
+  #     @read_specificity = false,
+  #     @include_phage = false
+  #   )
+  # end
 
-  test "fetch_top_taxons works" do
-    # TODO: (gdingle): num_results, sort
-    HeatmapHelper.fetch_top_taxons(
-      @samples,
-      @background_id,
-      @categories,
-      @read_specificity = false,
-      @include_phage = false,
-      @num_results = 1_000_000
-    )
-  end
+  # test "fetch_top_taxons works" do
+  #   # TODO: (gdingle): num_results, sort
+  #   HeatmapHelper.fetch_top_taxons(
+  #     @samples,
+  #     @background_id,
+  #     @categories,
+  #     @read_specificity = false,
+  #     @include_phage = false,
+  #     @num_results = 1_000_000
+  #   )
+  # end
 
-  test "samples_taxons_details works" do
-    # TODO: (gdingle): num_results, sort
-    HeatmapHelper.samples_taxons_details(
-      @samples,
-      taxon_ids,
-      @background_id,
-      @species_selected,
-      @threshold_filters
-    )
-  end
+  # test "samples_taxons_details works" do
+  #   # TODO: (gdingle): num_results, sort
+  #   HeatmapHelper.samples_taxons_details(
+  #     @samples,
+  #     taxon_ids,
+  #     @background_id,
+  #     @species_selected,
+  #     @threshold_filters
+  #   )
+  # end
 end

--- a/app/helpers/heatmap_helper_test.rb
+++ b/app/helpers/heatmap_helper_test.rb
@@ -1,0 +1,57 @@
+# TODO: (gdingle): store inputs and outputs from for known good values
+class HeatmapHelper < ActiveSupport::TestCase
+  setup do
+    @samples = "TODO"
+    @background_id = "TODO"
+    @num_results = "TODO"
+    @categories = "TODO"
+    @threshold_filters = "TODO"
+    @read_specificity = "TODO"
+    @include_phage = "TODO"
+    @species_selected = "TODO"
+
+    @sort_by_key = "TODO"
+  end
+
+  test "sample_taxons_dict works" do
+    HeatmapHelper.sample_taxons_dict(params,
+                                     @samples)
+  end
+
+  test "top_taxons_details works" do
+    HeatmapHelper.top_taxons_details(
+      @samples,
+      @background_id,
+      @num_results,
+      @sort_by_key,
+      @species_selected,
+      @categories,
+      @threshold_filters = {},
+      @read_specificity = false,
+      @include_phage = false
+    )
+  end
+
+  test "fetch_top_taxons works" do
+    # TODO: (gdingle): num_results, sort
+    HeatmapHelper.fetch_top_taxons(
+      @samples,
+      @background_id,
+      @categories,
+      @read_specificity = false,
+      @include_phage = false,
+      @num_results = 1_000_000
+    )
+  end
+
+  test "samples_taxons_details works" do
+    # TODO: (gdingle): num_results, sort
+    HeatmapHelper.samples_taxons_details(
+      @samples,
+      taxon_ids,
+      @background_id,
+      @species_selected,
+      @threshold_filters
+    )
+  end
+end

--- a/app/helpers/heatmap_helper_test.rb
+++ b/app/helpers/heatmap_helper_test.rb
@@ -22,21 +22,13 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       taxonsPerSample: @num_results,
       readSpecificity: 1,
       species: 1,
-      subcategories: {}
+      subcategories: {},
+      minReads: 1
     }
 
     @top_taxons_details = [{ 'tax_id' => 1,
                              'samples' => { @samples[0].id => [1, 1, 100, -100], @samples[1].id => [1, 1, 100, -100] },
                              'max_aggregate_score' => 100 }]
-
-    # TODO: (gdingle): avoid warning "warning: previous definition"
-    # Temp change for allowing less test data
-    @_min_read = HeatmapHelper::MINIMUM_READ_THRESHOLD
-    HeatmapHelper::MINIMUM_READ_THRESHOLD = 1
-  end
-
-  teardown do
-    HeatmapHelper::MINIMUM_READ_THRESHOLD = @_min_read
   end
 
   test "sample_taxons_dict works" do
@@ -62,7 +54,8 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @categories,
       @threshold_filters = {},
       @read_specificity = false,
-      @include_phage = false
+      @include_phage = false,
+      1, # min_reads
     )
     assert_equal @top_taxons_details, details
   end
@@ -75,7 +68,8 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @categories,
       @read_specificity,
       @include_phage,
-      @num_results
+      @num_results,
+      1, # min_reads
     )
     assert_equal 2, top_taxons.length
     top_taxon = top_taxons[@samples[0].pipeline_runs[0].id]

--- a/app/helpers/heatmap_helper_test.rb
+++ b/app/helpers/heatmap_helper_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 
-# TODO: (gdingle): store inputs and outputs from for known good values
 class HeatmapHelperTest < ActiveSupport::TestCase
   setup do
     @samples = [samples(:one), samples(:two)]
@@ -85,8 +84,7 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @samples,
       @background_id,
       @num_results,
-      # TODO: (gdingle): remove aggregate score
-      "highest_nt_aggregatescore",
+      "highest_nt_rpm",
       @species_selected,
       @categories,
       @threshold_filters = {},
@@ -94,7 +92,7 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @include_phage,
       @min_reads
     )
-    assert_equal 200_000_000.0, details[0]["max_aggregate_score"]
+    assert_equal 2_000_000.0, details[0]["max_aggregate_score"]
   end
 
   test "top_taxons_details species_selected false" do

--- a/app/helpers/heatmap_helper_test.rb
+++ b/app/helpers/heatmap_helper_test.rb
@@ -85,6 +85,7 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @samples,
       @background_id,
       @num_results,
+      # TODO: (gdingle): remove aggregate score
       "highest_nt_aggregatescore",
       @species_selected,
       @categories,

--- a/app/helpers/heatmap_helper_test.rb
+++ b/app/helpers/heatmap_helper_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class HeatmapHelperTest < ActiveSupport::TestCase
   setup do
     @samples = [samples(:one), samples(:two)]
-    @background = backgrounds(:one)
+    @background = backgrounds(:real_background)
     @num_results = 30 # default in UI
     @sort_by = "highest_nt_zscore"
 
@@ -24,48 +24,74 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       species: 1,
       subcategories: {}
     }
+
+    # TODO: (gdingle): avoid warning "warning: previous definition"
+    # Temp change for allowing less test data
+    @_min_read = HeatmapHelper::MINIMUM_READ_THRESHOLD
+    HeatmapHelper::MINIMUM_READ_THRESHOLD = 1
+  end
+
+  teardown do
+    HeatmapHelper::MINIMUM_READ_THRESHOLD = @_min_read
   end
 
   test "sample_taxons_dict works" do
-    dict = HeatmapHelper.sample_taxons_dict(@params, @samples)
-    assert_equal [
-      { sample_id: 980_190_962, name: "sample1", metadata: [], host_genome_name: nil },
-      { sample_id: 298_486_374, name: "sample2", metadata: [], host_genome_name: nil }
-    ], dict
+    dicts = HeatmapHelper.sample_taxons_dict(@params, @samples)
+    assert_equal @samples.length, dicts.length
+    dict = dicts[0]
+    assert_equal 1, dict[:taxons].length
+    taxon = dict[:taxons][0]
+    assert_equal 10, taxon["NT"].length
+    assert_equal 10, taxon["NR"].length
+    assert_equal 100, taxon["NT"]["zscore"]
+    assert_equal 100 * -1, taxon["NR"]["zscore"]
   end
 
-  # test "top_taxons_details works" do
-  #   HeatmapHelper.top_taxons_details(
-  #     @samples,
-  #     @background_id,
-  #     @num_results,
-  #     @sort_by,
-  #     @species_selected,
-  #     @categories,
-  #     @threshold_filters = {},
-  #     @read_specificity = false,
-  #     @include_phage = false
-  #   )
-  # end
+  # TODO: (gdingle): need fetch_top_taxons first
+  test "top_taxons_details works" do
+    details = HeatmapHelper.top_taxons_details(
+      @samples,
+      @background_id,
+      @num_results,
+      @sort_by,
+      @species_selected,
+      @categories,
+      @threshold_filters = {},
+      @read_specificity = false,
+      @include_phage = false
+    )
+    assert_equal [{ 'tax_id' => 1,
+                    'samples' => { @samples[0].id => [1, 1, 100, -100], @samples[1].id => [1, 1, 100, -100] },
+                    'max_aggregate_score' => 100 }],
+                 details
+  end
 
-  # test "fetch_top_taxons works" do
-  #   # TODO: (gdingle): num_results, sort
-  #   HeatmapHelper.fetch_top_taxons(
-  #     @samples,
-  #     @background_id,
-  #     @categories,
-  #     @read_specificity = false,
-  #     @include_phage = false,
-  #     @num_results = 1_000_000
-  #   )
-  # end
+  test "fetch_top_taxons works" do
+    # TODO: (gdingle): num_results, sort
+    top_taxons = HeatmapHelper.fetch_top_taxons(
+      @samples,
+      @background.id,
+      @categories,
+      @read_specificity,
+      @include_phage,
+      @num_results
+    )
+    assert_equal 2, top_taxons.length
+    top_taxon = top_taxons[@samples[0].pipeline_runs[0].id]
+    taxon_counts = top_taxon["taxon_counts"]
+    assert_equal 1, taxon_counts.length
+    taxon_count = taxon_counts[0]
+    assert_equal "some species", taxon_count["name"]
+    assert_equal 100, taxon_count["zscore"]
+    assert_equal 1_000_000, taxon_count["rpm"]
+  end
 
   # test "samples_taxons_details works" do
   #   # TODO: (gdingle): num_results, sort
   #   HeatmapHelper.samples_taxons_details(
   #     @samples,
   #     taxon_ids,
-  #     @background_id,
+  #     @background.id,
   #     @species_selected,
   #     @threshold_filters
   #   )

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -249,56 +249,6 @@ module ReportHelper
     end
   end
 
-  # TODO: (gdingle): refactor to class method
-  def samples_taxons_details(samples, taxon_ids, background_id, species_selected, threshold_filters)
-    results = {}
-
-    # Get sample results for the taxon ids
-    unless taxon_ids.empty?
-      samples_by_id = Hash[samples.map { |s| [s.id, s] }]
-      parent_ids = ReportHelper.fetch_parent_ids(taxon_ids, samples)
-      results_by_pr = ReportHelper.fetch_samples_taxons_counts(samples, taxon_ids, parent_ids, background_id)
-      results_by_pr.each do |_pr_id, res|
-        pr = res["pr"]
-        taxon_counts = res["taxon_counts"]
-        sample_id = pr.sample_id
-        tax_2d = ReportHelper.taxon_counts_cleanup(taxon_counts)
-        ReportHelper.only_species_or_genus_counts!(tax_2d, species_selected)
-
-        rows = []
-        tax_2d.each { |_tax_id, tax_info| rows << tax_info }
-        ReportHelper.compute_aggregate_scores_v2!(rows)
-
-        filtered_rows = rows
-                        .select { |row| taxon_ids.include?(row["tax_id"]) }
-                        .each { |row| row[:filtered] = ReportHelper.check_custom_filters(row, threshold_filters) }
-
-        results[sample_id] = {
-          sample_id: sample_id,
-          name: samples_by_id[sample_id].name,
-          metadata: samples_by_id[sample_id].metadata_with_base_type,
-          host_genome_name: samples_by_id[sample_id].host_genome_name,
-          taxons: filtered_rows
-        }
-      end
-    end
-
-    # For samples that didn't have matching taxons, just throw in the metadata.
-    samples.each do |sample|
-      unless results.key?(sample.id)
-        results[sample.id] = {
-          sample_id: sample.id,
-          name: sample.name,
-          metadata: sample.metadata_with_base_type,
-          host_genome_name: sample.host_genome_name
-        }
-      end
-    end
-
-    # Flatten the hash
-    results.values
-  end
-
   # All the methods below should be considered private, but I don't know enough
   # about ruby to actually make a class method private and call it.
   # private

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -471,7 +471,7 @@ module ReportHelper
         result_hash[pipeline_run_id] = { "pr" => pr, "taxon_counts" => [] }
       end
       if pr.total_reads
-        row["rpm"] = row["r"] / pr.rpm_denominator
+        row["rpm"] = pr.rpm(row["r"])
         row["zscore"] = row["stdev"].nil? ? ZSCORE_WHEN_ABSENT_FROM_BACKGROUND : ((row["rpm"] - row["mean"]) / row["stdev"])
         row["zscore"] = ZSCORE_MAX if row["zscore"] > ZSCORE_MAX && row["zscore"] != ZSCORE_WHEN_ABSENT_FROM_BACKGROUND
         row["zscore"] = ZSCORE_MIN if row["zscore"] < ZSCORE_MIN

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -685,7 +685,6 @@ module ReportHelper
     aggregate
   end
 
-  # TODO: (gdingle): remove aggregate score?
   def self.compute_genera_aggregate_scores!(rows, tax_2d)
     rows.each do |species_info|
       next unless species_info['tax_level'] == TaxonCount::TAX_LEVEL_SPECIES
@@ -701,7 +700,6 @@ module ReportHelper
     end
   end
 
-  # TODO: (gdingle): remove aggregate score?
   def self.compute_species_aggregate_scores!(rows, tax_2d, scoring_model)
     scoring_model ||= TaxonScoringModel::DEFAULT_MODEL_NAME
     tsm = TaxonScoringModel.find_by(name: scoring_model)

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -471,7 +471,7 @@ module ReportHelper
         result_hash[pipeline_run_id] = { "pr" => pr, "taxon_counts" => [] }
       end
       if pr.total_reads
-        row["rpm"] = row["r"] / ((pr.total_reads - pr.total_ercc_reads.to_i) * pr.subsample_fraction) * 1_000_000.0
+        row["rpm"] = row["r"] / pr.rpm_denominator
         row["zscore"] = row["stdev"].nil? ? ZSCORE_WHEN_ABSENT_FROM_BACKGROUND : ((row["rpm"] - row["mean"]) / row["stdev"])
         row["zscore"] = ZSCORE_MAX if row["zscore"] > ZSCORE_MAX && row["zscore"] != ZSCORE_WHEN_ABSENT_FROM_BACKGROUND
         row["zscore"] = ZSCORE_MIN if row["zscore"] < ZSCORE_MIN
@@ -798,6 +798,7 @@ module ReportHelper
     aggregate
   end
 
+  # TODO: (gdingle): remove aggregate score?
   def self.compute_aggregate_scores_v2!(rows)
     rows.each do |taxon_info|
       # NT and NR zscore are set to the same
@@ -809,6 +810,7 @@ module ReportHelper
     end
   end
 
+  # TODO: (gdingle): remove aggregate score?
   def self.compute_genera_aggregate_scores!(rows, tax_2d)
     rows.each do |species_info|
       next unless species_info['tax_level'] == TaxonCount::TAX_LEVEL_SPECIES
@@ -824,6 +826,7 @@ module ReportHelper
     end
   end
 
+  # TODO: (gdingle): remove aggregate score?
   def self.compute_species_aggregate_scores!(rows, tax_2d, scoring_model)
     scoring_model ||= TaxonScoringModel::DEFAULT_MODEL_NAME
     tsm = TaxonScoringModel.find_by(name: scoring_model)

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -24,7 +24,6 @@ module ReportHelper
   DECIMALS = 7
 
   DEFAULT_SORT_PARAM = 'highest_nt_aggregatescore'.freeze
-  DEFAULT_TAXON_SORT_PARAM = 'highest_nt_aggregatescore'.freeze
   DEFAULT_PARAMS = { sort_by: DEFAULT_SORT_PARAM }.freeze
 
   IGNORED_PARAMS = [:controller, :action, :id].freeze

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1450,7 +1450,9 @@ class PipelineRun < ApplicationRecord
     end
   end
 
-  def rpm_denominator
-    ((total_reads - total_ercc_reads.to_i) * subsample_fraction) * 1_000_000.0
+  # TODO: (gdingle): write docs
+  def rpm(raw_read_count)
+    raw_read_count /
+      ((total_reads - total_ercc_reads.to_i) * subsample_fraction) * 1_000_000.0
   end
 end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1449,4 +1449,8 @@ class PipelineRun < ApplicationRecord
       MetricUtil.put_metric_now("samples.cache.precached", 1)
     end
   end
+
+  def rpm_denominator
+    ((total_reads - total_ercc_reads.to_i) * subsample_fraction) * 1_000_000.0
+  end
 end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1450,7 +1450,6 @@ class PipelineRun < ApplicationRecord
     end
   end
 
-  # TODO: (gdingle): write docs
   def rpm(raw_read_count)
     raw_read_count /
       ((total_reads - total_ercc_reads.to_i) * subsample_fraction) * 1_000_000.0

--- a/test/fixtures/pipeline_runs.yml
+++ b/test/fixtures/pipeline_runs.yml
@@ -21,6 +21,7 @@ three:
   adjusted_remaining_reads: 1
   alignment_config: one
   total_ercc_reads: 0
+  job_status: "CHECKED"
 four:
   sample: two
   job_id: 'four'
@@ -28,6 +29,7 @@ four:
   adjusted_remaining_reads: 1
   alignment_config: one
   total_ercc_reads: 0
+  job_status: "CHECKED"
 five:
   job_id: 'five'
   total_reads: 1

--- a/test/fixtures/pipeline_runs.yml
+++ b/test/fixtures/pipeline_runs.yml
@@ -20,12 +20,14 @@ three:
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  total_ercc_reads: 0
 four:
   sample: two
   job_id: 'four'
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  total_ercc_reads: 0
 five:
   job_id: 'five'
   total_reads: 1

--- a/test/models/pipeline_run_test.rb
+++ b/test/models/pipeline_run_test.rb
@@ -31,14 +31,13 @@ class PipelineRunTest < ActiveSupport::TestCase
   end
 
   test "Reads per million is correct" do
-    pr = pipeline_runs(:four)
+    pr = pipeline_runs(:six)
 
-    # TODO: (gdingle): what are realistic values
-    assert_equal 1, pr.total_reads
-    assert_equal 0, pr.total_ercc_reads
+    assert_equal 1122, pr.total_reads
+    assert_equal nil, pr.total_ercc_reads
     assert_equal 1, pr.subsample_fraction
 
-    assert_equal 5_000_000.0, pr.rpm(5)
+    assert_equal 4456.327985739751, pr.rpm(5)
     assert_equal 0.0, pr.rpm(0)
   end
 end

--- a/test/models/pipeline_run_test.rb
+++ b/test/models/pipeline_run_test.rb
@@ -29,4 +29,16 @@ class PipelineRunTest < ActiveSupport::TestCase
 
     mock.verify
   end
+
+  test "Reads per million is correct" do
+    pr = pipeline_runs(:four)
+
+    # TODO: (gdingle): what are realistic values
+    assert_equal 1, pr.total_reads
+    assert_equal 0, pr.total_ercc_reads
+    assert_equal 1, pr.subsample_fraction
+
+    assert_equal 5_000_000.0, pr.rpm(5)
+    assert_equal 0.0, pr.rpm(0)
+  end
 end


### PR DESCRIPTION
# Description

This PR reduces the time to render the heatmap by about 40% on top of previous gains. In my test of a 49 sample project, time for the `samples_taxons` endpoint went down from 14s to 8s consistently. 

The improvement was achieved mostly by ranking and filtering in SQL instead of ruby. See `top_n_query`. 

Next, about 2 seconds was saved by converting two N+1 queries into a subquery to get the most recent pipeline run. 

Thirdly, the bottleneck SQL query was filtered more with `MINIMUM_ZSCORE_THRESHOLD` and `MINIMUM_READ_THRESHOLD`.

In the process, I refactored `HeatmapHelper` and `ReportHelper` a bunch. I moved all methods used only by `HeatmapHelper` into that class. There is still a lot of duplication of code in the two classes. I will leave that for another day. 

Other changes:
* I added a suite of unit tests to cover the public methods of `ReportHelper`. The tests cover different permutations of inputs but not all edge cases. 
* I removed the `aggregatescore` from the heatmap UI and code on recommendation by @cdebourcy .

# Notes

* **failed pipeline runs**: The original logic which I reproduced in SQL is to use the most recent run regardless of status. This doesn't seem right to me. 
* **missing pipeline runs**: I literally spent 3 hours debugging an issue which turned out to be caused by taxon counts referencing pipeline runs that did not exist. There appears to be 87 of such counts in prod. See https://modeanalytics.com/editor/chanzuckerberg/reports/46d9ac9db658 . It would be nice to enforce data integrity with either database constraints or garbage collecting scripts to avoid such head-scratching situations. 
* I **duplicated definitions** of user facing metrics such as zscore for performance reasons. This could easily lead to inconsistencies if not now then later which may be spotted by users. That said, there were **already** several duplicate definitions in the reports codebase, which is more troubling. 
* There are a bunch of **magic constants and hidden filtering** in the reports codebase without explanation. For example, phages are excluded by default without any indication in the UI.
* It seems like the **aggregate score** is no longer loved. If so we should kill it in the report page as well. 

# Test

`rails t` to cover basic param functionality


To cover metric definitions:

print the values of zscore and rpm, computed in ruby and in SQL
see the values are the same


To cover correct top N behavior: 

Load a large heatmap in dev branch
Load a large heatmap in master branch
See that the values on hover are the same
See that the grid of colors is very similar, differing only in equally ranked samples or taxons
Try all different metrics, different taxons per sample


To cover metric definitions:

Load a large heatmap in dev branch
print the values of zscore and rpm, computed in ruby and in SQL
see the values are the same