### PR TITLE
Clear search box and free text filter when clicking project.

### DIFF
--- a/app/assets/src/components/ui/controls/LiveSearchBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchBox.jsx
@@ -18,6 +18,16 @@ class LiveSearchBox extends React.Component {
     this.lastestTimerId = null;
   }
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.value !== state.prevValue) {
+      return {
+        prevValue: props.value,
+        value: props.value
+      };
+    }
+    return null;
+  }
+
   handleKeyDown = keyEvent => {
     const { onEnter, inputMode } = this.props;
     const { value, selectedResult } = this.state;
@@ -87,8 +97,7 @@ class LiveSearchBox extends React.Component {
 
   render() {
     const { className, placeholder, rectangular } = this.props;
-    const { isLoading, results } = this.state;
-    const value = this.props.value || this.state.value;
+    const { isLoading, results, value } = this.state;
 
     return (
       <Search

--- a/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
@@ -58,7 +58,7 @@ class DiscoveryHeader extends React.Component {
     const {
       currentTab,
       filterCount,
-      initialSearchValue,
+      searchValue,
       onFilterToggle,
       onSearchTriggered,
       onStatsToggle,
@@ -68,7 +68,6 @@ class DiscoveryHeader extends React.Component {
       tabs
     } = this.props;
 
-    // TODO(tiago): consider constraining what categories to ask for in the search box.
     return (
       <div className={cs.header}>
         <div className={cs.filtersTrigger} onClick={onFilterToggle}>
@@ -86,7 +85,7 @@ class DiscoveryHeader extends React.Component {
             onSearchTriggered={onSearchTriggered}
             onResultSelect={this.handleSearchResultSelected}
             onEnter={this.handleSearchEnterPressed}
-            initialValue={initialSearchValue}
+            value={searchValue}
           />
         </div>
         <Tabs
@@ -109,19 +108,19 @@ class DiscoveryHeader extends React.Component {
 
 DiscoveryHeader.defaultProps = {
   filterCount: 0,
-  initialSearchValue: ""
+  searchValue: ""
 };
 
 DiscoveryHeader.propTypes = {
   currentTab: PropTypes.string,
   filterCount: PropTypes.number,
-  initialSearchValue: PropTypes.string,
   onFilterToggle: PropTypes.func,
   onStatsToggle: PropTypes.func,
   onSearchEnterPressed: PropTypes.func,
   onSearchResultSelected: PropTypes.func,
   onSearchTriggered: PropTypes.func,
   onTabChange: PropTypes.func,
+  searchValue: PropTypes.string,
   showFilters: PropTypes.bool,
   showStats: PropTypes.bool,
   tabs: PropTypes.arrayOf(

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -587,7 +587,8 @@ class DiscoveryView extends React.Component {
       {
         currentTab: "samples",
         project,
-        projectId: project.id
+        projectId: project.id,
+        search: null
       },
       () => {
         this.updateBrowsingHistory();
@@ -822,18 +823,18 @@ class DiscoveryView extends React.Component {
           )}
           <DiscoveryHeader
             currentTab={currentTab}
-            tabs={tabs}
-            onTabChange={this.handleTabChange}
             filterCount={filterCount}
-            initialSearch={search}
             onFilterToggle={this.handleFilterToggle}
             onStatsToggle={this.handleStatsToggle}
             onSearchTriggered={this.handleSearchTriggered}
             onSearchSuggestionsReceived={this.handleSearchSuggestionsReceived}
             onSearchResultSelected={this.handleSearchSelected}
             onSearchEnterPressed={this.handleStringSearch}
+            onTabChange={this.handleTabChange}
+            searchValue={search || ""}
             showStats={showStats && !!dimensions}
             showFilters={showFilters && !!dimensions}
+            tabs={tabs}
           />
         </div>
         <Divider style="medium" />


### PR DESCRIPTION
### Description

When a user does a free text search, we projects and samples by that filter.
Currently, if a user clicks a project that results from that search, the free text search remains active. Normally samples of that project are filtered out by the free-text search filter.

This PR removes the filter and clears the search box once the user selects a project. 

![Jun-05-2019 10-52-59](https://user-images.githubusercontent.com/37312125/58978490-c5773b80-8780-11e9-84e2-5b1306972c89.gif)


### Testing

1. Do a partial search for a project name.
2. Click one of the projects that passed the filter
3. Verify that the project page show the samples for the project (that pass the left sidebar filters) and that the free text search is removed.
