### PR TITLE
Better heatmap cache key

### DIFF
--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -9,7 +9,10 @@ class VisualizationsController < ApplicationController
   caches_action(
     :samples_taxons,
     expires_in: 30.days,
-    cache_path: proc { |c| c.request.url }
+    cache_path: proc do |c|
+      sorted_params = c.request.params.to_h.sort.to_h
+      sorted_params.to_query
+    end
   )
 
   # GET /visualizations.json


### PR DESCRIPTION
# Description

I noticed that the heatmap was not caching on creation from the projects page. That's because the URL used for caching was different in ordering. This fixes it by sorting the URL params.

# Test and Reproduce

Open projects page
Create a heatmap
Check the cache key in the logs
Reload the page
See cache key is the same in the logs