### PR TITLE
Add filter tags to heatmap.

### DIFF
--- a/app/assets/src/components/common/ThresholdFilterTag.jsx
+++ b/app/assets/src/components/common/ThresholdFilterTag.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import PropTypes from "~/components/utils/propTypes";
+import ThresholdMap from "~/components/utils/ThresholdMap";
+
+import FilterTag from "~ui/controls/FilterTag";
+
+export default class ThresholdFilterTag extends React.Component {
+  render() {
+    const { threshold, onClose, className } = this.props;
+    const text = `${threshold.metricDisplay} ${threshold.operator} ${
+      threshold.value
+    }`;
+
+    if (ThresholdMap.isThresholdValid(threshold)) {
+      return <FilterTag text={text} onClose={onClose} className={className} />;
+    }
+    return null;
+  }
+}
+
+ThresholdFilterTag.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  threshold: PropTypes.shape({
+    metric: PropTypes.string,
+    value: PropTypes.string,
+    operator: PropTypes.string,
+    metricDisplay: PropTypes.string
+  }),
+  className: PropTypes.string
+};

--- a/app/assets/src/components/ui/controls/FilterTag.jsx
+++ b/app/assets/src/components/ui/controls/FilterTag.jsx
@@ -1,23 +1,34 @@
 import React from "react";
-import PropTypes from "prop-types";
-import cs from "./filter_tag.scss";
 import cx from "classnames";
-import { Label, Icon } from "semantic-ui-react";
 
-const FilterTag = props => {
-  const { className, onClose, text } = props;
-  return (
-    <Label className={cx(className, cs.filterTag)} size="tiny">
-      {text}
-      <Icon name="close" onClick={onClose} />
-    </Label>
-  );
-};
+import PropTypes from "~/components/utils/propTypes";
+import Label from "~/components/ui/labels/Label";
+import Icon from "~ui/icons/Icon";
+
+import cs from "./filter_tag.scss";
+
+export default class FilterTag extends React.Component {
+  render() {
+    const { text, onClose, className } = this.props;
+    const labelText = (
+      <React.Fragment>
+        {text}
+        <Icon name="close" onClick={onClose} />
+      </React.Fragment>
+    );
+
+    return (
+      <Label
+        className={cx(cs.filterTag, className)}
+        size="tiny"
+        text={labelText}
+      />
+    );
+  }
+}
 
 FilterTag.propTypes = {
-  className: PropTypes.string,
   text: PropTypes.string,
-  onClose: PropTypes.func
+  onClose: PropTypes.func.isRequired,
+  className: PropTypes.string
 };
-
-export default FilterTag;

--- a/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Grid } from "semantic-ui-react";
 import { forbidExtraProps } from "airbnb-prop-types";
 import PropTypes from "prop-types";
+import { get, find } from "lodash/fp";
 
 import BareDropdown from "~ui/controls/dropdowns/BareDropdown";
 import Dropdown from "~ui/controls/dropdowns/Dropdown";
@@ -96,6 +97,7 @@ class ThresholdFilterDropdown extends React.Component {
         ...this.state.thresholds,
         {
           metric: this.metrics[0].value,
+          metricDisplay: this.metrics[0].text,
           operator: this.operators[0],
           value: ""
         }
@@ -239,18 +241,24 @@ const ThresholdFilter = ({
   onChange,
   onRemove
 }) => {
-  let { metric, value, operator } = threshold;
+  let { metric, value, operator, metricDisplay } = threshold;
 
   const handleMetricChange = newMetric => {
-    onChange({ metric: newMetric, value, operator });
+    const newMetricDisplay = get("text", find(["value", newMetric], metrics));
+    onChange({
+      metric: newMetric,
+      value,
+      operator,
+      metricDisplay: newMetricDisplay
+    });
   };
 
   const handleOperatorChange = newOperator => {
-    onChange({ metric, value, operator: newOperator });
+    onChange({ metric, value, operator: newOperator, metricDisplay });
   };
 
   const handleValueChange = newValue => {
-    onChange({ metric, value: newValue, operator });
+    onChange({ metric, value: newValue, operator, metricDisplay });
   };
 
   return (
@@ -290,7 +298,14 @@ const ThresholdFilter = ({
 };
 
 ThresholdFilter.propTypes = forbidExtraProps({
-  metrics: PropTypes.array,
+  metrics: PropTypes.arrayOf(
+    PropTypes.shape({
+      metric: PropTypes.string,
+      value: PropTypes.string,
+      operator: PropTypes.string,
+      metricDisplay: PropTypes.string
+    })
+  ),
   onChange: PropTypes.func,
   onRemove: PropTypes.func,
   operators: PropTypes.array,

--- a/app/assets/src/components/ui/controls/filter_tag.scss
+++ b/app/assets/src/components/ui/controls/filter_tag.scss
@@ -1,8 +1,9 @@
 @import "~styles/themes/colors";
+@import "~styles/themes/typography";
 
-.filterTag {
+:global(.ui):global(.label).filterTag {
+  @include font-tag-s;
   background: $primary-light !important;
   border-color: $primary-light !important;
   color: $white !important;
-  margin: 0.4em;
 }

--- a/app/assets/src/components/ui/icons/Icon.jsx
+++ b/app/assets/src/components/ui/icons/Icon.jsx
@@ -3,15 +3,18 @@ import { forbidExtraProps } from "airbnb-prop-types";
 import PropTypes from "prop-types";
 import React from "react";
 
-const Icon = ({ name, size, className }) => {
-  return <BaseIcon className={className} name={name} size={size} />;
+const Icon = ({ name, size, className, onClick }) => {
+  return (
+    <BaseIcon className={className} name={name} size={size} onClick={onClick} />
+  );
 };
 
 Icon.propTypes = forbidExtraProps({
   // Add more as needed
   name: PropTypes.string,
   size: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  onClick: PropTypes.func
 });
 
 export default Icon;

--- a/app/assets/src/components/ui/labels/Label.jsx
+++ b/app/assets/src/components/ui/labels/Label.jsx
@@ -34,7 +34,7 @@ Label.propTypes = forbidExtraProps({
   size: PropTypes.string,
   circular: PropTypes.bool,
   floating: PropTypes.bool,
-  text: PropTypes.string,
+  text: PropTypes.node,
   onClick: PropTypes.func
 });
 

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -10,7 +10,8 @@ import {
   assign,
   get,
   set,
-  isEmpty
+  isEmpty,
+  find
 } from "lodash/fp";
 import DeepEqual from "fast-deep-equal";
 import { StickyContainer, Sticky } from "react-sticky";
@@ -151,7 +152,20 @@ class SamplesHeatmapView extends React.Component {
       urlParams.subcategories = JSON.parse(urlParams.subcategories);
     }
     if (typeof urlParams.thresholdFilters === "string") {
-      urlParams.thresholdFilters = JSON.parse(urlParams.thresholdFilters);
+      // If the saved threshold object doesn't have metricDisplay, add it. For backwards compatibility.
+      urlParams.thresholdFilters = map(
+        threshold => ({
+          metricDisplay: get(
+            "text",
+            find(
+              ["value", threshold.metric],
+              this.props.thresholdFilters.targets
+            )
+          ),
+          ...threshold
+        }),
+        JSON.parse(urlParams.thresholdFilters)
+      );
     }
     return urlParams;
   };

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/samples_heatmap_view.scss
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/samples_heatmap_view.scss
@@ -18,7 +18,16 @@
     background-color: $white;
 
     .filterRow {
-      margin: 20px 0;
+      margin-top: 20px;
+      margin-bottom: 15px;
+    }
+
+    .filterTag {
+      margin-right: 6px;
+
+      &:last-child {
+        margin-right: 0;
+      }
     }
   }
 

--- a/app/assets/src/components/views/discovery/discovery_filters.scss
+++ b/app/assets/src/components/views/discovery/discovery_filters.scss
@@ -16,10 +16,14 @@
       flex: 0 0 auto;
 
       .filterTag {
-        @include font-label-xs;
-
         margin: 0;
         padding: 0px 8px;
+
+        margin-right: 6px;
+
+        &:last-child {
+          margin-right: 0;
+        }
 
         &:not(:first-child) {
           margin-top: 2px;

--- a/app/assets/src/styles/reports.scss
+++ b/app/assets/src/styles/reports.scss
@@ -285,11 +285,14 @@ input[type="number"] {
       font-size: 1em !important;
     }
     .filter-tags-list {
-      padding-left: 15px;
-      .label-tags {
-        background: $primary-light !important;
-        border-color: $primary-light !important;
-        color: $white;
+      padding-top: 4px;
+
+      .filter-tag {
+        margin-right: 6px;
+
+        &:last-child {
+          margin-right: 0;
+        }
       }
     }
     .filter-btn {

--- a/app/assets/src/styles/themes/_typography.scss
+++ b/app/assets/src/styles/themes/_typography.scss
@@ -129,6 +129,13 @@ $font-weight-heavy: 800;
   text-transform: uppercase;
 }
 
+@mixin font-tag-s {
+  font-size: 11px;
+  line-height: 11px;
+  letter-spacing: 0.8px;
+  font-weight: 400;
+}
+
 @mixin viz-label {
   font-size: 9px;
   line-height: 13px;


### PR DESCRIPTION
Also use common FilterTag component in PipelineSampleReport.
Add some missing analytics.
Small tweaks to FilterTag component.
Add common ThresholdFilterTag component.
Add metricDisplay field to threshold object for easier display. Ensure backwards compatibility.

Verified that:
* Pills still work on PipelineSampleReport. Both styling and close behavior.
* Pills still work on DD Samples page.
* Pills work properly on Heatmap page.

On the heatmap:
![Screen Shot 2019-06-11 at 12 56 39 PM](https://user-images.githubusercontent.com/837004/59302272-70d43480-8c48-11e9-991d-c7fb41111a50.png)

On the report page:
![Screen Shot 2019-06-11 at 12 51 04 PM](https://user-images.githubusercontent.com/837004/59302277-73cf2500-8c48-11e9-97a5-a7634cbdaaaa.png)

On DD sample filters:
![Screen Shot 2019-06-11 at 12 56 59 PM](https://user-images.githubusercontent.com/837004/59302279-75005200-8c48-11e9-83ee-1ce7c9110e83.png)

