### PR TITLE
Fix pipeline page when no pipeline run

### DIFF
--- a/app/views/samples/pipeline_runs.html.erb
+++ b/app/views/samples/pipeline_runs.html.erb
@@ -22,7 +22,7 @@
 <% end %>
 
 <% pipeline_run = @sample.first_pipeline_run %>
-<% if pipeline_run.completed? %>
+<% if pipeline_run && pipeline_run.completed? %>
   <%= button_to 'rerun from top', kickoff_pipeline_sample_path(@sample), method: :put, form: {target: '_blank'} %>
 <% end %>
 


### PR DESCRIPTION
# Description

In response to an airbrake error. Not sure why there would be no run for a sample, but we shouldn't error the whole page. 

# Test

Force pipeline run to be nil in code
See no more error