### PR TITLE
Generalize coverage viz to handle genus taxons.

### DIFF
--- a/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
@@ -285,14 +285,18 @@ $accession-count-label-height: 20px;
   .optionText {
     @include font-body-xs;
     color: $darkest-grey;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
   }
 
   .optionSubtext {
     @include font-body-xxs;
     color: $light-grey;
     font-weight: $font-weight-regular;
+  }
+
+  .optionText,
+  .optionSubtext {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
 }

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -2,7 +2,8 @@
 // Also handles the sidebar and tabs logic.
 import React from "react";
 import cx from "classnames";
-import { get } from "lodash/fp";
+import Cookies from "js-cookie";
+import { get, flatten, compact, map, sum } from "lodash/fp";
 
 import { saveVisualization, getCoverageVizSummary } from "~/api";
 import {
@@ -46,7 +47,8 @@ class SampleView extends React.Component {
       sidebarMode: null,
       sidebarVisible: false,
       sidebarTaxonModeConfig: null,
-      coverageVizDataByTaxon: null
+      coverageVizDataByTaxon: null,
+      nameType: Cookies.get("name_type") || "Scientific name" // "Scientific name" or "Common name"
     };
 
     this.gsnapFilterStatus = this.generateGsnapFilterStatus();
@@ -132,6 +134,11 @@ class SampleView extends React.Component {
     logAnalyticsEvent(`SampleView_tab-${name}_clicked`, {
       tab: tab
     });
+  };
+
+  handleNameTypeChange = nameType => {
+    Cookies.set("name_type", nameType);
+    this.setState({ nameType });
   };
 
   toggleSampleDetailsSidebar = () => {
@@ -366,6 +373,8 @@ class SampleView extends React.Component {
             onTaxonClick={this.handleTaxonClick}
             onCoverageVizClick={this.handleCoverageVizClick}
             savedParamValues={this.props.savedParamValues}
+            nameType={this.state.nameType}
+            onNameTypeChange={this.handleNameTypeChange}
           />
         );
       } else if (this.pipelineInProgress()) {
@@ -397,6 +406,44 @@ class SampleView extends React.Component {
     return {};
   };
 
+  // Aggregate the accessions from multiple species into a single data object.
+  // Used for coverage viz.
+  getCombinedAccessionDataForSpecies = speciesTaxons => {
+    const { coverageVizDataByTaxon } = this.state;
+
+    // This helper function gets the best accessions for a species taxon.
+    const getSpeciesBestAccessions = taxon => {
+      const speciesBestAccessions = get(
+        [taxon.taxonId, "best_accessions"],
+        coverageVizDataByTaxon
+      );
+      // Add the species taxon name to each accession.
+      return map(
+        accession => ({
+          ...accession,
+          // Use snake_case for consistency with other fields.
+          taxon_name: taxon.taxonName,
+          taxon_common_name: taxon.taxonCommonName
+        }),
+        speciesBestAccessions
+      );
+    };
+
+    const speciesTaxIds = map("taxonId", speciesTaxons);
+
+    return {
+      best_accessions: flatten(
+        compact(map(getSpeciesBestAccessions, speciesTaxons))
+      ),
+      num_accessions: sum(
+        map(
+          taxId => get([taxId, "num_accessions"], coverageVizDataByTaxon),
+          speciesTaxIds
+        )
+      )
+    };
+  };
+
   getCoverageVizParams = () => {
     const { coverageVizParams, coverageVizDataByTaxon } = this.state;
 
@@ -404,11 +451,24 @@ class SampleView extends React.Component {
       return {};
     }
 
+    let accessionData = null;
+
+    // For genus-level taxons, we aggregate all the available species-level taxons for that genus.
+    if (coverageVizParams.taxLevel === "genus") {
+      accessionData = this.getCombinedAccessionDataForSpecies(
+        coverageVizParams.speciesTaxons
+      );
+    } else {
+      accessionData = get(coverageVizParams.taxId, coverageVizDataByTaxon);
+    }
+
     return {
       taxonId: coverageVizParams.taxId,
       taxonName: coverageVizParams.taxName,
+      taxonCommonName: coverageVizParams.taxCommonName,
+      taxonLevel: coverageVizParams.taxLevel,
       alignmentVizUrl: coverageVizParams.alignmentVizUrl,
-      accessionData: get(coverageVizParams.taxId, coverageVizDataByTaxon)
+      accessionData
     };
   };
 
@@ -580,6 +640,7 @@ class SampleView extends React.Component {
             params={this.getCoverageVizParams()}
             sampleId={sample.id}
             pipelineVersion={this.props.pipelineRun.pipeline_version}
+            nameType={this.state.nameType}
           />
         )}
       </div>

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -145,7 +145,11 @@ class TaxonTreeVis extends React.Component {
     }
 
     const { taxInfo } = node.data.modalData;
-    const taxonName = getTaxonName(taxInfo, this.props.nameType);
+    const taxonName = getTaxonName(
+      taxInfo["name"],
+      taxInfo["common_name"],
+      this.props.nameType
+    );
     // Pass config for taxon details sidebar.
     this.props.onTaxonClick({
       background: this.props.backgroundData,

--- a/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
+++ b/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
@@ -73,7 +73,8 @@ class HoverActions extends React.Component {
             params: {
               taxId: this.props.taxId,
               taxLevel: this.props.taxLevel === 1 ? "species" : "genus",
-              taxName: this.props.taxName
+              taxName: this.props.taxName,
+              taxCommonName: this.props.taxCommonName
             }
           }
         : {
@@ -191,6 +192,7 @@ HoverActions.propTypes = {
   taxId: PropTypes.number,
   taxLevel: PropTypes.number,
   taxName: PropTypes.string,
+  taxCommonName: PropTypes.string,
   ncbiEnabled: PropTypes.bool,
   onNcbiActionClick: PropTypes.func.isRequired,
   fastaEnabled: PropTypes.bool,

--- a/app/assets/src/helpers/taxon.js
+++ b/app/assets/src/helpers/taxon.js
@@ -1,9 +1,6 @@
 import StringHelper from "./StringHelper";
 
-export const getTaxonName = (taxInfo, nameType) => {
-  const scientificName = taxInfo["name"];
-  const commonName = taxInfo["common_name"];
-
+export const getTaxonName = (scientificName, commonName, nameType) => {
   return nameType.toLowerCase() !== "common name" ||
     !commonName ||
     commonName.trim() === ""


### PR DESCRIPTION
Also ensure coverage viz takes nameType into account (common vs scientific name)

When a genus-level taxon is opened, we show the species that the current accession belongs to. 
![Screen Shot 2019-06-05 at 2 25 45 PM](https://user-images.githubusercontent.com/837004/58992174-ecdd0100-879e-11e9-8da1-f44cc6b60e0b.png)

A tooltip helps clarify this further. Notice that the species name is also listed in the dropdown options, and all names now respect the nameType (common vs scientific) 
![Screen Shot 2019-06-05 at 2 26 23 PM](https://user-images.githubusercontent.com/837004/58992176-ee0e2e00-879e-11e9-8d06-27b19a992024.png)

Verified that:
* Species-level taxons still work as before.
* Genus-level taxons work as expected, for genuses with multiple species taxons with coverage.
* The nameType option still works properly for the report table and the taxon tree (since the refactor touched those)
* The nameType is still saved properly in the cookie.
