### PR TITLE
Add nanobar to DD project reports downloads.

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -903,6 +903,7 @@ class DiscoveryView extends React.Component {
                       ref={samplesView => (this.samplesView = samplesView)}
                       samples={samples}
                       selectableIds={sampleIds}
+                      admin={this.props.admin}
                     />
                   </div>
                   {!samples.length &&
@@ -945,7 +946,8 @@ DiscoveryView.propTypes = {
   ]).isRequired,
   projectId: PropTypes.number,
   allowedFeatures: PropTypes.arrayOf(PropTypes.string),
-  mapTilerKey: PropTypes.string
+  mapTilerKey: PropTypes.string,
+  admin: PropTypes.bool
 };
 
 export default DiscoveryView;

--- a/app/assets/src/components/views/samples/ReportsDownloader.js
+++ b/app/assets/src/components/views/samples/ReportsDownloader.js
@@ -2,6 +2,7 @@
 import axios from "axios";
 import { openUrl } from "~utils/links";
 import Cookies from "js-cookie";
+import Nanobar from "nanobar";
 
 export default class ReportsDownloader {
   constructor({
@@ -10,6 +11,11 @@ export default class ReportsDownloader {
     downloadOption,
     selectedSampleIds
   }) {
+    this.nanobar = new Nanobar({
+      id: "prog-bar",
+      class: "prog-bar"
+    });
+
     this.projectId = projectId || "all";
     this.selectedSampleIds = Array.from(selectedSampleIds);
     this.onDownloadFail = onDownloadFail;
@@ -25,6 +31,7 @@ export default class ReportsDownloader {
         let downloadStatus = result.data.status_display;
         if (downloadStatus === "complete") {
           openUrl(`/projects/${this.projectId}/${retrieveAction}`);
+          this.nanobar.go(100);
         } else {
           this.scheduleCheckReportDownload({
             result,
@@ -39,6 +46,7 @@ export default class ReportsDownloader {
           console.error("ReportsDownloader - Failed report download");
           this.onDownloadFail &&
             this.onDownloadFail({ projectId: this.projectId });
+          this.nanobar.go(100);
         };
       });
   };
@@ -50,6 +58,7 @@ export default class ReportsDownloader {
   }
 
   generateReport = ({ makeAction, statusAction, retrieveAction }) => {
+    this.nanobar.go(30);
     // TODO(tiago): stop using cookies
     const backgroundId = Cookies.get("background_id");
     let queryString = [];

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -218,6 +218,12 @@ class SamplesView extends React.Component {
         value: "project_reports"
       });
     }
+    if (this.props.admin) {
+      downloadOptions.push({
+        text: "Host Gene Counts",
+        value: "host_gene_counts"
+      });
+    }
     return (
       <DownloadIconDropdown
         iconClassName={cx(cs.icon, cs.download)}
@@ -462,7 +468,8 @@ SamplesView.propTypes = {
   projectId: PropTypes.number,
   protectedColumns: PropTypes.array,
   samples: PropTypes.array,
-  selectableIds: PropTypes.array.isRequired
+  selectableIds: PropTypes.array.isRequired,
+  admin: PropTypes.bool
 };
 
 export default SamplesView;

--- a/app/views/home/all_data.html.erb
+++ b/app/views/home/all_data.html.erb
@@ -3,6 +3,7 @@
   <%= javascript_tag do %>
     react_component('DiscoveryView', {
       domain: "all_data",
+      admin: <%= current_user.admin %>,
       projectId: <%= params[:project_id] || "null" %>,
       allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
       mapTilerKey: '<%= ENV["MAPTILER_API_KEY"] %>',

--- a/app/views/home/my_data.html.erb
+++ b/app/views/home/my_data.html.erb
@@ -3,6 +3,7 @@
   <%= javascript_tag do %>
     react_component('DiscoveryView', {
       domain: "my_data",
+      admin: <%= current_user.admin %>,
       projectId: <%= params[:project_id] || "null" %>,
       allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
       mapTilerKey: '<%= ENV["MAPTILER_API_KEY"] %>',

--- a/app/views/home/public.html.erb
+++ b/app/views/home/public.html.erb
@@ -3,6 +3,7 @@
   <%= javascript_tag do %>
     react_component('DiscoveryView', {
       domain: "public",
+      admin: <%= current_user.admin %>,
       projectId: <%= params[:project_id] || "null" %>,
       allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
       mapTilerKey: '<%= ENV["MAPTILER_API_KEY"] %>',


### PR DESCRIPTION
Also add host download option for admins only. (feature parity with legacy page)

![Screen Shot 2019-06-05 at 7 15 01 PM](https://user-images.githubusercontent.com/837004/59002129-44429780-87c6-11e9-8ca0-b8a0daf8c906.png)

Verified that:
* The option doesn't show up for non-admin users.
* The nanobar works for both download options. (not for Sample Table, since it downloads the file directly with openUrl)
