### PR TITLE
IDSEQ-955 Tweak styling for long sample names so sample status is vis…

### DIFF
--- a/app/assets/src/components/views/discovery/table_renderers.scss
+++ b/app/assets/src/components/views/discovery/table_renderers.scss
@@ -92,7 +92,8 @@
   }
 
   .sampleRightPane {
-    flex: 1 0 auto;
+    flex: 1 1 0;
+    min-width: 0;
     display: flex;
     flex-direction: column;
 
@@ -104,9 +105,12 @@
       .sampleName {
         @include font-body-s;
 
-        flex: 0 1 auto;
+        min-width: 0;
         text-align: left;
         color: $black;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
       }
 
       .sampleStatus {


### PR DESCRIPTION
Before:

<img width="869" alt="Screen Shot 2019-06-06 at 1 52 34 PM" src="https://user-images.githubusercontent.com/837004/59066193-4a3a8600-8863-11e9-8d97-a062d6188f6c.png">


After:

<img width="1135" alt="Screen Shot 2019-06-06 at 1 46 48 PM" src="https://user-images.githubusercontent.com/837004/59066190-4870c280-8863-11e9-9049-ff868c688f13.png">