### PR TITLE
[Maps] Add more locationV2 feature flags (so that we can add to all projects)

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -7,6 +7,7 @@ import PropTypes from "~/components/utils/propTypes";
 import Input from "~/components/ui/controls/Input";
 import MetadataInput from "~/components/common/MetadataInput";
 import { logAnalyticsEvent } from "~/api/analytics";
+import { RequestContext } from "~/components/common/RequestContext";
 
 import MetadataSection from "./MetadataSection";
 import { SAMPLE_ADDITIONAL_INFO } from "./constants";
@@ -20,10 +21,10 @@ class MetadataTab extends React.Component {
     this.state = {
       sectionOpen: {
         // Open the first section by default.
-        [sections[0].name]: true
+        [sections[0].name]: true,
       },
       sectionEditing: {},
-      sections
+      sections,
     };
   }
 
@@ -51,7 +52,7 @@ class MetadataTab extends React.Component {
     const { sectionOpen, sectionEditing } = this.state;
     const newValue = !sectionOpen[section.name];
     const newState = {
-      sectionOpen: set(section.name, newValue, sectionOpen)
+      sectionOpen: set(section.name, newValue, sectionOpen),
     };
 
     // If we are closing a section, stop editing it.
@@ -63,7 +64,7 @@ class MetadataTab extends React.Component {
     logAnalyticsEvent("MetadataTab_section_toggled", {
       section: section.name,
       sectionOpen: newValue,
-      ...this.props.additionalInfo
+      ...this.props.additionalInfo,
     });
   };
 
@@ -71,7 +72,7 @@ class MetadataTab extends React.Component {
     const { sectionEditing, sectionOpen } = this.state;
     const newValue = !sectionEditing[section.name];
     const newState = {
-      sectionEditing: set(section.name, newValue, sectionEditing)
+      sectionEditing: set(section.name, newValue, sectionEditing),
     };
 
     if (!sectionEditing[section.name]) {
@@ -85,7 +86,7 @@ class MetadataTab extends React.Component {
     logAnalyticsEvent("MetadataTab_section-edit_toggled", {
       section: section.name,
       sectionEditing: newValue,
-      ...this.props.additionalInfo
+      ...this.props.additionalInfo,
     });
   };
 
@@ -95,7 +96,7 @@ class MetadataTab extends React.Component {
       onMetadataChange,
       onMetadataSave,
       metadataErrors,
-      additionalInfo
+      additionalInfo,
     } = this.props;
 
     return (
@@ -136,7 +137,7 @@ class MetadataTab extends React.Component {
       metadataTypes,
       additionalInfo,
       onMetadataChange,
-      onMetadataSave
+      onMetadataSave,
     } = this.props;
     const { sectionEditing } = this.state;
 
@@ -148,6 +149,12 @@ class MetadataTab extends React.Component {
     // TODO: Consider refactoring so SAMPLE_ADDITIONAL_INFO doesn't have to be special.
     return (
       <div>
+        <RequestContext.Consumer>
+          {({ allowedFeatures }) => {
+            console.log("enabled in here: ", allowedFeatures);
+          }}
+        </RequestContext.Consumer>
+
         {/* Special section for Sample Info */}
         {section.name === "Sample Info" &&
           !isSectionEditing &&
@@ -229,9 +236,9 @@ MetadataTab.propTypes = {
     project_name: PropTypes.string.isRequired,
     upload_date: PropTypes.string,
     host_genome_name: PropTypes.string,
-    editable: PropTypes.bool
+    editable: PropTypes.bool,
   }).isRequired,
-  metadataErrors: PropTypes.objectOf(PropTypes.string)
+  metadataErrors: PropTypes.objectOf(PropTypes.string),
 };
 
 export default MetadataTab;

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -149,12 +149,6 @@ class MetadataTab extends React.Component {
     // TODO: Consider refactoring so SAMPLE_ADDITIONAL_INFO doesn't have to be special.
     return (
       <div>
-        <RequestContext.Consumer>
-          {({ allowedFeatures }) => {
-            console.log("enabled in here: ", allowedFeatures);
-          }}
-        </RequestContext.Consumer>
-
         {/* Special section for Sample Info */}
         {section.name === "Sample Info" &&
           !isSectionEditing &&
@@ -188,12 +182,24 @@ class MetadataTab extends React.Component {
             </div>
           )}
         {validKeys.map(key => (
-          <div className={cs.field} key={metadataTypes[key].key}>
-            <div className={cs.label}>{metadataTypes[key].name}</div>
-            {isSectionEditing
-              ? this.renderInput(metadataTypes[key])
-              : this.renderMetadataType(metadataTypes[key])}
-          </div>
+          <RequestContext.Consumer>
+            {({ allowedFeatures }) => {
+              if (
+                key === "collection_location_v2" &&
+                !allowedFeatures.includes("maqwdps")
+              ) {
+                return null;
+              }
+              return (
+                <div className={cs.field} key={metadataTypes[key].key}>
+                  <div className={cs.label}>{metadataTypes[key].name}</div>
+                  {isSectionEditing
+                    ? this.renderInput(metadataTypes[key])
+                    : this.renderMetadataType(metadataTypes[key])}
+                </div>
+              );
+            }}
+          </RequestContext.Consumer>
         ))}
       </div>
     );

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -184,9 +184,10 @@ class MetadataTab extends React.Component {
         {validKeys.map(key => (
           <RequestContext.Consumer>
             {({ allowedFeatures }) => {
+              // TODO(jsheu): Migrate all to location_v2 after release
               if (
                 key === "collection_location_v2" &&
-                !allowedFeatures.includes("maqwdps")
+                !allowedFeatures.includes("maps")
               ) {
                 return null;
               }

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -89,7 +89,6 @@ class Header extends React.Component {
             <div className={cs.fill} />
             <RequestContext.Consumer>
               {({ allowedFeatures }) => {
-                console.log("enabled: ", allowedFeatures);
                 if (allowedFeatures.includes("data_discovery")) {
                   return (
                     <MainMenu

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -13,7 +13,7 @@ import LogoIcon from "~ui/icons/LogoIcon";
 import {
   DISCOVERY_DOMAIN_MY_DATA,
   DISCOVERY_DOMAIN_ALL_DATA,
-  DISCOVERY_DOMAIN_PUBLIC
+  DISCOVERY_DOMAIN_PUBLIC,
 } from "~/components/views/discovery/discovery_api";
 import { openUrl } from "~utils/links";
 import { deleteAsync } from "~/api/core";
@@ -88,12 +88,13 @@ class Header extends React.Component {
             </div>
             <div className={cs.fill} />
             <RequestContext.Consumer>
-              {({ enabledFeatures }) => {
-                if (enabledFeatures.includes("data_discovery")) {
+              {({ allowedFeatures }) => {
+                console.log("enabled: ", allowedFeatures);
+                if (allowedFeatures.includes("data_discovery")) {
                   return (
                     <MainMenu
                       adminUser={adminUser}
-                      newSampleUpload={enabledFeatures.includes(
+                      newSampleUpload={allowedFeatures.includes(
                         "new_sample_upload"
                       )}
                     />
@@ -115,7 +116,7 @@ class Header extends React.Component {
 
 Header.propTypes = {
   adminUser: PropTypes.bool,
-  userSignedIn: PropTypes.bool
+  userSignedIn: PropTypes.bool,
 };
 
 const UserMenuDropDown = ({
@@ -124,11 +125,11 @@ const UserMenuDropDown = ({
   email,
   signInEndpoint,
   signOutEndpoint,
-  userName
+  userName,
 }) => {
   const signOut = () => {
     deleteAsync(`${signOutEndpoint}.json`, {
-      withCredentials: true
+      withCredentials: true,
     }).then(_ => {
       openUrl(signInEndpoint);
     });
@@ -238,15 +239,15 @@ const UserMenuDropDown = ({
   return (
     <div>
       <RequestContext.Consumer>
-        {({ enabledFeatures }) => (
+        {({ allowedFeatures }) => (
           <BareDropdown
             trigger={<div className={cs.userName}>{userName}</div>}
             className={cs.userDropdown}
             items={renderItems(
               adminUser,
               demoUser,
-              enabledFeatures.includes("data_discovery"),
-              enabledFeatures.includes("new_sample_upload")
+              allowedFeatures.includes("data_discovery"),
+              allowedFeatures.includes("new_sample_upload")
             )}
             direction="left"
           />
@@ -262,7 +263,7 @@ UserMenuDropDown.propTypes = forbidExtraProps({
   email: PropTypes.string.isRequired,
   signInEndpoint: PropTypes.string.isRequired,
   signOutEndpoint: PropTypes.string.isRequired,
-  userName: PropTypes.string.isRequired
+  userName: PropTypes.string.isRequired,
 });
 
 const MainMenu = ({ adminUser, newSampleUpload }) => {
@@ -315,7 +316,7 @@ const MainMenu = ({ adminUser, newSampleUpload }) => {
 
 MainMenu.propTypes = {
   adminUser: PropTypes.bool,
-  newSampleUpload: PropTypes.bool
+  newSampleUpload: PropTypes.bool,
 };
 
 export default Header;

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -13,7 +13,7 @@ import _fp, {
   sortBy,
   find,
   pickBy,
-  isEqual
+  isEqual,
 } from "lodash/fp";
 
 import { logAnalyticsEvent } from "~/api/analytics";
@@ -39,8 +39,8 @@ class MetadataManualInput extends React.Component {
     // Which cell the "Apply to All" button should appear on.
     applyToAllCell: {
       sampleName: null,
-      column: null
-    }
+      column: null,
+    },
   };
 
   componentDidMount() {
@@ -57,8 +57,8 @@ class MetadataManualInput extends React.Component {
       headers: {
         "Sample Name": "Sample Name",
         ...(samplesAreNew ? { "Host Genome": "Host Genome" } : {}),
-        ...mapValues("name", keyBy("key", projectMetadataFields))
-      }
+        ...mapValues("name", keyBy("key", projectMetadataFields)),
+      },
     });
 
     this.setDefaultHostGenomes();
@@ -85,7 +85,7 @@ class MetadataManualInput extends React.Component {
       });
       this.setState({
         headersToEdit: newHeaders,
-        metadataFieldsToEdit: newFields
+        metadataFieldsToEdit: newFields,
       });
       this.onMetadataChange(newHeaders, newFields);
     }
@@ -95,7 +95,7 @@ class MetadataManualInput extends React.Component {
     return [
       "Sample Name",
       ...(this.props.samplesAreNew ? ["Host Genome"] : []),
-      ...this.state.selectedFieldNames
+      ...this.state.selectedFieldNames,
     ];
   };
 
@@ -112,8 +112,8 @@ class MetadataManualInput extends React.Component {
       headersToEdit: newHeaders,
       applyToAllCell: {
         sampleName: sample.name,
-        column: key
-      }
+        column: key,
+      },
     });
 
     this.onMetadataChange(newHeaders, newFields);
@@ -142,8 +142,8 @@ class MetadataManualInput extends React.Component {
       headersToEdit: newHeaders,
       applyToAllCell: {
         sampleName: null,
-        column: null
-      }
+        column: null,
+      },
     });
 
     this.onMetadataChange(newHeaders, newFields);
@@ -165,11 +165,11 @@ class MetadataManualInput extends React.Component {
         rows: map(
           (fields, sampleName) => ({
             ...mapValues(value => value || "", fields),
-            sample_name: sampleName
+            sample_name: sampleName,
           }),
           fieldsForSamples
-        )
-      }
+        ),
+      },
     });
   };
 
@@ -188,7 +188,7 @@ class MetadataManualInput extends React.Component {
   handleColumnChange = selectedFieldNames => {
     this.setState({ selectedFieldNames });
     logAnalyticsEvent("MetadataManualInput_column-selector_changed", {
-      selectedFieldNames: selectedFieldNames.length
+      selectedFieldNames: selectedFieldNames.length,
     });
   };
 
@@ -197,14 +197,14 @@ class MetadataManualInput extends React.Component {
       "text",
       this.props.hostGenomes.map(hostGenome => ({
         text: hostGenome.name,
-        value: hostGenome.id
+        value: hostGenome.id,
       }))
     );
 
   renderColumnSelector = () => {
     const options = values(this.props.projectMetadataFields).map(field => ({
       value: field.key,
-      text: field.name
+      text: field.name,
     }));
 
     return (
@@ -244,7 +244,7 @@ class MetadataManualInput extends React.Component {
           this.applyToAll(column, sample);
           logAnalyticsEvent("MetadataManualInput_apply-all_clicked", {
             sampleName: sample.name,
-            column
+            column,
           });
         }}
       >
@@ -332,7 +332,7 @@ class MetadataManualInput extends React.Component {
                     logAnalyticsEvent("MetadataManualInput_input_changed", {
                       key,
                       value,
-                      sampleName: sample.name
+                      sampleName: sample.name,
                     });
                   }}
                   withinModal={this.props.withinModal}
@@ -353,6 +353,7 @@ class MetadataManualInput extends React.Component {
   };
 
   render() {
+    console.log("columns are: ", this.getManualInputColumns());
     return (
       <div className={cx(cs.metadataManualInput, this.props.className)}>
         <div className={cs.tableContainer}>
@@ -380,7 +381,7 @@ MetadataManualInput.propTypes = {
   samplesAreNew: PropTypes.bool,
   withinModal: PropTypes.bool,
   projectMetadataFields: PropTypes.object,
-  hostGenomes: PropTypes.array
+  hostGenomes: PropTypes.array,
 };
 
 export default MetadataManualInput;

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -353,7 +353,6 @@ class MetadataManualInput extends React.Component {
   };
 
   render() {
-    console.log("columns are: ", this.getManualInputColumns());
     return (
       <div className={cx(cs.metadataManualInput, this.props.className)}>
         <div className={cs.tableContainer}>

--- a/app/assets/src/components/common/RequestContext.jsx
+++ b/app/assets/src/components/common/RequestContext.jsx
@@ -1,5 +1,5 @@
 import React from "react";
 
 export const RequestContext = React.createContext({
-  enabledFeatures: new Set()
+  allowedFeatures: new Set(),
 });

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -18,6 +18,7 @@ import HeatmapIcon from "~ui/icons/HeatmapIcon";
 import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";
 import SaveIcon from "~ui/icons/SaveIcon";
 import Label from "~ui/labels/Label";
+import { RequestContext } from "~/components/common/RequestContext";
 
 import cs from "./samples_view.scss";
 import csTableRenderer from "../discovery/table_renderers.scss";
@@ -32,7 +33,7 @@ class SamplesView extends React.Component {
 
     this.state = {
       phyloTreeCreationModalOpen: false,
-      selectedSampleIds: new Set()
+      selectedSampleIds: new Set(),
     };
 
     this.columns = [
@@ -41,25 +42,25 @@ class SamplesView extends React.Component {
         flexGrow: 1,
         width: 350,
         cellRenderer: TableRenderers.renderSample,
-        headerClassName: cs.sampleHeader
+        headerClassName: cs.sampleHeader,
       },
       {
         dataKey: "createdAt",
         label: "Uploaded On",
         width: 120,
         className: cs.basicCell,
-        cellRenderer: TableRenderers.renderDateWithElapsed
+        cellRenderer: TableRenderers.renderDateWithElapsed,
       },
       {
         dataKey: "host",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       {
         dataKey: "collectionLocation",
         label: "Location",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       {
         dataKey: "totalReads",
@@ -67,14 +68,14 @@ class SamplesView extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatNumberWithCommas(rowData[dataKey])
+          TableRenderers.formatNumberWithCommas(rowData[dataKey]),
       },
       {
         dataKey: "nonHostReads",
         label: "Passed Filters",
         flexGrow: 1,
         className: cs.basicCell,
-        cellRenderer: TableRenderers.renderNumberAndPercentage
+        cellRenderer: TableRenderers.renderNumberAndPercentage,
       },
       {
         dataKey: "qcPercent",
@@ -82,7 +83,7 @@ class SamplesView extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatPercentage(rowData[dataKey])
+          TableRenderers.formatPercentage(rowData[dataKey]),
       },
       {
         dataKey: "duplicateCompressionRatio",
@@ -90,7 +91,7 @@ class SamplesView extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatPercentage(rowData[dataKey])
+          TableRenderers.formatPercentage(rowData[dataKey]),
       },
       {
         dataKey: "erccReads",
@@ -98,24 +99,24 @@ class SamplesView extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatNumberWithCommas(rowData[dataKey])
+          TableRenderers.formatNumberWithCommas(rowData[dataKey]),
       },
       {
         dataKey: "notes",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       {
         dataKey: "nucleotideType",
         label: "Nucleotide Type",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       {
         dataKey: "sampleType",
         label: "Sample Type",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       {
         dataKey: "subsampledFraction",
@@ -123,7 +124,7 @@ class SamplesView extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatNumber(rowData[dataKey])
+          TableRenderers.formatNumber(rowData[dataKey]),
       },
       {
         dataKey: "totalRuntime",
@@ -131,8 +132,8 @@ class SamplesView extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatDuration(rowData[dataKey])
-      }
+          TableRenderers.formatDuration(rowData[dataKey]),
+      },
     ];
 
     // TODO(jsheu): Upon release, replace Location 'v1'
@@ -141,7 +142,7 @@ class SamplesView extends React.Component {
         dataKey: "collectionLocationV2",
         label: "Location v2",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       });
     }
   }
@@ -156,7 +157,7 @@ class SamplesView extends React.Component {
     }
     this.setState({ selectedSampleIds: newSelected });
     logAnalyticsEvent("SamplesView_row_selected", {
-      selectedSampleIds: newSelected.length
+      selectedSampleIds: newSelected.length,
     });
   };
 
@@ -197,7 +198,7 @@ class SamplesView extends React.Component {
 
     const log = () =>
       logAnalyticsEvent("SamplesView_heatmap-icon_clicked", {
-        selectedSampleIds: targetSampleIds.length
+        selectedSampleIds: targetSampleIds.length,
       });
     return targetSampleIds.size < 2 ? (
       <HeatmapIcon className={cx(cs.icon, cs.disabled, cs.heatmap)} />
@@ -217,7 +218,7 @@ class SamplesView extends React.Component {
     const {
       projectId,
       currentDisplay,
-      mapSidebarSelectedSampleIds
+      mapSidebarSelectedSampleIds,
     } = this.props;
     const { selectedSampleIds } = this.state;
 
@@ -230,13 +231,13 @@ class SamplesView extends React.Component {
     if (projectId) {
       downloadOptions.push({
         text: "Sample Reports",
-        value: "project_reports"
+        value: "project_reports",
       });
     }
     if (this.props.admin) {
       downloadOptions.push({
         text: "Host Gene Counts",
-        value: "host_gene_counts"
+        value: "host_gene_counts",
       });
     }
     return (
@@ -247,12 +248,12 @@ class SamplesView extends React.Component {
           new ReportsDownloader({
             projectId,
             downloadOption,
-            selectedSampleIds: targetSampleIds
+            selectedSampleIds: targetSampleIds,
           });
           logAnalyticsEvent("SamplesView_download-dropdown-option_clicked", {
             projectId,
             selectedSamplesCount: targetSampleIds.length,
-            downloadOption
+            downloadOption,
           });
         }}
       />
@@ -264,7 +265,7 @@ class SamplesView extends React.Component {
       currentDisplay,
       mapPreviewedSamples,
       mapSidebarSelectedSampleIds,
-      samples
+      samples,
     } = this.props;
     const { selectedSampleIds } = this.state;
 
@@ -300,7 +301,7 @@ class SamplesView extends React.Component {
     const {
       allowedFeatures,
       currentDisplay,
-      mapSidebarSelectedSampleIds
+      mapSidebarSelectedSampleIds,
     } = this.props;
     const { selectedSampleIds } = this.state;
 
@@ -427,7 +428,7 @@ class SamplesView extends React.Component {
     onSampleSelected && onSampleSelected({ sample, currentEvent: event });
     logAnalyticsEvent("SamplesView_row_clicked", {
       sampleId: sample.id,
-      sampleName: sample.name
+      sampleName: sample.name,
     });
   };
 
@@ -436,6 +437,12 @@ class SamplesView extends React.Component {
     const { phyloTreeCreationModalOpen } = this.state;
     return (
       <div className={cs.container}>
+        <RequestContext.Consumer>
+          {({ allowedFeatures }) => {
+            console.log("enabled in here SamplesView: ", allowedFeatures);
+          }}
+        </RequestContext.Consumer>
+
         {this.renderToolbar()}
         {currentDisplay === "table" ? this.renderTable() : this.renderMap()}
         {phyloTreeCreationModalOpen && (
@@ -460,10 +467,10 @@ SamplesView.defaultProps = {
     "host",
     "collectionLocation",
     "nonHostReads",
-    "qcPercent"
+    "qcPercent",
   ],
   protectedColumns: ["sample"],
-  currentDisplay: "table"
+  currentDisplay: "table",
 };
 
 SamplesView.propTypes = {
@@ -482,7 +489,7 @@ SamplesView.propTypes = {
   protectedColumns: PropTypes.array,
   samples: PropTypes.array,
   selectableIds: PropTypes.array.isRequired,
-  admin: PropTypes.bool
+  admin: PropTypes.bool,
 };
 
 export default SamplesView;

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -18,7 +18,6 @@ import HeatmapIcon from "~ui/icons/HeatmapIcon";
 import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";
 import SaveIcon from "~ui/icons/SaveIcon";
 import Label from "~ui/labels/Label";
-import { RequestContext } from "~/components/common/RequestContext";
 
 import cs from "./samples_view.scss";
 import csTableRenderer from "../discovery/table_renderers.scss";
@@ -437,12 +436,6 @@ class SamplesView extends React.Component {
     const { phyloTreeCreationModalOpen } = this.state;
     return (
       <div className={cs.container}>
-        <RequestContext.Consumer>
-          {({ allowedFeatures }) => {
-            console.log("enabled in here SamplesView: ", allowedFeatures);
-          }}
-        </RequestContext.Consumer>
-
         {this.renderToolbar()}
         {currentDisplay === "table" ? this.renderTable() : this.renderMap()}
         {phyloTreeCreationModalOpen && (

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
   # TODO: (gdingle): how is this related to request_context in ApplicationHelper?
   def request_context
     {
-      enabledFeatures: current_user.allowed_featured_list
+      allowedFeatures: current_user.allowed_featured_list
     }
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,13 +47,6 @@ class ApplicationController < ActionController::Base
     raise "action doesn't check against access control" unless @access_checked
   end
 
-  # TODO: (gdingle): how is this related to request_context in ApplicationHelper?
-  def request_context
-    {
-      allowedFeatures: current_user.allowed_featured_list
-    }
-  end
-
   def get_background_id(sample)
     background_id = params[:background_id].to_i
     if background_id > 0

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -499,7 +499,7 @@ class ProjectsController < ApplicationController
                              .map(&:metadata_fields).flatten.uniq.map(&:field_info)
               end
     # TODO(jsheu): Migrate all to location_v2 after release
-    unless current_user.allowed_features.include?("mapssdfsdf")
+    unless current_user.allowed_features.include?("maps")
       results = results.reject { |f| f[:key] == "collection_location_v2" }
     end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -498,6 +498,10 @@ class ProjectsController < ApplicationController
                              .includes(metadata_fields: [:host_genomes])
                              .map(&:metadata_fields).flatten.uniq.map(&:field_info)
               end
+    # TODO(jsheu): Migrate all to location_v2 after release
+    unless current_user.allowed_features.include?("mapssdfsdf")
+      results = results.reject { |f| f[:key] == "collection_location_v2" }
+    end
 
     render json: results
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHelper
 
   def request_context
     {
-      enabledFeatures: current_user && current_user.allowed_feature_list
+      allowedFeatures: current_user && current_user.allowed_feature_list
     }
   end
 

--- a/app/views/samples/show.html.erb
+++ b/app/views/samples/show.html.erb
@@ -24,6 +24,6 @@
       amr: JSON.parse('<%= raw escape_json(@amr_counts) %>'),
       allBackgrounds: JSON.parse('<%= raw escape_json(@background_models) %>'),
       savedParamValues: JSON.parse('<%= raw escape_json(@saved_param_values) %>'),
-    }, 'sample_view');
+    }, 'sample_view', JSON.parse('<%= raw escape_json(request_context)%>'));
   <% end %>
 </div>


### PR DESCRIPTION
### Description
- This PR adds 2 more locationV2 feature flags so that we can start adding collection_location_v2 to all the projects/samples and have it in the background. This also makes the flag work for turning v1/v2 on-and-off.
- Please ignore the `prettier` comma additions.
- Add a locationV2 feature flag in MetadataTab and one in ProjectsController#metadata_field.
- Rename old references to enabledFeatures to make it consistent with allowedFeatures.
- Remove redundant #request_context in ApplicationController (keep the one in ApplicationHelper per Tiago).

### Demo
- Without the flag:
<img width="462" alt="Screen Shot 2019-06-11 at 3 45 09 PM" src="https://user-images.githubusercontent.com/5652739/59311929-12b34b80-8c60-11e9-9555-ca56ecc7fc18.png">
<img width="322" alt="Screen Shot 2019-06-11 at 3 34 12 PM" src="https://user-images.githubusercontent.com/5652739/59311944-1ba41d00-8c60-11e9-8ac5-cf16c8bb6914.png">

- With the flag:
<img width="448" alt="Screen Shot 2019-06-11 at 3 32 38 PM" src="https://user-images.githubusercontent.com/5652739/59311954-22cb2b00-8c60-11e9-9c26-bdbe84a60a49.png">
<img width="284" alt="Screen Shot 2019-06-11 at 3 43 30 PM" src="https://user-images.githubusercontent.com/5652739/59311962-265eb200-8c60-11e9-9b65-20bc243dccdd.png">

### Test and Reproduce
- Go to the right sidebar on a sample, project-level metadata upload modal, and new /samples/upload flow, and make sure you don't see locationV2 if you don't have "maps" enabled.
- I also made sure that it doesn't show up in the project-level modal even if you have values filled in for all of those.