### PR TITLE
[Maps] Go back to old map toggle style + change human level locations to COUNTY-level

### DIFF
--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -12,8 +12,6 @@ import ReportsDownloader from "~/components/views/samples/ReportsDownloader";
 import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 import { DownloadIconDropdown } from "~ui/controls/dropdowns";
 import { Menu, MenuItem } from "~ui/controls/Menu";
-import BulletListIcon from "~ui/icons/BulletListIcon";
-import GlobeLinedIcon from "~ui/icons/GlobeLinedIcon";
 import HeatmapIcon from "~ui/icons/HeatmapIcon";
 import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";
 import SaveIcon from "~ui/icons/SaveIcon";
@@ -388,11 +386,13 @@ class SamplesView extends React.Component {
                 `SamplesView_${display}-switch_clicked`
               )}
             >
-              {display === "map" ? (
-                <GlobeLinedIcon className={cs.icon} />
-              ) : (
-                <BulletListIcon className={cs.icon} />
-              )}
+              <i
+                className={cx(
+                  "fa",
+                  display === "map" ? "fa-globe" : "fa-list-ul",
+                  cs.icon
+                )}
+              />
             </MenuItem>
           ))}
         </Menu>

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -103,36 +103,19 @@
     .switcherMenu {
       margin: 0;
       min-height: 25px;
+      border-radius: 7px;
       box-shadow: none;
-      border: none;
 
       .menuItem {
-        padding: 5px 10px;
-        background: inherit;
+        padding: 5px 15px;
 
         .icon {
-          font-size: 18px;
-          margin-right: 0;
-          // Make the icon look thinner
-          -webkit-text-stroke: 0.7px $white;
-        }
-
-        &:hover {
-          background: inherit;
+          font-size: 15px;
         }
 
         &:global(.active) {
-          // Underline the icon
-          &:after {
-            position: absolute;
-            content: "";
-            border-bottom: 2px solid $primary-medium;
-            width: 50%;
-            bottom: 0;
-            // Move left edge to center and then center to midpoint
-            left: 50%;
-            transform: translateX(-50%);
-          }
+          // Important due to a { color: inherit !important; } in header.scss.
+          color: $primary-light !important;
         }
       }
     }

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -1,23 +1,23 @@
 module LocationHelper
   # Adapter function to munge responses from Location IQ API to our format
   def self.adapt_location_iq_response(body)
-    addr = body["address"]
+    address = body["address"]
     geo_level = ["city", "county", "state", "country"].each do |n|
-      break n if addr[n]
+      break n if address[n]
     end || ""
     {
       name: body["display_name"],
       geo_level: geo_level,
-      country_name: addr["country"] || "",
-      state_name: addr["state"] || "",
-      subdivision_name: addr["county"] || "",
+      country_name: address["country"] || "",
+      state_name: address["state"] || "",
+      subdivision_name: address["county"] || "",
       # Normalize extra provider fields to city. normalizecity param doesn't work all the time.
-      city_name: addr[%w[city city_distrct locality town borough municipality village hamlet quarter neighbourhood state_district].find { |k| addr.key?(k) }] || "",
+      city_name: address[%w[city city_distrct locality town borough municipality village hamlet quarter neighbourhood state_district].find { |k| address.key?(k) }] || "",
       # Round coordinates to enhance privacy
       lat: body["lat"] ? body["lat"].to_f.round(2) : nil,
       # LocationIQ uses 'lon'
       lng: body["lon"] ? body["lon"].to_f.round(2) : nil,
-      country_code: addr["country_code"] || "",
+      country_code: address["country_code"] || "",
       osm_id: body["osm_id"].to_i,
       osm_type: body["osm_type"],
       locationiq_id: body["place_id"].to_i

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -1,22 +1,23 @@
 module LocationHelper
   # Adapter function to munge responses from Location IQ API to our format
   def self.adapt_location_iq_response(body)
-    address = body["address"]
+    addr = body["address"]
     geo_level = ["city", "county", "state", "country"].each do |n|
-      break n if address[n]
+      break n if addr[n]
     end || ""
     {
       name: body["display_name"],
       geo_level: geo_level,
-      country_name: address["country"] || "",
-      state_name: address["state"] || "",
-      subdivision_name: address["county"] || "",
-      city_name: address["city"] || "",
+      country_name: addr["country"] || "",
+      state_name: addr["state"] || "",
+      subdivision_name: addr["county"] || "",
+      # Normalize extra provider fields to city. normalizecity param doesn't work all the time.
+      city_name: addr[%w[city city_distrct locality town borough municipality village hamlet quarter neighbourhood state_district].find { |k| addr.key?(k) }] || "",
       # Round coordinates to enhance privacy
       lat: body["lat"] ? body["lat"].to_f.round(2) : nil,
       # LocationIQ uses 'lon'
       lng: body["lon"] ? body["lon"].to_f.round(2) : nil,
-      country_code: address["country_code"] || "",
+      country_code: addr["country_code"] || "",
       osm_id: body["osm_id"].to_i,
       osm_type: body["osm_type"],
       locationiq_id: body["place_id"].to_i

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -48,7 +48,6 @@ class Location < ApplicationRecord
   def self.geosearch_by_osm_id(osm_id, osm_type)
     osm_type = osm_type[0].capitalize # (N)ode, (W)ay, or (R)elation
     endpoint_query = "reverse.php?osm_id=#{osm_id}&osm_type=#{osm_type}"
-    puts "foobar 11:08am: ", endpoint_query
     location_api_request(endpoint_query)
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -30,6 +30,12 @@ class Location < ApplicationRecord
     location_api_request(endpoint_query)
   end
 
+  # Search request to Location IQ API by country, state, and subdivision
+  def self.geosearch_by_country_state_subdivision(country_name, state_name, subdivision_name)
+    endpoint_query = "#{GEOSEARCH_BASE_QUERY}&country=#{country_name}&state=#{state_name}&county=#{subdivision_name}"
+    location_api_request(endpoint_query)
+  end
+
   # Instantiate a new Location from parameters WITHOUT saving
   def self.new_from_params(location_params)
     # Ignore fields that don't match columns
@@ -65,14 +71,15 @@ class Location < ApplicationRecord
     end
   end
 
-  # Restrict Human location specificity to State, Country. Return new Location if restriction added.
+  # Restrict Human location specificity to Subdivision, State, Country. Return new Location if
+  # restriction added.
   def self.check_and_restrict_specificity(location, host_genome_name)
-    # We don't want Human locations with subdivision or city
-    if host_genome_name == "Human" && (location.subdivision_name.present? || location.city_name.present?)
-      # Redo the search for just the country/state
-      success, resp = geosearch_by_country_and_state(location.country_name, location.state_name)
+    # We don't want Human locations with city
+    if host_genome_name == "Human" && location.city_name.present?
+      # Redo the search for just the subdivision/country/state
+      success, resp = geosearch_by_country_state_subdivision(location.country_name, location.state_name, location.subdivision_name)
       unless success && !resp.empty?
-        raise "Couldn't find #{location.state_name}, #{location.country_name} (state, country)"
+        raise "Couldn't find #{location.country_name}, #{location.state_name}, #{location.subdivision_name} (country, state, subdivision)"
       end
 
       result = LocationHelper.adapt_location_iq_response(resp[0])

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -23,3 +23,11 @@ california:
   country_name: "USA"
   state_name: "California"
   locationiq_id: 214330370
+
+sf_county:
+  name: "San Francisco City and County, California, USA"
+  geo_level: "subdivision"
+  country_name: "USA"
+  state_name: "California"
+  subdivision_name: "San Francisco City and County"
+  locationiq_id: 214379825

--- a/test/test_helpers/location_test_helper.rb
+++ b/test/test_helpers/location_test_helper.rb
@@ -51,4 +51,21 @@ module LocationTestHelper
       }
     }
   ].freeze
+  API_GEOSEARCH_SF_COUNTY_RESPONSE = [
+    {
+      "place_id" => "214379825",
+      "osm_type" => "relation",
+      "osm_id" => "396487",
+      "lat" => 37.76,
+      # LocationIQ uses 'lon'
+      "lon" => -122.46,
+      "display_name" => "San Francisco City and County, California, USA",
+      "address" => {
+        "county" => "San Francisco City and County",
+        "state" => "California",
+        "country" => "USA",
+        "country_code" => "us"
+      }
+    }
+  ].freeze
 end


### PR DESCRIPTION
### Description
- Change map toggle back to the old style (with less border-radius and less left/right margin now).
- Tweak geosearch adapter to normalize city_name better.
- Loosen human-level sample restriction to the COUNTY/subdivision level instead of state.

### Demo
![Screen Shot 2019-06-11 at 1 39 15 PM](https://user-images.githubusercontent.com/5652739/59305214-a67c1c00-8c4e-11e9-883e-713d60dc45cc.png)
![Jun-11-2019 13-41-08](https://user-images.githubusercontent.com/5652739/59305220-abd96680-8c4e-11e9-9277-c3bd23af37f3.gif)

### Test and Reproduce
- Go to data discovery samples, view the new map toggle. Go to a human sample in the project "CI", enter in a city location, save and refresh, and see it saved as the county level.