### PR TITLE
Fix filtering projects by id [IDseq-984] 

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -85,7 +85,7 @@ class ProjectsController < ApplicationController
                      current_power.projects
                    end
 
-        projects = projects.where(id: params[:projectId]) if project_id
+        projects = projects.where(id: project_id) if project_id
         projects = projects.db_search(search) if search
         projects = projects.order(Hash[order_by => order_dir])
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -57,6 +57,7 @@ class ProjectsController < ApplicationController
 
         order_by = sanitize_order_by(Project, params[:orderBy], :id)
         order_dir = sanitize_order_dir(params[:orderDir], :desc)
+        project_id = params[:projectId]
 
         # we do not want to search samples by name
         search = params.delete(:search)
@@ -84,6 +85,7 @@ class ProjectsController < ApplicationController
                      current_power.projects
                    end
 
+        projects = projects.where(id: params[:projectId]) if project_id
         projects = projects.db_search(search) if search
         projects = projects.order(Hash[order_by => order_dir])
 

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -323,7 +323,6 @@ RSpec.describe ProjectsController, type: :controller do
         end
       end
 
-
       ["my_data", "all_data"].each do |domain|
         describe "GET index for #{domain} domain" do
           it "sees all required fields" do

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -17,6 +17,8 @@ FactoryBot.define do
       end
     end
 
+    # guarantees that a samples is public by explicitly setting
+    # project's `days_to_keep_sample_private` and sample's `created_at` explicitly
     trait :with_public_sample do
       days_to_keep_sample_private { 365.days.ago }
       after :create do |project, options|

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -17,6 +17,13 @@ FactoryBot.define do
       end
     end
 
+    trait :with_public_sample do
+      days_to_keep_sample_private{ 365.days.ago }
+      after :create do |project, options|
+        create(:sample, project: project, host_genome_name: options.host_genome_name, created_at: 366.days.ago)
+      end
+    end
+
     after :create do |project, options|
       options.samples_data.each do |sample_data|
         create(:sample, project: project, **sample_data)

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     end
 
     trait :with_public_sample do
-      days_to_keep_sample_private{ 365.days.ago }
+      days_to_keep_sample_private { 365.days.ago }
       after :create do |project, options|
         create(:sample, project: project, host_genome_name: options.host_genome_name, created_at: 366.days.ago)
       end


### PR DESCRIPTION
# Description

Filtering by id was broken for all data, where multiple projects were returned if there were empty projects. 
Jira ticket: https://jira.czi.team/browse/IDSEQ-984

# Testing

Added integration tests.
To verify the bug was fix: 
1. Go to All Data page
2. Click any project with samples except for the first one and memorize the project name
3. Click a sample to go to report page
4. Click the project link above the sample title
5. Verify that the project name is correct (matches memorized project) 