### PR TITLE
Add endpoint for pipeline run stage results

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -973,7 +973,7 @@ class SamplesController < ApplicationController
       if stage.name == "Experimental" && !current_user.admin?
         next
       end
-      @results[stage.name] = stage.dag_json
+      @results[stage.name] = JSON.parse stage.dag_json
     end
     render json: { pipeline_stage_results: @results }
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -22,7 +22,8 @@ class SamplesController < ApplicationController
   READ_ACTIONS = [:show, :report_info, :report_csv, :assembly, :show_taxid_fasta, :nonhost_fasta, :unidentified_fasta,
                   :contigs_fasta, :contigs_fasta_by_byteranges, :contigs_sequences_by_byteranges, :contigs_summary,
                   :results_folder, :show_taxid_alignment, :show_taxid_alignment_viz, :metadata,
-                  :contig_taxid_list, :taxid_contigs, :summary_contig_counts, :coverage_viz_summary, :coverage_viz_data].freeze
+                  :contig_taxid_list, :taxid_contigs, :summary_contig_counts, :coverage_viz_summary, :coverage_viz_data,
+                  :stage_results].freeze
   EDIT_ACTIONS = [:edit, :update, :destroy, :reupload_source, :resync_prod_data_to_staging, :kickoff_pipeline, :retry_pipeline,
                   :pipeline_runs, :save_metadata, :save_metadata_v2, :raw_results_folder, :upload_heartbeat].freeze
 
@@ -964,6 +965,17 @@ class SamplesController < ApplicationController
         render json: { displayed_data: @file_list }
       end
     end
+  end
+
+  def stage_results
+    @results = {}
+    @sample.first_pipeline_run.pipeline_run_stages.each do |stage|
+      if stage.name == "Experimental" && !current_user.admin?
+        next
+      end
+      @results[stage.name] = stage.dag_json
+    end
+    render json: { pipeline_stage_results: @results }
   end
 
   def validate_sample_files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     get :contigs_summary, on: :member
     get :results_folder, on: :member
     get :raw_results_folder, on: :member
+    get :stage_results, on: :member
     post :bulk_upload, on: :collection
     post :bulk_upload_with_metadata, on: :collection
     get :metadata, on: :member

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -86,7 +86,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     @public_project = projects(:public_project)
     get "/samples.json?project_id=#{@public_project.id}"
     assert_response :success
-    assert JSON.parse(@response.body)["count"] == 4
+    assert JSON.parse(@response.body)["count"] == 5
   end
   # ===== END: /samples/index
 
@@ -120,7 +120,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     @public_project = projects(:public_project)
     get "/samples/index_v2.json?projectId=#{@public_project.id}"
     assert_response :success
-    assert JSON.parse(@response.body)["samples"].count == 4
+    assert JSON.parse(@response.body)["samples"].count == 5
   end
 
   test 'joe sees samples in its data set with index_v2' do
@@ -134,14 +134,14 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     sign_in(:joe)
     get "/samples/index_v2.json?domain=public"
     assert_response :success
-    assert JSON.parse(@response.body)["samples"].count == 6
+    assert JSON.parse(@response.body)["samples"].count == 7
   end
 
   test 'joe sees the samples that he has access to with index_v2' do
     sign_in(:joe)
     get "/samples/index_v2.json"
     assert_response :success
-    assert JSON.parse(@response.body)["samples"].count == 11
+    assert JSON.parse(@response.body)["samples"].count == 12
   end
   # ===== END: /samples/index_v2
 

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -11,6 +11,8 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     @sample_human_existing_metadata_joe_project = samples(:sample_human_existing_metadata_joe_project)
     @sample_human_existing_metadata_expired = samples(:sample_human_existing_metadata_expired)
     @deletable_sample = samples(:deletable_sample)
+    @pipeline_run_sample = samples(:sample_with_pipeline_stages)
+    @pipeline_run = pipeline_runs(:sample_run_with_pipeline_stages)
     @project = projects(:one)
     @user = users(:one)
     @user.authentication_token = 'sdfsdfsdff'
@@ -201,6 +203,34 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
       delete sample_url(@deletable_sample)
     end
     assert_redirected_to samples_url
+  end
+
+  test 'should return pipeline stage results' do
+    post user_session_path, params: @user_params
+    get stage_results_sample_url(@pipeline_run_sample)
+    assert_response :success
+
+    results = @response.parsed_body["pipeline_stage_results"]
+    assert_equal 4, results.length
+    @pipeline_run.pipeline_run_stages.each do |stage|
+      assert_equal stage.dag_json, results[stage.name]
+    end
+  end
+
+  test 'joe cannot see pipeline experimental stage results' do
+    post user_session_path, params: @user_nonadmin_params
+    get stage_results_sample_url(@pipeline_run_sample)
+    assert_response :success
+
+    results = @response.parsed_body["pipeline_stage_results"]
+    assert_equal 3, results.length
+    @pipeline_run.pipeline_run_stages.each do |stage|
+      if stage.name == "Experimental"
+        assert_nil results["Experimental"]
+      else
+        assert_equal stage.dag_json, results[stage.name]
+      end
+    end
   end
 
   test 'joe can fetch metadata for a public sample' do

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -213,7 +213,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     results = @response.parsed_body["pipeline_stage_results"]
     assert_equal 4, results.length
     @pipeline_run.pipeline_run_stages.each do |stage|
-      assert_equal stage.dag_json, results[stage.name]
+      assert_equal JSON.parse(stage.dag_json), results[stage.name]
     end
   end
 
@@ -228,7 +228,7 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
       if stage.name == "Experimental"
         assert_nil results["Experimental"]
       else
-        assert_equal stage.dag_json, results[stage.name]
+        assert_equal JSON.parse(stage.dag_json), results[stage.name]
       end
     end
   end

--- a/test/fixtures/pipeline_run_stages.yml
+++ b/test/fixtures/pipeline_run_stages.yml
@@ -20,3 +20,23 @@ public_sample_run_stage:
       }
     }
   }"
+
+sample_run_stage_host_filtering:
+  pipeline_run: sample_run_with_pipeline_stages
+  name: "Host Filtering"
+  dag_json: "asdfasdfasdf"
+
+sample_run_stage_alignment:
+  pipeline_run: sample_run_with_pipeline_stages
+  name: "GSNAPL/RAPSEARCH alignment"
+  dag_json: "weadsafsdfa"
+
+sample_run_stage_post_processing:
+  pipeline_run: sample_run_with_pipeline_stages
+  name: "Post Processing"
+  dag_json: "awerwerwe"
+
+sample_run_stage_experimental:
+  pipeline_run: sample_run_with_pipeline_stages
+  name: "Experimental"
+  dag_json: "uwu"

--- a/test/fixtures/pipeline_run_stages.yml
+++ b/test/fixtures/pipeline_run_stages.yml
@@ -24,19 +24,19 @@ public_sample_run_stage:
 sample_run_stage_host_filtering:
   pipeline_run: sample_run_with_pipeline_stages
   name: "Host Filtering"
-  dag_json: "asdfasdfasdf"
+  dag_json: "{\"key1\": \"value1\"}"
 
 sample_run_stage_alignment:
   pipeline_run: sample_run_with_pipeline_stages
   name: "GSNAPL/RAPSEARCH alignment"
-  dag_json: "weadsafsdfa"
+  dag_json: "{\"key2\": \"value2\"}"
 
 sample_run_stage_post_processing:
   pipeline_run: sample_run_with_pipeline_stages
   name: "Post Processing"
-  dag_json: "awerwerwe"
+  dag_json: "{\"key3\": \"value3\"}"
 
 sample_run_stage_experimental:
   pipeline_run: sample_run_with_pipeline_stages
   name: "Experimental"
-  dag_json: "uwu"
+  dag_json: "{\"key4\": \"value4\"}"

--- a/test/fixtures/pipeline_runs.yml
+++ b/test/fixtures/pipeline_runs.yml
@@ -100,3 +100,11 @@ public_sample_run:
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+sample_run_with_pipeline_stages:
+  sample: sample_with_pipeline_stages
+  pipeline_version: '1.0'
+  job_id: 'pipeline_stages_sample_job'
+  job_status: 'CHECKED'
+  total_reads: 1
+  adjusted_remaining_reads: 1
+  alignment_config: one

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -42,6 +42,10 @@ public_project_sampleB:
   project: public_project
   host_genome: human
 
+sample_with_pipeline_stages:
+  name: sample_with_pipeline_stages
+  project: public_project
+  
 joe_project_sampleB:
   name: joe_project_sampleB
   project: joe_project

--- a/test/models/pipeline_run_test.rb
+++ b/test/models/pipeline_run_test.rb
@@ -17,7 +17,7 @@ class PipelineRunTest < ActiveSupport::TestCase
     pr = pipeline_runs(:six)
 
     assert_equal 1122, pr.total_reads
-    assert_equal nil, pr.total_ercc_reads
+    assert_nil pr.total_ercc_reads
     assert_equal 1, pr.subsample_fraction
 
     assert_equal 4456.327985739751, pr.rpm(5)


### PR DESCRIPTION
# Add endpoint for pipeline run stage results

For the Pipeline Monitoring feature
* Add `stage_results` route to `samples_controller`, which takes the most recent pipeline run for the sample and returns a JSON combining the `dag_json` field of each pipeline run stage. Should include all four stages for admin users and only three stages for non-admin users (no experimental stage)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix a feature that knowingly causes existing functionality to not work as expected)

# Test and Reproduce
Visit `samples/[sample_id]/stage_results` to fetch json


