### PR TITLE
Fix server SQL error for heatmap if all taxons are filtered out.

### DIFF
--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -81,9 +81,11 @@ module HeatmapHelper
     taxon_ids = details.pluck('tax_id')
     taxon_ids -= removed_taxon_ids
 
-    # Refetch at genus level using species level
-    parent_ids = species_selected ? [] : HeatmapHelper.fetch_parent_ids(taxon_ids, samples)
-    results_by_pr = HeatmapHelper.fetch_samples_taxons_counts(samples, taxon_ids, parent_ids, background_id)
+    unless taxon_ids.empty?
+      # Refetch at genus level using species level
+      parent_ids = species_selected ? [] : HeatmapHelper.fetch_parent_ids(taxon_ids, samples)
+      results_by_pr = HeatmapHelper.fetch_samples_taxons_counts(samples, taxon_ids, parent_ids, background_id)
+    end
 
     HeatmapHelper.samples_taxons_details(
       results_by_pr,


### PR DESCRIPTION
If the user enters a threshold filter that filters out everything, the server will throw a 500 error because the generated SQL is invalid. Add a guard against that.

Verified that:
* filtering everything out now shows "No data to display" as expected.
* the heatmap otherwise behaves normally.