### PR TITLE
Factories, rspec tests for pipeline visualization stage_results endpoint

### DIFF
--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe SamplesController, type: :controller do
+  create_users
+
+  pipeline_stages = [{
+    name: "Host Filtering",
+    dag_json: "{\"key1\": \"value1\"}"
+  }, {
+    name: "GSNAPL/RAPSEARCH alignment",
+    dag_json: "{\"key2\": \"value2\"}"
+  }, {
+    name: "Post Processing",
+    dag_json: "{\"key3\": \"value3\"}"
+  }, {
+    name: "Experimental",
+    dag_json: "{\"key4\": \"value4\"}"
+  }]
+
+  # Admin specific behavior
+  context "Admin user" do
+    before do
+      sign_in @admin
+      @admin.add_allowed_feature("pipeline_viz")
+      @admin.save!
+    end
+
+    describe "GET pipeline stage results" do
+      it "sees all pipeline stage results" do
+        project = create(:public_project)
+        sample = create(:sample, project: project,
+                                 pipeline_runs_data: [{ pipeline_run_stages_data: pipeline_stages }])
+
+        get :stage_results, params: { id: sample.id }
+
+        json_response = JSON.parse(response.body)["pipeline_stage_results"]
+        expect(json_response.length).to eq(4)
+        expect(json_response["Experimental"]).to be_truthy
+        pipeline_stages.each do |stage|
+          expect(json_response[stage[:name]]).to eq(JSON.parse(stage[:dag_json]))
+        end
+      end
+    end
+
+    describe "GET pipeline stage results without pipeline viz flag enabled" do
+      it "cannot see stage results" do
+        project = create(:public_project)
+        sample = create(:sample, project: project,
+                                 pipeline_runs_data: [{ pipeline_run_stages_data: pipeline_stages }])
+
+        @admin.remove_allowed_feature("pipeline_viz")
+        @admin.save!
+        get :stage_results, params: { id: sample.id }
+
+        expect(response).to have_http_status 401
+      end
+    end
+  end
+
+  # Non-admin, aka Joe, specific behavior
+  context "Joe" do
+    before do
+      sign_in @joe
+      @joe.add_allowed_feature("pipeline_viz")
+      @joe.save!
+    end
+
+    describe "GET pipeline stage results" do
+      it "cannot see pipeline experimental stage results" do
+        project = create(:public_project)
+        sample = create(:sample, project: project,
+                                 pipeline_runs_data: [{ pipeline_run_stages_data: pipeline_stages }])
+
+        get :stage_results, params: { id: sample.id }
+
+        json_response = JSON.parse(response.body)["pipeline_stage_results"]
+        expect(json_response.length).to eq(3)
+        expect(json_response["Experimental"]).to be_nil
+        pipeline_stages.each do |stage|
+          unless stage[:name] == "Experimental"
+            expect(json_response[stage[:name]]).to eq(JSON.parse(stage[:dag_json]))
+          end
+        end
+      end
+    end
+
+    describe "GET pipeline stage results for another user\'s private sample" do
+      it "cannot access stage results" do
+        private_project = create(:project)
+        private_sample = create(:sample, project: private_project,
+                                         pipeline_runs_data: [{ pipeline_run_stages_data: pipeline_stages }])
+        expect do
+          get :stage_results, params: { id: private_sample.id }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/factories/pipeline_run_stages.rb
+++ b/spec/factories/pipeline_run_stages.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :pipeline_run_stage, class: PipelineRunStage do
+    name { nil }
+    dag_json { nil }
+  end
+end

--- a/spec/factories/pipeline_run_stages.rb
+++ b/spec/factories/pipeline_run_stages.rb
@@ -1,6 +1,29 @@
 FactoryBot.define do
   factory :pipeline_run_stage, class: PipelineRunStage do
-    name { nil }
-    dag_json { nil }
+    # Should be one of the four stages:
+    # Host Filtering, GSNAPLgcRAPSEARCH alignment,
+    # Post Processing, Experimental
+    name { "Host Filtering" }
+    dag_json do
+      {
+        output_dir_s3: "s3:gc/someBucket/samples/theProjectId/theSampleId/results",
+        targets: {
+          fastqs: ["input.fastq"],
+          star_out: ["unmapped1.fq"],
+          trimmomatic_out: ["trimmomatic1.fq"],
+          priceseq_out: ["priceseq1.fa"],
+          cdhitdup_out: ["dedup1.fa"],
+          lzw_out: ["lzw1.fa"],
+          bowtie2_out: ["bowtie2_1.fa"],
+          subsampled_out: ["subsampled_1.fa"],
+          gsnap_filter_out: ["gsnap_filter_1.fa"]
+        },
+        given_targets: {
+          fastqs: {
+            s3_dir: "s3:gc/someBucket/samples/theProjectId/theSampleId/fastqs"
+          }
+        }
+      }
+    end
   end
 end

--- a/spec/factories/pipeline_runs.rb
+++ b/spec/factories/pipeline_runs.rb
@@ -4,6 +4,9 @@ FactoryBot.define do
       # Array of taxon_counts entries to create.
       # The hash elements will be passed on to taxon_count factory as keyword arguments.
       taxon_counts_data { [] }
+      # Array of pipeline_run_stage entries to create.
+      # The hash elements will be passed on to pipeline_run_stage factory as keyword arguments.
+      pipeline_run_stages_data { [] }
     end
 
     alignment_config { create(:alignment_config) }
@@ -11,6 +14,15 @@ FactoryBot.define do
     after :create do |pipeline_run, options|
       options.taxon_counts_data.each do |taxon_count_data|
         create(:taxon_count, pipeline_run: pipeline_run, **taxon_count_data)
+      end
+
+      # If data for pipeline run stages explicitly included, override default/empty
+      # pipeline run stages.
+      unless options.pipeline_run_stages_data.empty?
+        pipeline_run.pipeline_run_stages = []
+        options.pipeline_run_stages_data.each do |pipeline_run_stage_data|
+          create(:pipeline_run_stage, pipeline_run: pipeline_run, **pipeline_run_stage_data)
+        end
       end
     end
   end

--- a/spec/factories/pipeline_runs.rb
+++ b/spec/factories/pipeline_runs.rb
@@ -16,13 +16,9 @@ FactoryBot.define do
         create(:taxon_count, pipeline_run: pipeline_run, **taxon_count_data)
       end
 
-      # If data for pipeline run stages explicitly included, override default/empty
-      # pipeline run stages.
-      unless options.pipeline_run_stages_data.empty?
-        pipeline_run.pipeline_run_stages = []
-        options.pipeline_run_stages_data.each do |pipeline_run_stage_data|
-          create(:pipeline_run_stage, pipeline_run: pipeline_run, **pipeline_run_stage_data)
-        end
+      pipeline_run.pipeline_run_stages = []
+      options.pipeline_run_stages_data.each do |pipeline_run_stage_data|
+        create(:pipeline_run_stage, pipeline_run: pipeline_run, **pipeline_run_stage_data)
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,20 +13,8 @@ FactoryBot.define do
   end
 
   factory :user do
-    transient do
-      # Array of strings to enable feature flags.
-      allowed_features { [] }
-    end
-
     sequence(:email, 'a') { |n| "user-#{n}@example.com" }
     sequence(:password, 'a') { |n| "user_#{n}_password" }
     sequence(:name, 'a') { |n| "User-#{n}" }
-
-    after :create do |user, options|
-      options.allowed_features.each do |allowed_feature|
-        user.add_allowed_feature allowed_feature
-        user.save!
-      end
-    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,8 +13,20 @@ FactoryBot.define do
   end
 
   factory :user do
+    transient do
+      # Array of strings to enable feature flags.
+      allowed_features { [] }
+    end
+
     sequence(:email, 'a') { |n| "user-#{n}@example.com" }
     sequence(:password, 'a') { |n| "user_#{n}_password" }
     sequence(:name, 'a') { |n| "User-#{n}" }
+
+    after :create do |user, options|
+      options.allowed_features.each do |allowed_feature|
+        user.add_allowed_feature allowed_feature
+        user.save!
+      end
+    end
   end
 end


### PR DESCRIPTION
# Factories, rspec tests for pipeline visualization stage_results endpoint
* `pipeline_run_stages` factory
* rspec tests in `samples_controller_spec.rb` specific to pipeline visualization stage_results endpoint (see https://github.com/chanzuckerberg/idseq-web/pull/2287, https://github.com/chanzuckerberg/idseq-web/pull/2285)

To run tests: `docker-compose run --rm web rspec -e "SamplesController"`

