### PR TITLE
Add status URL to long running message

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -923,7 +923,7 @@ class PipelineRun < ApplicationRecord
     if alert_sent.zero?
       threshold = 8.hours
       if run_time > threshold
-        msg = "LongRunningSampleEvent: Sample #{sample.id} by #{sample.user.role_name} has been running #{duration_hrs} hours. #{job_status_display}" \
+        msg = "LongRunningSampleEvent: Sample #{sample.id} by #{sample.user.role_name} has been running #{duration_hrs} hours. #{job_status_display} " \
           "See: #{status_url}"
         LogUtil.log_err_and_airbrake(msg)
         update(alert_sent: 1)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -923,7 +923,8 @@ class PipelineRun < ApplicationRecord
     if alert_sent.zero?
       threshold = 8.hours
       if run_time > threshold
-        msg = "LongRunningSampleEvent: Sample #{sample.id} has been running for #{duration_hrs} hours. #{job_status_display}."
+        msg = "LongRunningSampleEvent: Sample #{sample.id} by #{sample.user.role_name} has been running #{duration_hrs} hours. #{job_status_display}" \
+          "See: #{status_url}"
         LogUtil.log_err_and_airbrake(msg)
         update(alert_sent: 1)
       end


### PR DESCRIPTION
# Description

Makes it possible to investigate by phone. 

```
[2019-06-12T17:15:35] ERROR Rails : LongRunningSampleEvent: Sample 12766 by admin user has been running 140.89 hours. CHECKED. See: https://idseq.net/samples/12766/pipeline_runs
```

# Test

Open pr in rails c
set threshold to zero
run check_and_log_long_run
see new error message