### PR TITLE
Fix Host Genome "Apply to All" and Samples ActiveRecord order

### DIFF
--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -265,6 +265,8 @@ class MetadataManualInput extends React.Component {
       : sample.host_genome_id;
 
   isHostGenomeIdValidForField = (hostGenomeId, field) =>
+    // Special-case 'Host Genome' (the field that lets you change the Host Genome)
+    field === "Host Genome" ||
     includes(
       hostGenomeId,
       get([field, "host_genome_ids"], this.props.projectMetadataFields)

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1255,7 +1255,11 @@ class SamplesController < ApplicationController
     default_dir = 'id,desc'
     dir ||= default_dir
     column, direction = dir.split(',')
-    samples = samples.order("samples.#{column} #{direction}") if column && direction
+    if column && direction
+      if Sample.column_names.include?(column) && ["desc", "asc"].include?(direction)
+        samples = samples.order("samples.#{column} #{direction}")
+      end
+    end
     samples
   end
 end


### PR DESCRIPTION
### Description
- This fixes two issues that were surfaced over the weekend.
- 1) "Apply to All" wasn't working in the metadata uploader on the Host Genome field because the conditional isHostGenomeIdValidForField wouldn't allow the host genome field itself.
- 2) Fixes ActiveRecord .order string interpolation. I did not see any other .order strings interpolated but I thought so before too..

### Demo
- Before:
![Jun-02-2019 22-09-21 (before)](https://user-images.githubusercontent.com/5652739/58818041-01c06580-85e2-11e9-9fb2-909dd464fdb8.gif)

- After:
![Jun-02-2019 22-08-46 (after)](https://user-images.githubusercontent.com/5652739/58818059-09800a00-85e2-11e9-9657-177cbf41a244.gif)

### Test and Reproduce
- 1) Go to /samples/upload and go to the manual metadata entry mode and try Apply to All. Also made sure it went through at the end.
- 2) Load samples through the old index action (/legacy page) and see the proper ActiveRecord queries generated.