### PR TITLE
Fix default background for heatmap

### DIFF
--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -172,13 +172,21 @@ class VisualizationsController < ApplicationController
   end
 
   def download_heatmap
-    @sample_taxons_dict = HeatmapHelper.sample_taxons_dict(params, samples_for_heatmap)
+    @sample_taxons_dict = HeatmapHelper.sample_taxons_dict(
+      params,
+      samples_for_heatmap,
+      background_for_heatmap
+    )
     output_csv = generate_heatmap_csv(@sample_taxons_dict)
     send_data output_csv, filename: 'heatmap.csv'
   end
 
   def samples_taxons
-    @sample_taxons_dict = HeatmapHelper.sample_taxons_dict(params, samples_for_heatmap)
+    @sample_taxons_dict = HeatmapHelper.sample_taxons_dict(
+      params,
+      samples_for_heatmap,
+      background_for_heatmap
+    )
     render json: @sample_taxons_dict
   end
 
@@ -194,6 +202,14 @@ class VisualizationsController < ApplicationController
     current_power.samples
                  .where(id: sample_ids)
                  .includes([:host_genome, :pipeline_runs, metadata: [:metadata_field]])
+  end
+
+  def background_for_heatmap
+    background_id = params["background"].to_i
+    viewable_background_ids = current_power.backgrounds.pluck(:id)
+    if viewable_background_ids.include?(background_id)
+      return background_id
+    end
   end
 
   # The most recent update time of any samples pipeline run.

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -23,7 +23,8 @@ module HeatmapHelper
     { text: "NR r (total reads)", value: "NR.r" }
   ].freeze
 
-  def self.sample_taxons_dict(params, samples)
+  # Samples and background are assumed here to be vieweable.
+  def self.sample_taxons_dict(params, samples, background_id)
     return {} if samples.empty?
 
     num_results = params[:taxonsPerSample] ? params[:taxonsPerSample].to_i : DEFAULT_MAX_NUM_TAXONS
@@ -55,7 +56,7 @@ module HeatmapHelper
               HeatmapHelper::DEFAULT_TAXON_SORT_PARAM
     species_selected = params[:species] ? params[:species].to_i == 1 : false # Otherwise genus selected
 
-    background_id = params[:background] ? params[:background].to_i : samples.first.default_background_id
+    background_id = background_id && background_id > 0 ? background_id : samples.first.default_background_id
 
     results_by_pr = fetch_top_taxons(
       samples,

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -55,8 +55,7 @@ module HeatmapHelper
               HeatmapHelper::DEFAULT_TAXON_SORT_PARAM
     species_selected = params[:species] ? params[:species].to_i == 1 : false # Otherwise genus selected
 
-    first_sample = samples.first
-    background_id = params[:background] ? params[:background].to_i : get_background_id(first_sample)
+    background_id = params[:background] ? params[:background].to_i : samples.first.default_background_id
 
     results_by_pr = fetch_top_taxons(
       samples,


### PR DESCRIPTION
# Description

This was a consequence of my refactoring to a static class. It looks like the original code was useless anyway because it used a different param name for background. 

# Test

Load endpoint http://localhost:3000/visualizations/samples_taxons.json?sampleIds%5B%5D=17822
See no more error

Try loading valid background, all good
Try loading invalid background, see default loaded