### PR TITLE
Fix taxon tree png when no tree

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -747,12 +747,6 @@ class PipelineSampleReport extends React.Component {
     );
   };
 
-  handleViewClicked = (_, data) => {
-    this.setState({ view: data.name });
-    const friendlyName = data.name.replace(/_/g, "-");
-    logAnalyticsEvent(`PipelineSampleReport_${friendlyName}-view-menu_clicked`);
-  };
-
   // path to NCBI
   gotoNCBI = params => {
     const { taxId } = params;
@@ -1338,8 +1332,14 @@ class PipelineSampleReport extends React.Component {
         advanced_filter_tag_list={advanced_filter_tag_list}
         categories_filter_tag_list={categories_filter_tag_list}
         subcats_filter_tag_list={subcats_filter_tag_list}
-        view={this.state.view}
-        onViewClicked={this.handleViewClicked}
+        view={this.props.view}
+        onViewClick={(_, data) => {
+          this.props.onViewClick(data);
+          const friendlyName = data.name.replace(/_/g, "-");
+          logAnalyticsEvent(
+            `PipelineSampleReport_${friendlyName}-view-menu_clicked`
+          );
+        }}
         parent={this}
       />
     );
@@ -1410,19 +1410,6 @@ function AdvancedFilterTagList({ threshold, i, parent }) {
 }
 
 class RenderMarkup extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      view: this.props.view || "table"
-    };
-  }
-
-  componentWillReceiveProps(newProps) {
-    if (newProps.view && this.state.view != newProps.view) {
-      this.setState({ view: newProps.view });
-    }
-  }
-
   renderMenu() {
     return (
       <Menu icon floated="right" className="report-top-menu">
@@ -1430,8 +1417,8 @@ class RenderMarkup extends React.Component {
           trigger={
             <Menu.Item
               name="table"
-              active={this.state.view == "table"}
-              onClick={this.props.onViewClicked}
+              active={this.props.view == "table"}
+              onClick={this.props.onViewClick}
             >
               <Icon name="table" />
             </Menu.Item>
@@ -1444,8 +1431,8 @@ class RenderMarkup extends React.Component {
           trigger={
             <Menu.Item
               name="tree"
-              active={this.state.view == "tree"}
-              onClick={this.props.onViewClicked}
+              active={this.props.view == "tree"}
+              onClick={this.props.onViewClick}
             >
               <Icon name="fork" />
             </Menu.Item>
@@ -1535,7 +1522,7 @@ class RenderMarkup extends React.Component {
               onChange={parent.handleSpecificityChange}
             />
           </div>
-          {this.state.view == "tree" && (
+          {this.props.view == "tree" && (
             <div className="filter-lists-element">
               <MetricPicker
                 options={parent.treeMetrics}
@@ -1544,7 +1531,7 @@ class RenderMarkup extends React.Component {
               />
             </div>
           )}
-          {this.state.view == "table" && (
+          {this.props.view == "table" && (
             <div className="filter-lists-element">
               <MinContigSizeFilter
                 value={parent.state.minContigSize}
@@ -1613,8 +1600,8 @@ class RenderMarkup extends React.Component {
                 </div>
                 {filter_row_stats}
               </div>
-              {this.state.view == "table" && this.renderTable()}
-              {this.state.view == "tree" && this.renderTree()}
+              {this.props.view == "table" && this.renderTable()}
+              {this.props.view == "tree" && this.renderTree()}
               {parent.state.loading && (
                 <div className="loading-container">
                   <LoadingLabel />

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -48,7 +48,8 @@ class SampleView extends React.Component {
       sidebarVisible: false,
       sidebarTaxonModeConfig: null,
       coverageVizDataByTaxon: null,
-      nameType: Cookies.get("name_type") || "Scientific name" // "Scientific name" or "Common name"
+      nameType: Cookies.get("name_type") || "Scientific name", // "Scientific name" or "Common name"
+      view: "table"
     };
 
     this.gsnapFilterStatus = this.generateGsnapFilterStatus();
@@ -375,9 +376,11 @@ class SampleView extends React.Component {
             reportPageParams={this.props.reportPageParams}
             onTaxonClick={this.handleTaxonClick}
             onCoverageVizClick={this.handleCoverageVizClick}
+            onViewClick={this.handleViewClick}
             savedParamValues={this.props.savedParamValues}
             nameType={this.state.nameType}
             onNameTypeChange={this.handleNameTypeChange}
+            view={this.state.view}
           />
         );
       } else if (this.pipelineInProgress()) {
@@ -491,6 +494,10 @@ class SampleView extends React.Component {
       get("pipeline_version", this.props.reportPageParams)
     );
 
+  handleViewClick = data => {
+    this.setState({ view: data.name });
+  };
+
   render() {
     const versionDisplay = this.renderVersionDisplay();
 
@@ -597,6 +604,7 @@ class SampleView extends React.Component {
                 reportDetails={reportDetails}
                 reportPageParams={reportPageParams}
                 canEdit={this.props.canEdit}
+                view={this.state.view}
               />
             </ViewHeader.Controls>
           </ViewHeader>

--- a/app/assets/src/components/views/SampleView/SampleViewControls.jsx
+++ b/app/assets/src/components/views/SampleView/SampleViewControls.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import SvgSaver from "svgsaver";
 
-import PropTypes from "~/components/utils/propTypes";
 import { deleteSample } from "~/api";
 import { logAnalyticsEvent } from "~/api/analytics";
+import PropTypes from "~/components/utils/propTypes";
 import DownloadButtonDropdown from "~/components/ui/controls/dropdowns/DownloadButtonDropdown";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import {
@@ -90,7 +90,7 @@ class SampleViewControls extends React.Component {
   }
 
   checkTaxonTreeVisible() {
-    if (!this.getNode()) {
+    if (!this.getTaxonTreeNode()) {
       window.alert(
         "Switch to the Taxon Tree View first before downloading it as an image."
       );
@@ -100,10 +100,13 @@ class SampleViewControls extends React.Component {
   }
 
   getImageDownloadOptions() {
-    return [
-      { text: "Download Taxon Tree as SVG", value: "taxon_svg" },
-      { text: "Download Taxon Tree as PNG", value: "taxon_png" }
-    ];
+    if (this.props.view === "tree") {
+      return [
+        { text: "Download Taxon Tree as SVG", value: "taxon_svg" },
+        { text: "Download Taxon Tree as PNG", value: "taxon_png" }
+      ];
+    }
+    return [];
   }
 
   render() {
@@ -145,7 +148,8 @@ SampleViewControls.propTypes = {
     // TODO (gdingle): standardize on string or number
     background_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
   }),
-  canEdit: PropTypes.bool
+  canEdit: PropTypes.bool,
+  view: PropTypes.string
 };
 
 export default SampleViewControls;

--- a/app/assets/src/components/views/SampleView/SampleViewControls.jsx
+++ b/app/assets/src/components/views/SampleView/SampleViewControls.jsx
@@ -62,14 +62,14 @@ class SampleViewControls extends React.Component {
       this.downloadCSV();
       log();
       return;
-    } else if (option == "taxon_svg") {
+    } else if (option == "taxon_svg" && this.checkTaxonTreeVisible()) {
       // TODO (gdingle): filename per tree?
-      new SvgSaver().asSvg(this.getNode(), "taxon_tree.svg");
+      new SvgSaver().asSvg(this.getTaxonTreeNode(), "taxon_tree.svg");
       log();
       return;
-    } else if (option == "taxon_png") {
+    } else if (option == "taxon_png" && this.checkTaxonTreeVisible()) {
       // TODO (gdingle): filename per tree?
-      new SvgSaver().asPng(this.getNode(), "taxon_tree.png");
+      new SvgSaver().asPng(this.getTaxonTreeNode(), "taxon_tree.png");
       log();
       return;
     }
@@ -85,8 +85,25 @@ class SampleViewControls extends React.Component {
   };
 
   // TODO (gdingle): should we pass in a reference with React somehow?
-  getNode() {
+  getTaxonTreeNode() {
     return document.getElementsByClassName("taxon-tree-vis")[0];
+  }
+
+  checkTaxonTreeVisible() {
+    if (!this.getNode()) {
+      window.alert(
+        "Switch to the Taxon Tree View first before downloading it as an image."
+      );
+      return false;
+    }
+    return true;
+  }
+
+  getImageDownloadOptions() {
+    return [
+      { text: "Download Taxon Tree as SVG", value: "taxon_svg" },
+      { text: "Download Taxon Tree as PNG", value: "taxon_png" }
+    ];
   }
 
   render() {
@@ -99,8 +116,7 @@ class SampleViewControls extends React.Component {
           value: "download_csv"
         },
         ...getDownloadDropdownOptions(pipelineRun),
-        { text: "Download Taxon Tree as SVG", value: "taxon_svg" },
-        { text: "Download Taxon Tree as PNG", value: "taxon_png" }
+        ...this.getImageDownloadOptions()
       ];
 
       return (

--- a/app/assets/src/components/views/SampleView/SampleViewControls.jsx
+++ b/app/assets/src/components/views/SampleView/SampleViewControls.jsx
@@ -62,12 +62,12 @@ class SampleViewControls extends React.Component {
       this.downloadCSV();
       log();
       return;
-    } else if (option == "taxon_svg" && this.checkTaxonTreeVisible()) {
+    } else if (option == "taxon_svg") {
       // TODO (gdingle): filename per tree?
       new SvgSaver().asSvg(this.getTaxonTreeNode(), "taxon_tree.svg");
       log();
       return;
-    } else if (option == "taxon_png" && this.checkTaxonTreeVisible()) {
+    } else if (option == "taxon_png") {
       // TODO (gdingle): filename per tree?
       new SvgSaver().asPng(this.getTaxonTreeNode(), "taxon_tree.png");
       log();
@@ -87,16 +87,6 @@ class SampleViewControls extends React.Component {
   // TODO (gdingle): should we pass in a reference with React somehow?
   getTaxonTreeNode() {
     return document.getElementsByClassName("taxon-tree-vis")[0];
-  }
-
-  checkTaxonTreeVisible() {
-    if (!this.getTaxonTreeNode()) {
-      window.alert(
-        "Switch to the Taxon Tree View first before downloading it as an image."
-      );
-      return false;
-    }
-    return true;
   }
 
   getImageDownloadOptions() {


### PR DESCRIPTION
# Description

This is a fix to https://jira.czi.team/browse/IDSEQ-915 by showing relevant options only during tree view. 

![image](https://user-images.githubusercontent.com/28797/59233230-73795000-8b9c-11e9-9b62-cd806aa8596a.png)

![image](https://user-images.githubusercontent.com/28797/59233262-9572d280-8b9c-11e9-8fb3-ce694200179d.png)


# Test

In report page
Open download dropdown
See no PNG

Switch to taxon tree view
See PNG 

Repeat for SVG

Check that analytics is still sent in logs