### PR TITLE
make description on pathogen labels more accurate

### DIFF
--- a/app/assets/src/components/ui/labels/PathogenLabel.jsx
+++ b/app/assets/src/components/ui/labels/PathogenLabel.jsx
@@ -5,21 +5,23 @@ import cs from "./pathogen_label.scss";
 
 const NIAID_URL =
   "https://www.niaid.nih.gov/research/emerging-infectious-diseases-pathogens";
+const BASE_LABEL = "NIAID priority";
+
 export const CATEGORIES = {
   categoryA: {
-    text: "pathogenic | a",
+    text: BASE_LABEL + " | a",
     color: "red",
     tooltip: "NIAID pathogen priority list | category A",
     url: NIAID_URL
   },
   categoryB: {
-    text: "pathogenic | b",
+    text: BASE_LABEL + " | b",
     color: "orange",
     tooltip: "NIAID pathogen priority list | category B",
     url: NIAID_URL
   },
   categoryC: {
-    text: "pathogenic | c",
+    text: BASE_LABEL + " | c",
     color: "yellow",
     tooltip: "NIAID pathogen priority list | category C",
     url: NIAID_URL


### PR DESCRIPTION
Taxa that do not carry the "PathogenLabel" are NOT guaranteed to be non-pathogenic. This PR aligns the description on the label with what the label actually represents to preserve trust.