### PR TITLE
[Maps] Add locationV2 to DiscoverySidebar + tweak styles

### DIFF
--- a/app/assets/src/components/ui/icons/BulletListIcon.jsx
+++ b/app/assets/src/components/ui/icons/BulletListIcon.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Icon } from "semantic-ui-react";
+
+const BulletListIcon = props => {
+  const { className } = props;
+  return <Icon name="fa-list-ul" className={className} />;
+};
+
+BulletListIcon.propTypes = {
+  className: PropTypes.string
+};
+
+export default BulletListIcon;

--- a/app/assets/src/components/ui/icons/GlobeLinedIcon.jsx
+++ b/app/assets/src/components/ui/icons/GlobeLinedIcon.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Icon } from "semantic-ui-react";
+
+const GlobeLinedIcon = props => {
+  const { className } = props;
+  return <Icon name="fa-globe" className={className} />;
+};
+
+GlobeLinedIcon.propTypes = {
+  className: PropTypes.string
+};
+
+export default GlobeLinedIcon;

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -238,7 +238,7 @@ export default class DiscoverySidebar extends React.Component {
   }
 
   render() {
-    const { className, currentTab, loading } = this.props;
+    const { allowedFeatures, className, currentTab, loading } = this.props;
     if (!loading && !this.hasData()) {
       return (
         <div className={cx(className, cs.sidebar)}>
@@ -337,10 +337,12 @@ export default class DiscoverySidebar extends React.Component {
               <span className={cs.rowLabel}>Location</span>
               {this.buildMetadataRows("location")}
             </div>
-            <div className={cs.hasBackground}>
-              <span className={cs.rowLabel}>Location v2</span>
-              {this.buildMetadataRows("locationV2")}
-            </div>
+            {allowedFeatures.includes("maps") && (
+              <div className={cs.hasBackground}>
+                <span className={cs.rowLabel}>Location v2</span>
+                {this.buildMetadataRows("locationV2")}
+              </div>
+            )}
           </Accordion>
         </div>
       </div>
@@ -355,6 +357,7 @@ DiscoverySidebar.defaultProps = {
 };
 
 DiscoverySidebar.propTypes = {
+  allowedFeatures: PropTypes.arrayOf(PropTypes.string),
   className: PropTypes.string,
   currentTab: PropTypes.string.isRequired,
   defaultNumberOfMetadataRows: PropTypes.number,
@@ -363,6 +366,6 @@ DiscoverySidebar.propTypes = {
   projectDimensions: PropTypes.array,
   projects: PropTypes.arrayOf(PropTypes.Project),
   sampleDimensions: PropTypes.array,
-  sampleStats: PropTypes.object,
-  samples: PropTypes.arrayOf(PropTypes.Sample)
+  samples: PropTypes.arrayOf(PropTypes.Sample),
+  sampleStats: PropTypes.object
 };

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -59,6 +59,7 @@ export default class DiscoverySidebar extends React.Component {
         host: DiscoverySidebar.loadDimension(dimensions, "host"),
         tissue: DiscoverySidebar.loadDimension(dimensions, "tissue"),
         location: DiscoverySidebar.loadDimension(dimensions, "location"),
+        locationV2: DiscoverySidebar.loadDimension(dimensions, "locationV2"),
         time: DiscoverySidebar.loadDimension(dimensions, "time_bins")
       }
     };
@@ -335,6 +336,10 @@ export default class DiscoverySidebar extends React.Component {
             <div className={cs.hasBackground}>
               <span className={cs.rowLabel}>Location</span>
               {this.buildMetadataRows("location")}
+            </div>
+            <div className={cs.hasBackground}>
+              <span className={cs.rowLabel}>Location v2</span>
+              {this.buildMetadataRows("locationV2")}
             </div>
           </Accordion>
         </div>

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -732,6 +732,7 @@ class DiscoveryView extends React.Component {
   };
 
   renderRightPane = () => {
+    const { allowedFeatures } = this.props;
     const {
       currentDisplay,
       currentTab,
@@ -773,6 +774,7 @@ class DiscoveryView extends React.Component {
           ["samples", "projects"].includes(currentTab) &&
           currentDisplay === "table" && (
             <DiscoverySidebar
+              allowedFeatures={allowedFeatures}
               className={cs.sidebar}
               samples={samples}
               projects={projects}

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -218,10 +218,20 @@ export default class MapPreviewSidebar extends React.Component {
     );
   };
 
-  render() {
-    const { className } = this.props;
+  renderNoData = () => {
     return (
-      <div className={cx(className, cs.sidebar)}>{this.renderTable()}</div>
+      <div className={cs.noData}>
+        Select a location to see summary info and samples.
+      </div>
+    );
+  };
+
+  render() {
+    const { className, samples } = this.props;
+    return (
+      <div className={cx(className, cs.sidebar)}>
+        {samples.length === 0 ? this.renderNoData() : this.renderTable()}
+      </div>
     );
   }
 }

--- a/app/assets/src/components/views/discovery/mapping/circle_marker.scss
+++ b/app/assets/src/components/views/discovery/mapping/circle_marker.scss
@@ -2,13 +2,11 @@
 
 .circle {
   cursor: pointer;
-  fill: $primary-light;
-  opacity: 0.5;
+  fill: $celery;
 
   &.hoverable {
     &:hover {
       fill: $primary-medium;
-      opacity: 1;
     }
   }
 }

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -1,3 +1,5 @@
+@import "~styles/themes/colors";
+
 .sidebar {
   font-size: 12px;
   width: 300px;
@@ -15,6 +17,11 @@
       display: flex;
       flex-direction: column;
     }
+  }
+
+  .noData {
+    color: $medium-grey;
+    margin: 20px;
   }
 }
 

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,22 +1,24 @@
 import React from "react";
 import { difference, find, isEmpty, union } from "lodash/fp";
 import cx from "classnames";
-import { Icon } from "semantic-ui-react";
 
-import PropTypes from "~/components/utils/propTypes";
-import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
+import BulletListIcon from "~ui/icons/BulletListIcon";
+import CollectionModal from "./CollectionModal";
+import DiscoveryMap from "~/components/views/discovery/mapping/DiscoveryMap";
+import GlobeLinedIcon from "~ui/icons/GlobeLinedIcon";
+import HeatmapIcon from "~ui/icons/HeatmapIcon";
 import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 import Label from "~ui/labels/Label";
-import HeatmapIcon from "~ui/icons/HeatmapIcon";
-import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";
-import SaveIcon from "~ui/icons/SaveIcon";
 import PhyloTreeCreationModal from "~/components/views/phylo_tree/PhyloTreeCreationModal";
-import { DownloadIconDropdown } from "~ui/controls/dropdowns";
-import TableRenderers from "~/components/views/discovery/TableRenderers";
-import { Menu, MenuItem } from "~ui/controls/Menu";
-import DiscoveryMap from "~/components/views/discovery/mapping/DiscoveryMap";
+import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";
+import PropTypes from "~/components/utils/propTypes";
 import ReportsDownloader from "./ReportsDownloader";
-import CollectionModal from "./CollectionModal";
+import SaveIcon from "~ui/icons/SaveIcon";
+import TableRenderers from "~/components/views/discovery/TableRenderers";
+import { DownloadIconDropdown } from "~ui/controls/dropdowns";
+import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
+import { Menu, MenuItem } from "~ui/controls/Menu";
+
 import cs from "./samples_view.scss";
 import csTableRenderer from "../discovery/table_renderers.scss";
 
@@ -386,10 +388,11 @@ class SamplesView extends React.Component {
                 `SamplesView_${display}-switch_clicked`
               )}
             >
-              <Icon
-                name={display === "map" ? "fa-globe" : "fa-list-ul"}
-                className={cs.icon}
-              />
+              {display === "map" ? (
+                <GlobeLinedIcon className={cs.icon} />
+              ) : (
+                <BulletListIcon className={cs.icon} />
+              )}
             </MenuItem>
           ))}
         </Menu>

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,23 +1,23 @@
-import React from "react";
-import { difference, find, isEmpty, union } from "lodash/fp";
 import cx from "classnames";
+import { difference, find, isEmpty, union } from "lodash/fp";
+import React from "react";
 
-import BulletListIcon from "~ui/icons/BulletListIcon";
-import CollectionModal from "./CollectionModal";
+import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
+import PropTypes from "~/components/utils/propTypes";
 import DiscoveryMap from "~/components/views/discovery/mapping/DiscoveryMap";
+import TableRenderers from "~/components/views/discovery/TableRenderers";
+import PhyloTreeCreationModal from "~/components/views/phylo_tree/PhyloTreeCreationModal";
+import CollectionModal from "~/components/views/samples/CollectionModal";
+import ReportsDownloader from "~/components/views/samples/ReportsDownloader";
+import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
+import { DownloadIconDropdown } from "~ui/controls/dropdowns";
+import { Menu, MenuItem } from "~ui/controls/Menu";
+import BulletListIcon from "~ui/icons/BulletListIcon";
 import GlobeLinedIcon from "~ui/icons/GlobeLinedIcon";
 import HeatmapIcon from "~ui/icons/HeatmapIcon";
-import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
-import Label from "~ui/labels/Label";
-import PhyloTreeCreationModal from "~/components/views/phylo_tree/PhyloTreeCreationModal";
 import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";
-import PropTypes from "~/components/utils/propTypes";
-import ReportsDownloader from "./ReportsDownloader";
 import SaveIcon from "~ui/icons/SaveIcon";
-import TableRenderers from "~/components/views/discovery/TableRenderers";
-import { DownloadIconDropdown } from "~ui/controls/dropdowns";
-import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
-import { Menu, MenuItem } from "~ui/controls/Menu";
+import Label from "~ui/labels/Label";
 
 import cs from "./samples_view.scss";
 import csTableRenderer from "../discovery/table_renderers.scss";

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { difference, find, isEmpty, union } from "lodash/fp";
 import cx from "classnames";
+import { Icon } from "semantic-ui-react";
 
 import PropTypes from "~/components/utils/propTypes";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
@@ -385,12 +386,9 @@ class SamplesView extends React.Component {
                 `SamplesView_${display}-switch_clicked`
               )}
             >
-              <i
-                className={cx(
-                  "fa",
-                  display === "map" ? "fa-globe" : "fa-list-ul",
-                  cs.icon
-                )}
+              <Icon
+                name={display === "map" ? "fa-globe" : "fa-list-ul"}
+                className={cs.icon}
               />
             </MenuItem>
           ))}

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -111,10 +111,10 @@
         background: inherit;
 
         .icon {
-          font-size: 15px;
+          font-size: 18px;
           margin-right: 0;
           // Make the icon look thinner
-          -webkit-text-stroke: 0.5px $white;
+          -webkit-text-stroke: 0.7px $white;
         }
 
         &:hover {

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -122,7 +122,7 @@
         }
 
         &:global(.active) {
-          // Underline
+          // Underline the icon
           &:after {
             position: absolute;
             content: "";

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -103,19 +103,36 @@
     .switcherMenu {
       margin: 0;
       min-height: 25px;
-      border-radius: 10px;
       box-shadow: none;
+      border: none;
 
       .menuItem {
-        padding: 5px 20px;
+        padding: 5px 10px;
+        background: inherit;
 
         .icon {
           font-size: 15px;
+          margin-right: 0;
+          // Make the icon look thinner
+          -webkit-text-stroke: 0.5px $white;
+        }
+
+        &:hover {
+          background: inherit;
         }
 
         &:global(.active) {
-          // Important due to a { color: inherit !important; } in header.scss.
-          color: $primary-light !important;
+          // Underline
+          &:after {
+            position: absolute;
+            content: "";
+            border-bottom: 2px solid $primary-medium;
+            width: 50%;
+            bottom: 0;
+            // Move left edge to center and then center to midpoint
+            left: 50%;
+            transform: translateX(-50%);
+          }
         }
       }
     }

--- a/app/assets/src/styles/themes/_colors.scss
+++ b/app/assets/src/styles/themes/_colors.scss
@@ -39,3 +39,4 @@ $box-shadow-light: rgba(0, 0, 0, 0.22);
 $box-shadow-dark: rgba(34, 36, 38, 0.5);
 
 $melrose: #a9bdfc;
+$celery: rgba(147, 193, 81, 0.8);

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -29,15 +29,17 @@ module LocationHelper
   end
 
   def self.truncate_name(name)
-    # For long names, just take the first and last two parts so they look a little better downstream
-    # (e.g. in dropdown filters).
-    max_chars = 40
+    # Shorten long names so they look a little better downstream (e.g. in dropdown filters). Try to take the first 2 + last 2 parts, or just the first + last 2 parts.
+    max_chars = 30
     if name.size > max_chars
       parts = name.split(", ")
       if parts.size >= 4
-        parts = parts.first(2) + parts.last(2)
+        last = parts[-2..-1]
+        name = parts[0..1].concat(last).join(", ")
+        if name.size > max_chars
+          name = [parts[0]].concat(last).join(", ")
+        end
       end
-      name = parts.join(", ")
     end
     name
   end

--- a/spec/helpers/location_helper_spec.rb
+++ b/spec/helpers/location_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe LocationHelper, type: :helper do
     it "truncates a name" do
       name = "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"
       result = LocationHelper.truncate_name(name)
-      expect(result).to eq("Chania, Chania Municipality, 73135, Greece")
+      expect(result).to eq("Chania, 73135, Greece")
     end
 
     it "doesn't truncate shorter names" do
@@ -41,9 +41,9 @@ RSpec.describe LocationHelper, type: :helper do
 
       expected = [
         { value: "Alaska, USA", text: "Alaska, USA", count: 1 },
-        { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, Chania Municipality, 73135, Greece", count: 1 },
+        { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, 73135, Greece", count: 1 },
         { value: "Hanoi, Vietnam", text: "Hanoi, Vietnam", count: 1 },
-        { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, San Mateo County, California, USA", count: 112 },
+        { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, California, USA", count: 112 },
         { value: "Zimbabwe", text: "Zimbabwe", count: 1 },
         { value: "not_set", text: "Unknown", count: 740 }
       ]
@@ -67,9 +67,9 @@ RSpec.describe LocationHelper, type: :helper do
 
       expected = [
         { value: "Alaska, USA", text: "Alaska, USA", count: 1 },
-        { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, Chania Municipality, 73135, Greece", count: 1 },
+        { value: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece", text: "Chania, 73135, Greece", count: 1 },
         { value: "Hanoi, Vietnam", text: "Hanoi, Vietnam", count: 1 },
-        { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, San Mateo County, California, USA", count: 1 },
+        { value: "Redwood City, San Mateo County, California, USA", text: "Redwood City, California, USA", count: 1 },
         { value: "Zimbabwe", text: "Zimbabwe", count: 1 }
       ]
       result = LocationHelper.project_dimensions([1, 2, 3], field_name)


### PR DESCRIPTION
### Description
- Add locationV2 to the right summary info DiscoverySidebar.
- Add a message to MapPreviewSidebar when there's no data.
- Update color of the bubble icon and style of the map toggler according to the mocks.
- Tweak name truncation method.

### Demo
![Screen Shot 2019-06-06 at 5 08 08 PM](https://user-images.githubusercontent.com/5652739/59075601-626fcc80-8886-11e9-8b6b-735b11ca1e0a.png)
![Screen Shot 2019-06-06 at 6 19 53 PM](https://user-images.githubusercontent.com/5652739/59075863-c1821100-8887-11e9-92f5-2049fd9efad6.png)

### Test and Reproduce
- Go to data discovery samples tab, find locationV2 in the right pane sidebar. Go to the map and observe the new styles.