### PR TITLE
Precache with less strict update time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'airbrake', '~> 9.2.2'
-gem 'airbrake-ruby', '~> 4.4'
+gem 'airbrake', '~> 8'
+gem 'airbrake-ruby', '~> 4.2.1' # 4.4 broke perf monitoring
 gem 'aws-sdk-ecs'
 gem 'aws-sdk-resources'
 gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,9 +45,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    airbrake (9.2.2)
-      airbrake-ruby (~> 4.4)
-    airbrake-ruby (4.4.0)
+    airbrake (8.3.2)
+      airbrake-ruby (~> 4.1)
+    airbrake-ruby (4.2.5)
       rbtree3 (~> 0.5)
     analytics-ruby (2.0.13)
     arel (8.0.0)
@@ -1107,8 +1107,8 @@ DEPENDENCIES
   active_record_query_trace
   activerecord-import
   activesupport
-  airbrake (~> 9.2.2)
-  airbrake-ruby (~> 4.4)
+  airbrake (~> 8)
+  airbrake-ruby (~> 4.2.1)
   analytics-ruby (~> 2.0.0)
   aws-sdk
   aws-sdk-ecs

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1419,8 +1419,9 @@ class PipelineRun < ApplicationRecord
       # Default background is complicated... see get_background_id. In any case,
       # we precache all backgrounds. See precache_report_info below.
       background_id: nil,
-      # For invalidation when underlying data changes
-      report_ts: max_updated_at.utc.to_i,
+      # For invalidation if underlying data changes. This should only happen in
+      # exceptional situations, such as manual DB edits.
+      report_ts: max_updated_at.utc.beginning_of_day.to_i,
       format: "json"
     }
   end


### PR DESCRIPTION
# Description

By debugging, I found that the update time in the cache key set by precahing was 15 min different from the update time on sample report view. This change truncates to the nearest day so there is little chance of mismatch. 

Any new pipeline runs are assumed to be run with a new pipeline version. The `report_ts` covers exceptional situations. 

# Note

I don't know why a pipeline run would be updated after this: 

```
    # Check if run is complete:
    if all_output_states_terminal?

      if all_output_states_loaded? && !compiling_stats_failed
        update(results_finalized: FINALIZED_SUCCESS)

        # Precache reports for all backgrounds
        Resque.enqueue(PrecacheReportInfo, id)
```

Any ideas? It is important to know if any such update would affect the report counts. 

# Test

load report page
see no errors

check datadog in prod for cache hits after preaching