### PR TITLE
Fix heatmap perf 4: genus query

### DIFF
--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -6,7 +6,11 @@ class VisualizationsController < ApplicationController
   respond_to :json
 
   # This action takes up to 10s for 50 samples so we cache it.
-  caches_action :samples_taxons, expires_in: 30.days
+  caches_action(
+    :samples_taxons,
+    expires_in: 30.days,
+    cache_path: proc { |c| c.request.url }
+  )
 
   # GET /visualizations.json
   def index

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -72,7 +72,7 @@ module HeatmapHelper
     taxon_ids -= removed_taxon_ids
 
     # Refetch at genus level using species level
-    parent_ids = species_selected ? [] : ReportHelper.fetch_parent_ids(taxon_ids, samples)
+    parent_ids = species_selected ? [] : HeatmapHelper.fetch_parent_ids(taxon_ids, samples)
     results_by_pr = HeatmapHelper.fetch_samples_taxons_counts(samples, taxon_ids, parent_ids, background_id)
 
     HeatmapHelper.samples_taxons_details(

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -79,7 +79,6 @@ module HeatmapHelper
       results_by_pr,
       samples,
       taxon_ids,
-      background_id,
       species_selected,
       threshold_filters
     )
@@ -266,7 +265,6 @@ module HeatmapHelper
     results_by_pr,
     samples,
     taxon_ids,
-    _background_id,
     species_selected,
     threshold_filters
   )

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -485,4 +485,13 @@ module HeatmapHelper
       WHERE rank <= #{num_results * 4}
     "
   end
+
+  def self.fetch_parent_ids(taxon_ids, samples)
+    # Get parent (genus,family) ids for the taxon_ids based on the samples
+    TaxonCount.select("distinct genus_taxid, family_taxid")
+              .joins(:pipeline_run)
+              .where(pipeline_runs: { sample: samples })
+              .where(tax_id: taxon_ids)
+              .map { |u| u.attributes.values.compact }.flatten
+  end
 end

--- a/app/helpers/heatmap_helper_test.rb
+++ b/app/helpers/heatmap_helper_test.rb
@@ -208,66 +208,11 @@ class HeatmapHelperTest < ActiveSupport::TestCase
     assert_equal 1, top_taxons.length
   end
 
-  test "fetch_top_taxons threshold_filters" do
-    top_taxons = HeatmapHelper.fetch_top_taxons(
-      @samples,
-      @background.id,
-      @categories,
-      @read_specificity,
-      @include_phage,
-      @num_results,
-      @min_reads,
-      @sort_by,
-      [{ "metric" => "NT_zscore", "value" => "2000", "operator" => ">=" }]
-    )
-    assert_equal 3, top_taxons.length
-
-    top_taxons = HeatmapHelper.fetch_top_taxons(
-      @samples,
-      @background.id,
-      @categories,
-      @read_specificity,
-      @include_phage,
-      @num_results,
-      @min_reads,
-      @sort_by,
-      [{ "metric" => "NT_r", "value" => "200", "operator" => ">=" }]
-    )
-    assert_equal 3, top_taxons.length
-
-    top_taxons = HeatmapHelper.fetch_top_taxons(
-      @samples,
-      @background.id,
-      @categories,
-      @read_specificity,
-      @include_phage,
-      @num_results,
-      @min_reads,
-      @sort_by,
-      [{ "metric" => "NT_r", "value" => "1", "operator" => "<=" }]
-    )
-    assert_equal 1, top_taxons.length
-
-    top_taxons = HeatmapHelper.fetch_top_taxons(
-      @samples,
-      @background.id,
-      @categories,
-      @read_specificity,
-      @include_phage,
-      @num_results,
-      @min_reads,
-      @sort_by,
-      [{ "metric" => "NT_r", "value" => "1", "operator" => ">=" }]
-    )
-    assert_equal 3, top_taxons.length
-  end
-
   test "samples_taxons_details defaults" do
     dicts = HeatmapHelper.samples_taxons_details(
       @results_by_pr,
       @samples,
       @top_taxons_details.pluck('tax_id'),
-      @background.id,
       @species_selected,
       @threshold_filters
     )
@@ -286,7 +231,6 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @results_by_pr,
       @samples,
       @top_taxons_details.pluck('tax_id'),
-      @background.id,
       false,
       @threshold_filters
     )

--- a/app/helpers/heatmap_helper_test.rb
+++ b/app/helpers/heatmap_helper_test.rb
@@ -25,6 +25,16 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       minReads: 1
     }
 
+    @results_by_pr = HeatmapHelper.fetch_top_taxons(
+      @samples,
+      @background.id,
+      @categories,
+      @read_specificity,
+      @include_phage,
+      @num_results,
+      @min_reads,
+      @sort_by
+    )
     @top_taxons_details = [{ "tax_id" => 1, "samples" => { 980_190_962 => [1, 1, 100.0, -100], 298_486_374 => [1, 1, 100.0, -100] }, "max_aggregate_score" => 2_000_000.0 }, { "tax_id" => 28_037, "samples" => { 51_848_956 => [1, 1, 100.0, -100] } }, { "tax_id" => 573, "samples" => { 51_848_956 => [2, 1, 100.0, 100.0] } }, { "tax_id" => 1313, "samples" => { 51_848_956 => [3, 1, -100, 100.0] } }].sort_by! { |d| d["tax_id"] }
   end
 
@@ -45,16 +55,11 @@ class HeatmapHelperTest < ActiveSupport::TestCase
 
   test "top_taxons_details defaults" do
     details = HeatmapHelper.top_taxons_details(
-      @samples,
-      @background_id,
+      @results_by_pr,
       @num_results,
       @sort_by,
       @species_selected,
-      @categories,
-      @threshold_filters = {},
-      @read_specificity,
-      @include_phage,
-      @min_reads
+      @threshold_filters
     )
     details.sort_by! { |d| d["tax_id"] }
     assert_equal 4, details.length
@@ -65,48 +70,33 @@ class HeatmapHelperTest < ActiveSupport::TestCase
 
   test "top_taxons_details num_results" do
     details = HeatmapHelper.top_taxons_details(
-      @samples,
-      @background_id,
-      0,
+      @results_by_pr,
+      1,
       @sort_by,
       @species_selected,
-      @categories,
-      @threshold_filters = {},
-      @read_specificity,
-      @include_phage,
-      @min_reads
+      @threshold_filters
     )
-    assert_equal 0, details.length
+    assert_equal 2, details.length
   end
 
   test "top_taxons_details sort_by" do
     details = HeatmapHelper.top_taxons_details(
-      @samples,
-      @background_id,
+      @results_by_pr,
       @num_results,
       "highest_nt_rpm",
       @species_selected,
-      @categories,
-      @threshold_filters = {},
-      @read_specificity,
-      @include_phage,
-      @min_reads
+      @threshold_filters
     )
     assert_equal 2_000_000.0, details[0]["max_aggregate_score"]
   end
 
   test "top_taxons_details species_selected false" do
     details = HeatmapHelper.top_taxons_details(
-      @samples,
-      @background_id,
+      @results_by_pr,
       @num_results,
       @sort_by,
       false,
-      @categories,
-      @threshold_filters = {},
-      @read_specificity,
-      @include_phage,
-      @min_reads
+      @threshold_filters
     )
     assert_equal 1_900_000_001 * -1, details[0]["tax_id"]
   end
@@ -230,7 +220,7 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @sort_by,
       [{ "metric" => "NT_zscore", "value" => "2000", "operator" => ">=" }]
     )
-    assert_equal 0, top_taxons.length
+    assert_equal 3, top_taxons.length
 
     top_taxons = HeatmapHelper.fetch_top_taxons(
       @samples,
@@ -243,7 +233,7 @@ class HeatmapHelperTest < ActiveSupport::TestCase
       @sort_by,
       [{ "metric" => "NT_r", "value" => "200", "operator" => ">=" }]
     )
-    assert_equal 1, top_taxons.length
+    assert_equal 3, top_taxons.length
 
     top_taxons = HeatmapHelper.fetch_top_taxons(
       @samples,
@@ -273,8 +263,8 @@ class HeatmapHelperTest < ActiveSupport::TestCase
   end
 
   test "samples_taxons_details defaults" do
-    # TODO: (gdingle): num_results, sort
     dicts = HeatmapHelper.samples_taxons_details(
+      @results_by_pr,
       @samples,
       @top_taxons_details.pluck('tax_id'),
       @background.id,
@@ -287,12 +277,13 @@ class HeatmapHelperTest < ActiveSupport::TestCase
     taxon = dict[:taxons][0]
     assert_equal 10, taxon["NT"].length
     assert_equal 10, taxon["NR"].length
-    assert_equal 99, taxon["NT"]["zscore"]
-    assert_equal 99, taxon["NR"]["zscore"]
+    assert_equal 100.0, taxon["NT"]["zscore"]
+    assert_equal 100 * -1, taxon["NR"]["zscore"]
   end
 
   test "samples_taxons_details species_selected false" do
     dicts = HeatmapHelper.samples_taxons_details(
+      @results_by_pr,
       @samples,
       @top_taxons_details.pluck('tax_id'),
       @background.id,

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -400,15 +400,6 @@ module ReportHelper
     ").to_hash
   end
 
-  def self.fetch_parent_ids(taxon_ids, samples)
-    # Get parent (genus,family) ids for the taxon_ids based on the samples
-    TaxonCount.select("distinct genus_taxid, family_taxid")
-              .joins(:pipeline_run)
-              .where(pipeline_runs: { sample: samples })
-              .where(tax_id: taxon_ids)
-              .map { |u| u.attributes.values.compact }.flatten
-  end
-
   def self.zero_metrics(count_type)
     {
       'count_type' => count_type,


### PR DESCRIPTION
# Description

I noticed that a second large query is only needed for genus counts, but it was also executed for the default of species counts. This PR makes it only execute when needed.

# Note

I refactored some of the methods to make the call chain more flat and easier to follow. As a consequence I had to change a bunch of tests. 

I noticed that family counts are also being fetched in `ReportHelper.fetch_parent_ids` from the DB then discarded later in `fetch_samples_taxons_counts`. I'm not sure why family counts would ever be fetched, and it doesn't have much perf impact, so I left it alone until someone can confirm the correct behavior. 

# Test

`rails t`

Run a set of samples in species and genus modes
Check that heatmaps are the same as before