### PR TITLE
Make taxon tree scroll horizontally on overflow

### DIFF
--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -352,6 +352,7 @@ class TaxonTreeVis extends React.Component {
           ref={container => {
             this.treeContainer = container;
           }}
+          style={{ overflowX: "scroll" }}
         >
           <div className="pathogen-labels">{this.renderPathogenLabels()}</div>
         </div>

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -352,7 +352,6 @@ class TaxonTreeVis extends React.Component {
           ref={container => {
             this.treeContainer = container;
           }}
-          style={{ overflowX: "scroll" }}
         >
           <div className="pathogen-labels">{this.renderPathogenLabels()}</div>
         </div>

--- a/app/assets/src/components/visualizations/TidyTree.js
+++ b/app/assets/src/components/visualizations/TidyTree.js
@@ -14,7 +14,7 @@ export default class TidyTree {
         addOverlays: true,
         attribute: "aggregatescore",
         leafNodeHeight: 35,
-        minWidth: 1000,
+        minWidth: 960,
         minHeight: 300,
         transitionDuration: 500,
         onNodeHover: null,
@@ -27,7 +27,7 @@ export default class TidyTree {
         largerFont: 12,
         onCollapsedStateChange: () => {},
         collapsed: new Set(),
-        svgBackgroundColor: "white"
+        svgBackgroundColor: "white",
       },
       options || {}
     );
@@ -36,7 +36,7 @@ export default class TidyTree {
       top: 20,
       right: 200,
       left: 40,
-      bottom: 20
+      bottom: 20,
     };
 
     this.range = [0, 1];
@@ -123,7 +123,7 @@ export default class TidyTree {
       Math.min(
         ...this.root.leaves().map(l => l.data.values[this.options.attribute])
       ),
-      this.root.data.values[this.options.attribute]
+      this.root.data.values[this.options.attribute],
     ];
 
     let collapsedScale = scaleLinear()
@@ -174,8 +174,8 @@ export default class TidyTree {
                 ),
                 scientificName: `(${d.collapsedChildren.length})`,
                 lineageRank: d.collapsedChildren[0].data.lineageRank,
-                values: d.collapsedChildren[0].data.values
-              }
+                values: d.collapsedChildren[0].data.values,
+              },
             });
           }
         }
@@ -218,7 +218,7 @@ export default class TidyTree {
     this.update(
       Object.assign(node, {
         x0: node.x,
-        y0: node.y
+        y0: node.y,
       })
     );
     this.options.onCollapsedStateChange &&

--- a/app/assets/src/styles/views/taxon_tree_vis.scss
+++ b/app/assets/src/styles/views/taxon_tree_vis.scss
@@ -4,6 +4,7 @@
   &__container {
     position: relative;
     margin-bottom: 15rem;
+    overflow-x: scroll;
 
     .node-overlay {
       opacity: 0;


### PR DESCRIPTION
# Description

This fixes issue https://jira.czi.team/browse/IDSEQ-1005?filter=10801 by making the a horizontal scrollbar appear when the viewport width is less than 1200px.

# Notes

* I checked and there are no callers that set any of the affected viz options . 

* I tried a variety of approaches before settling on this very simple one, including 
  * shrinking to fit: made trees too small for many samples
  * determining size from container: didn't play nice with dynamic height resizing that depends on number of leaves

# Test

Make tree scroll:
![image](https://user-images.githubusercontent.com/28797/59302646-48990580-8c49-11e9-9776-3554b689e957.png)

Make tree not scroll:
![image](https://user-images.githubusercontent.com/28797/59302628-3f0f9d80-8c49-11e9-9fd8-d961d875376a.png)
