### PR TITLE
[Locations] Automatically restrict overly-specific locations to the state-level + map attribution compaction

### DIFF
--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -52,9 +52,8 @@ class BaseMap extends React.Component {
 
   handleLoad = () => {
     // Show compact attribution tags
-    document
-      .getElementsByClassName("mapboxgl-ctrl-attrib")[0]
-      .classList.add("mapboxgl-compact");
+    const tag = document.getElementsByClassName("mapboxgl-ctrl-attrib")[0];
+    tag && tag.classList.add("mapboxgl-compact");
   };
 
   render() {

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -50,6 +50,13 @@ class BaseMap extends React.Component {
     updateViewport && updateViewport(viewport);
   };
 
+  handleLoad = () => {
+    // Show compact attribution tags
+    document
+      .getElementsByClassName("mapboxgl-ctrl-attrib")[0]
+      .classList.add("mapboxgl-compact");
+  };
+
   render() {
     const { mapTilerKey, tooltip, markers, popups } = this.props;
     const { viewport } = this.state;
@@ -61,6 +68,7 @@ class BaseMap extends React.Component {
           {...viewport}
           onViewportChange={this.updateViewport}
           mapStyle={styleURL}
+          onLoad={this.handleLoad}
         >
           {tooltip}
           {markers}

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -23,6 +23,11 @@ class Location < ApplicationRecord
     location_api_request(endpoint_query)
   end
 
+  def self.geosearch_by_country_and_state(country_name, state_name)
+    endpoint_query = "search.php?addressdetails=1&normalizecity=1&country=#{country_name}&state=#{state_name}"
+    location_api_request(endpoint_query)
+  end
+
   # Create a Location from parameters
   def self.create_from_params(location_params)
     # Ignore fields that don't match columns
@@ -54,6 +59,19 @@ class Location < ApplicationRecord
 
       resp = LocationHelper.adapt_location_iq_response(resp)
       create_from_params(resp)
+    end
+  end
+
+  def self.check_and_restrict_specificity(location, host_genome_name)
+    if host_genome_name == "Human"
+      if location.subdivision_name.present? || location.city_name.present?
+        # Redo the search for just the state/country and pick the first result (should be unique)
+        success, results = self.geosearch("#{location.state_name}, #{location.country_name}")
+        if success
+          results = resp.map { |r| LocationHelper.adapt_location_iq_response(r) }
+        end
+        puts "foobar 11:34am", results
+      end
     end
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -66,7 +66,7 @@ class Location < ApplicationRecord
     if host_genome_name == "Human"
       if location.subdivision_name.present? || location.city_name.present?
         # Redo the search for just the state/country and pick the first result (should be unique)
-        success, results = self.geosearch("#{location.state_name}, #{location.country_name}")
+        success, results = geosearch("#{location.state_name}, #{location.country_name}")
         if success
           results = resp.map { |r| LocationHelper.adapt_location_iq_response(r) }
         end

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -4,6 +4,7 @@ require 'elasticsearch/model'
 class Metadatum < ApplicationRecord
   include ErrorHelper
   include DateHelper
+  include LocationHelper
 
   if ELASTICSEARCH_ON
     include Elasticsearch::Model
@@ -128,6 +129,8 @@ class Metadatum < ApplicationRecord
     # Set to existing Location or create a new one based on the external IDs. For the sake of not
     # trusting user input, we'll potentially re-fetch location details based on the API and OSM IDs.
     result = Location.find_or_create_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
+    result = Location.check_and_restrict_specificity(result, sample.host_genome_name)
+
     # At this point, discard raw_value (too long to store anyway)
     self.raw_value = nil
     self.string_validated_value = nil

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -128,13 +128,14 @@ class Metadatum < ApplicationRecord
 
     # Set to existing Location or create a new one based on the external IDs. For the sake of not
     # trusting user input, we'll potentially re-fetch location details based on the API and OSM IDs.
-    result = Location.find_or_create_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
-    result = Location.check_and_restrict_specificity(result, sample.host_genome_name)
+    location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
+    location = Location.check_and_restrict_specificity(location, sample.host_genome_name)
+    location.save!
 
     # At this point, discard raw_value (too long to store anyway)
     self.raw_value = nil
     self.string_validated_value = nil
-    self.location_id = result.id
+    self.location_id = location.id
   rescue
     errors.add(:raw_value, MetadataValidationErrors::INVALID_LOCATION)
   end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -54,7 +54,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     results = JSON.parse(@response.body)
-    assert_equal 1, results.count
+    assert_equal 2, results.count
     assert_includes @response.body, locations(:swamp).name
   end
 
@@ -76,7 +76,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     results = JSON.parse(@response.body)
     loc = locations(:swamp)
     actual_object = results[loc.id.to_s]
-    expected_object = { "id" => loc.id, "name" => loc.name, "geo_level" => loc.geo_level, "country_name" => loc.country_name, "state_name" => loc.state_name, "subdivision_name" => loc.subdivision_name, "city_name" => loc.city_name, "lat" => loc.lat.to_s, "lng" => loc.lng.to_s, "sample_ids" => [samples(:joe_project_sample_mosquito).id] }
+    expected_object = { "id" => loc.id, "name" => loc.name, "geo_level" => loc.geo_level, "country_name" => loc.country_name, "state_name" => loc.state_name, "subdivision_name" => loc.subdivision_name, "city_name" => loc.city_name, "lat" => loc.lat.to_s, "lng" => loc.lng.to_s, "sample_ids" => [samples(:joe_project_sample_mosquito).id, samples(:joe_sample).id] }
 
     assert_equal actual_object, expected_object
   end

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -1,6 +1,10 @@
 ucsf:
   name: "University of California, San Francisco, Parnassus Avenue, Inner Sunset, San Francisco, San Francisco City and County, California, 94131, USA"
   geo_level: "city"
+  country_name: "USA"
+  state_name: "California"
+  subdivision_name: "San Francisco City and County"
+  city_name: "San Francisco"
 
 swamp:
   name: "Swamp of Mosquitos"
@@ -12,3 +16,9 @@ swamp:
   city_name: "Redwood City"
   lat: "37.49"
   lng: "-122.23"
+
+california:
+  name: "California, USA"
+  geo_level: "state"
+  country_name: "USA"
+  state_name: "California"

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -22,3 +22,4 @@ california:
   geo_level: "state"
   country_name: "USA"
   state_name: "California"
+  locationiq_id: 214330370

--- a/test/fixtures/metadata.yml
+++ b/test/fixtures/metadata.yml
@@ -84,4 +84,4 @@ sample_human_collection_location_v2:
   raw_value: "{\"locationiq_id\":\"123\",\"osm_id\":\"321\",\"osm_type\":\"Way\"}"
   metadata_field: collection_location_v2
   location_id: 1
-  sample: sample_human_existing_metadata_joe_project
+  sample: joe_sample

--- a/test/fixtures/metadata.yml
+++ b/test/fixtures/metadata.yml
@@ -78,3 +78,10 @@ sample_collection_location_v2:
   metadata_field: collection_location_v2
   location_id: 1
   sample: joe_project_sample_mosquito
+
+sample_human_collection_location_v2:
+  key: "collection_location_v2"
+  raw_value: "{\"locationiq_id\":\"123\",\"osm_id\":\"321\",\"osm_type\":\"Way\"}"
+  metadata_field: collection_location_v2
+  location_id: 1
+  sample: sample_human_existing_metadata_joe_project

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -55,20 +55,20 @@ class LocationTest < ActiveSupport::TestCase
     params_with_junk[:junk] = "junkvalue"
     new_location = Location.new
 
-    mock_create = MiniTest::Mock.new
-    mock_create.expect(:call, new_location, [location_params])
-    Location.stub :create!, mock_create do
-      res = Location.create_from_params(params_with_junk)
+    mock_new = MiniTest::Mock.new
+    mock_new.expect(:call, new_location, [location_params])
+    Location.stub :new, mock_new do
+      res = Location.new_from_params(params_with_junk)
       assert_equal new_location, res
     end
-    assert mock_create.verify
+    assert mock_new.verify
   end
 
   test "should raise Location creation error" do
     err = assert_raises RuntimeError do
-      Location.create_from_params("")
+      Location.new_from_params("")
     end
-    assert_match "Couldn't save Location", err.message
+    assert_match "Couldn't make new Location", err.message
   end
 
   test "should geosearch by OSM ID and type" do
@@ -90,7 +90,7 @@ class LocationTest < ActiveSupport::TestCase
     mock = MiniTest::Mock.new
     mock.expect(:call, new_location, [{ locationiq_id: "123" }])
     Location.stub :find_by, mock do
-      res = Location.find_or_create_by_api_ids("123", nil, nil)
+      res = Location.find_or_new_by_api_ids("123", nil, nil)
       assert_equal new_location, res
     end
   end
@@ -105,8 +105,8 @@ class LocationTest < ActiveSupport::TestCase
     mock_geosearch.expect(:call, [true, api_response], [osm_id, osm_type])
     Location.stub :find_by, nil do
       Location.stub :geosearch_by_osm_id, mock_geosearch do
-        Location.stub :create_from_params, new_location do
-          res = Location.find_or_create_by_api_ids("123", osm_id, osm_type)
+        Location.stub :new_from_params, new_location do
+          res = Location.find_or_new_by_api_ids("123", osm_id, osm_type)
           assert_equal new_location, res
         end
       end
@@ -131,7 +131,7 @@ class LocationTest < ActiveSupport::TestCase
     mock = MiniTest::Mock.new
     mock.expect(:call, api_response, [bad_location.country_name, bad_location.state_name])
     Location.stub :geosearch_by_country_and_state, mock do
-      Location.stub :create_from_params, locations(:california) do
+      Location.stub :new_from_params, locations(:california) do
         new_location = Location.check_and_restrict_specificity(bad_location, "Human")
         assert_equal locations(:california), new_location
       end

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -23,4 +23,17 @@ class MetadatumTest < ActiveSupport::TestCase
     loc.check_and_set_location_type
     assert_match MetadataValidationErrors::INVALID_LOCATION, loc.errors.full_messages[0]
   end
+
+  test "should check and set Location Metadatum types and check specificity" do
+    mock_create = MiniTest::Mock.new
+    loc = metadata(:sample_human_collection_location_v2)
+    fields = JSON.parse(loc.raw_value, symbolize_names: true)
+    mock_create.expect(:call, locations(:ucsf), [fields[:locationiq_id], fields[:osm_id], fields[:osm_type]])
+
+    Location.stub :find_or_create_by_api_ids, mock_create do
+      res = loc.check_and_set_location_type
+      assert_equal locations(:ucsf).id, res
+    end
+    mock_create.verify
+  end
 end

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -10,7 +10,7 @@ class MetadatumTest < ActiveSupport::TestCase
     fields = JSON.parse(loc.raw_value, symbolize_names: true)
     mock_create.expect(:call, locations(:ucsf), [fields[:locationiq_id], fields[:osm_id], fields[:osm_type]])
 
-    Location.stub :find_or_create_by_api_ids, mock_create do
+    Location.stub :find_or_new_by_api_ids, mock_create do
       res = loc.check_and_set_location_type
       assert_equal locations(:ucsf).id, res
     end

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -23,17 +23,4 @@ class MetadatumTest < ActiveSupport::TestCase
     loc.check_and_set_location_type
     assert_match MetadataValidationErrors::INVALID_LOCATION, loc.errors.full_messages[0]
   end
-
-  test "should check and set Location Metadatum types and check specificity" do
-    mock_create = MiniTest::Mock.new
-    loc = metadata(:sample_human_collection_location_v2)
-    fields = JSON.parse(loc.raw_value, symbolize_names: true)
-    mock_create.expect(:call, locations(:ucsf), [fields[:locationiq_id], fields[:osm_id], fields[:osm_type]])
-
-    Location.stub :find_or_create_by_api_ids, mock_create do
-      res = loc.check_and_set_location_type
-      assert_equal locations(:ucsf).id, res
-    end
-    mock_create.verify
-  end
 end

--- a/test/test_helpers/location_test_helper.rb
+++ b/test/test_helpers/location_test_helper.rb
@@ -35,4 +35,20 @@ module LocationTestHelper
       "locationiq_id" => 89_640_023
     }
   ].freeze
+  API_GEOSEARCH_CALIFORNIA_RESPONSE = [
+    {
+      "place_id" => "214330370",
+      "osm_type" => "relation",
+      "osm_id" => "165475",
+      "lat" => 36.70,
+      # LocationIQ uses 'lon'
+      "lon" => -118.76,
+      "display_name" => "California, USA",
+      "address" => {
+        "state" => "California",
+        "country" => "USA",
+        "country_code" => "us"
+      }
+    }
+  ].freeze
 end


### PR DESCRIPTION
### Description
- First change was an opportunistic tweak to display map attribution tags in a compact mode by default to make the map look more clean (still shows attribution on hover).
- Add restrictions for locations for Human. If they enter a location below the state-level, automatically do a search for just the (State, Country) and save that instead.

- TODO: Adding nice UI warnings when this occurs + auto-refreshing the values. Alternatively I am leaning towards having a special-case Human location input component that only accepts and geosearches for "State, Country".

### Test and Reproduce
- Start with geosearch keys, go to a sample, go to metadata, type in a location like "UCSF", save, refresh and see the value was changed to "California, USA".
- Can also call the flow manually in Rails console.
- See tests.