### PR TITLE
[Maps] Add location_v2 to the dimensions endpoints, left pane filters, and main sample table

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
@@ -129,6 +129,7 @@ class DiscoveryFilters extends React.Component {
     const {
       hostSelected,
       locationSelected,
+      locationV2Selected,
       taxonSelected,
       timeSelected,
       tissueSelected,
@@ -136,10 +137,12 @@ class DiscoveryFilters extends React.Component {
     } = this.state;
 
     const {
+      allowedFeatures,
       className,
       domain,
       host,
       location,
+      locationV2,
       time,
       tissue,
       visibility
@@ -164,6 +167,19 @@ class DiscoveryFilters extends React.Component {
           />
           {this.renderTags("location")}
         </div>
+        {allowedFeatures.includes("maps") && (
+          <div className={cs.filterContainer}>
+            <BaseMultipleFilter
+              onChange={this.handleChange.bind(this, "locationV2Selected")}
+              selected={
+                locationV2 && locationV2.length ? locationV2Selected : null
+              }
+              options={locationV2}
+              label="Location v2"
+            />
+            {/*{this.renderTags("location")}*/}
+          </div>
+        )}
         <div className={cs.filterContainer}>
           <BaseSingleFilter
             label="Timeframe"
@@ -208,18 +224,21 @@ class DiscoveryFilters extends React.Component {
 DiscoveryFilters.defaultProps = {
   host: [],
   location: [],
+  locationV2: [],
   time: [],
   tissue: [],
   visibility: []
 };
 
 DiscoveryFilters.propTypes = {
+  allowedFeatures: PropTypes.arrayOf(PropTypes.string),
   className: PropTypes.string,
   domain: PropTypes.string,
 
   // Filter options and counters
   host: PropTypes.array,
   location: PropTypes.array,
+  locationV2: PropTypes.array,
   time: PropTypes.array,
   tissue: PropTypes.array,
   visibility: PropTypes.array,
@@ -227,6 +246,7 @@ DiscoveryFilters.propTypes = {
   // Selected values
   hostSelected: PropTypes.array,
   locationSelected: PropTypes.array,
+  locationV2Selected: PropTypes.array,
   taxonSelected: PropTypes.array,
   timeSelected: PropTypes.string,
   tissueSelected: PropTypes.array,

--- a/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
@@ -43,6 +43,7 @@ class DiscoveryFilters extends React.Component {
       [
         "hostSelected",
         "locationSelected",
+        "locationV2Selected",
         "taxonSelected",
         "timeSelected",
         "tissueSelected",
@@ -59,6 +60,7 @@ class DiscoveryFilters extends React.Component {
       [
         "hostSelected",
         "locationSelected",
+        "locationV2Selected",
         "taxonSelected",
         "timeSelected",
         "tissueSelected",
@@ -177,7 +179,7 @@ class DiscoveryFilters extends React.Component {
               options={locationV2}
               label="Location v2"
             />
-            {/*{this.renderTags("location")}*/}
+            {this.renderTags("locationV2")}
           </div>
         )}
         <div className={cs.filterContainer}>

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -821,8 +821,6 @@ class DiscoveryView extends React.Component {
 
     const tabs = this.computeTabs();
     const dimensions = this.getCurrentDimensions();
-    console.log("dimensions: ", dimensions);
-    console.log("filters: ", filters);
     const filterCount = this.getFilterCount();
 
     return (

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -821,6 +821,8 @@ class DiscoveryView extends React.Component {
 
     const tabs = this.computeTabs();
     const dimensions = this.getCurrentDimensions();
+    console.log("dimensions: ", dimensions);
+    console.log("filters: ", filters);
     const filterCount = this.getFilterCount();
 
     return (
@@ -863,6 +865,7 @@ class DiscoveryView extends React.Component {
                   {...filters}
                   domain={domain}
                   onFilterChange={this.handleFilterChange}
+                  allowedFeatures={allowedFeatures}
                 />
               )}
           </div>

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -43,6 +43,8 @@ const getDiscoveryDimensions = async ({
       getProjectDimensions({ domain, filters, projectId, search })
     ];
     const [sampleDimensions, projectDimensions] = await Promise.all(actions);
+    console.log("sample dims: ", sampleDimensions);
+    console.log("project dims: ", projectDimensions);
     return { sampleDimensions, projectDimensions };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -80,6 +80,10 @@ const processRawSample = sample => {
       ).toLowerCase()
     },
     collectionLocation: get("metadata.collection_location", sample.details),
+    collectionLocationV2: get(
+      "metadata.collection_location_v2",
+      sample.details
+    ),
     createdAt: sample.created_at,
     duplicateCompressionRatio: get(
       "derived_sample_output.summary_stats.compression_ratio",

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -43,8 +43,6 @@ const getDiscoveryDimensions = async ({
       getProjectDimensions({ domain, filters, projectId, search })
     ];
     const [sampleDimensions, projectDimensions] = await Promise.all(actions);
-    console.log("sample dims: ", sampleDimensions);
-    console.log("project dims: ", projectDimensions);
     return { sampleDimensions, projectDimensions };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -38,7 +38,7 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         className: cs.basicCell
       },
-      // If you already have access to Maps, just show Location V2 here.
+      // If you already have access to Maps, just see Location V2 here.
       {
         dataKey: "collectionLocationV2",
         label: "Location",

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -38,8 +38,9 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         className: cs.basicCell
       },
+      // If you already have access to Maps, just show Location V2 here.
       {
-        dataKey: "collectionLocation",
+        dataKey: "collectionLocationV2",
         label: "Location",
         flexGrow: 1,
         className: cs.basicCell

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -25,6 +25,8 @@ class SamplesView extends React.Component {
   constructor(props) {
     super(props);
 
+    const { allowedFeatures } = this.props;
+
     this.state = {
       phyloTreeCreationModalOpen: false,
       selectedSampleIds: new Set()
@@ -129,6 +131,16 @@ class SamplesView extends React.Component {
           TableRenderers.formatDuration(rowData[dataKey])
       }
     ];
+
+    // TODO(jsheu): Upon release, replace Location 'V1'
+    if (allowedFeatures.includes("maps")) {
+      this.columns.push({
+        dataKey: "collectionLocationV2",
+        label: "Location V2",
+        flexGrow: 1,
+        className: cs.basicCell
+      });
+    }
   }
 
   handleSelectRow = (value, checked) => {

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -471,7 +471,7 @@ SamplesView.propTypes = {
   currentDisplay: PropTypes.string.isRequired,
   mapLocationData: PropTypes.objectOf(PropTypes.Location),
   mapPreviewedSamples: PropTypes.array,
-  mapSidebarSelectedSampleIds: PropTypes.set,
+  mapSidebarSelectedSampleIds: PropTypes.instanceOf(Set),
   mapTilerKey: PropTypes.string,
   onDisplaySwitch: PropTypes.func,
   onLoadRows: PropTypes.func.isRequired,

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -132,11 +132,11 @@ class SamplesView extends React.Component {
       }
     ];
 
-    // TODO(jsheu): Upon release, replace Location 'V1'
+    // TODO(jsheu): Upon release, replace Location 'v1'
     if (allowedFeatures.includes("maps")) {
       this.columns.push({
         dataKey: "collectionLocationV2",
-        label: "Location V2",
+        label: "Location v2",
         flexGrow: 1,
         className: cs.basicCell
       });

--- a/app/assets/src/components/visualizations/table/InfiniteTable.jsx
+++ b/app/assets/src/components/visualizations/table/InfiniteTable.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { defaultTableRowRenderer, InfiniteLoader } from "react-virtualized";
+import { isObject } from "lodash/fp";
 import BaseTable from "./BaseTable";
 import cs from "./infinite_table.scss";
 import cx from "classnames";
@@ -72,7 +73,12 @@ class InfiniteTable extends React.Component {
     // Guarantees that we have at least one child div in the cell
     return (
       <div className={cs.cellContent}>
-        {cellData == null ? "" : String(cellData)}
+        {/* Use .name if val is an object (e.g. location object) */}
+        {cellData == null
+          ? ""
+          : isObject(cellData)
+            ? cellData.name
+            : String(cellData)}
       </div>
     );
   };

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -68,7 +68,7 @@ class ProjectsController < ApplicationController
         samples = filter_samples(samples, params)
 
         # if we are applying any filters that constrain project's samples, we should not show projects with zero samples
-        hide_empty_projects = [:host, :location, :taxon, :time, :tissue, :visibility].any? do |key|
+        hide_empty_projects = [:host, :location, :locationV2, :taxon, :time, :tissue, :visibility].any? do |key|
           params.key? key
         end
 
@@ -156,13 +156,8 @@ class ProjectsController < ApplicationController
     projects = Project.where(id: project_ids)
     projects_count = projects.count
 
-    locations = samples_by_metadata_field(sample_ids, "collection_location")
-                .joins(:sample)
-                .distinct
-                .count(:project_id)
-    locations = locations.map do |location, count|
-      { value: location, text: location, count: count }
-    end
+    locations = LocationHelper.project_dimensions(sample_ids, "collection_location")
+    locations_v2 = LocationHelper.project_dimensions(sample_ids, "collection_location_v2")
 
     tissues = samples_by_metadata_field(sample_ids, "sample_type")
               .joins(:sample)
@@ -244,6 +239,7 @@ class ProjectsController < ApplicationController
       format.json do
         render json: [
           { dimension: "location", values: locations },
+          { dimension: "locationV2", values: locations_v2 },
           { dimension: "visibility", values: visibility },
           { dimension: "time", values: times },
           { dimension: "time_bins", values: time_bins },

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -159,10 +159,10 @@ class ProjectsController < ApplicationController
     locations = LocationHelper.project_dimensions(sample_ids, "collection_location")
     locations_v2 = LocationHelper.project_dimensions(sample_ids, "collection_location_v2")
 
-    tissues = samples_by_metadata_field(sample_ids, "sample_type")
-              .joins(:sample)
-              .distinct
-              .count(:project_id)
+    tissues = SamplesHelper.samples_by_metadata_field(sample_ids, "sample_type")
+                           .joins(:sample)
+                           .distinct
+                           .count(:project_id)
     tissues = tissues.map do |tissue, count|
       { value: tissue, text: tissue, count: count }
     end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -206,6 +206,15 @@ class SamplesController < ApplicationController
       locations << { value: "not_set", text: "Unknown", count: not_set_count }
     end
 
+    locations_v2 = samples_by_metadata_field(sample_ids, "collection_location_v2").count
+    locations_v2 = locations_v2.map do |location, count|
+      { value: location.name, text: location.name, count: count }
+    end
+    not_set_count = samples_count - locations_v2.sum { |l| l[:count] }
+    if not_set_count > 0
+      locations_v2 << { value: "not_set", text: "Unknown", count: not_set_count }
+    end
+
     tissues = samples_by_metadata_field(sample_ids, "sample_type").count
     tissues = tissues.map do |tissue, count|
       { value: tissue, text: tissue, count: count }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -198,8 +198,8 @@ class SamplesController < ApplicationController
     sample_ids = samples.pluck(:id)
     samples_count = samples.count
 
-    locations = LocationHelper.dimensions(sample_ids, "collection_location", samples_count)
-    locations_v2 = LocationHelper.dimensions(sample_ids, "collection_location_v2", samples_count)
+    locations = LocationHelper.sample_dimensions(sample_ids, "collection_location", samples_count)
+    locations_v2 = LocationHelper.sample_dimensions(sample_ids, "collection_location_v2", samples_count)
 
     tissues = samples_by_metadata_field(sample_ids, "sample_type").count
     tissues = tissues.map do |tissue, count|

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1,11 +1,12 @@
 class SamplesController < ApplicationController
   include ApplicationHelper
+  include ElasticsearchHelper
+  include ErrorHelper
+  include HeatmapHelper
+  include LocationHelper
+  include PipelineOutputsHelper
   include ReportHelper
   include SamplesHelper
-  include PipelineOutputsHelper
-  include ElasticsearchHelper
-  include HeatmapHelper
-  include ErrorHelper
 
   ########################################
   # Note to developers:
@@ -197,23 +198,8 @@ class SamplesController < ApplicationController
     sample_ids = samples.pluck(:id)
     samples_count = samples.count
 
-    locations = samples_by_metadata_field(sample_ids, "collection_location").count
-    locations = locations.map do |location, count|
-      { value: location, text: location, count: count }
-    end
-    not_set_count = samples_count - locations.sum { |l| l[:count] }
-    if not_set_count > 0
-      locations << { value: "not_set", text: "Unknown", count: not_set_count }
-    end
-
-    locations_v2 = samples_by_metadata_field(sample_ids, "collection_location_v2").count
-    locations_v2 = locations_v2.map do |location, count|
-      { value: location.name, text: location.name, count: count }
-    end
-    not_set_count = samples_count - locations_v2.sum { |l| l[:count] }
-    if not_set_count > 0
-      locations_v2 << { value: "not_set", text: "Unknown", count: not_set_count }
-    end
+    locations = LocationHelper.dimensions(sample_ids, "collection_location", samples_count)
+    locations_v2 = LocationHelper.dimensions(sample_ids, "collection_location_v2", samples_count)
 
     tissues = samples_by_metadata_field(sample_ids, "sample_type").count
     tissues = tissues.map do |tissue, count|
@@ -290,6 +276,7 @@ class SamplesController < ApplicationController
       format.json do
         render json: [
           { dimension: "location", values: locations },
+          { dimension: "location_v2", values: locations_v2 },
           { dimension: "visibility", values: visibility },
           { dimension: "time", values: times },
           { dimension: "time_bins", values: time_bins },

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -276,7 +276,7 @@ class SamplesController < ApplicationController
       format.json do
         render json: [
           { dimension: "location", values: locations },
-          { dimension: "location_v2", values: locations_v2 },
+          { dimension: "locationV2", values: locations_v2 },
           { dimension: "visibility", values: visibility },
           { dimension: "time", values: times },
           { dimension: "time_bins", values: time_bins },

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -201,7 +201,7 @@ class SamplesController < ApplicationController
     locations = LocationHelper.sample_dimensions(sample_ids, "collection_location", samples_count)
     locations_v2 = LocationHelper.sample_dimensions(sample_ids, "collection_location_v2", samples_count)
 
-    tissues = samples_by_metadata_field(sample_ids, "sample_type").count
+    tissues = SamplesHelper.samples_by_metadata_field(sample_ids, "sample_type").count
     tissues = tissues.map do |tissue, count|
       { value: tissue, text: tissue, count: count }
     end

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -28,12 +28,22 @@ module LocationHelper
     name.gsub(%r{[;%_^<>\/?\\]}, "")
   end
 
+  def self.truncate_name(name)
+    # Truncate long names so they look a little better downstream (e.g. in the filters)
+    # TODO(jsheu): Look into shortening names by leaving out fields like 'neighborhoods'
+    max_chars = 45
+    if name.size > max_chars
+      name = "#{name.first(max_chars)}..."
+    end
+    name
+  end
+
   def self.sample_dimensions(sample_ids, field_name, samples_count)
     # See pattern in SamplesController dimensions
     locations = SamplesHelper.samples_by_metadata_field(sample_ids, field_name).count
     locations = locations.map do |loc, count|
       location = loc.is_a?(Array) ? (loc[0] || loc[1]) : loc
-      { value: location, text: location, count: count }
+      { value: location, text: truncate_name(location), count: count }
     end
     not_set_count = samples_count - locations.sum { |l| l[:count] }
     if not_set_count > 0
@@ -50,7 +60,7 @@ module LocationHelper
                              .count(:project_id)
     locations.map do |loc, count|
       location = loc.is_a?(Array) ? (loc[0] || loc[1]) : loc
-      { value: location, text: location, count: count }
+      { value: location, text: truncate_name(location), count: count }
     end
   end
 

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -55,7 +55,7 @@ module LocationHelper
   def self.project_dimensions(sample_ids, field_name)
     # See pattern in ProjectsController dimensions
     locations = SamplesHelper.samples_by_metadata_field(sample_ids, field_name)
-                             .joins(:sample)
+                             .includes(:sample)
                              .distinct
                              .count(:project_id)
     locations.map do |loc, count|

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -41,4 +41,11 @@ module LocationHelper
     end
     locations
   end
+
+  def self.filter_by_name(samples_with_metadata, query)
+    samples = samples_with_metadata.includes(metadata: :location)
+    # Plain text locations in string_validated_value
+    samples.where(metadata: { string_validated_value: query })
+           .or(samples.where(metadata: { locations: { name: query } }))
+  end
 end

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -28,18 +28,30 @@ module LocationHelper
     name.gsub(%r{[;%_^<>\/?\\]}, "")
   end
 
-  def self.dimensions(sample_ids, field_name, samples_count)
-    # See pattern in SamplesController#dimensions
+  def self.sample_dimensions(sample_ids, field_name, samples_count)
+    # See pattern in SamplesController dimensions
     locations = SamplesHelper.samples_by_metadata_field(sample_ids, field_name).count
-    locations = locations.map do |location, count|
-      loc = location.is_a?(Array) ? (location[0] || location[1]) : location
-      { value: loc, text: loc, count: count }
+    locations = locations.map do |loc, count|
+      location = loc.is_a?(Array) ? (loc[0] || loc[1]) : loc
+      { value: location, text: location, count: count }
     end
     not_set_count = samples_count - locations.sum { |l| l[:count] }
     if not_set_count > 0
       locations << { value: "not_set", text: "Unknown", count: not_set_count }
     end
     locations
+  end
+
+  def self.project_dimensions(sample_ids, field_name)
+    # See pattern in ProjectsController dimensions
+    locations = SamplesHelper.samples_by_metadata_field(sample_ids, field_name)
+                             .joins(:sample)
+                             .distinct
+                             .count(:project_id)
+    locations.map do |loc, count|
+      location = loc.is_a?(Array) ? (loc[0] || loc[1]) : loc
+      { value: location, text: location, count: count }
+    end
   end
 
   def self.filter_by_name(samples_with_metadata, query)

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -27,4 +27,18 @@ module LocationHelper
   def self.sanitize_name(name)
     name.gsub(%r{[;%_^<>\/?\\]}, "")
   end
+
+  def self.dimensions(sample_ids, field_name, samples_count)
+    # See pattern in SamplesController#dimensions
+    locations = SamplesHelper.samples_by_metadata_field(sample_ids, field_name).count
+    locations = locations.map do |location, count|
+      loc = location.is_a?(Array) ? (location[0] || location[1]) : location
+      { value: loc, text: loc, count: count }
+    end
+    not_set_count = samples_count - locations.sum { |l| l[:count] }
+    if not_set_count > 0
+      locations << { value: "not_set", text: "Unknown", count: not_set_count }
+    end
+    locations
+  end
 end

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -29,11 +29,15 @@ module LocationHelper
   end
 
   def self.truncate_name(name)
-    # Truncate long names so they look a little better downstream (e.g. in the filters)
-    # TODO(jsheu): Look into shortening names by leaving out fields like 'neighborhoods'
-    max_chars = 45
+    # For long names, just take the first and last two parts so they look a little better downstream
+    # (e.g. in dropdown filters).
+    max_chars = 40
     if name.size > max_chars
-      name = "#{name.first(max_chars)}..."
+      parts = name.split(", ")
+      if parts.size >= 4
+        parts = parts.first(2) + parts.last(2)
+      end
+      name = parts.join(", ")
     end
     name
   end

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -543,12 +543,12 @@ module SamplesHelper
                     Metadatum.where(key: field_name).first.validated_field
                   end
     res = Metadatum
-        .joins(:metadata_field)
-        .where(
+          .joins(:metadata_field)
+          .where(
             metadata_fields: { name: field_name },
             sample_id: sample_ids
-        )
-        .group(group_field)
+          )
+          .group(group_field)
     puts "3:28pm ", res.to_json
     return res
   end

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -588,12 +588,7 @@ module SamplesHelper
                             .where(metadata: { metadata_field_id: metadatum.metadata_field_id })
 
     samples_filtered = if metadatum.metadata_field.base_type == Metadatum::LOCATION_TYPE
-                         samples_with_metadata
-                           .includes(metadata: :location)
-                           .where(metadata: { string_validated_value: query })
-                           .or(samples_with_metadata
-                                                        .includes(metadata: :location)
-                                                        .where(metadata: { locations: { name: query } }))
+                         LocationHelper.filter_by_name(samples_with_metadata, query)
                        else
                          samples_with_metadata
                            .where(metadata: { metadatum.validated_field => query })

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -539,16 +539,16 @@ module SamplesHelper
   def samples_by_metadata_field(sample_ids, field_name)
     # Special-case locations
     if MetadataField.find_by(name: field_name).base_type == Metadatum::LOCATION_TYPE
-      join_fields = [:metadata_field, :location]
+      include_fields = [:metadata_field, :location]
       # Plain-text locations in string_validated_value
       group_fields = [:string_validated_value, "locations.name"]
     else
-      join_fields = :metadata_field
+      include_fields = :metadata_field
       group_fields = Metadatum.where(key: field_name).first.validated_field
     end
 
     Metadatum
-      .joins([join_fields])
+      .includes(include_fields)
       .where(
         metadata_fields: { name: field_name },
         sample_id: sample_ids

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -536,7 +536,7 @@ module SamplesHelper
     end
   end
 
-  def samples_by_metadata_field(sample_ids, field_name)
+  def self.samples_by_metadata_field(sample_ids, field_name)
     # Special-case locations
     if MetadataField.find_by(name: field_name).base_type == Metadatum::LOCATION_TYPE
       include_fields = [:metadata_field, :location]
@@ -627,7 +627,4 @@ module SamplesHelper
     requested_sample_ids.class.name
     samples.where(id: requested_sample_ids.is_a?(Array) ? requested_sample_ids : JSON.parse(requested_sample_ids))
   end
-
-  # Callable without include/extend
-  module_function :samples_by_metadata_field
 end

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -183,6 +183,7 @@ module SamplesHelper
   def filter_samples(samples, params)
     host = params[:host]
     location = params[:location]
+    location_v2 = params[:locationV2]
     taxon = params[:taxon]
     time = params[:time]
     tissue = params[:tissue]
@@ -195,6 +196,7 @@ module SamplesHelper
     samples = filter_by_taxid(samples, taxon) if taxon.present?
     samples = filter_by_host(samples, host) if host.present?
     samples = filter_by_metadata_key(samples, "collection_location", location) if location.present?
+    samples = filter_by_metadata_key(samples, "collection_location_v2", location_v2) if location_v2.present?
     samples = filter_by_time(samples, Date.parse(time[0]), Date.parse(time[1])) if time.present?
     samples = filter_by_metadata_key(samples, "sample_type", tissue) if tissue.present?
     samples = filter_by_visibility(samples, visibility) if visibility.present?
@@ -578,15 +580,24 @@ module SamplesHelper
   end
 
   def filter_by_metadata_key(samples, key, query)
-    # TODO(tiago): replace 'filter_by_metadatum' once we decide to includeing not set values
-    metadata_field = Metadatum.where(key: key).first
+    # TODO(tiago): replace 'filter_by_metadatum' once we decide about including not set values
+    metadatum = Metadatum.where(key: key).first
 
     samples_with_metadata = samples
                             .includes(metadata: :metadata_field)
-                            .where(metadata: { metadata_field_id: metadata_field.metadata_field_id })
+                            .where(metadata: { metadata_field_id: metadatum.metadata_field_id })
 
-    samples_filtered = samples_with_metadata
-                       .where(metadata: { metadata_field.validated_field => query })
+    samples_filtered = if metadatum.metadata_field.base_type == Metadatum::LOCATION_TYPE
+                         samples_with_metadata
+                           .includes(metadata: :location)
+                           .where(metadata: { string_validated_value: query })
+                           .or(samples_with_metadata
+                                                        .includes(metadata: :location)
+                                                        .where(metadata: { locations: { name: query } }))
+                       else
+                         samples_with_metadata
+                           .where(metadata: { metadatum.validated_field => query })
+                       end
 
     not_set_ids = []
     if query.include?("not_set")

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -535,13 +535,22 @@ module SamplesHelper
   end
 
   def samples_by_metadata_field(sample_ids, field_name)
-    return Metadatum
-           .joins(:metadata_field)
-           .where(
-             metadata_fields: { name: field_name },
-             sample_id: sample_ids
-           )
-           .group(Metadatum.where(key: field_name).first.validated_field)
+    # Special-case locations (and avoid a call to MetadataField.base_type)
+    group_field = if field_name == "collection_location_v2"
+                    # Plain-text locations are in string_validated_value and have null location_id
+                    [:location_id, :string_validated_value]
+                  else
+                    Metadatum.where(key: field_name).first.validated_field
+                  end
+    res = Metadatum
+        .joins(:metadata_field)
+        .where(
+            metadata_fields: { name: field_name },
+            sample_id: sample_ids
+        )
+        .group(group_field)
+    puts "3:28pm ", res.to_json
+    return res
   end
 
   private

--- a/spec/helpers/location_helper_spec.rb
+++ b/spec/helpers/location_helper_spec.rb
@@ -78,6 +78,6 @@ RSpec.describe LocationHelper, type: :helper do
   end
 
   describe "#filter_by_name" do
-    # TODO: Add tests with samples Factories or Fixtures
+    pending "add test for filtering by location names (with Factories)"
   end
 end

--- a/spec/helpers/location_helper_spec.rb
+++ b/spec/helpers/location_helper_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe LocationHelper, type: :helper do
     it "gets and formats project location dimensions" do
       field_name = "collection_location_v2"
       mock_filtered = { [nil, "Alaska, USA"] => 1, [nil, "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"] => 1, [nil, "Hanoi, Vietnam"] => 1, [nil, "Redwood City, San Mateo County, California, USA"] => 1, [nil, "Zimbabwe"] => 1 }
-      allow(SamplesHelper).to receive_message_chain(:samples_by_metadata_field, :joins, :distinct, :count).and_return(mock_filtered)
+      allow(SamplesHelper).to receive_message_chain(:samples_by_metadata_field, :includes, :distinct, :count).and_return(mock_filtered)
 
       expected = [{ value: "Alaska, USA", text: "Alaska, USA", count: 1 },
                   { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, Chania Municipality, Chania Regional ...", count: 1 },

--- a/spec/helpers/location_helper_spec.rb
+++ b/spec/helpers/location_helper_spec.rb
@@ -1,0 +1,67 @@
+# See deprecated test/helpers/location_helper_test.rb
+
+require "rails_helper"
+
+RSpec.describe LocationHelper, type: :helper do
+  describe "#sanitize_name" do
+    it "sanitizes a name" do
+      name = "California, USA; DROP TABLE USERS; <div></div>"
+      result = LocationHelper.sanitize_name(name)
+      expect(result).to eq("California, USA DROP TABLE USERS divdiv")
+    end
+  end
+
+  describe "#truncate_name" do
+    it "truncates a name" do
+      name = "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"
+      result = LocationHelper.truncate_name(name)
+      expect(result).to eq("Chania, Chania Municipality, Chania Regional ...")
+    end
+
+    it "doesn't truncate shorter names" do
+      name = "Alaska, USA"
+      result = LocationHelper.truncate_name(name)
+      expect(result).to eq("Alaska, USA")
+    end
+  end
+
+  # TODO: These tests would be improved with Factories and SamplesHelper tests
+  describe "#sample_dimensions" do
+    it "gets and formats sample location dimensions" do
+      sample_ids = [1, 2, 3]
+      field_name = "collection_location_v2"
+      mock_filtered = { [nil, "Alaska, USA"] => 1, [nil, "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"] => 1, [nil, "Hanoi, Vietnam"] => 1, [nil, "Redwood City, San Mateo County, California, USA"] => 112, [nil, "Zimbabwe"] => 1 }
+      allow(SamplesHelper).to receive_message_chain(:samples_by_metadata_field, :count).and_return(mock_filtered)
+
+      expected = [{ value: "Alaska, USA", text: "Alaska, USA", count: 1 },
+                  { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, Chania Municipality, Chania Regional ...", count: 1 },
+                  { value: "Hanoi, Vietnam", text: "Hanoi, Vietnam", count: 1 },
+                  { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, San Mateo County, California, U...", count: 112 },
+                  { value: "Zimbabwe", text: "Zimbabwe", count: 1 },
+                  { value: "not_set", text: "Unknown", count: 740 }]
+      result = LocationHelper.sample_dimensions(sample_ids, field_name, 856)
+      expect(result).to eq(expected)
+    end
+  end
+
+  # TODO: These tests would be improved with Factories and SamplesHelper tests
+  describe "#project_dimensions" do
+    it "gets and formats project location dimensions" do
+      field_name = "collection_location_v2"
+      mock_filtered = { [nil, "Alaska, USA"] => 1, [nil, "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"] => 1, [nil, "Hanoi, Vietnam"] => 1, [nil, "Redwood City, San Mateo County, California, USA"] => 1, [nil, "Zimbabwe"] => 1 }
+      allow(SamplesHelper).to receive_message_chain(:samples_by_metadata_field, :joins, :distinct, :count).and_return(mock_filtered)
+
+      expected = [{ value: "Alaska, USA", text: "Alaska, USA", count: 1 },
+                  { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, Chania Municipality, Chania Regional ...", count: 1 },
+                  { value: "Hanoi, Vietnam", text: "Hanoi, Vietnam", count: 1 },
+                  { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, San Mateo County, California, U...", count: 1 },
+                  { value: "Zimbabwe", text: "Zimbabwe", count: 1 }]
+      result = LocationHelper.project_dimensions([1, 2, 3], field_name)
+      expect(result).to eq(expected)
+    end
+  end
+
+  describe "#filter_by_name" do
+    # TODO: Add tests with samples Factories or Fixtures
+  end
+end

--- a/spec/helpers/location_helper_spec.rb
+++ b/spec/helpers/location_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe LocationHelper, type: :helper do
     it "truncates a name" do
       name = "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"
       result = LocationHelper.truncate_name(name)
-      expect(result).to eq("Chania, Chania Municipality, Chania Regional ...")
+      expect(result).to eq("Chania, Chania Municipality, 73135, Greece")
     end
 
     it "doesn't truncate shorter names" do
@@ -30,15 +30,23 @@ RSpec.describe LocationHelper, type: :helper do
     it "gets and formats sample location dimensions" do
       sample_ids = [1, 2, 3]
       field_name = "collection_location_v2"
-      mock_filtered = { [nil, "Alaska, USA"] => 1, [nil, "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"] => 1, [nil, "Hanoi, Vietnam"] => 1, [nil, "Redwood City, San Mateo County, California, USA"] => 112, [nil, "Zimbabwe"] => 1 }
+      mock_filtered = {
+        [nil, "Alaska, USA"] => 1,
+        [nil, "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"] => 1,
+        [nil, "Hanoi, Vietnam"] => 1,
+        [nil, "Redwood City, San Mateo County, California, USA"] => 112,
+        [nil, "Zimbabwe"] => 1
+      }
       allow(SamplesHelper).to receive_message_chain(:samples_by_metadata_field, :count).and_return(mock_filtered)
 
-      expected = [{ value: "Alaska, USA", text: "Alaska, USA", count: 1 },
-                  { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, Chania Municipality, Chania Regional ...", count: 1 },
-                  { value: "Hanoi, Vietnam", text: "Hanoi, Vietnam", count: 1 },
-                  { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, San Mateo County, California, U...", count: 112 },
-                  { value: "Zimbabwe", text: "Zimbabwe", count: 1 },
-                  { value: "not_set", text: "Unknown", count: 740 }]
+      expected = [
+        { value: "Alaska, USA", text: "Alaska, USA", count: 1 },
+        { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, Chania Municipality, 73135, Greece", count: 1 },
+        { value: "Hanoi, Vietnam", text: "Hanoi, Vietnam", count: 1 },
+        { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, San Mateo County, California, USA", count: 112 },
+        { value: "Zimbabwe", text: "Zimbabwe", count: 1 },
+        { value: "not_set", text: "Unknown", count: 740 }
+      ]
       result = LocationHelper.sample_dimensions(sample_ids, field_name, 856)
       expect(result).to eq(expected)
     end
@@ -48,14 +56,22 @@ RSpec.describe LocationHelper, type: :helper do
   describe "#project_dimensions" do
     it "gets and formats project location dimensions" do
       field_name = "collection_location_v2"
-      mock_filtered = { [nil, "Alaska, USA"] => 1, [nil, "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"] => 1, [nil, "Hanoi, Vietnam"] => 1, [nil, "Redwood City, San Mateo County, California, USA"] => 1, [nil, "Zimbabwe"] => 1 }
+      mock_filtered = {
+        [nil, "Alaska, USA"] => 1,
+        [nil, "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"] => 1,
+        [nil, "Hanoi, Vietnam"] => 1,
+        [nil, "Redwood City, San Mateo County, California, USA"] => 1,
+        [nil, "Zimbabwe"] => 1
+      }
       allow(SamplesHelper).to receive_message_chain(:samples_by_metadata_field, :includes, :distinct, :count).and_return(mock_filtered)
 
-      expected = [{ value: "Alaska, USA", text: "Alaska, USA", count: 1 },
-                  { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, Chania Municipality, Chania Regional ...", count: 1 },
-                  { value: "Hanoi, Vietnam", text: "Hanoi, Vietnam", count: 1 },
-                  { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, San Mateo County, California, U...", count: 1 },
-                  { value: "Zimbabwe", text: "Zimbabwe", count: 1 }]
+      expected = [
+        { value: "Alaska, USA", text: "Alaska, USA", count: 1 },
+        { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, Chania Municipality, 73135, Greece", count: 1 },
+        { value: "Hanoi, Vietnam", text: "Hanoi, Vietnam", count: 1 },
+        { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, San Mateo County, California, USA", count: 1 },
+        { value: "Zimbabwe", text: "Zimbabwe", count: 1 }
+      ]
       result = LocationHelper.project_dimensions([1, 2, 3], field_name)
       expect(result).to eq(expected)
     end

--- a/test/helpers/location_helper_test.rb
+++ b/test/helpers/location_helper_test.rb
@@ -1,3 +1,5 @@
+# DEPRECATED: Add new tests to spec/helpers/location_helper_spec.rb
+
 require "test_helper"
 require "test_helpers/location_test_helper"
 


### PR DESCRIPTION
### Description
- Add locationV2 dropdown filter to the left sidebar (just based on the full name for now).
- Add locationV2 to the main data table.
- Modify sample and project dimensions endpoints to return locationV2 names. Moved code into LocationHelper sample_dimensions/project_dimensions.
- I decided to continue adding everything as locationV2 (instead of not rendering locationV1) because it makes it easier to verify changes and keep track of what has been updated.
- The test I added to location_helper_test.rb can be improved with some new RSpec factories and tests for SamplesHelper.

### Demo
![Jun-05-2019 20-11-56](https://user-images.githubusercontent.com/5652739/59004599-05650f80-87cf-11e9-820f-d8f01c06f61c.gif)
![Jun-05-2019 20-13-39](https://user-images.githubusercontent.com/5652739/59004600-072ed300-87cf-11e9-819a-24ef8b60dd56.gif)

### Test and Reproduce
- Go to data discovery samples, add "Location v2" column, see locations.
- Use the left pane filters on samples and projects and see Location v2 filter as expected.