### PR TITLE
Make heatmap back compatible

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -65,7 +65,7 @@ class SamplesHeatmapView extends React.Component {
 
     this.state = {
       selectedOptions: {
-        metric: this.urlParams.metric || (this.props.metrics[0] || {}).value,
+        metric: this.getSelectedMetric(),
         categories: this.urlParams.categories || [],
         subcategories: this.urlParams.subcategories || {},
         background: parseAndCheckInt(
@@ -95,6 +95,15 @@ class SamplesHeatmapView extends React.Component {
       this.urlParams.removedTaxonIds || this.props.removedTaxonIds || []
     );
     this.lastRequestToken = null;
+  }
+
+  // For converting legacy URLs
+  getSelectedMetric() {
+    if (this.props.metrics.map(m => m.value).includes(this.urlParams.metric)) {
+      return this.urlParams.metric;
+    } else {
+      return (this.props.metrics[0] || {}).value;
+    }
   }
 
   initOnBeforeUnload(savedParamValues) {

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -142,14 +142,7 @@ class VisualizationsController < ApplicationController
       subcategories: {
         Viruses: ["Phage"]
       },
-      metrics: [
-        { text: "NT rPM", value: "NT.rpm" },
-        { text: "NT Z Score", value: "NT.zscore" },
-        { text: "NT r (total reads)", value: "NT.r" },
-        { text: "NR rPM", value: "NR.rpm" },
-        { text: "NR Z Score", value: "NR.zscore" },
-        { text: "NR r (total reads)", value: "NR.r" }
-      ],
+      metrics: HeatmapHelper::ALL_METRICS,
       backgrounds: current_power.backgrounds.map do |background|
         { name: background.name, value: background.id }
       end,

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -14,6 +14,15 @@ module HeatmapHelper
 
   MINIMUM_ZSCORE_THRESHOLD = 1.7
 
+  ALL_METRICS = [
+    { text: "NT rPM", value: "NT.rpm" },
+    { text: "NT Z Score", value: "NT.zscore" },
+    { text: "NT r (total reads)", value: "NT.r" },
+    { text: "NR rPM", value: "NR.rpm" },
+    { text: "NR Z Score", value: "NR.zscore" },
+    { text: "NR r (total reads)", value: "NR.r" }
+  ].freeze
+
   def self.sample_taxons_dict(params, samples)
     return {} if samples.empty?
 
@@ -41,8 +50,9 @@ module HeatmapHelper
     include_phage = subcategories.fetch("Viruses", []).include?("Phage")
     read_specificity = params[:readSpecificity] ? params[:readSpecificity].to_i == 1 : false
 
-    # TODO: should fail if field is not well formatted and return proper error to client
-    sort_by = params[:sortBy] || HeatmapHelper::DEFAULT_TAXON_SORT_PARAM
+    sort_by = params[:sortBy] &&
+              HeatmapHelper::ALL_METRICS.map { |m| m["name"] }.includes(params[:sortBy]) ||
+              HeatmapHelper::DEFAULT_TAXON_SORT_PARAM
     species_selected = params[:species] ? params[:species].to_i == 1 : false # Otherwise genus selected
 
     first_sample = samples.first

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -51,7 +51,7 @@ module HeatmapHelper
     read_specificity = params[:readSpecificity] ? params[:readSpecificity].to_i == 1 : false
 
     sort_by = params[:sortBy] &&
-              HeatmapHelper::ALL_METRICS.map { |m| m["name"] }.includes(params[:sortBy]) ||
+              HeatmapHelper::ALL_METRICS.map { |m| m[:value] }.include?(params[:sortBy]) ||
               HeatmapHelper::DEFAULT_TAXON_SORT_PARAM
     species_selected = params[:species] ? params[:species].to_i == 1 : false # Otherwise genus selected
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", null: false
+    t.string "name"
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type", null: false
+    t.string "source_type"
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -164,7 +164,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
   end
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "key", null: false
+    t.string "key", null: false, collation: "latin1_swedish_ci"
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9
@@ -318,7 +318,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1
+    t.integer "public_access", limit: 1, default: 0
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -436,14 +436,15 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.integer "family_taxid", default: -300, null: false
     t.integer "is_phage", limit: 1, default: 0, null: false
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
+    t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
   end
 
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
     t.string "title"
-    t.text "summary"
-    t.text "description"
+    t.text "summary", limit: 16_777_215
+    t.text "description", limit: 16_777_215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -533,11 +534,11 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email", default: "", null: false
+    t.string "email"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password", default: "", null: false
+    t.string "encrypted_password"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -550,6 +551,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.integer "role"
     t.text "allowed_features"
     t.string "institution", limit: 100
+    t.integer "projects_count", default: 0, null: false
     t.integer "samples_count", default: 0, null: false
     t.integer "favorite_projects_count", default: 0, null: false
     t.integer "favorites_count", default: 0, null: false
@@ -570,4 +572,6 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.string "name"
     t.index ["user_id"], name: "index_visualizations_on_user_id"
   end
+
+  add_foreign_key "visualizations", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type"
+    t.string "source_type", null: false
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -164,7 +164,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
   end
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "key", null: false, collation: "latin1_swedish_ci"
+    t.string "key", null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9
@@ -318,7 +318,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1, default: 0
+    t.integer "public_access", limit: 1
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -436,15 +436,14 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.integer "family_taxid", default: -300, null: false
     t.integer "is_phage", limit: 1, default: 0, null: false
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
-    t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
   end
 
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
     t.string "title"
-    t.text "summary", limit: 16_777_215
-    t.text "description", limit: 16_777_215
+    t.text "summary"
+    t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -534,11 +533,11 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email"
+    t.string "email", default: "", null: false
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password"
+    t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -551,7 +550,6 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.integer "role"
     t.text "allowed_features"
     t.string "institution", limit: 100
-    t.integer "projects_count", default: 0, null: false
     t.integer "samples_count", default: 0, null: false
     t.integer "favorite_projects_count", default: 0, null: false
     t.integer "favorites_count", default: 0, null: false
@@ -572,6 +570,4 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.string "name"
     t.index ["user_id"], name: "index_visualizations_on_user_id"
   end
-
-  add_foreign_key "visualizations", "users"
 end


### PR DESCRIPTION
# Description

This fixes links to heatmaps that use `aggregatescore`. 

# Test

open a url that has `NT.aggregatescore` such as http://localhost:3000/visualizations/heatmap?background=26&dataScaleIdx=0&metric=NT.aggregatescore&readSpecificity=1&sampleIds[]=11082&sampleIds[]=11081&species=1&subcategories=%7B%7D&taxonsPerSample=30&thresholdFilters=%5B%5D

see no more error

see URL change to default metric `NT.rpm`

see UI change to default metric `NT.rpm`

change UI control metric

see change persist