### PR TITLE
Add load time estimate to heatmap UI

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -493,13 +493,15 @@ class SamplesHeatmapView extends React.Component {
   renderLoading() {
     const numSamples = this.state.sampleIds.length;
     // This was determined empirically by varying the number of samples from 4
-    // to 55 in prod.
+    // to 55 in prod. The time increased linearly close to a factor of 0.5.
     const estimate = Math.round(numSamples / 2);
     return (
       <p className={cs.loadingIndicator}>
         <i className="fa fa-spinner fa-pulse fa-fw" />
-        Loading for {numSamples} samples. Please wait up to {estimate}{" "}
-        seconds...
+        Loading for {numSamples} samples. Please wait up to {estimate} second{estimate >
+        1
+          ? "s"
+          : ""}...
       </p>
     );
   }

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -491,10 +491,15 @@ class SamplesHeatmapView extends React.Component {
   }
 
   renderLoading() {
+    const numSamples = this.state.sampleIds.length;
+    // This was determined empirically by varying the number of samples from 4
+    // to 55 in prod.
+    const estimate = Math.round(numSamples / 2);
     return (
       <p className={cs.loadingIndicator}>
         <i className="fa fa-spinner fa-pulse fa-fw" />
-        Loading for {this.state.sampleIds.length} samples...
+        Loading for {numSamples} samples. Please wait up to {estimate}{" "}
+        seconds...
       </p>
     );
   }


### PR DESCRIPTION
# Description

See screenshot.

![image](https://user-images.githubusercontent.com/28797/58840703-89769600-861b-11e9-9278-ee9817d1e4e5.png)


# Test

Load a heatmap and see numerical estimate