### PR TITLE
[Maps] Add Summary tab to preview sidebar + enhance filtering functionality

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -36,7 +36,7 @@ export default class DiscoverySidebar extends React.Component {
       currentTab,
       loading,
       projectDimensions,
-      projects,
+      projectStats,
       sampleDimensions,
       sampleStats
     } = newProps;
@@ -47,7 +47,7 @@ export default class DiscoverySidebar extends React.Component {
     return {
       stats: {
         numSamples: DiscoverySidebar.formatNumber((sampleStats || {}).count),
-        numProjects: DiscoverySidebar.formatNumber(projects.length),
+        numProjects: DiscoverySidebar.formatNumber((projectStats || {}).count),
         avgTotalReads: DiscoverySidebar.formatNumber(
           (sampleStats || {}).avgTotalReads
         ),
@@ -337,12 +337,13 @@ export default class DiscoverySidebar extends React.Component {
               <span className={cs.rowLabel}>Location</span>
               {this.buildMetadataRows("location")}
             </div>
-            {allowedFeatures.includes("maps") && (
-              <div className={cs.hasBackground}>
-                <span className={cs.rowLabel}>Location v2</span>
-                {this.buildMetadataRows("locationV2")}
-              </div>
-            )}
+            {allowedFeatures &&
+              allowedFeatures.includes("maps") && (
+                <div className={cs.hasBackground}>
+                  <span className={cs.rowLabel}>Location v2</span>
+                  {this.buildMetadataRows("locationV2")}
+                </div>
+              )}
           </Accordion>
         </div>
       </div>
@@ -351,8 +352,6 @@ export default class DiscoverySidebar extends React.Component {
 }
 
 DiscoverySidebar.defaultProps = {
-  projects: [],
-  samples: [],
   defaultNumberOfMetadataRows: 4
 };
 
@@ -364,8 +363,7 @@ DiscoverySidebar.propTypes = {
   loading: PropTypes.bool,
   onFilterClick: PropTypes.func,
   projectDimensions: PropTypes.array,
-  projects: PropTypes.arrayOf(PropTypes.Project),
+  projectStats: PropTypes.object,
   sampleDimensions: PropTypes.array,
-  samples: PropTypes.arrayOf(PropTypes.Sample),
   sampleStats: PropTypes.object
 };

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -836,6 +836,7 @@ class DiscoveryView extends React.Component {
       showFilters,
       showStats,
       visualizations,
+      mapPreviewedLocationId,
       mapPreviewedSamples,
       mapSidebarSelectedSampleIds,
     } = this.state;
@@ -915,6 +916,7 @@ class DiscoveryView extends React.Component {
                       allowedFeatures={allowedFeatures}
                       currentDisplay={currentDisplay}
                       mapLocationData={mapLocationData}
+                      mapPreviewedLocationId={mapPreviewedLocationId}
                       mapPreviewedSamples={mapPreviewedSamples}
                       mapSidebarSelectedSampleIds={mapSidebarSelectedSampleIds}
                       mapTilerKey={mapTilerKey}

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -104,6 +104,7 @@ class DiscoveryView extends React.Component {
         mapPreviewedSampleIds: [],
         mapPreviewedSamples: [],
         mapSidebarSelectedSampleIds: new Set(),
+        mapSidebarTab: "Summary Info",
         project: null,
         projectDimensions: [],
         projectId: projectId,
@@ -731,6 +732,10 @@ class DiscoveryView extends React.Component {
     this.setState({ mapSidebarSelectedSampleIds });
   };
 
+  handleMapSidebarTabChange = mapSidebarTab => {
+    this.setState({ mapSidebarTab });
+  };
+
   renderRightPane = () => {
     const { allowedFeatures } = this.props;
     const {
@@ -744,6 +749,7 @@ class DiscoveryView extends React.Component {
       mapPreviewedSampleIds,
       mapPreviewedSamples,
       mapSidebarSelectedSampleIds,
+      mapSidebarTab,
       projectDimensions,
       projects,
       sampleDimensions,
@@ -760,9 +766,11 @@ class DiscoveryView extends React.Component {
           currentTab === "samples" &&
           currentDisplay === "map" && (
             <MapPreviewSidebar
+              currentTab={mapSidebarTab}
               initialSelectedSampleIds={mapSidebarSelectedSampleIds}
               onSampleClicked={this.handleSampleSelected}
               onSelectionUpdate={this.handleMapSidebarSelectUpdate}
+              onTabChange={this.handleMapSidebarTabChange}
               ref={mapPreviewSidebar =>
                 (this.mapPreviewSidebar = mapPreviewSidebar)
               }

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -728,7 +728,7 @@ class DiscoveryView extends React.Component {
     } = this.state;
     const sampleIds = mapLocationData[mapPreviewedLocationId].sample_ids;
 
-    // Update samples
+    // Fetch previewed samples
     // TODO(jsheu): Consider paginating fetching for thousands of samples at a location
     const {
       samples: fetchedSamples,
@@ -748,7 +748,7 @@ class DiscoveryView extends React.Component {
       }
     );
 
-    // Update stats and dimensions for the map sidebar. Special request with the current filters
+    // Fetch stats and dimensions for the map sidebar. Special request with the current filters
     // and the previewed location.
     const locationName = mapLocationData[mapPreviewedLocationId].name;
     const filters = this.preparedFilters();

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -704,6 +704,17 @@ class DiscoveryView extends React.Component {
     );
   };
 
+  handleMapMarkerClick = locationId => {
+    this.setState(
+      {
+        mapPreviewedLocationId: locationId,
+        mapSidebarTab: "Summary",
+        showStats: true
+      },
+      () => this.refreshMapPreviewedSamples()
+    );
+  };
+
   refreshMapPreviewedSamples = async () => {
     const { mapPreviewedLocationId, mapLocationData } = this.state;
     const sampleIds = mapLocationData[mapPreviewedLocationId].sample_ids;
@@ -909,6 +920,7 @@ class DiscoveryView extends React.Component {
                       mapTilerKey={mapTilerKey}
                       onDisplaySwitch={this.handleDisplaySwitch}
                       onLoadRows={this.handleLoadSampleRows}
+                      onMapMarkerClick={this.handleMapMarkerClick}
                       onMapTooltipTitleClick={this.handleMapTooltipTitleClick}
                       onSampleSelected={this.handleSampleSelected}
                       projectId={projectId}

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -104,7 +104,7 @@ class DiscoveryView extends React.Component {
         mapPreviewedSampleIds: [],
         mapPreviewedSamples: [],
         mapSidebarSelectedSampleIds: new Set(),
-        mapSidebarTab: "Summary Info",
+        mapSidebarTab: "Summary",
         project: null,
         projectDimensions: [],
         projectId: projectId,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -753,12 +753,17 @@ class DiscoveryView extends React.Component {
       projectDimensions,
       projects,
       sampleDimensions,
-      samples,
       search,
       showStats,
     } = this.state;
 
     const filterCount = this.getFilterCount();
+    const computedProjectDimensions =
+      filterCount || search ? filteredProjectDimensions : projectDimensions;
+    const computedSampleDimensions =
+      filterCount || search ? filteredSampleDimensions : sampleDimensions;
+    const loading = loadingDimensions || loadingStats;
+    const projectStats = { count: projects.length };
 
     return (
       <div className={cs.rightPane}>
@@ -766,15 +771,22 @@ class DiscoveryView extends React.Component {
           currentTab === "samples" &&
           currentDisplay === "map" && (
             <MapPreviewSidebar
+              allowedFeatures={allowedFeatures}
               currentTab={mapSidebarTab}
+              discoveryCurrentTab={currentTab}
               initialSelectedSampleIds={mapSidebarSelectedSampleIds}
+              loading={loading}
               onSampleClicked={this.handleSampleSelected}
               onSelectionUpdate={this.handleMapSidebarSelectUpdate}
               onTabChange={this.handleMapSidebarTabChange}
+              projectDimensions={computedProjectDimensions}
+              projectStats={projectStats}
               ref={mapPreviewSidebar =>
                 (this.mapPreviewSidebar = mapPreviewSidebar)
               }
+              sampleDimensions={computedSampleDimensions}
               samples={mapPreviewedSamples}
+              sampleStats={filteredSampleStats}
               selectableIds={mapPreviewedSampleIds}
             />
           )}
@@ -783,22 +795,12 @@ class DiscoveryView extends React.Component {
             currentTab === "projects") && (
             <DiscoverySidebar
               allowedFeatures={allowedFeatures}
-              className={cs.sidebar}
-              samples={samples}
-              projects={projects}
-              sampleDimensions={
-                filterCount || search
-                  ? filteredSampleDimensions
-                  : sampleDimensions
-              }
-              sampleStats={filteredSampleStats}
-              projectDimensions={
-                filterCount || search
-                  ? filteredProjectDimensions
-                  : projectDimensions
-              }
               currentTab={currentTab}
-              loading={loadingDimensions || loadingStats}
+              loading={loading}
+              projectDimensions={computedProjectDimensions}
+              projectStats={projectStats}
+              sampleDimensions={computedSampleDimensions}
+              sampleStats={filteredSampleStats}
             />
           )}
       </div>

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -717,7 +717,7 @@ class DiscoveryView extends React.Component {
         mapPreviewedLocationId: locationId,
         showStats: true
       },
-      () => this.refreshMapPreviewedSamples()
+      this.refreshMapPreviewedSamples
     );
   };
 

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -715,7 +715,7 @@ class DiscoveryView extends React.Component {
     this.setState(
       {
         mapPreviewedLocationId: locationId,
-        showStats: true
+        showStats: true,
       },
       this.refreshMapPreviewedSamples
     );
@@ -727,7 +727,7 @@ class DiscoveryView extends React.Component {
       mapLocationData,
       mapPreviewedLocationId,
       projectId,
-      search
+      search,
     } = this.state;
 
     if (!mapPreviewedLocationId) return;
@@ -764,18 +764,18 @@ class DiscoveryView extends React.Component {
       domain,
       projectId,
       filters,
-      search
+      search,
     };
     const { sampleStats } = await getDiscoveryStats(params);
     const {
       projectDimensions,
-      sampleDimensions
+      sampleDimensions,
     } = await getDiscoveryDimensions(params);
 
     this.setState({
       mapSidebarProjectDimensions: projectDimensions,
       mapSidebarSampleDimensions: sampleDimensions,
-      mapSidebarSampleStats: sampleStats
+      mapSidebarSampleStats: sampleStats,
     });
   };
 
@@ -838,9 +838,10 @@ class DiscoveryView extends React.Component {
                   ? computedProjectDimensions
                   : mapSidebarProjectDimensions
               }
-              // TODO: Add projectStats to getDiscoveryStats to have a project count in preview mode
               projectStats={
-                isEmpty(mapSidebarProjectDimensions) ? projectStats : null
+                isEmpty(mapSidebarSampleStats)
+                  ? projectStats
+                  : { count: mapSidebarSampleStats.projectCount }
               }
               ref={mapPreviewSidebar =>
                 (this.mapPreviewSidebar = mapPreviewSidebar)

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -386,7 +386,10 @@ class DiscoveryView extends React.Component {
       search,
     });
 
-    this.setState({ mapLocationData, loadingLocations: false });
+    this.setState(
+      { mapLocationData, loadingLocations: false },
+      this.refreshMapPreviewedSamples
+    );
   };
 
   computeTabs = () => {
@@ -726,6 +729,9 @@ class DiscoveryView extends React.Component {
       projectId,
       search
     } = this.state;
+
+    if (!mapPreviewedLocationId) return;
+
     const sampleIds = mapLocationData[mapPreviewedLocationId].sample_ids;
 
     // Fetch previewed samples
@@ -834,7 +840,7 @@ class DiscoveryView extends React.Component {
               }
               // TODO: Add projectStats to getDiscoveryStats to have a project count in preview mode
               projectStats={
-                isEmpty(mapSidebarProjectDimensions) && projectStats
+                isEmpty(mapSidebarProjectDimensions) ? projectStats : null
               }
               ref={mapPreviewSidebar =>
                 (this.mapPreviewSidebar = mapPreviewSidebar)

--- a/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
@@ -6,7 +6,7 @@ import cs from "./circle_marker.scss";
 
 class CircleMarker extends React.Component {
   render() {
-    const { size, onMouseEnter, onMouseLeave, onClick } = this.props;
+    const { active, size, onMouseEnter, onMouseLeave, onClick } = this.props;
 
     return (
       <svg
@@ -16,7 +16,11 @@ class CircleMarker extends React.Component {
         style={{ transform: `translate(${-size / 2}px, ${-size / 2}px)` }}
       >
         <circle
-          className={cx(cs.circle, onMouseEnter && cs.hoverable)}
+          className={cx(
+            cs.circle,
+            onMouseEnter && cs.hoverable,
+            active && cs.active
+          )}
           // Circle in the center of the viewBox
           cx="50%"
           cy="50%"
@@ -31,6 +35,7 @@ class CircleMarker extends React.Component {
 }
 
 CircleMarker.propTypes = {
+  active: PropTypes.bool,
   size: PropTypes.number,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -65,6 +65,7 @@ class DiscoveryMap extends React.Component {
   };
 
   renderMarker = markerData => {
+    const { previewedLocationId } = this.props;
     const { viewport } = this.state;
     const id = markerData.id;
     const name = markerData.name;
@@ -82,6 +83,7 @@ class DiscoveryMap extends React.Component {
     return (
       <Marker key={`marker-${markerData.id}`} latitude={lat} longitude={lng}>
         <CircleMarker
+          active={id === previewedLocationId}
           size={markerSize}
           onClick={() => this.handleMarkerClick(id)}
           onMouseEnter={() =>
@@ -109,10 +111,11 @@ class DiscoveryMap extends React.Component {
 }
 
 DiscoveryMap.propTypes = {
-  mapTilerKey: PropTypes.string,
   mapLocationData: PropTypes.objectOf(PropTypes.Location),
+  mapTilerKey: PropTypes.string,
   onMarkerClick: PropTypes.func,
-  onTooltipTitleClick: PropTypes.func
+  onTooltipTitleClick: PropTypes.func,
+  previewedLocationId: PropTypes.number
 };
 
 export default DiscoveryMap;

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -23,6 +23,11 @@ class DiscoveryMap extends React.Component {
     this.setState({ viewport });
   };
 
+  handleMarkerClick = markerData => {
+    const { onMarkerClick } = this.props;
+    onMarkerClick && onMarkerClick(markerData);
+  };
+
   handleMarkerMouseEnter = hoverInfo => {
     const title = `${hoverInfo.pointCount} Sample${
       hoverInfo.pointCount > 1 ? "s" : ""
@@ -78,6 +83,7 @@ class DiscoveryMap extends React.Component {
       <Marker key={`marker-${markerData.id}`} latitude={lat} longitude={lng}>
         <CircleMarker
           size={markerSize}
+          onClick={() => this.handleMarkerClick(id)}
           onMouseEnter={() =>
             this.handleMarkerMouseEnter({ id, name, lat, lng, pointCount })
           }
@@ -105,6 +111,7 @@ class DiscoveryMap extends React.Component {
 DiscoveryMap.propTypes = {
   mapTilerKey: PropTypes.string,
   mapLocationData: PropTypes.objectOf(PropTypes.Location),
+  onMarkerClick: PropTypes.func,
   onTooltipTitleClick: PropTypes.func
 };
 

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -1,13 +1,16 @@
-import React from "react";
 import cx from "classnames";
 import { difference, find, isEmpty, union } from "lodash/fp";
+import React from "react";
 
-import PropTypes from "~/components/utils/propTypes";
-import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
-import TableRenderers from "~/components/views/discovery/TableRenderers";
 import { logAnalyticsEvent } from "~/api/analytics";
+import Tabs from "~/components/ui/controls/Tabs";
+import PropTypes from "~/components/utils/propTypes";
+import TableRenderers from "~/components/views/discovery/TableRenderers";
+import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 
 import cs from "./map_preview_sidebar.scss";
+
+const TABS = ["Summary Info", "Samples"];
 
 export default class MapPreviewSidebar extends React.Component {
   constructor(props) {
@@ -227,9 +230,16 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   render() {
-    const { className, samples } = this.props;
+    const { className, currentTab, onTabChange, samples } = this.props;
     return (
       <div className={cx(className, cs.sidebar)}>
+        <Tabs
+          className={cs.tabs}
+          hideBorder
+          onChange={onTabChange}
+          tabs={TABS}
+          value={currentTab}
+        />
         {samples.length === 0 ? this.renderNoData() : this.renderTable()}
       </div>
     );
@@ -238,15 +248,18 @@ export default class MapPreviewSidebar extends React.Component {
 
 MapPreviewSidebar.defaultProps = {
   activeColumns: ["sample"],
-  protectedColumns: ["sample"]
+  protectedColumns: ["sample"],
+  currentTab: "Summary Info"
 };
 
 MapPreviewSidebar.propTypes = {
   activeColumns: PropTypes.array,
   className: PropTypes.string,
+  currentTab: PropTypes.string,
   initialSelectedSampleIds: PropTypes.instanceOf(Set),
   onSampleClicked: PropTypes.func,
   onSelectionUpdate: PropTypes.func,
+  onTabChange: PropTypes.func,
   protectedColumns: PropTypes.array,
   samples: PropTypes.array,
   selectableIds: PropTypes.array.isRequired

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -10,7 +10,7 @@ import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 
 import cs from "./map_preview_sidebar.scss";
 
-const TABS = ["Summary Info", "Samples"];
+const TABS = ["Summary", "Samples"];
 
 export default class MapPreviewSidebar extends React.Component {
   constructor(props) {
@@ -249,7 +249,7 @@ export default class MapPreviewSidebar extends React.Component {
 MapPreviewSidebar.defaultProps = {
   activeColumns: ["sample"],
   protectedColumns: ["sample"],
-  currentTab: "Summary Info"
+  currentTab: "Summary"
 };
 
 MapPreviewSidebar.propTypes = {

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -183,19 +183,17 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   computeTabs = () => {
+    const { sampleStats } = this.props;
     return [
       {
-        label: (
-          <div>
-            <span className={cs.tabLabel}>Summary</span>
-          </div>
-        ),
+        label: "Summary",
         value: "Summary"
       },
       {
         label: (
           <div>
             <span className={cs.tabLabel}>Samples</span>
+            <span className={cs.tabCounter}>{(sampleStats || {}).count}</span>
           </div>
         ),
         value: "Samples"

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -183,7 +183,7 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   computeTabs = () => {
-    const { sampleStats } = this.props;
+    const { samples } = this.props;
     return [
       {
         label: "Summary",
@@ -193,7 +193,9 @@ export default class MapPreviewSidebar extends React.Component {
         label: (
           <div>
             <span className={cs.tabLabel}>Samples</span>
-            <span className={cs.tabCounter}>{(sampleStats || {}).count}</span>
+            {samples.length > 0 && (
+              <span className={cs.tabCounter}>{samples.length}</span>
+            )}
           </div>
         ),
         value: "Samples"
@@ -241,9 +243,7 @@ export default class MapPreviewSidebar extends React.Component {
 
   renderNoData = () => {
     return (
-      <div className={cs.noData}>
-        {`Select a location's tooltip title to preview samples.`}
-      </div>
+      <div className={cs.noData}>Select a location to preview samples.</div>
     );
   };
 

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -11,8 +11,6 @@ import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 
 import cs from "./map_preview_sidebar.scss";
 
-const TABS = ["Summary", "Samples"];
-
 export default class MapPreviewSidebar extends React.Component {
   constructor(props) {
     super(props);
@@ -184,6 +182,27 @@ export default class MapPreviewSidebar extends React.Component {
     onSelectionUpdate && onSelectionUpdate(selectedSampleIds);
   };
 
+  computeTabs = () => {
+    return [
+      {
+        label: (
+          <div>
+            <span className={cs.tabLabel}>Summary</span>
+          </div>
+        ),
+        value: "Summary"
+      },
+      {
+        label: (
+          <div>
+            <span className={cs.tabLabel}>Samples</span>
+          </div>
+        ),
+        value: "Samples"
+      }
+    ];
+  };
+
   reset = () => {
     this.infiniteTable && this.infiniteTable.reset();
     this.setSelectedSampleIds(new Set());
@@ -268,7 +287,7 @@ export default class MapPreviewSidebar extends React.Component {
           className={cs.tabs}
           hideBorder
           onChange={onTabChange}
-          tabs={TABS}
+          tabs={this.computeTabs()}
           value={currentTab}
         />
         {currentTab === "Summary"

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -5,6 +5,7 @@ import React from "react";
 import { logAnalyticsEvent } from "~/api/analytics";
 import Tabs from "~/components/ui/controls/Tabs";
 import PropTypes from "~/components/utils/propTypes";
+import DiscoverySidebar from "~/components/views/discovery/DiscoverySidebar";
 import TableRenderers from "~/components/views/discovery/TableRenderers";
 import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 
@@ -224,13 +225,43 @@ export default class MapPreviewSidebar extends React.Component {
   renderNoData = () => {
     return (
       <div className={cs.noData}>
-        Select a location to see summary info and samples.
+        {`Select a location's tooltip title to preview samples.`}
       </div>
     );
   };
 
+  renderSummaryTab = () => {
+    const {
+      allowedFeatures,
+      discoveryCurrentTab,
+      loading,
+      projectDimensions,
+      projectStats,
+      sampleDimensions,
+      sampleStats
+    } = this.props;
+
+    return (
+      <DiscoverySidebar
+        allowedFeatures={allowedFeatures}
+        className={cs.summaryInfo}
+        currentTab={discoveryCurrentTab}
+        loading={loading}
+        projectDimensions={projectDimensions}
+        projectStats={projectStats}
+        sampleDimensions={sampleDimensions}
+        sampleStats={sampleStats}
+      />
+    );
+  };
+
+  renderSamplesTab = () => {
+    const { samples } = this.props;
+    return samples.length === 0 ? this.renderNoData() : this.renderTable();
+  };
+
   render() {
-    const { className, currentTab, onTabChange, samples } = this.props;
+    const { className, currentTab, onTabChange } = this.props;
     return (
       <div className={cx(className, cs.sidebar)}>
         <Tabs
@@ -240,7 +271,9 @@ export default class MapPreviewSidebar extends React.Component {
           tabs={TABS}
           value={currentTab}
         />
-        {samples.length === 0 ? this.renderNoData() : this.renderTable()}
+        {currentTab === "Summary"
+          ? this.renderSummaryTab()
+          : this.renderSamplesTab()}
       </div>
     );
   }
@@ -254,13 +287,20 @@ MapPreviewSidebar.defaultProps = {
 
 MapPreviewSidebar.propTypes = {
   activeColumns: PropTypes.array,
+  allowedFeatures: PropTypes.arrayOf(PropTypes.string),
   className: PropTypes.string,
   currentTab: PropTypes.string,
+  discoveryCurrentTab: PropTypes.string,
   initialSelectedSampleIds: PropTypes.instanceOf(Set),
+  loading: PropTypes.bool,
   onSampleClicked: PropTypes.func,
   onSelectionUpdate: PropTypes.func,
   onTabChange: PropTypes.func,
+  projectDimensions: PropTypes.array,
+  projectStats: PropTypes.object,
   protectedColumns: PropTypes.array,
+  sampleDimensions: PropTypes.array,
   samples: PropTypes.array,
+  sampleStats: PropTypes.object,
   selectableIds: PropTypes.array.isRequired
 };

--- a/app/assets/src/components/views/discovery/mapping/circle_marker.scss
+++ b/app/assets/src/components/views/discovery/mapping/circle_marker.scss
@@ -9,4 +9,8 @@
       fill: $primary-medium;
     }
   }
+
+  &.active {
+    fill: $primary-medium;
+  }
 }

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -23,6 +23,10 @@
     color: $medium-grey;
     margin: 20px;
   }
+
+  .tabs {
+    margin: 20px 10px;
+  }
 }
 
 .tableDataRow {

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -1,4 +1,5 @@
 @import "~styles/themes/colors";
+@import "~styles/themes/typography";
 
 .sidebar {
   font-size: 12px;
@@ -27,6 +28,17 @@
 
   .tabs {
     margin: 15px 10px;
+
+    .tabLabel {
+      font-size: $font-size-h6;
+      margin-right: 10px;
+    }
+
+    .tabCounter {
+      color: $medium-grey;
+      font-size: $font-size;
+      font-weight: $font-weight-regular;
+    }
   }
 
   .summaryInfo {

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -22,11 +22,15 @@
   .noData {
     color: $medium-grey;
     margin: 20px;
+    text-align: center;
   }
 
   .tabs {
-    margin-top: 20px;
-    margin-left: 10px;
+    margin: 15px 10px;
+  }
+
+  .summaryInfo {
+    width: initial;
   }
 }
 

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -25,7 +25,8 @@
   }
 
   .tabs {
-    margin: 20px 10px;
+    margin-top: 20px;
+    margin-left: 10px;
   }
 }
 

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -403,6 +403,7 @@ class SamplesView extends React.Component {
   renderMap = () => {
     const {
       mapLocationData,
+      mapPreviewedLocationId,
       mapTilerKey,
       onMapMarkerClick,
       onMapTooltipTitleClick
@@ -414,6 +415,7 @@ class SamplesView extends React.Component {
           mapTilerKey={mapTilerKey}
           onMarkerClick={onMapMarkerClick}
           onTooltipTitleClick={onMapTooltipTitleClick}
+          previewedLocationId={mapPreviewedLocationId}
         />
       </div>
     );
@@ -477,6 +479,7 @@ SamplesView.propTypes = {
   allowedFeatures: PropTypes.arrayOf(PropTypes.string),
   currentDisplay: PropTypes.string.isRequired,
   mapLocationData: PropTypes.objectOf(PropTypes.Location),
+  mapPreviewedLocationId: PropTypes.number,
   mapPreviewedSamples: PropTypes.array,
   mapSidebarSelectedSampleIds: PropTypes.instanceOf(Set),
   mapTilerKey: PropTypes.string,

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -401,12 +401,18 @@ class SamplesView extends React.Component {
   };
 
   renderMap = () => {
-    const { mapTilerKey, mapLocationData, onMapTooltipTitleClick } = this.props;
+    const {
+      mapLocationData,
+      mapTilerKey,
+      onMapMarkerClick,
+      onMapTooltipTitleClick
+    } = this.props;
     return (
       <div className={cs.map}>
         <DiscoveryMap
-          mapTilerKey={mapTilerKey}
           mapLocationData={mapLocationData}
+          mapTilerKey={mapTilerKey}
+          onMarkerClick={onMapMarkerClick}
           onTooltipTitleClick={onMapTooltipTitleClick}
         />
       </div>
@@ -476,6 +482,7 @@ SamplesView.propTypes = {
   mapTilerKey: PropTypes.string,
   onDisplaySwitch: PropTypes.func,
   onLoadRows: PropTypes.func.isRequired,
+  onMapMarkerClick: PropTypes.func,
   onMapTooltipTitleClick: PropTypes.func,
   onSampleSelected: PropTypes.func,
   projectId: PropTypes.number,

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -292,8 +292,12 @@ class SamplesController < ApplicationController
 
     samples = samples_by_domain(domain)
     samples = filter_samples(samples, params)
-    sample_ids = samples.pluck(:id)
+    sample_data = samples.pluck(:id, :project_id)
+    sample_ids = sample_data.map { |s| s[0] }
+    project_ids = sample_data.map { |s| s[1] }.uniq
 
+    avg_total_reads = nil
+    avg_remaining_reads = nil
     if sample_ids.count > 0
       pipeline_run_ids = top_pipeline_runs_multiget(sample_ids).values
       avg_total_reads, avg_remaining_reads = PipelineRun
@@ -307,6 +311,7 @@ class SamplesController < ApplicationController
       format.json do
         render json: {
           count: sample_ids.count,
+          projectCount: project_ids.count,
           avgTotalReads: avg_total_reads.present? ? avg_total_reads : 0,
           avgAdjustedRemainingReads: avg_remaining_reads.present? ? avg_remaining_reads : 0
         }


### PR DESCRIPTION
### Description
- DiscoverySidebar: Get rid of unused 'samples' prop, replace 'projects' with its count (all that was used) to simplify props passing.
- Enhance the filtering behavior in MapPreviewSidebar by refreshing the previewed data on filter change. refreshMapPreviewedSamples will now fetch discoveryStats and discoveryDimensions with that additional location restriction. This was Design's intended behavior.
- Add the summary stats tab to the MapPreviewSidebar.
- Add functionality to click a map marker -> open the summary stats.
- Make the selected CircleMarker stay highlighted.
- Limitations: Before selecting anything, you still won't "see all" in the MapPreviewSidebar samples list. This is a separate task now.

### Demo
![Jun-10-2019 18-50-52](https://user-images.githubusercontent.com/5652739/59238274-2dc78200-8bb2-11e9-9635-d6903dd3f5aa.gif)
![Jun-10-2019 18-53-38](https://user-images.githubusercontent.com/5652739/59238276-2f914580-8bb2-11e9-811d-20e2a4856923.gif)

### Test and Reproduce
- Go to data discovery samples tab, open up the map. Click a circle to preview that location. Click the Summary and Samples tabs. Use the left sidebar filters and see the right pane subset responsively.