### PR TITLE
fix read count in alert

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -844,9 +844,12 @@ class PipelineRun < ApplicationRecord
         self.job_status = STATUS_FAILED
         self.finalized = 1
         self.known_user_error, self.error_message = check_for_user_error(prs)
-        log_message = "SampleFailedEvent: Sample #{sample.id} by #{sample.user.admin? ? 'admin user' : 'non-admin user'} " \
-          "failed #{prs.name} with #{adjusted_remaining_reads || 0} reads remaining after #{duration_hrs} hours. " \
-          "See: #{status_url}"
+        log_message = "SampleFailedEvent: Sample #{sample.id} " \
+          "by #{sample.user.admin? ? 'admin user' : 'non-admin user'} " \
+          "failed #{prs.name} " +
+                      (adjusted_remaining_reads ? "with #{adjusted_remaining_reads} reads remaining " : "") +
+                      "after #{duration_hrs} hours. " \
+                      "See: #{status_url}"
         LogUtil.log_err_and_airbrake(log_message) unless known_user_error
       elsif !prs.started?
         # we're moving on to a new stage


### PR DESCRIPTION
If the read count has not yet been calculated, the alert should omit it rather than claiming it is 0