### PR TITLE
[Maps] Adjust map framing + other small fixes

### DIFF
--- a/app/assets/src/components/ui/controls/Checkbox.jsx
+++ b/app/assets/src/components/ui/controls/Checkbox.jsx
@@ -12,6 +12,16 @@ class Checkbox extends React.Component {
     this.handleClick = this.handleClick.bind(this);
   }
 
+  static getDerivedStateFromProps(props, state) {
+    if (props.checked !== state.oldIsChecked) {
+      return {
+        isChecked: props.checked,
+        oldIsChecked: props.checked
+      };
+    }
+    return null;
+  }
+
   handleClick(event) {
     const { value, onChange } = this.props;
 

--- a/app/assets/src/components/ui/controls/Checkbox.jsx
+++ b/app/assets/src/components/ui/controls/Checkbox.jsx
@@ -12,16 +12,6 @@ class Checkbox extends React.Component {
     this.handleClick = this.handleClick.bind(this);
   }
 
-  static getDerivedStateFromProps(props, state) {
-    if (props.checked !== state.oldIsChecked) {
-      return {
-        isChecked: props.checked,
-        oldIsChecked: props.checked
-      };
-    }
-    return null;
-  }
-
   handleClick(event) {
     const { value, onChange } = this.props;
 

--- a/app/assets/src/components/ui/icons/BulletListIcon.jsx
+++ b/app/assets/src/components/ui/icons/BulletListIcon.jsx
@@ -4,7 +4,7 @@ import { Icon } from "semantic-ui-react";
 
 const BulletListIcon = props => {
   const { className } = props;
-  return <Icon name="fa-list-ul" className={className} />;
+  return <Icon name="list ul" className={className} />;
 };
 
 BulletListIcon.propTypes = {

--- a/app/assets/src/components/ui/icons/GlobeLinedIcon.jsx
+++ b/app/assets/src/components/ui/icons/GlobeLinedIcon.jsx
@@ -4,7 +4,7 @@ import { Icon } from "semantic-ui-react";
 
 const GlobeLinedIcon = props => {
   const { className } = props;
-  return <Icon name="fa-globe" className={className} />;
+  return <Icon name="globe" className={className} />;
 };
 
 GlobeLinedIcon.propTypes = {

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -201,7 +201,7 @@ class DiscoveryView extends React.Component {
   };
 
   resetData = ({ callback }) => {
-    const { project, mapPreviewedLocationId } = this.state;
+    const { project } = this.state;
 
     this.setState(
       {
@@ -219,7 +219,6 @@ class DiscoveryView extends React.Component {
       },
       () => {
         this.samplesView && this.samplesView.reset();
-        this.mapPreviewSidebar && this.mapPreviewSidebar.reset();
         callback && callback();
       }
     );
@@ -742,14 +741,12 @@ class DiscoveryView extends React.Component {
       filteredSampleStats,
       loadingDimensions,
       loadingStats,
-      mapPreviewedLocationId,
       mapPreviewedSampleIds,
       mapPreviewedSamples,
       mapSidebarSelectedSampleIds,
       projectDimensions,
       projects,
       sampleDimensions,
-      sampleIds,
       samples,
       search,
       showStats
@@ -764,16 +761,13 @@ class DiscoveryView extends React.Component {
           currentDisplay === "map" && (
             <MapPreviewSidebar
               initialSelectedSampleIds={mapSidebarSelectedSampleIds}
-              mapPreviewedLocationId={mapPreviewedLocationId}
               onSampleClicked={this.handleSampleSelected}
               onSelectionUpdate={this.handleMapSidebarSelectUpdate}
               ref={mapPreviewSidebar =>
                 (this.mapPreviewSidebar = mapPreviewSidebar)
               }
-              samples={mapPreviewedLocationId ? mapPreviewedSamples : samples}
-              selectableIds={
-                mapPreviewedLocationId ? mapPreviewedSampleIds : sampleIds
-              }
+              samples={mapPreviewedSamples}
+              selectableIds={mapPreviewedSampleIds}
             />
           )}
         {showStats &&

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -771,8 +771,8 @@ class DiscoveryView extends React.Component {
             />
           )}
         {showStats &&
-          ["samples", "projects"].includes(currentTab) &&
-          currentDisplay === "table" && (
+          ((currentTab === "samples" && currentDisplay === "table") ||
+            currentTab === "projects") && (
             <DiscoverySidebar
               allowedFeatures={allowedFeatures}
               className={cs.sidebar}

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -201,7 +201,7 @@ class DiscoveryView extends React.Component {
   };
 
   resetData = ({ callback }) => {
-    const { project } = this.state;
+    const { project, mapPreviewedLocationId } = this.state;
 
     this.setState(
       {
@@ -219,6 +219,7 @@ class DiscoveryView extends React.Component {
       },
       () => {
         this.samplesView && this.samplesView.reset();
+        this.mapPreviewSidebar && this.mapPreviewSidebar.reset();
         callback && callback();
       }
     );
@@ -741,12 +742,14 @@ class DiscoveryView extends React.Component {
       filteredSampleStats,
       loadingDimensions,
       loadingStats,
+      mapPreviewedLocationId,
       mapPreviewedSampleIds,
       mapPreviewedSamples,
       mapSidebarSelectedSampleIds,
       projectDimensions,
       projects,
       sampleDimensions,
+      sampleIds,
       samples,
       search,
       showStats
@@ -761,13 +764,16 @@ class DiscoveryView extends React.Component {
           currentDisplay === "map" && (
             <MapPreviewSidebar
               initialSelectedSampleIds={mapSidebarSelectedSampleIds}
+              mapPreviewedLocationId={mapPreviewedLocationId}
               onSampleClicked={this.handleSampleSelected}
               onSelectionUpdate={this.handleMapSidebarSelectUpdate}
               ref={mapPreviewSidebar =>
                 (this.mapPreviewSidebar = mapPreviewSidebar)
               }
-              samples={mapPreviewedSamples}
-              selectableIds={mapPreviewedSampleIds}
+              samples={mapPreviewedLocationId ? mapPreviewedSamples : samples}
+              selectableIds={
+                mapPreviewedLocationId ? mapPreviewedSampleIds : sampleIds
+              }
             />
           )}
         {showStats &&

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -68,6 +68,7 @@ class BaseMap extends React.Component {
           onViewportChange={this.updateViewport}
           mapStyle={styleURL}
           onLoad={this.setCompactAttribution}
+          style={{ position: "absolute" }} // Fixes div in Safari
         >
           {tooltip}
           {markers}

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -102,18 +102,18 @@ BaseMap.propTypes = {
 BaseMap.defaultProps = {
   width: "100%",
   height: "100%",
-  // United States framed
-  latitude: 40,
-  longitude: -98,
-  zoom: 3,
-  // These bounds prevent panning too far north or south, although you will still see those regions at the widest zoom levels. minZoom level frames most of the world. maxZoom level keeps you at an area about the size of a metropolitan area.
+  // Frame most of the world
+  latitude: 27,
+  longitude: 0,
+  zoom: 1.4,
+  // These bounds prevent panning too far north or south, although you will still see those regions at the widest zoom levels. minZoom level frames most of the world.
   viewBounds: {
     minLatitude: -60,
     maxLatitude: 60,
     minLongitude: -180,
     maxLongitude: 180,
-    minZoom: 1.4,
-    maxZoom: 12
+    minZoom: 0.5,
+    maxZoom: 17
   }
 };
 

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -68,7 +68,8 @@ class BaseMap extends React.Component {
           onViewportChange={this.updateViewport}
           mapStyle={styleURL}
           onLoad={this.setCompactAttribution}
-          style={{ position: "absolute" }} // Fixes div in Safari
+          // Style prop applies to the container and all overlays
+          style={{ position: "absolute" }}
         >
           {tooltip}
           {markers}
@@ -107,12 +108,15 @@ BaseMap.defaultProps = {
   longitude: 0,
   zoom: 1.4,
   viewBounds: {
-    minLatitude: -60, // Limit panning too far north or south
+    // Limit panning too far north or south
+    minLatitude: -60,
     maxLatitude: 60,
     minLongitude: -180,
     maxLongitude: 180,
-    minZoom: 0.5, // Limit to whole-world view
-    maxZoom: 17 // Limit to city-level at most
+    // Limit to whole-world view
+    minZoom: 0.5,
+    // Limit to city-level at most
+    maxZoom: 17
   }
 };
 

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -102,18 +102,17 @@ BaseMap.propTypes = {
 BaseMap.defaultProps = {
   width: "100%",
   height: "100%",
-  // Frame most of the world
+  // Frame most of the world by default
   latitude: 27,
   longitude: 0,
   zoom: 1.4,
-  // These bounds prevent panning too far north or south, although you will still see those regions at the widest zoom levels. minZoom level frames most of the world.
   viewBounds: {
-    minLatitude: -60,
+    minLatitude: -60, // Limit panning too far north or south
     maxLatitude: 60,
     minLongitude: -180,
     maxLongitude: 180,
-    minZoom: 0.5,
-    maxZoom: 17
+    minZoom: 0.5, // Limit to whole-world view
+    maxZoom: 17 // Limit to city-level at most
   }
 };
 

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -122,12 +122,8 @@ export default class MapPreviewSidebar extends React.Component {
 
   handleLoadSampleRows = async () => {
     // TODO(jsheu): Add pagination on the endpoint and loading for long lists of samples
-    const { onLoadRows, samples } = this.props;
-    if (onLoadRows) {
-      onLoadRows();
-    } else {
-      return samples;
-    }
+    const { samples } = this.props;
+    return samples;
   };
 
   handleSelectRow = (value, checked) => {
@@ -190,8 +186,6 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   renderTable = () => {
-    console.log("my samples are: ", this.props.samples);
-
     const { activeColumns, protectedColumns } = this.props;
     const { selectedSampleIds } = this.state;
 
@@ -251,7 +245,6 @@ MapPreviewSidebar.propTypes = {
   activeColumns: PropTypes.array,
   className: PropTypes.string,
   initialSelectedSampleIds: PropTypes.instanceOf(Set),
-  onLoadRows: PropTypes.func,
   onSampleClicked: PropTypes.func,
   onSelectionUpdate: PropTypes.func,
   protectedColumns: PropTypes.array,

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -244,7 +244,7 @@ MapPreviewSidebar.defaultProps = {
 MapPreviewSidebar.propTypes = {
   activeColumns: PropTypes.array,
   className: PropTypes.string,
-  initialSelectedSampleIds: PropTypes.array,
+  initialSelectedSampleIds: PropTypes.instanceOf(Set),
   onSampleClicked: PropTypes.func,
   onSelectionUpdate: PropTypes.func,
   protectedColumns: PropTypes.array,

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -122,8 +122,12 @@ export default class MapPreviewSidebar extends React.Component {
 
   handleLoadSampleRows = async () => {
     // TODO(jsheu): Add pagination on the endpoint and loading for long lists of samples
-    const { samples } = this.props;
-    return samples;
+    const { onLoadRows, samples } = this.props;
+    if (onLoadRows) {
+      onLoadRows();
+    } else {
+      return samples;
+    }
   };
 
   handleSelectRow = (value, checked) => {
@@ -186,6 +190,8 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   renderTable = () => {
+    console.log("my samples are: ", this.props.samples);
+
     const { activeColumns, protectedColumns } = this.props;
     const { selectedSampleIds } = this.state;
 
@@ -245,6 +251,7 @@ MapPreviewSidebar.propTypes = {
   activeColumns: PropTypes.array,
   className: PropTypes.string,
   initialSelectedSampleIds: PropTypes.instanceOf(Set),
+  onLoadRows: PropTypes.func,
   onSampleClicked: PropTypes.func,
   onSelectionUpdate: PropTypes.func,
   protectedColumns: PropTypes.array,


### PR DESCRIPTION
### Description
- Small clean-up PR
- Fix some prop errors
- Fix a bug where you wouldn't see the project stats sidebar after switching over from the map
- Fix div on Safari/iOS (so that the map shows up at all)
- Adjust the default map framing to show most of the world

### Test and Reproduce
- Go to data discovery maps, click to map view, view the map framing, click over to the projects tab, see your stats right panel still open.