### PR TITLE
Add trailing comma to all js and jsx files

### DIFF
--- a/app/assets/src/api/analytics.js
+++ b/app/assets/src/api/analytics.js
@@ -11,7 +11,7 @@ import { isArray, isObject, camelCase, snakeCase, lowerFirst } from "lodash/fp";
 // ANALYTICS_EVENT_NAMES, which does not require registration here and uses a
 // more elaborate naming convention.
 export const ANALYTICS_EVENT_NAMES = {
-  sampleViewed: "sample_viewed"
+  sampleViewed: "sample_viewed",
 };
 
 // See https://czi.quip.com/bKDnAITc6CbE/How-to-start-instrumenting-analytics-2019-03-06
@@ -34,7 +34,7 @@ export const logAnalyticsEvent = async (eventName, eventData = {}) => {
         label: JSON.stringify(eventData),
         category: eventName.split("_")[0],
         // caller can override above traits if they know what they are doing
-        ...eventData
+        ...eventData,
       };
     }
     window.analytics.track(eventName, eventData);

--- a/app/assets/src/api/core.js
+++ b/app/assets/src/api/core.js
@@ -5,7 +5,7 @@ const postWithCSRF = async (url, params) => {
     const resp = await axios.post(url, {
       ...params,
       // Fetch the CSRF token from the DOM.
-      authenticity_token: document.getElementsByName("csrf-token")[0].content
+      authenticity_token: document.getElementsByName("csrf-token")[0].content,
     });
 
     // Just return the data.
@@ -22,7 +22,7 @@ const putWithCSRF = async (url, params) => {
     const resp = await axios.put(url, {
       ...params,
       // Fetch the CSRF token from the DOM.
-      authenticity_token: document.getElementsByName("csrf-token")[0].content
+      authenticity_token: document.getElementsByName("csrf-token")[0].content,
     });
 
     // Just return the data.
@@ -54,8 +54,8 @@ const deleteWithCSRF = async url => {
     const resp = await axios.delete(url, {
       data: {
         // Fetch the CSRF token from the DOM.
-        authenticity_token: document.getElementsByName("csrf-token")[0].content
-      }
+        authenticity_token: document.getElementsByName("csrf-token")[0].content,
+      },
     });
 
     return resp.data;

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -13,7 +13,7 @@ import { get, postWithCSRF, putWithCSRF, deleteWithCSRF } from "./core";
 const saveSampleField = (id, field, value) =>
   postWithCSRF(`/samples/${id}/save_metadata`, {
     field,
-    value
+    value,
   });
 
 const saveSampleName = (id, name) => saveSampleField(id, "name", name);
@@ -55,12 +55,12 @@ const createSample = (
       return {
         source_type: sourceType,
         source: cleanFilePath(file.name),
-        parts: cleanFilePath(file.name)
+        parts: cleanFilePath(file.name),
       };
     } else {
       return {
         source_type: sourceType,
-        source: file
+        source: file,
       };
     }
   });
@@ -80,8 +80,8 @@ const createSample = (
       pipeline_branch: pipelineBranch,
       dag_vars: dagVariables,
       max_input_fragments: maxInputFragments,
-      subsample: subsample
-    }
+      subsample: subsample,
+    },
   });
 };
 
@@ -90,13 +90,13 @@ const getAllHostGenomes = () => get("/host_genomes.json");
 // TODO(mark): Remove this method once we launch the new sample upload flow.
 const bulkUploadRemoteSamples = samples =>
   postWithCSRF(`/samples/bulk_upload.json`, {
-    samples
+    samples,
   });
 
 const saveVisualization = (type, data) =>
   postWithCSRF(`/visualizations/${type}/save`, {
     type,
-    data
+    data,
   });
 
 const shortenUrl = url => postWithCSRF("/visualizations/shorten_url", { url });
@@ -106,16 +106,16 @@ const bulkImportRemoteSamples = ({ projectId, hostGenomeId, bulkPath }) =>
     params: {
       project_id: projectId,
       host_genome_id: hostGenomeId,
-      bulk_path: bulkPath
-    }
+      bulk_path: bulkPath,
+    },
   });
 
 const markSampleUploaded = sampleId =>
   putWithCSRF(`/samples/${sampleId}.json`, {
     sample: {
       id: sampleId,
-      status: "uploaded"
-    }
+      status: "uploaded",
+    },
   });
 
 const uploadFileToUrl = async (
@@ -124,7 +124,7 @@ const uploadFileToUrl = async (
   { onUploadProgress, onSuccess, onError }
 ) => {
   const config = {
-    onUploadProgress
+    onUploadProgress,
   };
 
   return axios
@@ -140,7 +140,7 @@ const uploadFileToUrlWithRetries = async (
   { onUploadProgress, onSuccess, onError }
 ) => {
   const config = {
-    onUploadProgress
+    onUploadProgress,
   };
 
   // Retry up to 5 times with a 30s delay. axiosRetry interceptor means that 'catch' won't be
@@ -149,7 +149,7 @@ const uploadFileToUrlWithRetries = async (
   axiosRetry(client, {
     retries: 5,
     retryDelay: () => 30000,
-    retryCondition: () => true
+    retryCondition: () => true,
   });
 
   return client
@@ -167,7 +167,7 @@ const getTaxonDistributionForBackground = (backgroundId, taxonId) =>
 const getSampleTaxons = (params, cancelToken) =>
   get("/visualizations/samples_taxons.json", {
     params,
-    cancelToken
+    cancelToken,
   });
 
 // TODO(tiago): still needs to accepts field to sort by
@@ -179,7 +179,7 @@ const getSamples = ({
   offset,
   filters,
   listAllIds,
-  sampleIds
+  sampleIds,
 } = {}) =>
   get("/samples/index_v2.json", {
     params: {
@@ -191,8 +191,8 @@ const getSamples = ({
       listAllIds,
       // &sampleIds=[1,2] instead of default &sampleIds[]=1&sampleIds[]=2 format.
       sampleIds: JSON.stringify(sampleIds),
-      ...filters
-    }
+      ...filters,
+    },
   });
 
 const getSampleDimensions = ({ domain, filters, projectId, search }) =>
@@ -201,8 +201,8 @@ const getSampleDimensions = ({ domain, filters, projectId, search }) =>
       domain,
       projectId,
       search,
-      ...filters
-    }
+      ...filters,
+    },
   });
 
 const getSampleStats = ({ domain, filters, projectId, search }) =>
@@ -211,8 +211,8 @@ const getSampleStats = ({ domain, filters, projectId, search }) =>
       domain,
       projectId,
       search,
-      ...filters
-    }
+      ...filters,
+    },
   });
 
 const getProjectDimensions = ({ domain, filters, projectId, search }) =>
@@ -221,8 +221,8 @@ const getProjectDimensions = ({ domain, filters, projectId, search }) =>
       domain,
       search,
       projectId,
-      ...filters
-    }
+      ...filters,
+    },
   });
 
 const getSamplesV1 = params => get("/samples.json", { params });
@@ -234,8 +234,8 @@ const getProjects = ({ domain, filters, search, projectId, basic } = {}) =>
       search,
       projectId,
       basic,
-      ...filters
-    }
+      ...filters,
+    },
   });
 
 const getVisualizations = ({ domain, filters, search } = {}) =>
@@ -243,13 +243,13 @@ const getVisualizations = ({ domain, filters, search } = {}) =>
     params: {
       domain,
       search,
-      ...filters
-    }
+      ...filters,
+    },
   });
 
 const createProject = params =>
   postWithCSRF("/projects.json", {
-    project: params
+    project: params,
   });
 
 const validateSampleNames = (projectId, sampleNames) => {
@@ -258,7 +258,7 @@ const validateSampleNames = (projectId, sampleNames) => {
   }
 
   return postWithCSRF(`/projects/${projectId}/validate_sample_names`, {
-    sample_names: sampleNames
+    sample_names: sampleNames,
   });
 };
 
@@ -268,7 +268,7 @@ const validateSampleFiles = sampleFiles => {
   }
 
   return postWithCSRF(`/samples/validate_sample_files`, {
-    sample_files: sampleFiles
+    sample_files: sampleFiles,
   });
 };
 
@@ -277,15 +277,15 @@ const getSearchSuggestions = ({ categories, query, domain }) =>
     params: {
       categories,
       query,
-      domain
-    }
+      domain,
+    },
   });
 
 const createBackground = ({ description, name, sampleIds }) =>
   postWithCSRF("/backgrounds", {
     name,
     description,
-    sample_ids: sampleIds
+    sample_ids: sampleIds,
   });
 
 const getCoverageVizSummary = sampleId =>
@@ -301,7 +301,7 @@ const getContigsSequencesByByteranges = (
 ) => {
   const params = getURLParamString({
     byteranges: byteranges.map(byterange => byterange.join(",")),
-    pipelineVersion
+    pipelineVersion,
   });
   return get(`/samples/${sampleId}/contigs_sequences_by_byteranges?${params}`);
 };
@@ -317,8 +317,8 @@ const getSamplesLocations = ({ domain, filters, projectId, search }) =>
       domain,
       search,
       projectId,
-      ...filters
-    }
+      ...filters,
+    },
   });
 
 export {
@@ -357,5 +357,5 @@ export {
   uploadFileToUrlWithRetries,
   validatePhyloTreeName,
   validateSampleFiles,
-  validateSampleNames
+  validateSampleNames,
 };

--- a/app/assets/src/api/locations.js
+++ b/app/assets/src/api/locations.js
@@ -2,5 +2,5 @@ import { get } from "./core";
 
 export const getGeoSearchSuggestions = query =>
   get("/locations/external_search", {
-    params: { query }
+    params: { query },
   });

--- a/app/assets/src/api/metadata.js
+++ b/app/assets/src/api/metadata.js
@@ -16,28 +16,28 @@ const getSampleMetadata = (id, pipelineVersion) => {
 const getSampleMetadataFields = ids =>
   get("/samples/metadata_fields", {
     params: {
-      sampleIds: flatten([ids])
-    }
+      sampleIds: flatten([ids]),
+    },
   });
 
 // Get MetadataField info for the sample(s) (either one ID or an array)
 const getProjectMetadataFields = ids =>
   get("/projects/metadata_fields", {
     params: {
-      projectIds: flatten([ids])
-    }
+      projectIds: flatten([ids]),
+    },
   });
 
 const saveSampleMetadata = (id, field, value) =>
   postWithCSRF(`/samples/${id}/save_metadata_v2`, {
     field,
-    value
+    value,
   });
 
 // Validate CSV metadata against samples in an existing project.
 const validateMetadataCSVForProject = (id, metadata) =>
   postWithCSRF(`/projects/${id}/validate_metadata_csv`, {
-    metadata
+    metadata,
   });
 
 // Validate manually input metadata against samples in an existing project.
@@ -57,7 +57,7 @@ const validateManualMetadataForProject = (id, metadata) => {
 const validateMetadataCSVForNewSamples = (samples, metadata) =>
   postWithCSRF("/metadata/validate_csv_for_new_samples", {
     metadata,
-    samples
+    samples,
   });
 
 // Validate manually input metadata for new samples.
@@ -74,7 +74,7 @@ const validateManualMetadataForNewSamples = (samples, metadata) => {
 
 const uploadMetadataForProject = (id, metadata) =>
   postWithCSRF(`/projects/${id}/upload_metadata`, {
-    metadata
+    metadata,
   });
 
 const getOfficialMetadataFields = () =>
@@ -85,7 +85,7 @@ const bulkUploadWithMetadata = (samples, metadata) =>
   postWithCSRF(`/samples/bulk_upload_with_metadata.json`, {
     samples,
     metadata,
-    client: "web"
+    client: "web",
   });
 
 export {
@@ -99,5 +99,5 @@ export {
   validateMetadataCSVForProject,
   validateMetadataCSVForNewSamples,
   validateManualMetadataForProject,
-  validateManualMetadataForNewSamples
+  validateManualMetadataForNewSamples,
 };

--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -2,7 +2,7 @@ import {
   bulkUploadRemoteSamples,
   createSample,
   markSampleUploaded,
-  uploadFileToUrlWithRetries
+  uploadFileToUrlWithRetries,
 } from "~/api";
 
 import { bulkUploadWithMetadata } from "~/api/metadata";
@@ -21,7 +21,7 @@ export const bulkUploadLocalWithMetadata = ({
   onUploadProgress,
   onUploadError,
   onAllUploadsComplete,
-  onMarkSampleUploadedError
+  onMarkSampleUploadedError,
 }) => {
   // Store the upload progress of file names, so we can track when
   // everything is done.
@@ -78,7 +78,7 @@ export const bulkUploadLocalWithMetadata = ({
               }
             },
             onSuccess: () => onFileUploadSuccess(sampleName, sample.id),
-            onError: error => onUploadError(file, error)
+            onError: error => onUploadError(file, error),
           });
         });
       });
@@ -99,7 +99,7 @@ export const bulkUploadLocal = ({
   onUploadProgress,
   onUploadError,
   onAllUploadsComplete,
-  onMarkSampleUploadedError
+  onMarkSampleUploadedError,
 }) => {
   // Store the upload progress of file names, so we can track when
   // everything is done.
@@ -157,7 +157,7 @@ export const bulkUploadLocal = ({
               }
             },
             onSuccess: () => onFileUploadSuccess(sampleName, sampleId),
-            onError: error => onUploadError(file, error)
+            onError: error => onUploadError(file, error),
           });
         });
       })

--- a/app/assets/src/components/AMRView.jsx
+++ b/app/assets/src/components/AMRView.jsx
@@ -7,37 +7,37 @@ const columns = [
   {
     Header: "Antibiotic Class",
     accessor: "drug_family",
-    filterable: false
+    filterable: false,
   },
   {
     Header: "Gene",
     accessor: "gene",
     aggregate: vals => "",
     style: {
-      textAlign: "center"
+      textAlign: "center",
     },
-    filterable: false
+    filterable: false,
   },
   {
     Header: "Coverage",
     accessor: "coverage",
     style: {
-      textAlign: "center"
+      textAlign: "center",
     },
     aggregate: vals => _.round(_.mean(vals)),
     filterMethod: (filter, row) => row[filter.id] >= filter.value,
-    Cell: props => parseFloat(props.value).toFixed(1)
+    Cell: props => parseFloat(props.value).toFixed(1),
   },
   {
     Header: "Depth",
     accessor: "depth",
     aggregate: vals => _.round(_.sum(vals)),
     style: {
-      textAlign: "center"
+      textAlign: "center",
     },
     filterMethod: (filter, row) => row[filter.id] >= filter.value,
-    Cell: props => parseFloat(props.value).toFixed(1)
-  }
+    Cell: props => parseFloat(props.value).toFixed(1),
+  },
 ];
 
 class AMRView extends React.Component {
@@ -72,8 +72,8 @@ class AMRView extends React.Component {
           defaultSorted={[
             {
               id: "coverage",
-              desc: true
-            }
+              desc: true,
+            },
           ]}
           className="-striped -highlight"
         />

--- a/app/assets/src/components/AccessionViz.jsx
+++ b/app/assets/src/components/AccessionViz.jsx
@@ -11,7 +11,7 @@ class AccessionViz extends React.Component {
     this.renderMoreReads = this.renderMoreReads.bind(this);
     this.state = {
       reads: this.allReads.slice(0, this.readsPerPage),
-      rendering: false
+      rendering: false,
     };
   }
 
@@ -29,7 +29,7 @@ class AccessionViz extends React.Component {
       numReads + this.readsPerPage
     );
     this.setState(prevState => ({
-      reads: [...prevState.reads, ...nextPageReads]
+      reads: [...prevState.reads, ...nextPageReads],
     }));
   }
 
@@ -96,7 +96,10 @@ class AccessionViz extends React.Component {
             onClick={withAnalytics(
               this.renderMoreReads,
               "AccessionViz_more-reads-link_clicked",
-              { reads: this.state.reads.length, allReads: this.allReads.length }
+              {
+                reads: this.state.reads.length,
+                allReads: this.allReads.length,
+              }
             )}
             style={{ cursor: "pointer" }}
           >

--- a/app/assets/src/components/BasicPopup.jsx
+++ b/app/assets/src/components/BasicPopup.jsx
@@ -13,11 +13,11 @@ class BasicPopup extends React.Component {
 
 BasicPopup.propTypes = {
   size: PropTypes.string,
-  wide: PropTypes.string
+  wide: PropTypes.string,
 };
 
 BasicPopup.defaultProps = {
-  size: "tiny"
+  size: "tiny",
 };
 
 export default BasicPopup;

--- a/app/assets/src/components/BulkUploadImport.jsx
+++ b/app/assets/src/components/BulkUploadImport.jsx
@@ -71,13 +71,13 @@ class BulkUploadImport extends React.Component {
       // Local upload fields
       localUploadMode: false,
       sampleNamesToFiles: {},
-      fileNamesToProgress: {}
+      fileNamesToProgress: {},
     };
   }
 
   componentDidUpdate() {
     $(".custom-select-dropdown").dropdown({
-      belowOrigin: true
+      belowOrigin: true,
     });
   }
 
@@ -102,7 +102,7 @@ class BulkUploadImport extends React.Component {
     $(".new-project-button").toggleClass("active");
     this.setState(
       {
-        disableProjectSelect: !this.state.disableProjectSelect
+        disableProjectSelect: !this.state.disableProjectSelect,
       },
       () => {
         this.initializeSelectTag();
@@ -112,7 +112,7 @@ class BulkUploadImport extends React.Component {
 
   selectSample(e) {
     this.setState({
-      allChecked: false
+      allChecked: false,
     });
     // current array of options
     const sampleList = this.state.selectedSampleIndices;
@@ -138,7 +138,7 @@ class BulkUploadImport extends React.Component {
       const checkedStatus = e.target.checked;
       this.setState(
         {
-          allChecked: checkedStatus
+          allChecked: checkedStatus,
         },
         () => {
           $("input:checkbox")
@@ -167,7 +167,7 @@ class BulkUploadImport extends React.Component {
       .animate({ scrollTop: 0 }, 200, "swing");
     if (!this.isUploadFormInvalid()) {
       this.setState({
-        submitting: true
+        submitting: true,
       });
       this.bulkUploadRemoteSubmit();
     }
@@ -179,20 +179,20 @@ class BulkUploadImport extends React.Component {
     if (!this.isImportFormInvalid()) {
       if (this.state.localUploadMode) {
         this.setState({
-          submitting: true
+          submitting: true,
         });
         this.props.onBulkUploadLocal({
           sampleNamesToFiles: this.state.sampleNamesToFiles,
           project: {
             name: this.state.project,
-            id: this.state.projectId
+            id: this.state.projectId,
           },
           hostId: this.state.hostId,
           onCreateSampleError: this.handleCreateLocalSampleError,
           onUploadProgress: this.handleLocalUploadProgress,
           onUploadError: this.handleLocalUploadError,
           onAllUploadsComplete: this.handleAllLocalUploadsComplete,
-          onMarkSampleUploadedError: this.handleMarkSampleUploadedError
+          onMarkSampleUploadedError: this.handleMarkSampleUploadedError,
         });
       } else {
         this.bulkUploadRemoteImport();
@@ -207,7 +207,7 @@ class BulkUploadImport extends React.Component {
       invalid: true,
       errorMessage: `${
         this.state.errorMessage
-      }\n\n${sampleName}: ${joinServerError(error)}`
+      }\n\n${sampleName}: ${joinServerError(error)}`,
     });
     this.onRemoved(sampleName);
   };
@@ -216,7 +216,7 @@ class BulkUploadImport extends React.Component {
     // Update the UI on progress
     // TODO: Maybe a circular progress indicator that will fill up.
     const newProgress = merge(this.state.fileNamesToProgress, {
-      [file.name]: percent
+      [file.name]: percent,
     });
     this.setState({ fileNamesToProgress: newProgress });
   };
@@ -224,7 +224,7 @@ class BulkUploadImport extends React.Component {
   handleLocalUploadError = (file, error) => {
     this.setState({
       invalid: true,
-      errorMessage: `${file.name}: ${joinServerError(error)}`
+      errorMessage: `${file.name}: ${joinServerError(error)}`,
     });
   };
 
@@ -233,7 +233,7 @@ class BulkUploadImport extends React.Component {
       submitting: false,
       successMessage: "All uploads finished!",
       success: true,
-      invalid: false
+      invalid: false,
     });
 
     openUrlWithTimeout(`/home?project_id=${this.state.projectId}`);
@@ -241,7 +241,7 @@ class BulkUploadImport extends React.Component {
 
   handleMarkSampleUploadedError = error => {
     this.setState({
-      errorMessage: `${this.state.errorMessage}. ${joinServerError(error)}`
+      errorMessage: `${this.state.errorMessage}. ${joinServerError(error)}`,
     });
   };
 
@@ -251,13 +251,13 @@ class BulkUploadImport extends React.Component {
 
   clearError() {
     this.setState({
-      invalid: false
+      invalid: false,
     });
   }
 
   toggleCheckBox(e) {
     this.setState({
-      [e.target.id]: e.target.value == "true" ? false : true
+      [e.target.id]: e.target.value == "true" ? false : true,
     });
   }
 
@@ -277,9 +277,9 @@ class BulkUploadImport extends React.Component {
       .post("/projects.json", {
         project: {
           name: this.refs.new_project.value,
-          public_access: this.state.publicChecked ? 1 : 0
+          public_access: this.state.publicChecked ? 1 : 0,
         },
-        authenticity_token: this.csrf
+        authenticity_token: this.csrf,
       })
       .then(response => {
         var newProjectList = that.state.allProjects.slice();
@@ -290,7 +290,7 @@ class BulkUploadImport extends React.Component {
             project: response.data.name,
             projectId: response.data.id,
             success: true,
-            successMessage: "Project added successfully"
+            successMessage: "Project added successfully",
           },
           () => {
             this.refs.new_project.value = "";
@@ -301,7 +301,7 @@ class BulkUploadImport extends React.Component {
       .catch(error => {
         that.setState({
           invalid: true,
-          errorMessage: "Project exists already or is invalid"
+          errorMessage: "Project exists already or is invalid",
         });
       });
   }
@@ -313,7 +313,7 @@ class BulkUploadImport extends React.Component {
     ) {
       this.setState({
         invalid: true,
-        errorMessage: "Please enter valid project name"
+        errorMessage: "Please enter valid project name",
       });
       return true;
     } else {
@@ -323,7 +323,7 @@ class BulkUploadImport extends React.Component {
 
   bulkUploadRemoteImport() {
     this.setState({
-      submitting: true
+      submitting: true,
     });
 
     var that = this;
@@ -333,8 +333,8 @@ class BulkUploadImport extends React.Component {
           project_id: this.state.projectId,
           host_genome_id: this.state.hostId,
           bulk_path: this.state.selectedBulkPath,
-          authenticity_token: this.csrf
-        }
+          authenticity_token: this.csrf,
+        },
       })
       .then(response => {
         that.setState({
@@ -342,7 +342,7 @@ class BulkUploadImport extends React.Component {
           success: true,
           successMessage: "Samples imported. Pick the ones you want to submit.",
           samples: response.data.samples,
-          imported: true
+          imported: true,
         });
         that.initializeSelectTag();
         that.initializeSelectAll();
@@ -353,7 +353,7 @@ class BulkUploadImport extends React.Component {
           submitting: false,
           invalid: true,
           errorMessage: error.response.data.status || "Something went wrong",
-          serverErrors: error.response.data
+          serverErrors: error.response.data,
         });
       });
   }
@@ -369,15 +369,15 @@ class BulkUploadImport extends React.Component {
         samples,
         project: {
           id: this.state.projectId,
-          name: this.state.project
-        }
+          name: this.state.project,
+        },
       })
       .then(response => {
         that.setState({
           success: true,
           successMessage: "Samples created. Redirecting...",
           createdSampleIds: response.sample_ids,
-          submitting: false
+          submitting: false,
         });
         openUrlWithTimeout(`/home?project_id=${that.state.projectId}`);
       })
@@ -389,7 +389,7 @@ class BulkUploadImport extends React.Component {
             error.status ||
             "Unable to process sample(s), " +
               "ensure sample is not a duplicate in the selected project",
-          serverErrors: error
+          serverErrors: error,
         });
       });
   }
@@ -418,7 +418,7 @@ class BulkUploadImport extends React.Component {
     const errorsLength = Object.keys(errors).length;
     this.setState({
       invalid: errorsLength > 0,
-      errors
+      errors,
     });
     return errorsLength;
   }
@@ -427,7 +427,7 @@ class BulkUploadImport extends React.Component {
     if (!this.state.selectedSampleIndices.length) {
       this.setState({
         invalid: true,
-        errorMessage: "Please select desired samples"
+        errorMessage: "Please select desired samples",
       });
       return true;
     }
@@ -441,7 +441,7 @@ class BulkUploadImport extends React.Component {
     }
     this.setState({
       project: e.target.value.trim(),
-      projectId: projectId
+      projectId: projectId,
     });
     this.clearError();
   }
@@ -458,7 +458,7 @@ class BulkUploadImport extends React.Component {
     const samples = this.state.samples;
     samples[samplesId].project_id = this.state.allProjects[projectId].id;
     this.setState({
-      samples: samples
+      samples: samples,
     });
     this.clearError();
     this.resolveSampleNames();
@@ -468,7 +468,7 @@ class BulkUploadImport extends React.Component {
     const samples = this.state.samples;
     samples[samplesId].host_genome_id = this.state.hostGenomes[hostGenomeId].id;
     this.setState({
-      samples: samples
+      samples: samples,
     });
     this.clearError();
   }
@@ -485,7 +485,7 @@ class BulkUploadImport extends React.Component {
         );
       logAnalyticsEvent(`BulkUploadImport_errors_displayed`, {
         serverErrors,
-        formattedError
+        formattedError,
       });
       return ret;
     } else {
@@ -500,7 +500,7 @@ class BulkUploadImport extends React.Component {
 
   handleBulkPathChange(e) {
     this.setState({
-      selectedBulkPath: e.target.value.trim()
+      selectedBulkPath: e.target.value.trim(),
     });
   }
 
@@ -513,7 +513,7 @@ class BulkUploadImport extends React.Component {
         this.setState({
           successMessage: `${this.state.successMessage}\n\n${
             sample.name
-          } already exists, so name updated to ${resp[0]}.`
+          } already exists, so name updated to ${resp[0]}.`,
         });
         sample.name = resp[0];
       }
@@ -541,7 +541,7 @@ class BulkUploadImport extends React.Component {
                   {
                     samples: this.state.samples.length,
                     projectId: this.state.projectId,
-                    hostId: this.state.hostId
+                    hostId: this.state.hostId,
                   }
                 )}
               >
@@ -633,7 +633,7 @@ class BulkUploadImport extends React.Component {
                                           "BulkUploadImport_host-dropdown_clicked",
                                           {
                                             samplesId: i,
-                                            hostGenomeId: j
+                                            hostGenomeId: j,
                                           }
                                         );
                                       }}
@@ -682,7 +682,7 @@ class BulkUploadImport extends React.Component {
                                           "BulkUploadImport_project-dropdown_clicked",
                                           {
                                             samplesId: i,
-                                            hostGenomeId: j
+                                            hostGenomeId: j,
                                           }
                                         );
                                       }}
@@ -773,7 +773,7 @@ class BulkUploadImport extends React.Component {
       sampleNamesToFiles: merge(
         this.state.sampleNamesToFiles,
         sampleNamesToFiles
-      )
+      ),
     });
   };
 
@@ -783,7 +783,7 @@ class BulkUploadImport extends React.Component {
     this.setState(
       {
         sampleNamesToFiles: omit(sampleName, this.state.sampleNamesToFiles),
-        fileNamesToProgress: omit(sampleName, this.state.fileNamesToProgress)
+        fileNamesToProgress: omit(sampleName, this.state.fileNamesToProgress),
       },
       () => {
         // If there's nothing to upload anymore, submitting is no longer in progress
@@ -806,7 +806,7 @@ class BulkUploadImport extends React.Component {
           {
             projectId: this.state.projectId,
             hostId: this.state.hostId,
-            selectedBulkPath: this.state.selectedBulkPath
+            selectedBulkPath: this.state.selectedBulkPath,
           }
         )}
       >
@@ -1055,7 +1055,7 @@ class BulkUploadImport extends React.Component {
                         logAnalyticsEvent(
                           "BulkUploadImport_create-project-button_clicked",
                           {
-                            newProject
+                            newProject,
                           }
                         );
                       }
@@ -1140,7 +1140,7 @@ class BulkUploadImport extends React.Component {
                               "BulkUploadImport_host-selector_clicked",
                               {
                                 hostId: g.id,
-                                hostName: g.name
+                                hostName: g.name,
                               }
                             );
                           }}
@@ -1193,7 +1193,7 @@ class BulkUploadImport extends React.Component {
               checked={this.state.consentChecked}
               onChange={() =>
                 this.setState({
-                  consentChecked: !this.state.consentChecked
+                  consentChecked: !this.state.consentChecked,
                 })
               }
             />
@@ -1234,7 +1234,7 @@ BulkUploadImport.propTypes = {
   projects: PropTypes.arrayOf(PropTypes.Project),
   csrf: PropTypes.string,
   host_genomes: PropTypes.arrayOf(PropTypes.HostGenome),
-  admin: PropTypes.bool
+  admin: PropTypes.bool,
 };
 
 export default BulkUploadImport;

--- a/app/assets/src/components/CreateUser.jsx
+++ b/app/assets/src/components/CreateUser.jsx
@@ -25,7 +25,7 @@ class CreateUser extends React.Component {
       password: "",
       id: this.user ? this.user.id : null,
       password_confirmation: "",
-      adminStatus: this.user ? this.user.admin : null
+      adminStatus: this.user ? this.user.admin : null,
     };
     this.state = {
       submitting: false,
@@ -40,7 +40,7 @@ class CreateUser extends React.Component {
       password: this.selectedUser.password || "",
       pConfirm: this.selectedUser.password_confirmation || "",
       adminstatus: this.selectedUser.adminStatus,
-      id: this.selectedUser.id
+      id: this.selectedUser.id,
     };
   }
 
@@ -48,7 +48,7 @@ class CreateUser extends React.Component {
     e.preventDefault();
     if (!this.isCreateFormInvalid()) {
       this.setState({
-        submitting: true
+        submitting: true,
       });
       this.createUser();
     }
@@ -58,7 +58,7 @@ class CreateUser extends React.Component {
     e.preventDefault();
     if (!this.isUpdateFormValid()) {
       this.setState({
-        submitting: true
+        submitting: true,
       });
       this.updateUser();
     }
@@ -71,37 +71,37 @@ class CreateUser extends React.Component {
   toggleCheckBox(e) {
     this.setState({
       isAdmin: e.target.value == "true" ? false : true,
-      adminstatus: e.target.value == "true" ? false : true
+      adminstatus: e.target.value == "true" ? false : true,
     });
   }
 
   handlePasswordChange(e) {
     this.setState({
-      password: e.target.value
+      password: e.target.value,
     });
   }
 
   handlePConfirmChange(e) {
     this.setState({
-      pConfirm: e.target.value
+      pConfirm: e.target.value,
     });
   }
 
   handleEmailChange(e) {
     this.setState({
-      email: e.target.value
+      email: e.target.value,
     });
   }
 
   handleNameChange(e) {
     this.setState({
-      name: e.target.value
+      name: e.target.value,
     });
   }
 
   handleInstitutionChange(e) {
     this.setState({
-      institution: e.target.value
+      institution: e.target.value,
     });
   }
 
@@ -113,19 +113,19 @@ class CreateUser extends React.Component {
     ) {
       this.setState({
         showFailed: true,
-        errorMessage: "Please fill all fields"
+        errorMessage: "Please fill all fields",
       });
       return true;
     } else if (this.state.password === "") {
       this.setState({
         showFailed: true,
-        errorMessage: "Please enter password"
+        errorMessage: "Please enter password",
       });
       return true;
     } else if (this.state.password_confirmation === "") {
       this.setState({
         showFailed: true,
-        errorMessage: "Please re-enter password"
+        errorMessage: "Please re-enter password",
       });
       return true;
     } else {
@@ -137,7 +137,7 @@ class CreateUser extends React.Component {
     if (this.state.email === "") {
       this.setState({
         showFailed: true,
-        errorMessage: "Please enter valid email address"
+        errorMessage: "Please enter valid email address",
       });
       return true;
     } else {
@@ -157,8 +157,8 @@ class CreateUser extends React.Component {
             institution: this.state.institution,
             password: this.state.password,
             password_confirmation: this.state.password_confirmation,
-            role: this.state.isAdmin ? 1 : 0
-          }
+            role: this.state.isAdmin ? 1 : 0,
+          },
         },
         { headers: { "X-CSRF-TOKEN": this.csrf } }
       )
@@ -167,7 +167,7 @@ class CreateUser extends React.Component {
           {
             submitting: false,
             success: true,
-            successMessage: "User created successfully"
+            successMessage: "User created successfully",
           },
           () => {
             openUrl("/users");
@@ -178,7 +178,7 @@ class CreateUser extends React.Component {
         that.setState({
           submitting: false,
           showFailed: true,
-          serverErrors: err.response.data
+          serverErrors: err.response.data,
         });
       });
   }
@@ -195,8 +195,8 @@ class CreateUser extends React.Component {
             institution: this.state.institution,
             password: this.state.password,
             password_confirmation: this.state.pConfirm,
-            role: this.state.adminstatus ? 1 : 0
-          }
+            role: this.state.adminstatus ? 1 : 0,
+          },
         },
         { headers: { "X-CSRF-TOKEN": this.csrf } }
       )
@@ -205,7 +205,7 @@ class CreateUser extends React.Component {
           {
             success: true,
             submitting: false,
-            successMessage: "User updated successfully"
+            successMessage: "User updated successfully",
           },
           () => {
             openUrl("/users");
@@ -216,7 +216,7 @@ class CreateUser extends React.Component {
         that.setState({
           showFailed: true,
           submitting: false,
-          serverErrors: err.response.data
+          serverErrors: err.response.data,
         });
       });
   }
@@ -238,7 +238,7 @@ class CreateUser extends React.Component {
       logAnalyticsEvent(`CreateUser_${form}-errors_displayed`, {
         form,
         serverErrors,
-        formattedError
+        formattedError,
       });
       return ret;
     } else {

--- a/app/assets/src/components/ERCCScatterPlot.jsx
+++ b/app/assets/src/components/ERCCScatterPlot.jsx
@@ -14,7 +14,7 @@ class ERCCScatterPlot extends React.Component {
         data.push({
           name: row.name,
           actual: Math.log10(row.actual),
-          expected: Math.log10(row.expected)
+          expected: Math.log10(row.expected),
         });
       }
     }
@@ -39,7 +39,7 @@ class ERCCScatterPlot extends React.Component {
 ERCCScatterPlot.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
-  ercc_comparison: PropTypes.ERCCComparison
+  ercc_comparison: PropTypes.ERCCComparison,
 };
 
 export default ERCCScatterPlot;

--- a/app/assets/src/components/ForgotPassword.jsx
+++ b/app/assets/src/components/ForgotPassword.jsx
@@ -43,14 +43,14 @@ ForgotPassword.propTypes = {
   endpoint: PropTypes.string,
   errors: PropTypes.string,
   csrf: PropTypes.string,
-  emailLabel: PropTypes.string
+  emailLabel: PropTypes.string,
 };
 
 ForgotPassword.defaultProps = {
   endpoint: PropTypes.string,
   errors: PropTypes.string,
   csrf: PropTypes.string,
-  emailLabel: PropTypes.string
+  emailLabel: PropTypes.string,
 };
 
 export default ForgotPassword;

--- a/app/assets/src/components/Login.jsx
+++ b/app/assets/src/components/Login.jsx
@@ -19,7 +19,7 @@ class Login extends React.Component {
       success: false,
       showFailedLogin: false,
       errorMessage: "",
-      successMessage: ""
+      successMessage: "",
     };
   }
 
@@ -34,7 +34,7 @@ class Login extends React.Component {
   clearError() {
     this.setState({
       showFailedLogin: false,
-      success: false
+      success: false,
     });
   }
 
@@ -45,15 +45,15 @@ class Login extends React.Component {
         user: {
           email: this.refs.email ? this.refs.email.value : "",
           password: this.refs.password ? this.refs.password.value : "",
-          remember_me: this.refs.remember_me ? this.refs.remember_me.value : ""
+          remember_me: this.refs.remember_me ? this.refs.remember_me.value : "",
         },
-        authenticity_token: this.csrf
+        authenticity_token: this.csrf,
       })
       .then(response => {
         that.setState(
           {
             success: true,
-            successMessage: "User signed in"
+            successMessage: "User signed in",
           },
           () => {
             openUrl("/");
@@ -64,13 +64,13 @@ class Login extends React.Component {
         that.setState(
           {
             showFailedLogin: true,
-            errorMessage: "Invalid Email or Password"
+            errorMessage: "Invalid Email or Password",
           },
           () =>
             logAnalyticsEvent(
               "Login_invalid-email-or-password-error_displayed",
               {
-                errorMessage: this.state.errorMessage
+                errorMessage: this.state.errorMessage,
               }
             )
         );
@@ -80,14 +80,14 @@ class Login extends React.Component {
   isFormInValid() {
     const logError = () =>
       logAnalyticsEvent("Login_login-form-error_displayed", {
-        errorMessage: this.state.errorMessage
+        errorMessage: this.state.errorMessage,
       });
 
     if (this.refs.email.value === "" && this.refs.password.value === "") {
       this.setState(
         {
           showFailedLogin: true,
-          errorMessage: "Please enter email and password"
+          errorMessage: "Please enter email and password",
         },
         logError
       );
@@ -96,7 +96,7 @@ class Login extends React.Component {
       this.setState(
         {
           showFailedLogin: true,
-          errorMessage: "Please enter email"
+          errorMessage: "Please enter email",
         },
         logError
       );
@@ -105,7 +105,7 @@ class Login extends React.Component {
       this.setState(
         {
           showFailedLogin: true,
-          errorMessage: "Please enter password"
+          errorMessage: "Please enter password",
         },
         logError
       );
@@ -118,7 +118,7 @@ class Login extends React.Component {
   toggleCheckBox() {
     var checkboxValue = $("#remember_me").prop("checked");
     this.setState({
-      isChecked: checkboxValue
+      isChecked: checkboxValue,
     });
     this.state.isChecked = !this.state.isChecked;
   }
@@ -154,7 +154,7 @@ class Login extends React.Component {
                   email: this.refs.email ? this.refs.email.value : "",
                   remember_me: this.refs.remember_me
                     ? this.refs.remember_me.value
-                    : ""
+                    : "",
                 }
               )}
             >

--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -11,7 +11,7 @@ import {
   map,
   mapValues,
   get,
-  find
+  find,
 } from "lodash/fp";
 import Nanobar from "nanobar";
 import PropTypes from "prop-types";
@@ -27,7 +27,7 @@ import {
   isTaxonIncluded,
   getTaxonSortComparator,
   getCategoryAdjective,
-  addContigCountsToTaxonomyDetails
+  addContigCountsToTaxonomyDetails,
 } from "./views/report/utils/taxon";
 import BasicPopup from "./BasicPopup";
 import ThresholdFilterDropdown from "./ui/controls/dropdowns/ThresholdFilterDropdown";
@@ -51,7 +51,7 @@ import { getTaxonName, getGeneraContainingTags } from "../helpers/taxon";
 import ThresholdMap from "./utils/ThresholdMap";
 import {
   pipelineVersionHasAssembly,
-  pipelineVersionHasCoverageViz
+  pipelineVersionHasCoverageViz,
 } from "./utils/sample";
 
 const DEFAULT_MIN_CONTIG_SIZE = 4;
@@ -62,7 +62,7 @@ class PipelineSampleReport extends React.Component {
     super(props);
     this.nanobar = new Nanobar({
       id: "prog-bar",
-      class: "prog-bar"
+      class: "prog-bar",
     });
     this.admin = props.admin;
     this.allowedFeatures = props.allowedFeatures;
@@ -111,7 +111,7 @@ class PipelineSampleReport extends React.Component {
       { text: "NR contig reads", value: "NR_contigreads" },
       { text: "NR %id", value: "NR_percentidentity" },
       { text: "NR L (alignment length in bp)", value: "NR_alignmentlength" },
-      { text: "NR log(1/e)", value: "NR_neglogevalue" }
+      { text: "NR log(1/e)", value: "NR_neglogevalue" },
     ];
 
     // If the saved threshold object doesn't have metricDisplay, add it. For backwards compatibility.
@@ -121,7 +121,7 @@ class PipelineSampleReport extends React.Component {
           "text",
           find(["value", threshold.metric], this.allThresholds)
         ),
-        ...threshold
+        ...threshold,
       }),
       ThresholdMap.getSavedThresholdFilters()
     );
@@ -133,7 +133,7 @@ class PipelineSampleReport extends React.Component {
       { text: "NT r (total reads)", value: "nt_r" },
       { text: "NT rPM", value: "nt_rpm" },
       { text: "NR r (total reads)", value: "nr_r" },
-      { text: "NR rPM", value: "nr_rpm" }
+      { text: "NR rPM", value: "nr_rpm" },
     ];
 
     this.categoryChildParent = { Phage: "Viruses" };
@@ -158,7 +158,7 @@ class PipelineSampleReport extends React.Component {
       topScoringTaxa: [],
       backgroundData: {
         id: defaultBackgroundId,
-        name: ""
+        name: "",
       },
       search_taxon_id: 0,
       lineage_map: {},
@@ -189,7 +189,7 @@ class PipelineSampleReport extends React.Component {
       phyloTreeModalOpen: true,
       contigTaxidList: [],
       minContigSize: cachedMinContigSize || DEFAULT_MIN_CONTIG_SIZE,
-      hoverRowId: null
+      hoverRowId: null,
     };
 
     this.state = {
@@ -197,7 +197,7 @@ class PipelineSampleReport extends React.Component {
       // Override from explicit save
       ...props.savedParamValues,
       // Override from the URL
-      ...parseUrlParams()
+      ...parseUrlParams(),
     };
 
     this.expandAll = false;
@@ -231,7 +231,7 @@ class PipelineSampleReport extends React.Component {
   fetchReportData = async () => {
     this.nanobar.go(30);
     this.setState({
-      loading: true
+      loading: true,
     });
     let params = `?${window.location.search.replace("?", "")}&report_ts=${
       this.report_ts
@@ -239,7 +239,7 @@ class PipelineSampleReport extends React.Component {
 
     const [sampleReportInfo, summaryContigCounts] = await Promise.all([
       getSampleReportInfo(this.sampleId, params),
-      getSummaryContigCounts(this.sampleId, this.state.minContigSize)
+      getSummaryContigCounts(this.sampleId, this.state.minContigSize),
     ]);
 
     this.nanobar.go(100);
@@ -259,7 +259,7 @@ class PipelineSampleReport extends React.Component {
       map(taxon => ({
         taxonId: taxon.tax_id,
         taxonName: taxon.name,
-        taxonCommonName: taxon.common_name
+        taxonCommonName: taxon.common_name,
       })),
       groupBy("genus_taxid", speciesTaxons)
     );
@@ -279,9 +279,9 @@ class PipelineSampleReport extends React.Component {
         topScoringTaxa: sampleReportInfo.topScoringTaxa,
         backgroundData: {
           id: sampleReportInfo.background_info.id,
-          name: sampleReportInfo.background_info.name
+          name: sampleReportInfo.background_info.name,
         },
-        contigTaxidList: sampleReportInfo.contig_taxid_list
+        contigTaxidList: sampleReportInfo.contig_taxid_list,
       },
       () => {
         this.applyFilters(true);
@@ -313,7 +313,7 @@ class PipelineSampleReport extends React.Component {
         ),
         pagesRendered: 1,
         rows_passing_filters: this.state.taxonomy_details.length,
-        readSpecificity: 0
+        readSpecificity: 0,
       },
       () => {
         ThresholdMap.saveThresholdFilters([]);
@@ -369,7 +369,7 @@ class PipelineSampleReport extends React.Component {
             taxon.lineage.class_taxid,
             taxon.lineage.phylum_taxid,
             taxon.lineage.kingdom_taxid,
-            taxon.lineage.superkingdom_taxid
+            taxon.lineage.superkingdom_taxid,
           ]);
           if (match_keys && match_keys.has(searchTaxonId)) {
             matched_taxons.push(taxon);
@@ -468,7 +468,7 @@ class PipelineSampleReport extends React.Component {
       selected_taxons,
       selected_taxons_top: selected_taxons.slice(0, this.max_rows_to_render),
       pagesRendered: 1,
-      rows_passing_filters: selected_taxons.length
+      rows_passing_filters: selected_taxons.length,
     });
   };
 
@@ -549,7 +549,7 @@ class PipelineSampleReport extends React.Component {
       );
       this.setState(prevState => ({
         selected_taxons_top: [...prevState.selected_taxons_top, ...next_page],
-        pagesRendered: currentPage + 1
+        pagesRendered: currentPage + 1,
       }));
     }
   };
@@ -562,7 +562,7 @@ class PipelineSampleReport extends React.Component {
         delay: 0,
         html: true,
         placement: "top",
-        offset: "0px 50px"
+        offset: "0px 50px",
       });
       $(".sort-controls").hover(() => {
         const selectTooltip = $(".tooltip");
@@ -588,7 +588,7 @@ class PipelineSampleReport extends React.Component {
     secondary_sort[0] = secondary_sort[0].toUpperCase();
     this.sortParams = {
       primary: primary_sort,
-      secondary: secondary_sort
+      secondary: secondary_sort,
     };
   };
 
@@ -608,7 +608,7 @@ class PipelineSampleReport extends React.Component {
     this.setState(
       {
         includedCategories: newIncludedCategories,
-        includedSubcategories
+        includedSubcategories,
       },
       () => {
         Cookies.set(
@@ -622,7 +622,7 @@ class PipelineSampleReport extends React.Component {
         this.applyFilters();
         logAnalyticsEvent("PipelineSampleReport_included-categories_changed", {
           includedCategories: this.state.includedCategories.length,
-          includedSubcategories: includedSubcategories.length
+          includedSubcategories: includedSubcategories.length,
         });
       }
     );
@@ -664,7 +664,7 @@ class PipelineSampleReport extends React.Component {
     this.setState({
       selected_taxons: selected_taxons,
       selected_taxons_top: selected_taxons.slice(0, this.max_rows_to_render),
-      pagesRendered: 1
+      pagesRendered: 1,
     });
     this.thresholded_taxons = this.thresholded_taxons.sort(taxonSortComparator);
     this.state.taxonomy_details = this.state.taxonomy_details.sort(
@@ -696,15 +696,15 @@ class PipelineSampleReport extends React.Component {
       {
         backgroundData: {
           name: backgroundName,
-          id: backgroundId
-        }
+          id: backgroundId,
+        },
       },
       () => {
         logAnalyticsEvent(
           "PipelineSampleReport_background-model-filter_changed",
           {
             backgroundName,
-            backgroundId
+            backgroundId,
           }
         );
         // TODO (gdingle): do we really want to reload the page here?
@@ -716,7 +716,7 @@ class PipelineSampleReport extends React.Component {
   handleNameTypeChange = nameType => {
     this.props.onNameTypeChange(nameType);
     logAnalyticsEvent("PipelineSampleReport_name-type-filter_changed", {
-      nameType
+      nameType,
     });
   };
 
@@ -725,7 +725,7 @@ class PipelineSampleReport extends React.Component {
     this.setState({ readSpecificity }, () => {
       this.applyFilters();
       logAnalyticsEvent("PipelineSampleReport_specificity-filter_changed", {
-        readSpecificity
+        readSpecificity,
       });
     });
   };
@@ -734,7 +734,7 @@ class PipelineSampleReport extends React.Component {
     Cookies.set("treeMetric", treeMetric);
     this.setState({ treeMetric }, () => {
       logAnalyticsEvent("PipelineSampleReport_tree-metric-picker_changed", {
-        treeMetric
+        treeMetric,
       });
     });
   };
@@ -743,7 +743,7 @@ class PipelineSampleReport extends React.Component {
     Cookies.set("minContigSize", minContigSize);
     this.setState({ minContigSize }, () => {
       logAnalyticsEvent("PipelineSampleReport_min-contig-size-filter_changed", {
-        minContigSize
+        minContigSize,
       });
     });
 
@@ -760,7 +760,7 @@ class PipelineSampleReport extends React.Component {
 
     this.setState(
       {
-        taxonomy_details: taxonomyDetails
+        taxonomy_details: taxonomyDetails,
       },
       () => {
         // Since the contig columns have changed, we need to maybe compute the thresholds again.
@@ -817,7 +817,7 @@ class PipelineSampleReport extends React.Component {
         taxCommonName,
         taxLevel,
         alignmentVizUrl,
-        speciesTaxons
+        speciesTaxons,
       });
     } else {
       window.open(alignmentVizUrl);
@@ -851,7 +851,7 @@ class PipelineSampleReport extends React.Component {
       sampleId: this.sampleId,
       taxId: taxInfo.tax_id,
       taxLevel: taxInfo.tax_level,
-      taxName: taxInfo.name
+      taxName: taxInfo.name,
     };
     return (
       <HoverActions
@@ -919,7 +919,7 @@ class PipelineSampleReport extends React.Component {
       onTaxonClick({
         taxInfo: tax_info,
         backgroundData,
-        taxonName
+        taxonName,
       });
 
     if (tax_info.tax_id > 0) {
@@ -1074,7 +1074,7 @@ class PipelineSampleReport extends React.Component {
           logAnalyticsEvent("PipelineSampleReport_column-sort-arrow_clicked", {
             column,
             desiredSortDirection,
-            arrowDirection
+            arrowDirection,
           });
         }}
         className={className}
@@ -1095,7 +1095,7 @@ class PipelineSampleReport extends React.Component {
         onClick={() => {
           this.applySort(columnName);
           logAnalyticsEvent("PipelineSampleReport_column-header_clicked", {
-            columnName
+            columnName,
           });
         }}
       >
@@ -1192,12 +1192,12 @@ class PipelineSampleReport extends React.Component {
   searchSelectedTaxon = (e, { result }) => {
     this.setState(
       {
-        search_taxon_id: result.taxid
+        search_taxon_id: result.taxid,
       },
       () => {
         this.applyFilters();
         logAnalyticsEvent("PipelineSampleReport_taxon-search_returned", {
-          search_taxon_id: result.taxid
+          search_taxon_id: result.taxid,
         });
       }
     );
@@ -1304,7 +1304,7 @@ class PipelineSampleReport extends React.Component {
             logAnalyticsEvent("PipelineSampleReport_threshold-filter_removed", {
               value: threshold.value,
               operator: threshold.operator,
-              metric: threshold.metric
+              metric: threshold.metric,
             });
           }}
         />
@@ -1323,7 +1323,7 @@ class PipelineSampleReport extends React.Component {
               logAnalyticsEvent(
                 "PipelineSampleReport_categories-filter_removed",
                 {
-                  category
+                  category,
                 }
               );
             }}
@@ -1344,7 +1344,7 @@ class PipelineSampleReport extends React.Component {
               logAnalyticsEvent(
                 "PipelineSampleReport_subcategories-filter_removed",
                 {
-                  subcat
+                  subcat,
                 }
               );
             }}
@@ -1388,7 +1388,7 @@ function CollapseExpand({ tax_info, parent }) {
             parent.collapseGenus,
             "PipelineSampleReport_collapse-genus_clicked",
             {
-              tax_id: tax_info.tax_id
+              tax_id: tax_info.tax_id,
             }
           )}
         />
@@ -1404,7 +1404,7 @@ function CollapseExpand({ tax_info, parent }) {
             parent.expandGenusClick,
             "PipelineSampleReport_expand-genus_clicked",
             {
-              tax_id: tax_info.tax_id
+              tax_id: tax_info.tax_id,
             }
           )}
         />
@@ -1480,7 +1480,7 @@ class RenderMarkup extends React.Component {
               serverSearchActionArgs={{
                 // TODO (gdingle): change backend to support filter by sampleId
                 args: "species,genus",
-                project_id: parent.projectId
+                project_id: parent.projectId,
               }}
               onResultSelect={parent.searchSelectedTaxon}
               placeholder="Taxon name"
@@ -1514,7 +1514,7 @@ class RenderMarkup extends React.Component {
             <ThresholdFilterDropdown
               options={{
                 targets: parent.allThresholds,
-                operators: [">=", "<="]
+                operators: [">=", "<="],
               }}
               thresholds={parent.state.activeThresholds}
               onApply={parent.handleThresholdFiltersChange}
@@ -1587,7 +1587,7 @@ class RenderMarkup extends React.Component {
       advanced_filter_tag_list,
       categories_filter_tag_list,
       subcats_filter_tag_list,
-      parent
+      parent,
     } = this.props;
 
     return (
@@ -1623,7 +1623,7 @@ class RenderMarkup extends React.Component {
 // TODO(mark): Add other propType signatures.
 PipelineSampleReport.propTypes = {
   nameType: PropTypes.oneOf(["Scientific name", "Common name"]),
-  onNameTypeChange: PropTypes.func.isRequired
+  onNameTypeChange: PropTypes.func.isRequired,
 };
 
 export default PipelineSampleReport;

--- a/app/assets/src/components/ProjectSelection.jsx
+++ b/app/assets/src/components/ProjectSelection.jsx
@@ -12,7 +12,7 @@ class ProjectSelection extends React.Component {
     super(props);
     this.nanobar = new Nanobar({
       id: "prog-bar",
-      class: "prog-bar"
+      class: "prog-bar",
     });
     this.csrf = props.csrf;
     this.favoriteProjects = props.favoriteProjects;
@@ -27,7 +27,7 @@ class ProjectSelection extends React.Component {
       formattedFavProjectList: [],
       favIds: [],
       showLess: true,
-      showLessFavorites: true
+      showLessFavorites: true,
     };
   }
 
@@ -46,7 +46,7 @@ class ProjectSelection extends React.Component {
 
   toggleDisplayFavProjects() {
     this.setState(prevState => ({
-      showLessFavorites: !prevState.showLessFavorites
+      showLessFavorites: !prevState.showLessFavorites,
     }));
   }
 
@@ -61,7 +61,7 @@ class ProjectSelection extends React.Component {
           favStatus == "true" ? "remove_favorite" : "add_favorite"
         }?`,
         {
-          authenticity_token: this.csrf
+          authenticity_token: this.csrf,
         }
       )
       .then(() => {
@@ -94,7 +94,7 @@ class ProjectSelection extends React.Component {
     this.setState({
       formattedProjectList: formattedList,
       formattedFavProjectList: favProjects,
-      favIds: favIds
+      favIds: favIds,
     });
 
     return formattedList;
@@ -142,7 +142,7 @@ class ProjectSelection extends React.Component {
       favIds.splice(projectIdIndex, 1);
       this.setState({
         formattedFavProjectList: updatedFavouriteProjects,
-        favIds
+        favIds,
       });
     }
   }
@@ -154,9 +154,9 @@ class ProjectSelection extends React.Component {
     this.setState({
       formattedFavProjectList: [
         ...this.state.formattedFavProjectList,
-        ...updatedProject
+        ...updatedProject,
       ],
-      favIds: [...this.state.favIds, updatedProject[0].id]
+      favIds: [...this.state.favIds, updatedProject[0].id],
     });
   }
 

--- a/app/assets/src/components/ReactNouislider.jsx
+++ b/app/assets/src/components/ReactNouislider.jsx
@@ -72,7 +72,7 @@ ReactNouislider.propTypes = {
   // http://refreshless.com/nouislider/slider-options/#section-Connect
   connect: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.bool),
-    PropTypes.bool
+    PropTypes.bool,
   ]),
   // http://refreshless.com/nouislider/slider-options/#section-cssPrefix
   cssPrefix: PropTypes.string,
@@ -111,10 +111,10 @@ ReactNouislider.propTypes = {
     PropTypes.bool,
     PropTypes.arrayOf(
       PropTypes.shape({
-        to: PropTypes.func
+        to: PropTypes.func,
       })
-    )
-  ])
+    ),
+  ]),
 };
 
 export default ReactNouislider;

--- a/app/assets/src/components/ReadViz.jsx
+++ b/app/assets/src/components/ReadViz.jsx
@@ -84,7 +84,7 @@ class ReadViz extends React.Component {
     let quality_string_display = [
       white_space_left,
       quality_string,
-      white_space_right
+      white_space_right,
     ].join("|");
 
     // generate quality string
@@ -93,7 +93,7 @@ class ReadViz extends React.Component {
       read_part: readPart,
       ref_display: ref_seq_display,
       read_display: read_seq_display,
-      quality_display: quality_string_display
+      quality_display: quality_string_display,
     };
   }
 
@@ -160,7 +160,7 @@ class ReadViz extends React.Component {
           style={{
             whiteSpace: "pre",
             fontFamily: "monospace",
-            overflow: "scroll"
+            overflow: "scroll",
           }}
         >
           <table>

--- a/app/assets/src/components/SampleUpload.jsx
+++ b/app/assets/src/components/SampleUpload.jsx
@@ -89,7 +89,7 @@ class SampleUpload extends React.Component {
       id: this.sample.id || "",
       inputFiles:
         props.inputFiles && props.inputFiles.length ? props.inputFiles : [],
-      status: this.sample.status
+      status: this.sample.status,
     };
     this.firstInput =
       this.selected.inputFiles.length && this.selected.inputFiles[0]
@@ -135,7 +135,7 @@ class SampleUpload extends React.Component {
       localFilesToUpload: [],
       localFilesDoneUploading: [],
       localUploadShouldStart: false,
-      localFileUploadURLs: ["", ""]
+      localFileUploadURLs: ["", ""],
     };
   }
 
@@ -156,7 +156,7 @@ class SampleUpload extends React.Component {
 
   parseUrlParams() {
     let urlParams = QueryString.parse(location.search, {
-      arrayFormat: "bracket"
+      arrayFormat: "bracket",
     });
     urlParams.projectId = parseInt(urlParams.projectId);
     return urlParams;
@@ -175,7 +175,7 @@ class SampleUpload extends React.Component {
         delay: 0,
         html: true,
         placement: "top",
-        offset: "0px 50px"
+        offset: "0px 50px",
       });
     });
   }
@@ -209,21 +209,21 @@ class SampleUpload extends React.Component {
     this.setState({
       invalid: false,
       success: false,
-      errors: {}
+      errors: {},
     });
   }
 
   toggleCheckBox(e) {
     this.setState(
       {
-        [e.target.id]: e.target.value == "true" ? false : true
+        [e.target.id]: e.target.value == "true" ? false : true,
         /* Note: "[e.target.id]" indicates a "computed property name".
          This allows us to use toggleCheckBox(event) to set different state variables
          depending on the id attached to the event. */
       },
       () => {
         logAnalyticsEvent("SampleUpload_public-checkbox_toggled", {
-          [e.target.id]: this.state[e.target.id]
+          [e.target.id]: this.state[e.target.id],
         });
       }
     );
@@ -240,7 +240,7 @@ class SampleUpload extends React.Component {
     logAnalyticsEvent("SampleUpload_create-project-link_clicked", {
       name: this.refs.new_project.value,
       publicChecked: this.state.publicChecked,
-      isProjectInvalid: this.isProjectInvalid()
+      isProjectInvalid: this.isProjectInvalid(),
     });
   }
 
@@ -250,9 +250,9 @@ class SampleUpload extends React.Component {
       .post("/projects.json", {
         project: {
           name: this.refs.new_project.value,
-          public_access: this.state.publicChecked ? 1 : 0
+          public_access: this.state.publicChecked ? 1 : 0,
         },
-        authenticity_token: this.csrf
+        authenticity_token: this.csrf,
       })
       .then(response => {
         var newProjectList = that.state.allProjects.slice();
@@ -263,7 +263,7 @@ class SampleUpload extends React.Component {
             selectedProject: response.data.name,
             selectedPId: response.data.id,
             success: true,
-            successMessage: "Project added successfully"
+            successMessage: "Project added successfully",
           },
           () => {
             this.refs.new_project.value = "";
@@ -274,7 +274,7 @@ class SampleUpload extends React.Component {
       .catch(error => {
         that.setState({
           invalid: true,
-          errors: { selectedProject: "Project already exists or is invalid" }
+          errors: { selectedProject: "Project already exists or is invalid" },
         });
       });
   }
@@ -286,7 +286,7 @@ class SampleUpload extends React.Component {
     ) {
       this.setState({
         invalid: true,
-        errorMessage: "Please enter valid project name"
+        errorMessage: "Please enter valid project name",
       });
       return true;
     } else {
@@ -296,12 +296,12 @@ class SampleUpload extends React.Component {
 
   uploadSampleFromRemote() {
     this.setState({
-      submitting: true
+      submitting: true,
     });
 
     const inputFiles = [
       this.refs.first_file_source.value.trim(),
-      this.refs.second_file_source.value.trim()
+      this.refs.second_file_source.value.trim(),
     ];
     createSample(
       this.state.sampleName,
@@ -320,7 +320,7 @@ class SampleUpload extends React.Component {
         this.setState({
           success: true,
           submitting: false,
-          successMessage: "Sample created successfully"
+          successMessage: "Sample created successfully",
         });
         openUrlWithTimeout(`/samples/${response.id}`);
       })
@@ -328,7 +328,7 @@ class SampleUpload extends React.Component {
         this.setState({
           invalid: true,
           submitting: false,
-          errorMessage: joinServerError(error)
+          errorMessage: joinServerError(error),
         });
       });
   }
@@ -336,7 +336,7 @@ class SampleUpload extends React.Component {
   updateSample() {
     let that = this;
     that.setState({
-      submitting: true
+      submitting: true,
     });
 
     axios
@@ -351,15 +351,15 @@ class SampleUpload extends React.Component {
           max_input_fragments: this.state.selectedMaxInputFragments,
           subsample: this.state.selectedSubsample,
           alignment_config_name: this.state.selectedAlignmentConfigName,
-          host_genome_id: this.state.selectedHostGenomeId
+          host_genome_id: this.state.selectedHostGenomeId,
         },
-        authenticity_token: this.csrf
+        authenticity_token: this.csrf,
       })
       .then(response => {
         that.setState({
           success: true,
           submitting: false,
-          successMessage: "Sample updated successfully"
+          successMessage: "Sample updated successfully",
         });
         openUrlWithTimeout(`/samples/${that.state.id}`);
       })
@@ -367,7 +367,7 @@ class SampleUpload extends React.Component {
         that.setState({
           submitting: false,
           invalid: true,
-          errorMessage: joinServerError(error.response.data)
+          errorMessage: joinServerError(error.response.data),
         });
       });
   }
@@ -386,25 +386,25 @@ class SampleUpload extends React.Component {
     ) {
       this.setState({
         invalid: true,
-        errorMessage: "Please fill in name, host genome and select a project"
+        errorMessage: "Please fill in name, host genome and select a project",
       });
       return true;
     } else if (this.state.sampleName === "") {
       this.setState({
         invalid: true,
-        errorMessage: "Please fill in Sample name"
+        errorMessage: "Please fill in Sample name",
       });
       return true;
     } else if (this.state.selectedProject === "Select a Project") {
       this.setState({
         invalid: true,
-        errorMessage: "Please select a project"
+        errorMessage: "Please select a project",
       });
       return true;
     } else if (this.state.selectedHostGenome === "") {
       this.setState({
         invalid: true,
-        errorMessage: "Please select a host genome"
+        errorMessage: "Please select a host genome",
       });
       return true;
     } else {
@@ -484,12 +484,12 @@ class SampleUpload extends React.Component {
       this.setState({
         selectedProject: e.target.value.trim(),
         selectedPId: this.state.allProjects[selectedIndex].id,
-        errors: Object.assign({}, this.state.errors, { selectedProject: null })
+        errors: Object.assign({}, this.state.errors, { selectedProject: null }),
       });
       logAnalyticsEvent("SampleUpload_project-selector_changed", {
         project: e.target.value.trim(),
         projectId: this.state.allProjects[selectedIndex].id,
-        errors: Object.keys(this.state.errors).length
+        errors: Object.keys(this.state.errors).length,
       });
     }
     this.clearError();
@@ -498,46 +498,46 @@ class SampleUpload extends React.Component {
   handleHostChange(hostId, hostName) {
     this.setState({
       selectedHostGenome: hostName,
-      selectedHostGenomeId: hostId
+      selectedHostGenomeId: hostId,
     });
     this.clearError();
     logAnalyticsEvent("SampleUpload_host-genome_changed", {
       selectedHostGenome: hostName,
-      selectedHostGenomeId: hostId
+      selectedHostGenomeId: hostId,
     });
   }
 
   handleBranchChange(e) {
     this.setState({
-      selectedBranch: e.target.value.trim()
+      selectedBranch: e.target.value.trim(),
     });
     this.clearError();
   }
 
   handleDagVarsChange = e => {
     this.setState({
-      selectedDagVars: e.target.value
+      selectedDagVars: e.target.value,
     });
     this.clearError();
   };
 
   handleSubsampleChange = e => {
     this.setState({
-      selectedSubsample: e.target.value
+      selectedSubsample: e.target.value,
     });
     this.clearError();
   };
 
   handleMaxInputFragmentsChange = e => {
     this.setState({
-      selectedMaxInputFragments: e.target.value
+      selectedMaxInputFragments: e.target.value,
     });
     this.clearError();
   };
 
   handleAlignmentConfigNameChange(e) {
     this.setState({
-      selectedAlignmentConfigName: e.target.value.trim()
+      selectedAlignmentConfigName: e.target.value.trim(),
     });
     this.clearError();
   }
@@ -545,14 +545,14 @@ class SampleUpload extends React.Component {
   // TODO (gdingle): is this used anywhere?
   handleNameChange(e) {
     this.setState({
-      sampleName: e.target.value.trim()
+      sampleName: e.target.value.trim(),
     });
   }
 
   // TODO (gdingle): is this used anywhere?
   handleResultChange(e) {
     this.setState({
-      selectedResultPath: e.target.value.trim()
+      selectedResultPath: e.target.value.trim(),
     });
   }
 
@@ -563,12 +563,12 @@ class SampleUpload extends React.Component {
     $(".new-project-button").toggleClass("active");
     this.setState(
       {
-        disableProjectSelect: !this.state.disableProjectSelect
+        disableProjectSelect: !this.state.disableProjectSelect,
       },
       () => {
         this.initializeSelectTag();
         logAnalyticsEvent("SampleUpload_new-project-input_toggled", {
-          disableProjectSelect: this.state.disableProjectSelect
+          disableProjectSelect: this.state.disableProjectSelect,
         });
       }
     );
@@ -613,14 +613,14 @@ class SampleUpload extends React.Component {
           this.refs.sample_name.value = simplified;
           this.setState({ sampleName: simplified });
           logAnalyticsEvent("SampleUpload_sample-name_changed", {
-            sampleName: simplified
+            sampleName: simplified,
           });
         }
       }
     } else {
       this.setState({ sampleName: sampleField });
       logAnalyticsEvent("SampleUpload_sample-name_changed", {
-        sampleName: sampleField
+        sampleName: sampleField,
       });
     }
   }
@@ -645,7 +645,7 @@ class SampleUpload extends React.Component {
       }
 
       this.setState({
-        localFilesToUpload: newFiles
+        localFilesToUpload: newFiles,
       });
 
       let sampleNameFromFile = null;
@@ -661,19 +661,19 @@ class SampleUpload extends React.Component {
         accepted: accepted.length,
         newFiles: newFiles.length,
         // eslint-disable-next-line no-undef
-        sampleName: this.state.sampleName || sampleNameFromFile
+        sampleName: this.state.sampleName || sampleNameFromFile,
       });
       return;
     }
     logAnalyticsEvent("SampleUpload_files_dropped", {
       pos,
-      accepted: accepted.length
+      accepted: accepted.length,
     });
   };
 
   uploadBoxHandleSuccess = file => {
     this.setState({
-      localFilesDoneUploading: this.state.localFilesDoneUploading.concat(file)
+      localFilesDoneUploading: this.state.localFilesDoneUploading.concat(file),
     });
     if (
       this.state.localFilesToUpload.length ===
@@ -683,7 +683,7 @@ class SampleUpload extends React.Component {
         submitting: false,
         successMessage: "All uploads finished!",
         success: true,
-        invalid: false
+        invalid: false,
       });
 
       // Mark as uploaded
@@ -691,9 +691,9 @@ class SampleUpload extends React.Component {
         .put(`/samples/${this.state.id}.json`, {
           sample: {
             id: this.state.id,
-            status: "uploaded"
+            status: "uploaded",
           },
-          authenticity_token: this.csrf
+          authenticity_token: this.csrf,
         })
         .then(() => {
           window.onbeforeunload = null;
@@ -703,7 +703,7 @@ class SampleUpload extends React.Component {
           this.setState({
             invalid: true,
             submitting: false,
-            errorMessage: joinServerError(error.response.data)
+            errorMessage: joinServerError(error.response.data),
           });
         });
     }
@@ -717,7 +717,7 @@ class SampleUpload extends React.Component {
         `Upload of ${
           file.name
         } failed for some reason. Please delete the created sample and try again or ask us our team for help. ` +
-        err
+        err,
     });
   };
 
@@ -731,7 +731,7 @@ class SampleUpload extends React.Component {
       } else {
         newURLs = [
           createResponse[0].presigned_url,
-          createResponse[1].presigned_url
+          createResponse[1].presigned_url,
         ];
       }
 
@@ -742,7 +742,7 @@ class SampleUpload extends React.Component {
         submitting: true,
         invalid: true,
         errorMessage:
-          "Upload in progress... Please keep this page open until completed..."
+          "Upload in progress... Please keep this page open until completed...",
       });
 
       // Chrome will show a generic message and not this message.
@@ -753,7 +753,7 @@ class SampleUpload extends React.Component {
 
   uploadSampleFromLocal = () => {
     this.setState({
-      submitting: true
+      submitting: true,
     });
 
     createSample(
@@ -771,7 +771,7 @@ class SampleUpload extends React.Component {
     )
       .then(response => {
         this.setState({
-          id: response.id
+          id: response.id,
         });
         startUploadHeartbeat(response.id);
         this.uploadLocalFiles(response.input_files);
@@ -780,7 +780,7 @@ class SampleUpload extends React.Component {
         this.setState({
           invalid: true,
           submitting: false,
-          errorMessage: joinServerError(error)
+          errorMessage: joinServerError(error),
         });
       });
   };
@@ -801,7 +801,7 @@ class SampleUpload extends React.Component {
                 this.handleUpload,
                 "SampleUpload_upload-button_clicked",
                 {
-                  localUploadMode: this.state.localUploadMode
+                  localUploadMode: this.state.localUploadMode,
                 }
               )
         }
@@ -1010,7 +1010,7 @@ class SampleUpload extends React.Component {
                       this.handleUpload,
                       "SampleUpload_upload-form_submitted",
                       {
-                        localUploadMode: this.state.localUploadMode
+                        localUploadMode: this.state.localUploadMode,
                       }
                     )
               }
@@ -1393,13 +1393,13 @@ class SampleUpload extends React.Component {
                     onChange={() =>
                       this.setState(
                         {
-                          consentChecked: !this.state.consentChecked
+                          consentChecked: !this.state.consentChecked,
                         },
                         () =>
                           logAnalyticsEvent(
                             "SampleUpload_consent-checkbox_clicked",
                             {
-                              consentChecked: this.state.consentChecked
+                              consentChecked: this.state.consentChecked,
                             }
                           )
                       )

--- a/app/assets/src/components/ScatterPlot.jsx
+++ b/app/assets/src/components/ScatterPlot.jsx
@@ -19,7 +19,7 @@ class ScatterPlot extends React.Component {
       top: 10,
       left: 40,
       right: 10,
-      bottom: 40
+      bottom: 40,
     };
 
     this.scale = d3.scale.linear;

--- a/app/assets/src/components/SortHelper.jsx
+++ b/app/assets/src/components/SortHelper.jsx
@@ -13,7 +13,7 @@ class SortHelper {
     let currentSort = {};
     if (sortBy) {
       currentSort = {
-        sortQuery: `sort_by=${sortBy}`
+        sortQuery: `sort_by=${sortBy}`,
       };
     }
     return currentSort;

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
@@ -24,7 +24,7 @@ import HitGroupViz from "./HitGroupViz";
 import {
   getHistogramTooltipData,
   generateCoverageVizData,
-  getSortedAccessionSummaries
+  getSortedAccessionSummaries,
 } from "./utils";
 import cs from "./coverage_viz_bottom_sidebar.scss";
 
@@ -38,54 +38,54 @@ const METRIC_COLUMNS = [
     {
       key: "referenceNCBIEntry",
       name: "Reference NCBI Entry",
-      tooltip: "The NCBI Genbank entry for the reference accession."
+      tooltip: "The NCBI Genbank entry for the reference accession.",
     },
     {
       key: "referenceLength",
       name: "Reference Length",
-      tooltip: "Length in base pairs of the reference accession."
-    }
+      tooltip: "Length in base pairs of the reference accession.",
+    },
   ],
   [
     {
       key: "alignedContigs",
       name: "Aligned Contigs",
-      tooltip: "Number of contigs for which this accession was the best match."
+      tooltip: "Number of contigs for which this accession was the best match.",
     },
     {
       key: "alignedReads",
       name: "Aligned Reads",
-      tooltip: "Number of reads for which this accession was the best match."
-    }
+      tooltip: "Number of reads for which this accession was the best match.",
+    },
   ],
   [
     {
       key: "coverageDepth",
       name: "Coverage Depth",
       tooltip:
-        "The average read depth of aligned contigs and reads over the length of the accession."
+        "The average read depth of aligned contigs and reads over the length of the accession.",
     },
     {
       key: "coverageBreadth",
       name: "Coverage Breadth",
       tooltip:
-        "The percentage of the accession that is covered by at least one read or contig."
-    }
+        "The percentage of the accession that is covered by at least one read or contig.",
+    },
   ],
   [
     {
       key: "maxAlignedLength",
       name: "Max Alignment Length",
       tooltip:
-        "Length of the longest aligned region over all reads and contigs."
+        "Length of the longest aligned region over all reads and contigs.",
     },
     {
       key: "avgMismatchedPercent",
       name: "Avg. Mismatched %",
       tooltip:
-        "Percentage of aligned regions that are mismatches, averaged over all reads and contigs."
-    }
-  ]
+        "Percentage of aligned regions that are mismatches, averaged over all reads and contigs.",
+    },
+  ],
 ];
 
 export default class CoverageVizBottomSidebar extends React.Component {
@@ -94,7 +94,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
   state = {
     currentAccessionSummary: null,
     histogramTooltipLocation: null,
-    histogramTooltipData: null
+    histogramTooltipData: null,
   };
 
   componentDidUpdate(prevProps, prevState) {
@@ -119,7 +119,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
     if (prevProps.visible && !visible) {
       this.setState({
         histogramTooltipLocation: null,
-        histogramTooltipData: null
+        histogramTooltipData: null,
       });
     }
   }
@@ -144,8 +144,8 @@ export default class CoverageVizBottomSidebar extends React.Component {
     this.setState({
       currentAccessionData: {
         ...data,
-        id: accession.id
-      }
+        id: accession.id,
+      },
     });
   };
 
@@ -158,7 +158,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
 
     this.setState({
       currentAccessionSummary: accession,
-      currentAccessionData: null
+      currentAccessionData: null,
     });
 
     if (accession) {
@@ -174,7 +174,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
         histogramTooltipData: getHistogramTooltipData(
           currentAccessionData,
           hoverData[1]
-        )
+        ),
       });
     }
   };
@@ -183,15 +183,15 @@ export default class CoverageVizBottomSidebar extends React.Component {
     this.setState({
       histogramTooltipLocation: {
         left: clientX,
-        top: clientY
-      }
+        top: clientY,
+      },
     });
   };
 
   handleHistogramBarExit = () => {
     this.setState({
       histogramTooltipLocation: null,
-      histogramTooltipData: null
+      histogramTooltipData: null,
     });
   };
 
@@ -217,14 +217,14 @@ export default class CoverageVizBottomSidebar extends React.Component {
           left: 170,
           right: 40,
           top: 30,
-          bottom: 30
+          bottom: 30,
         },
         numTicksY: 2,
         labelYOffset: 15,
         labelYLarge: true,
         onHistogramBarHover: this.handleHistogramBarHover,
         onHistogramBarEnter: this.handleHistogramBarEnter,
-        onHistogramBarExit: this.handleHistogramBarExit
+        onHistogramBarExit: this.handleHistogramBarExit,
       }
     );
     this.coverageViz.update();
@@ -236,7 +236,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
       [[0, data.total_length, 0]],
       {
         domain: [0, data.total_length],
-        colors: [REF_ACC_COLOR]
+        colors: [REF_ACC_COLOR],
       }
     );
     this.refAccesssionViz.update();
@@ -267,7 +267,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
             ) : null}
           </div>
         </div>
-      )
+      ),
     }));
   };
 
@@ -296,7 +296,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
                   {
                     accessionId: currentAccessionSummary.id,
                     taxonId: params.taxonId,
-                    sampleId
+                    sampleId,
                   }
                 )
               }
@@ -323,7 +323,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
       alignedReads: currentAccessionSummary.num_reads,
       avgMismatchedPercent: formatPercent(
         currentAccessionData.avg_prop_mismatch
-      )
+      ),
     };
   };
 
@@ -397,7 +397,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
                 {
                   accessionId,
                   taxonId: params.taxonId,
-                  sampleId
+                  sampleId,
                 }
               );
               this.setCurrentAccession(accessionId);
@@ -429,7 +429,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
                   {
                     accessionId: currentAccessionSummary.id,
                     taxonId: params.taxonId,
-                    sampleId
+                    sampleId,
                   }
                 )
               }
@@ -503,7 +503,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
                     {
                       accessionId: currentAccessionSummary.id,
                       taxonId: params.taxonId,
-                      sampleId
+                      sampleId,
                     }
                   )
                 }
@@ -579,7 +579,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
                     "CoverageVizBottomSidebar_no-data-alignment-viz-link_clicked",
                     {
                       taxonId: params.taxonId,
-                      sampleId
+                      sampleId,
                     }
                   )
                 }
@@ -632,15 +632,15 @@ CoverageVizBottomSidebar.propTypes = {
           score: PropTypes.number,
           coverage_depth: PropTypes.number,
           taxon_name: PropTypes.string,
-          taxon_common_name: PropTypes.string
+          taxon_common_name: PropTypes.string,
         })
       ),
-      num_accessions: PropTypes.number
+      num_accessions: PropTypes.number,
     }),
     // Link to the old alignment viz.
-    alignmentVizUrl: PropTypes.string
+    alignmentVizUrl: PropTypes.string,
   }),
   sampleId: PropTypes.number,
   pipelineVersion: PropTypes.string,
-  nameType: PropTypes.string
+  nameType: PropTypes.string,
 };

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/HitGroupViz.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/HitGroupViz.jsx
@@ -31,7 +31,7 @@ export default class HitGroupViz extends React.Component {
     genomeVizTooltipData: null,
     contigDownloaderLocation: null,
     contigDownloaderData: null,
-    currentCopyIconMessage: DEFAULT_CONTIG_COPY_MESSAGE
+    currentCopyIconMessage: DEFAULT_CONTIG_COPY_MESSAGE,
   };
 
   componentDidMount() {
@@ -73,7 +73,7 @@ export default class HitGroupViz extends React.Component {
 
     if (hoverData !== null) {
       this.setState({
-        genomeVizTooltipData: getGenomeVizTooltipData(accessionData, hoverData)
+        genomeVizTooltipData: getGenomeVizTooltipData(accessionData, hoverData),
       });
     }
   };
@@ -82,8 +82,8 @@ export default class HitGroupViz extends React.Component {
     this.setState({
       genomeVizTooltipLocation: {
         left: clientX,
-        top: clientY
-      }
+        top: clientY,
+      },
     });
   };
 
@@ -92,7 +92,7 @@ export default class HitGroupViz extends React.Component {
     if (dataIndex === null) {
       this.setState({
         contigDownloaderData: null,
-        contigDownloaderLocation: null
+        contigDownloaderLocation: null,
       });
     } else {
       // Only open the contig downloader if there are contigs in this hitGroup.
@@ -100,18 +100,18 @@ export default class HitGroupViz extends React.Component {
       if (hitGroup[0] > 0 && hitGroup[10].length > 0) {
         this.setState({
           contigDownloaderData: {
-            contigByteranges: hitGroup[10]
+            contigByteranges: hitGroup[10],
           },
           contigDownloaderLocation: {
             // We apply a translate 100% in CSS to move the tooltip to the correct location.
             left: barRight,
-            top: barTop
-          }
+            top: barTop,
+          },
         });
       } else {
         this.setState({
           contigDownloaderData: null,
-          contigDownloaderLocation: null
+          contigDownloaderLocation: null,
         });
       }
     }
@@ -120,7 +120,7 @@ export default class HitGroupViz extends React.Component {
   handleGenomeVizBarExit = () => {
     this.setState({
       genomeVizTooltipLocation: null,
-      genomeVizTooltipData: null
+      genomeVizTooltipData: null,
     });
   };
 
@@ -140,7 +140,7 @@ export default class HitGroupViz extends React.Component {
         onGenomeVizBarEnter: this.handleGenomeVizBarEnter,
         onGenomeVizBarExit: this.handleGenomeVizBarExit,
         onGenomeVizBarClick: this.handleGenomeVizBarClick,
-        hoverDarkenFactor: 0.4
+        hoverDarkenFactor: 0.4,
       }
     );
     this.hitGroupViz.update();
@@ -154,7 +154,7 @@ export default class HitGroupViz extends React.Component {
         byteranges: contigDownloaderData.contigByteranges.map(byterange =>
           byterange.join(",")
         ),
-        pipelineVersion: this.props.pipelineVersion
+        pipelineVersion: this.props.pipelineVersion,
       });
       location.href = `/samples/${
         this.props.sampleId
@@ -174,13 +174,13 @@ export default class HitGroupViz extends React.Component {
     copy(Object.values(data).join("\n"));
 
     this.setState({
-      currentCopyIconMessage: "Copied to clipboard!"
+      currentCopyIconMessage: "Copied to clipboard!",
     });
   };
 
   restoreCopyIconMessage = () => {
     this.setState({
-      currentCopyIconMessage: DEFAULT_CONTIG_COPY_MESSAGE
+      currentCopyIconMessage: DEFAULT_CONTIG_COPY_MESSAGE,
     });
   };
 
@@ -206,7 +206,7 @@ export default class HitGroupViz extends React.Component {
       <div
         style={{
           left: contigDownloaderLocation.left,
-          top: contigDownloaderLocation.top - 5
+          top: contigDownloaderLocation.top - 5,
         }}
         className={cs.contigDownloader}
         ref={c => (this._contigDownloader = c)}
@@ -227,7 +227,7 @@ export default class HitGroupViz extends React.Component {
                   ),
                   accessionId: accessionData.id,
                   taxonId,
-                  sampleId
+                  sampleId,
                 }
               )}
             >
@@ -254,7 +254,7 @@ export default class HitGroupViz extends React.Component {
                   ),
                   accessionId: accessionData.id,
                   taxonId,
-                  sampleId
+                  sampleId,
                 }
               )}
               onMouseEnter={this.restoreCopyIconMessage}
@@ -276,7 +276,7 @@ export default class HitGroupViz extends React.Component {
       genomeVizTooltipLocation,
       genomeVizTooltipData,
       contigDownloaderLocation,
-      contigDownloaderData
+      contigDownloaderData,
     } = this.state;
 
     return (
@@ -310,16 +310,16 @@ HitGroupViz.propTypes = {
       PropTypes.arrayOf(
         PropTypes.oneOfType([
           PropTypes.number,
-          PropTypes.arrayOf(PropTypes.number)
+          PropTypes.arrayOf(PropTypes.number),
         ])
       )
     ),
     id: PropTypes.number,
     max_aligned_length: PropTypes.number,
     name: PropTypes.string,
-    total_length: PropTypes.number
+    total_length: PropTypes.number,
   }),
   sampleId: PropTypes.number,
   taxonId: PropTypes.number,
-  pipelineVersion: PropTypes.string
+  pipelineVersion: PropTypes.string,
 };

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
@@ -19,14 +19,14 @@ export const getHistogramTooltipData = memoize(
             // \u2013 is en-dash
             `${Math.round(coverageObj[0] * binSize)}\u2013${Math.round(
               (coverageObj[0] + 1) * binSize
-            )}`
+            )}`,
           ],
           ["Coverage Depth", `${coverageObj[1]}x`],
           ["Coverage Breadth", formatPercent(coverageObj[2])],
           ["Overlapping Contigs", coverageObj[3]],
-          ["Overlapping Reads", coverageObj[4]]
-        ]
-      }
+          ["Overlapping Reads", coverageObj[4]],
+        ],
+      },
     ];
   }
 );
@@ -52,7 +52,7 @@ export const getGenomeVizTooltipData = memoize((accessionData, dataIndex) => {
     counts = [
       ["# Contigs", numContigs],
       ["# Reads", numReads],
-      ["Contig Read Count", hitObj[2]]
+      ["Contig Read Count", hitObj[2]],
     ];
   } else if (numReads > 1) {
     name = "Aggregated Reads";
@@ -77,21 +77,21 @@ export const getGenomeVizTooltipData = memoize((accessionData, dataIndex) => {
         [
           "Reference Alignment Range",
           // \u2013 is en-dash
-          `${Math.round(hitObj[3])}\u2013${Math.round(hitObj[4])}`
+          `${Math.round(hitObj[3])}\u2013${Math.round(hitObj[4])}`,
         ],
         [averagePrefix + "Alignment Length", hitObj[5]],
         [averagePrefix + "Percentage Matched", formatPercent(hitObj[6])],
         [averagePrefix + "# Mismatches", hitObj[7]],
-        [averagePrefix + "# Gaps", hitObj[8]]
-      ]
-    }
+        [averagePrefix + "# Gaps", hitObj[8]],
+      ],
+    },
   ];
 });
 
 export const generateCoverageVizData = (coverageData, coverageBinSize) =>
   coverageData.map(valueArr => ({
     x0: valueArr[0] * coverageBinSize,
-    length: valueArr[1] // Actually the height. This is a d3-histogram naming convention.
+    length: valueArr[1], // Actually the height. This is a d3-histogram naming convention.
   }));
 
 export const generateContigReadVizData = (hitGroups, coverageBinSize) => {
@@ -111,7 +111,7 @@ export const generateContigReadVizData = (hitGroups, coverageBinSize) => {
       return [
         hitObj[9] * coverageBinSize,
         (hitObj[9] + 1) * coverageBinSize,
-        hasContig
+        hasContig,
       ];
     }
 

--- a/app/assets/src/components/common/DetailsSidebar/DetailsSidebar.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/DetailsSidebar.jsx
@@ -40,5 +40,5 @@ DetailsSidebar.propTypes = {
   mode: PropTypes.string,
   visible: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
-  params: PropTypes.any // the params that are required depends on the mode. See subclasses like SampleDetailsMode for needed params.
+  params: PropTypes.any, // the params that are required depends on the mode. See subclasses like SampleDetailsMode for needed params.
 };

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataSection.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataSection.jsx
@@ -9,7 +9,7 @@ class MetadataSection extends React.Component {
   state = {
     hasSaved: false,
     prevSavePending: this.props.savePending,
-    prevEditing: this.props.editing
+    prevEditing: this.props.editing,
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -28,7 +28,7 @@ class MetadataSection extends React.Component {
     return {
       hasSaved,
       prevSavePending: props.savePending,
-      prevEditing: props.editing
+      prevEditing: props.editing,
     };
   }
 
@@ -58,7 +58,7 @@ class MetadataSection extends React.Component {
       children,
       onEditToggle,
       alwaysShowEditLink,
-      className
+      className,
     } = this.props;
 
     const header = (
@@ -115,7 +115,7 @@ MetadataSection.propTypes = {
   onEditToggle: PropTypes.func,
   savePending: PropTypes.bool,
   alwaysShowEditLink: PropTypes.bool,
-  children: PropTypes.node
+  children: PropTypes.node,
 };
 
 export default MetadataSection;

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/NotesTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/NotesTab.jsx
@@ -6,12 +6,12 @@ import cs from "./sample_details_mode.scss";
 
 class NotesTab extends React.Component {
   state = {
-    editing: false
+    editing: false,
   };
 
   toggleEditing = () => {
     this.setState({
-      editing: !this.state.editing
+      editing: !this.state.editing,
     });
   };
 
@@ -21,7 +21,7 @@ class NotesTab extends React.Component {
       onNoteChange,
       onNoteSave,
       savePending,
-      editable
+      editable,
     } = this.props;
 
     const notesEmpty = !notes || notes.length === 0;
@@ -63,7 +63,7 @@ NotesTab.propTypes = {
   editable: PropTypes.bool,
   onNoteChange: PropTypes.func.isRequired,
   onNoteSave: PropTypes.func.isRequired,
-  savePending: PropTypes.bool
+  savePending: PropTypes.bool,
 };
 
 export default NotesTab;

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -15,10 +15,10 @@ class PipelineTab extends React.Component {
     sectionOpen: {
       pipelineInfo: true,
       erccScatterplot: false,
-      downloads: false
+      downloads: false,
     },
     sectionEditing: {},
-    graphWidth: 0
+    graphWidth: 0,
   };
 
   componentDidMount() {
@@ -32,7 +32,7 @@ class PipelineTab extends React.Component {
   updateGraphDimensions = () => {
     if (this._graphContainer && this.state.graphWidth === 0) {
       this.setState({
-        graphWidth: this._graphContainer.offsetWidth
+        graphWidth: this._graphContainer.offsetWidth,
       });
     }
   };
@@ -42,12 +42,12 @@ class PipelineTab extends React.Component {
 
     const newValue = !sectionOpen[section];
     this.setState({
-      sectionOpen: set(section, newValue, sectionOpen)
+      sectionOpen: set(section, newValue, sectionOpen),
     });
     logAnalyticsEvent("PipelineTab_section_toggled", {
       section: section,
       sectionOpen: newValue,
-      sampleId: this.props.sampleId
+      sampleId: this.props.sampleId,
     });
   };
 
@@ -116,7 +116,7 @@ class PipelineTab extends React.Component {
                       newPage: option.newPage,
                       label: option.label,
                       href: option.path,
-                      sampleId: this.props.sampleId
+                      sampleId: this.props.sampleId,
                     })
                   }
                 >
@@ -134,7 +134,7 @@ PipelineTab.propTypes = {
   pipelineInfo: PropTypes.objectOf(PropTypes.string).isRequired,
   sampleId: PropTypes.number.isRequired,
   erccComparison: PropTypes.ERCCComparison,
-  pipelineRun: PropTypes.PipelineRun
+  pipelineRun: PropTypes.PipelineRun,
 };
 
 export default PipelineTab;

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
@@ -8,7 +8,7 @@ import { saveSampleName, saveSampleNotes } from "~/api";
 import {
   getSampleMetadata,
   saveSampleMetadata,
-  getSampleMetadataFields
+  getSampleMetadataFields,
 } from "~/api/metadata";
 import { logAnalyticsEvent } from "~/api/analytics";
 import { processMetadata, processMetadataTypes } from "~utils/metadata";
@@ -31,14 +31,14 @@ class SampleDetailsMode extends React.Component {
     metadataSavePending: {},
     lastValidMetadata: null,
     metadataErrors: {},
-    currentTab: TABS[0]
+    currentTab: TABS[0],
   };
 
   onTabChange = tab => {
     this.setState({ currentTab: tab });
     logAnalyticsEvent("SampleDetailsMode_tab_changed", {
       sampleId: this.props.sampleId,
-      tab
+      tab,
     });
   };
 
@@ -58,7 +58,7 @@ class SampleDetailsMode extends React.Component {
     this.setState({
       metadata: null,
       additionalInfo: null,
-      pipelineInfo: null
+      pipelineInfo: null,
     });
 
     if (!this.props.sampleId) {
@@ -67,7 +67,7 @@ class SampleDetailsMode extends React.Component {
 
     const [metadata, metadataTypes] = await Promise.all([
       getSampleMetadata(this.props.sampleId, this.props.pipelineVersion),
-      getSampleMetadataFields(this.props.sampleId)
+      getSampleMetadataFields(this.props.sampleId),
     ]);
 
     const processedMetadata = processMetadata(metadata.metadata, true);
@@ -80,7 +80,7 @@ class SampleDetailsMode extends React.Component {
       pipelineRun: metadata.additional_info.pipeline_run,
       metadataTypes: metadataTypes
         ? processMetadataTypes(metadataTypes)
-        : this.state.metadataTypes
+        : this.state.metadataTypes,
     });
   };
 
@@ -91,7 +91,7 @@ class SampleDetailsMode extends React.Component {
     if (key === "name" || key === "notes") {
       this.setState({
         additionalInfo: set(key, value, this.state.additionalInfo),
-        metadataChanged: set(key, true, this.state.metadataChanged)
+        metadataChanged: set(key, true, this.state.metadataChanged),
       });
 
       return;
@@ -101,7 +101,7 @@ class SampleDetailsMode extends React.Component {
       {
         metadata: set(key, value, this.state.metadata),
         metadataChanged: set(key, !shouldSave, this.state.metadataChanged),
-        metadataErrors: set(key, null, this.state.metadataErrors)
+        metadataErrors: set(key, null, this.state.metadataErrors),
       },
       () => {
         if (shouldSave) {
@@ -115,7 +115,7 @@ class SampleDetailsMode extends React.Component {
       key,
       value,
       shouldSave,
-      metadataErrors: Object.keys(this.state.metadataErrors).length
+      metadataErrors: Object.keys(this.state.metadataErrors).length,
     });
   };
 
@@ -128,7 +128,7 @@ class SampleDetailsMode extends React.Component {
 
       this.setState(
         {
-          metadataChanged: set(key, false, this.state.metadataChanged)
+          metadataChanged: set(key, false, this.state.metadataChanged),
         },
         () => {
           this._save(this.props.sampleId, key, newValue);
@@ -138,7 +138,7 @@ class SampleDetailsMode extends React.Component {
       logAnalyticsEvent("SampleDetailsMode_metadata_saved", {
         sampleId: this.props.sampleId,
         key,
-        newValue
+        newValue,
       });
     }
   };
@@ -150,7 +150,7 @@ class SampleDetailsMode extends React.Component {
     }
 
     this.setState({
-      metadataSavePending: set(key, true, this.state.metadataSavePending)
+      metadataSavePending: set(key, true, this.state.metadataSavePending),
     });
 
     let lastValidMetadata = this.state.lastValidMetadata;
@@ -181,7 +181,7 @@ class SampleDetailsMode extends React.Component {
       metadataSavePending: set(key, false, this.state.metadataSavePending),
       metadataErrors,
       metadata,
-      lastValidMetadata
+      lastValidMetadata,
     });
   };
 
@@ -193,7 +193,7 @@ class SampleDetailsMode extends React.Component {
       additionalInfo,
       pipelineInfo,
       pipelineRun,
-      metadataErrors
+      metadataErrors,
     } = this.state;
 
     const savePending = some(metadataSavePending);
@@ -272,7 +272,7 @@ SampleDetailsMode.propTypes = {
   sampleId: PropTypes.number,
   pipelineVersion: PropTypes.string, // Needs to be string for 3.1 vs. 3.10.
   onMetadataUpdate: PropTypes.func,
-  showReportLink: PropTypes.bool
+  showReportLink: PropTypes.bool,
 };
 
 export default SampleDetailsMode;

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/constants.js
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/constants.js
@@ -1,49 +1,49 @@
 export const SAMPLE_ADDITIONAL_INFO = [
   {
     name: "Sample Name",
-    key: "name"
+    key: "name",
   },
   {
     name: "Project",
-    key: "project_name"
+    key: "project_name",
   },
   {
     name: "Upload Date",
-    key: "upload_date"
+    key: "upload_date",
   },
   {
     name: "Host",
-    key: "host_genome_name"
-  }
+    key: "host_genome_name",
+  },
 ];
 
 export const PIPELINE_INFO_FIELDS = [
   {
     name: "Total Reads",
-    key: "totalReads"
+    key: "totalReads",
   },
   {
     name: "ERCC Reads",
-    key: "totalErccReads"
+    key: "totalErccReads",
   },
   {
     name: "Passed Filters",
-    key: "nonhostReads"
+    key: "nonhostReads",
   },
   {
     name: "Unmapped Reads",
-    key: "unmappedReads"
+    key: "unmappedReads",
   },
   {
     name: "Passed Quality Control",
-    key: "qcPercent"
+    key: "qcPercent",
   },
   {
     name: "Compression Ratio",
-    key: "compressionRatio"
+    key: "compressionRatio",
   },
   {
     name: "Date Processed",
-    key: "lastProcessedAt"
-  }
+    key: "lastProcessedAt",
+  },
 ];

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/utils.js
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/utils.js
@@ -5,7 +5,7 @@ import { numberWithCommas } from "~/helpers/strings";
 export const processPipelineInfo = additionalInfo => {
   const {
     pipeline_run: pipelineRun,
-    summary_stats: summaryStats
+    summary_stats: summaryStats,
   } = additionalInfo;
 
   const pipelineInfo = {};
@@ -66,5 +66,5 @@ export const processPipelineInfo = additionalInfo => {
 // Format the upload date.
 export const processAdditionalInfo = additionalInfo => ({
   ...additionalInfo,
-  upload_date: moment(additionalInfo.upload_date).format("YYYY-MM-DD")
+  upload_date: moment(additionalInfo.upload_date).format("YYYY-MM-DD"),
 });

--- a/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
@@ -21,7 +21,7 @@ export default class TaxonDetailsMode extends React.Component {
     collapseTaxonDescription: true,
     collapseParentDescription: true,
     taxonDescriptionTall: false,
-    parentDescriptionTall: false
+    parentDescriptionTall: false,
   };
 
   componentDidMount() {
@@ -47,7 +47,7 @@ export default class TaxonDetailsMode extends React.Component {
       !this.state.taxonDescriptionTall
     ) {
       this.setState({
-        taxonDescriptionTall: true
+        taxonDescriptionTall: true,
       });
     }
 
@@ -57,7 +57,7 @@ export default class TaxonDetailsMode extends React.Component {
       !this.state.parentDescriptionTall
     ) {
       this.setState({
-        parentDescriptionTall: true
+        parentDescriptionTall: true,
       });
     }
   }
@@ -73,13 +73,13 @@ export default class TaxonDetailsMode extends React.Component {
       collapseTaxonDescription: true,
       collapseParentDescription: true,
       taxonDescriptionTall: false,
-      parentDescriptionTall: false
+      parentDescriptionTall: false,
     });
 
     await Promise.all([this.loadTaxonInfo(), this.loadBackgroundInfo()]);
 
     this.setState({
-      loading: false
+      loading: false,
     });
   };
 
@@ -97,14 +97,14 @@ export default class TaxonDetailsMode extends React.Component {
         if (taxonInfo) {
           this.setState({
             taxonDescription: response[this.props.taxonId].summary || "",
-            wikiUrl: response[this.props.taxonId].wiki_url || ""
+            wikiUrl: response[this.props.taxonId].wiki_url || "",
           });
         }
 
         if (parentTaxonInfo) {
           this.setState({
             taxonParentName: response[this.props.parentTaxonId].title,
-            taxonParentDescription: response[this.props.parentTaxonId].summary
+            taxonParentDescription: response[this.props.parentTaxonId].summary,
           });
         }
       })
@@ -137,7 +137,7 @@ export default class TaxonDetailsMode extends React.Component {
           let rpmSeries = [data.NT.rpm_list, data.NR.rpm_list];
           this.setState({
             histogramRpmSeries: rpmSeries,
-            showHistogram: true
+            showHistogram: true,
           });
         }
       })
@@ -150,13 +150,13 @@ export default class TaxonDetailsMode extends React.Component {
 
   expandTaxonDescription = () => {
     this.setState({
-      collapseTaxonDescription: false
+      collapseTaxonDescription: false,
     });
   };
 
   expandParentDescription = () => {
     this.setState({
-      collapseParentDescription: false
+      collapseParentDescription: false,
     });
   };
 
@@ -173,10 +173,10 @@ export default class TaxonDetailsMode extends React.Component {
             name: "sample",
             values: [
               this.props.taxonValues.NT.rpm,
-              this.props.taxonValues.NR.rpm
-            ]
-          }
-        ]
+              this.props.taxonValues.NR.rpm,
+            ],
+          },
+        ],
       }
     );
     this.histogram.update();
@@ -212,7 +212,7 @@ export default class TaxonDetailsMode extends React.Component {
         url,
         taxonId: this.props.taxonId,
         taxonName: this.props.taxonName,
-        parentTaxonId: this.props.parentTaxonId
+        parentTaxonId: this.props.parentTaxonId,
       });
     }
   }
@@ -246,7 +246,7 @@ export default class TaxonDetailsMode extends React.Component {
                     {
                       taxonId: this.props.taxonId,
                       taxonName: this.props.taxonName,
-                      parentTaxonId: this.props.parentTaxonId
+                      parentTaxonId: this.props.parentTaxonId,
                     }
                   )}
                 >
@@ -283,7 +283,7 @@ export default class TaxonDetailsMode extends React.Component {
                     {
                       taxonId: this.props.taxonId,
                       taxonName: this.props.taxonName,
-                      parentTaxonId: this.props.parentTaxonId
+                      parentTaxonId: this.props.parentTaxonId,
                     }
                   )}
                 >
@@ -351,5 +351,5 @@ TaxonDetailsMode.propTypes = {
   taxonName: PropTypes.string.isRequired,
   parentTaxonId: PropTypes.number,
   taxonValues: PropTypes.object,
-  background: PropTypes.object
+  background: PropTypes.object,
 };

--- a/app/assets/src/components/common/MetadataCSVUpload.jsx
+++ b/app/assets/src/components/common/MetadataCSVUpload.jsx
@@ -6,7 +6,7 @@ import { filter, map, zip, fromPairs, isNull, isEqual } from "lodash/fp";
 import CSVUpload from "~ui/controls/CSVUpload";
 import {
   validateMetadataCSVForProject,
-  validateMetadataCSVForNewSamples
+  validateMetadataCSVForNewSamples,
 } from "~/api/metadata";
 import cs from "./metadata_csv_upload.scss";
 import PropTypes from "prop-types";
@@ -26,7 +26,7 @@ const processCSVMetadata = csv => {
       // The below code makes sure this case is handled correctly by filtering before converting to an object.
       row => fromPairs(filter(pair => pair[1] !== "", zip(headers, row))),
       rows
-    )
+    ),
   };
 };
 
@@ -38,7 +38,7 @@ class MetadataCSVUpload extends React.Component {
     validatingCSV: false,
     // Keep track of the last sample names and project id validated so we can re-validate if the samples changed.
     lastSampleNamesValidated: null,
-    lastProjectIdValidated: null
+    lastProjectIdValidated: null,
   };
 
   componentDidUpdate(prevProps) {
@@ -70,9 +70,9 @@ class MetadataCSVUpload extends React.Component {
       metadata: null,
       issues: {
         errors: [],
-        warnings: []
+        warnings: [],
       },
-      validatingCSV: true
+      validatingCSV: true,
     });
 
     let serverResponse;
@@ -82,7 +82,7 @@ class MetadataCSVUpload extends React.Component {
       // We assume that all samples are being uploaded to this.props.project.
       this.setState({
         lastSampleNamesValidated: map("name", this.props.samples),
-        lastProjectIdValidated: this.props.project.id
+        lastProjectIdValidated: this.props.project.id,
       });
 
       serverResponse = await validateMetadataCSVForNewSamples(
@@ -100,7 +100,7 @@ class MetadataCSVUpload extends React.Component {
     this.props.onMetadataChange({
       metadata: processCSVMetadata(csv),
       issues: serverResponse.issues,
-      validatingCSV: false
+      validatingCSV: false,
     });
   };
 
@@ -122,14 +122,14 @@ MetadataCSVUpload.propTypes = {
   // For uploading metadata to existing samples in a project.
   project: PropTypes.shape({
     id: PropTypes.number,
-    name: PropTypes.string
+    name: PropTypes.string,
   }),
   // For uploading metadata together with new samples.
   samples: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
       project_id: PropTypes.number,
-      host_genome_id: PropTypes.number
+      host_genome_id: PropTypes.number,
     })
   ),
   className: PropTypes.string,
@@ -138,7 +138,7 @@ MetadataCSVUpload.propTypes = {
   visible: PropTypes.bool,
   // Immediately called when the user changes anything, even before validation has returned.
   // Can be used to disable the header navigation.
-  onDirty: PropTypes.func.isRequired
+  onDirty: PropTypes.func.isRequired,
 };
 
 export default MetadataCSVUpload;

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -14,13 +14,13 @@ class MetadataInput extends React.Component {
       onSave,
       metadataType,
       className,
-      isHuman
+      isHuman,
     } = this.props;
 
     if (isArray(metadataType.options)) {
       const options = metadataType.options.map(option => ({
         text: option,
-        value: option
+        value: option,
       }));
       return (
         <Dropdown
@@ -76,14 +76,14 @@ MetadataInput.propTypes = {
   metadataType: PropTypes.shape({
     key: PropTypes.string,
     dataType: PropTypes.oneOf(["number", "string", "date", "location"]),
-    options: PropTypes.arrayOf(PropTypes.string)
+    options: PropTypes.arrayOf(PropTypes.string),
   }),
   // Third optional parameter signals to the parent whether to immediately save. false means "wait for onSave to fire".
   // This is useful for the text input, where the parent wants to save onBlur, not onChange.
   onChange: PropTypes.func.isRequired,
   onSave: PropTypes.func,
   withinModal: PropTypes.bool,
-  isHuman: PropTypes.bool
+  isHuman: PropTypes.bool,
 };
 
 export default MetadataInput;

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -23,21 +23,21 @@ class MetadataUpload extends React.Component {
     currentTab: "Manual Input",
     issues: {
       errors: [],
-      warnings: []
+      warnings: [],
     },
     projectMetadataFields: null,
     hostGenomes: [],
-    validatingCSV: false
+    validatingCSV: false,
   };
 
   async componentDidMount() {
     const [projectMetadataFields, hostGenomes] = await Promise.all([
       getProjectMetadataFields(this.props.project.id),
-      getAllHostGenomes()
+      getAllHostGenomes(),
     ]);
     this.setState({
       projectMetadataFields: keyBy("key", projectMetadataFields),
-      hostGenomes
+      hostGenomes,
     });
   }
 
@@ -47,12 +47,12 @@ class MetadataUpload extends React.Component {
     this.props.onMetadataChange({
       metadata: null,
       issues: null,
-      wasManual: tab === "Manual Input"
+      wasManual: tab === "Manual Input",
     });
     logAnalyticsEvent("MetadataUpload_tab_changed", {
       tab,
       projectId: this.props.project.id,
-      projectName: this.props.project.name
+      projectName: this.props.project.name,
     });
   };
 
@@ -61,7 +61,7 @@ class MetadataUpload extends React.Component {
     this.props.onMetadataChange({ metadata, issues, wasManual: false });
     this.setState({
       issues,
-      validatingCSV
+      validatingCSV,
     });
     if (!validatingCSV) {
       // We only want to log on the second call when issues are present
@@ -69,7 +69,7 @@ class MetadataUpload extends React.Component {
         errors: issues.errors.length,
         warnings: issues.warnings.length,
         projectId: this.props.project.id,
-        projectName: this.props.project.name
+        projectName: this.props.project.name,
       });
     }
   };
@@ -83,7 +83,7 @@ class MetadataUpload extends React.Component {
     this.props.onMetadataChange({ metadata, wasManual: true });
     logAnalyticsEvent("MetadataUpload_manual-metadata_changed", {
       projectId: this.props.project.id,
-      projectName: this.props.project.name
+      projectName: this.props.project.name,
     });
   };
 
@@ -92,7 +92,7 @@ class MetadataUpload extends React.Component {
       ...(this.props.samplesAreNew
         ? { new_sample_names: map("name", this.props.samples) }
         : {}),
-      project_id: this.props.project.id
+      project_id: this.props.project.id,
     };
 
     return `/metadata/metadata_template_csv?${getURLParamString(params)}`;
@@ -150,7 +150,7 @@ class MetadataUpload extends React.Component {
                 "MetadataUpload_download-csv-template_clicked",
                 {
                   projectId: this.props.project.id,
-                  projectName: this.props.project.name
+                  projectName: this.props.project.name,
                 }
               )
             }
@@ -260,7 +260,7 @@ class MetadataUpload extends React.Component {
                       "MetadataUpload_full-dictionary-link_clicked",
                       {
                         projectId: this.props.project.id,
-                        projectName: this.props.project.name
+                        projectName: this.props.project.name,
                       }
                     )
                   }
@@ -281,7 +281,7 @@ class MetadataUpload extends React.Component {
                 onClick={() =>
                   logAnalyticsEvent("MetadataUpload_dictionary-link_clicked", {
                     projectId: this.props.project.id,
-                    projectName: this.props.project.name
+                    projectName: this.props.project.name,
                   })
                 }
               >
@@ -307,7 +307,7 @@ MetadataUpload.propTypes = {
   className: PropTypes.string,
   issues: PropTypes.shape({
     errors: PropTypes.arrayOf(PropTypes.string),
-    warnings: PropTypes.arrayOf(PropTypes.string)
+    warnings: PropTypes.arrayOf(PropTypes.string),
   }),
   onMetadataChange: PropTypes.func.isRequired,
   onShowCSVInstructions: PropTypes.func.isRequired,
@@ -318,7 +318,7 @@ MetadataUpload.propTypes = {
   visible: PropTypes.bool,
   // Immediately called when the user changes anything, even before validation has returned.
   // Can be used to disable the header navigation.
-  onDirty: PropTypes.func
+  onDirty: PropTypes.func,
 };
 
 export default MetadataUpload;

--- a/app/assets/src/components/common/ProjectCreationForm.jsx
+++ b/app/assets/src/components/common/ProjectCreationForm.jsx
@@ -14,12 +14,12 @@ class ProjectCreationForm extends React.Component {
   state = {
     name: "",
     publicAccess: -1, // No selection by default
-    error: ""
+    error: "",
   };
 
   handleNameChange = name => {
     this.setState({
-      name
+      name,
     });
   };
 
@@ -28,23 +28,23 @@ class ProjectCreationForm extends React.Component {
       return;
     }
     this.setState({
-      error: ""
+      error: "",
     });
     try {
       const newProject = await createProject({
         name: this.state.name,
-        public_access: this.state.publicAccess
+        public_access: this.state.publicAccess,
       });
 
       this.props.onCreate(newProject);
     } catch (e) {
       if (e[0] === "Name has already been taken") {
         this.setState({
-          error: "Project name is already taken."
+          error: "Project name is already taken.",
         });
       } else {
         this.setState({
-          error: "There was an error creating your project."
+          error: "There was an error creating your project.",
         });
       }
     }
@@ -120,7 +120,7 @@ class ProjectCreationForm extends React.Component {
 
 ProjectCreationForm.propTypes = {
   onCancel: PropTypes.func.isRequired,
-  onCreate: PropTypes.func.isRequired
+  onCreate: PropTypes.func.isRequired,
 };
 
 export default ProjectCreationForm;

--- a/app/assets/src/components/common/ProjectSelect.jsx
+++ b/app/assets/src/components/common/ProjectSelect.jsx
@@ -8,7 +8,7 @@ class ProjectSelect extends React.Component {
   getOptions = () =>
     (sortBy("name", this.props.projects) || []).map(project => ({
       value: project.id,
-      text: project.name
+      text: project.name,
     }));
 
   onChange = projectId => {
@@ -34,7 +34,7 @@ ProjectSelect.propTypes = {
   projects: PropTypes.arrayOf(PropTypes.Project),
   value: PropTypes.number, // the project id
   onChange: PropTypes.func.isRequired, // the entire project object is returned
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
 };
 
 export default ProjectSelect;

--- a/app/assets/src/components/common/ThresholdFilterTag.jsx
+++ b/app/assets/src/components/common/ThresholdFilterTag.jsx
@@ -25,7 +25,7 @@ ThresholdFilterTag.propTypes = {
     metric: PropTypes.string,
     value: PropTypes.string,
     operator: PropTypes.string,
-    metricDisplay: PropTypes.string
+    metricDisplay: PropTypes.string,
   }),
-  className: PropTypes.string
+  className: PropTypes.string,
 };

--- a/app/assets/src/components/common/filters/BaseMultipleFilter.jsx
+++ b/app/assets/src/components/common/filters/BaseMultipleFilter.jsx
@@ -28,7 +28,7 @@ BaseMultipleFilter.propTypes = {
   onChange: PropTypes.func,
   options: PropTypes.array,
   counters: PropTypes.object,
-  label: PropTypes.string
+  label: PropTypes.string,
 };
 
 export default BaseMultipleFilter;

--- a/app/assets/src/components/common/filters/BaseSingleFilter.jsx
+++ b/app/assets/src/components/common/filters/BaseSingleFilter.jsx
@@ -24,7 +24,7 @@ BaseSingleFilter.propTypes = {
   onChange: PropTypes.func,
   options: PropTypes.array,
   counters: PropTypes.object,
-  label: PropTypes.string
+  label: PropTypes.string,
 };
 
 export default BaseSingleFilter;

--- a/app/assets/src/components/common/filters/TaxonFilter.jsx
+++ b/app/assets/src/components/common/filters/TaxonFilter.jsx
@@ -11,13 +11,13 @@ class TaxonFilter extends React.Component {
     const searchResults = await getSearchSuggestions({
       query,
       categories: ["taxon"],
-      domain
+      domain,
     });
     const options = (((searchResults || {}).Taxon || {}).results || [])
       .filter(result => result.taxid > 0)
       .map(result => ({
         value: result.taxid,
-        text: result.title
+        text: result.title,
       }));
     return options;
   };
@@ -41,7 +41,7 @@ class TaxonFilter extends React.Component {
 TaxonFilter.propTypes = {
   domain: PropTypes.string,
   selectedOptions: PropTypes.array,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
 };
 
 export default TaxonFilter;

--- a/app/assets/src/components/common/filters/VisibilityFilter.jsx
+++ b/app/assets/src/components/common/filters/VisibilityFilter.jsx
@@ -9,7 +9,7 @@ class VisibilityFilter extends React.Component {
 
     this.options = [
       { value: "public", text: "Public" },
-      { value: "private", text: "Private" }
+      { value: "private", text: "Private" },
     ];
   }
 
@@ -29,7 +29,7 @@ class VisibilityFilter extends React.Component {
 VisibilityFilter.propTypes = {
   selected: PropTypes.string,
   onChange: PropTypes.func,
-  counters: PropTypes.object
+  counters: PropTypes.object,
 };
 
 export default VisibilityFilter;

--- a/app/assets/src/components/layout/Accordion.jsx
+++ b/app/assets/src/components/layout/Accordion.jsx
@@ -9,7 +9,7 @@ class Accordion extends React.Component {
   onToggle = () => {
     this.setState({
       open: this.state.wasToggled ? !this.state.open : !this.props.open,
-      wasToggled: true
+      wasToggled: true,
     });
   };
 
@@ -20,7 +20,7 @@ class Accordion extends React.Component {
       toggleable,
       className,
       iconClassName,
-      bottomContentPadding
+      bottomContentPadding,
     } = this.props;
 
     const open = this.state.wasToggled ? this.state.open : this.props.open;
@@ -68,12 +68,12 @@ Accordion.propTypes = {
   // Useful for separating the accordion content from the elements below it.
   bottomContentPadding: PropTypes.bool,
   header: PropTypes.node,
-  children: PropTypes.node
+  children: PropTypes.node,
 };
 
 Accordion.defaultProps = {
   toggleable: true,
-  open: false
+  open: false,
 };
 
 export default Accordion;

--- a/app/assets/src/components/layout/Divider.jsx
+++ b/app/assets/src/components/layout/Divider.jsx
@@ -8,11 +8,11 @@ const Divider = ({ style }) => {
 };
 
 Divider.defaultProps = {
-  style: "thin"
+  style: "thin",
 };
 
 Divider.propTypes = {
-  style: PropTypes.oneOf(["thin", "medium"])
+  style: PropTypes.oneOf(["thin", "medium"]),
 };
 
 export default Divider;

--- a/app/assets/src/components/layout/FilterRow.jsx
+++ b/app/assets/src/components/layout/FilterRow.jsx
@@ -22,8 +22,8 @@ const FilterRow = ({ children }) => {
 FilterRow.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ])
+    PropTypes.node,
+  ]),
 };
 
 export default FilterRow;

--- a/app/assets/src/components/layout/NarrowContainer.jsx
+++ b/app/assets/src/components/layout/NarrowContainer.jsx
@@ -16,10 +16,10 @@ const NarrowContainer = ({ children, className, size }) => {
 NarrowContainer.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
+    PropTypes.node,
   ]).isRequired,
   className: PropTypes.string,
-  size: PropTypes.oneOf(["small"])
+  size: PropTypes.oneOf(["small"]),
 };
 
 export default NarrowContainer;

--- a/app/assets/src/components/layout/ViewHeader/Content.jsx
+++ b/app/assets/src/components/layout/ViewHeader/Content.jsx
@@ -9,7 +9,7 @@ class ViewHeaderContent extends React.Component {
 }
 
 ViewHeaderContent.propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
 };
 
 ViewHeaderContent.CLASS_NAME = "ViewHeaderContent";

--- a/app/assets/src/components/layout/ViewHeader/Controls.jsx
+++ b/app/assets/src/components/layout/ViewHeader/Controls.jsx
@@ -15,7 +15,7 @@ class ViewHeaderControls extends React.Component {
 
 ViewHeaderControls.propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 ViewHeaderControls.CLASS_NAME = "ViewHeaderControls";

--- a/app/assets/src/components/layout/ViewHeader/Pretitle.jsx
+++ b/app/assets/src/components/layout/ViewHeader/Pretitle.jsx
@@ -22,7 +22,7 @@ class Pretitle extends React.Component {
 
 Pretitle.propTypes = {
   breadcrumbLink: PropTypes.string,
-  children: PropTypes.node
+  children: PropTypes.node,
 };
 
 export default Pretitle;

--- a/app/assets/src/components/layout/ViewHeader/Title.jsx
+++ b/app/assets/src/components/layout/ViewHeader/Title.jsx
@@ -8,7 +8,7 @@ import cs from "./view_header.scss";
 
 class Title extends React.Component {
   state = {
-    nameOverflows: false
+    nameOverflows: false,
   };
 
   componentDidMount() {
@@ -31,7 +31,7 @@ class Title extends React.Component {
     // If-statement prevents infinite loop
     if (this.state.nameOverflows !== nameOverflows) {
       this.setState({
-        nameOverflows
+        nameOverflows,
       });
     }
   };
@@ -95,11 +95,11 @@ Title.propTypes = {
     PropTypes.shape({
       label: PropTypes.string.isRequired,
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      onClick: PropTypes.func.isRequired
+      onClick: PropTypes.func.isRequired,
     })
   ),
   label: PropTypes.string,
-  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 export default Title;

--- a/app/assets/src/components/layout/ViewHeader/ViewHeader.jsx
+++ b/app/assets/src/components/layout/ViewHeader/ViewHeader.jsx
@@ -12,7 +12,7 @@ import cs from "./view_header.scss";
 const ViewHeader = ({ className, children }) => {
   const [content, controls] = extractChildren(children, [
     Content.CLASS_NAME,
-    Controls.CLASS_NAME
+    Controls.CLASS_NAME,
   ]);
 
   return (
@@ -36,8 +36,8 @@ ViewHeader.propTypes = {
   subTitle: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ])
+    PropTypes.node,
+  ]),
 };
 
 export default ViewHeader;

--- a/app/assets/src/components/ui/containers/Container.jsx
+++ b/app/assets/src/components/ui/containers/Container.jsx
@@ -19,8 +19,8 @@ class Container extends React.Component {
 Container.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ]).isRequired
+    PropTypes.node,
+  ]).isRequired,
 };
 
 export default Container;

--- a/app/assets/src/components/ui/containers/ContextPlaceholder.jsx
+++ b/app/assets/src/components/ui/containers/ContextPlaceholder.jsx
@@ -13,7 +13,7 @@ export default class ContextPlaceholder extends React.PureComponent {
 
     this.state = {
       style: this.getStyle(),
-      open: this.props.open
+      open: this.props.open,
     };
   }
 
@@ -128,13 +128,13 @@ ContextPlaceholder.defaultProps = {
   horizontalOffset: 0,
   verticalOffset: 0,
   closeOnOutsideClick: false,
-  open: true
+  open: true,
 };
 
 ContextPlaceholder.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
+    PropTypes.node,
   ]),
   onClose: PropTypes.func,
   horizontalOffset: PropTypes.number,
@@ -142,5 +142,5 @@ ContextPlaceholder.propTypes = {
   open: PropTypes.bool,
   position: PropTypes.string,
   closeOnOutsideClick: PropTypes.bool,
-  context: PropTypes.instanceOf(Element)
+  context: PropTypes.instanceOf(Element),
 };

--- a/app/assets/src/components/ui/containers/DataTooltip.jsx
+++ b/app/assets/src/components/ui/containers/DataTooltip.jsx
@@ -50,11 +50,11 @@ DataTooltip.propTypes = {
   data: PropTypes.array,
   subtitle: PropTypes.string,
   title: PropTypes.string,
-  singleColumn: PropTypes.bool
+  singleColumn: PropTypes.bool,
 };
 
 DataTooltip.defaultProps = {
-  singleColumn: false
+  singleColumn: false,
 };
 
 export default DataTooltip;

--- a/app/assets/src/components/ui/containers/HelpIcon.jsx
+++ b/app/assets/src/components/ui/containers/HelpIcon.jsx
@@ -27,7 +27,7 @@ class HelpIcon extends React.Component {
 
 HelpIcon.propTypes = {
   className: PropTypes.string,
-  text: PropTypes.string
+  text: PropTypes.string,
 };
 
 export default HelpIcon;

--- a/app/assets/src/components/ui/containers/Modal.jsx
+++ b/app/assets/src/components/ui/containers/Modal.jsx
@@ -51,7 +51,7 @@ class Modal extends React.Component {
 Modal.propTypes = forbidExtraProps({
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
+    PropTypes.node,
   ]).isRequired,
   className: PropTypes.string,
   onClose: PropTypes.func,
@@ -61,7 +61,7 @@ Modal.propTypes = forbidExtraProps({
   narrowest: PropTypes.bool, // Decrease the width of the Modal for the smallest modals.
   wide: PropTypes.bool, // Increase the width of the Modal for the wider modals.
   tall: PropTypes.bool, // Increase the max-height of the Modal for tall content.
-  title: PropTypes.string
+  title: PropTypes.string,
 });
 
 export default Modal;

--- a/app/assets/src/components/ui/containers/Sidebar.jsx
+++ b/app/assets/src/components/ui/containers/Sidebar.jsx
@@ -28,11 +28,11 @@ Sidebar.propTypes = forbidExtraProps({
   visible: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
-  onClose: PropTypes.func.isRequired
+  onClose: PropTypes.func.isRequired,
 });
 
 Sidebar.defaultProps = {
-  direction: "right"
+  direction: "right",
 };
 
 export default Sidebar;

--- a/app/assets/src/components/ui/containers/Wizard.jsx
+++ b/app/assets/src/components/ui/containers/Wizard.jsx
@@ -6,7 +6,7 @@ import SecondaryButton from "../controls/buttons/SecondaryButton";
 
 const WizardContext = React.createContext({
   currentPage: 0,
-  actions: {}
+  actions: {},
 });
 
 class Wizard extends React.Component {
@@ -16,7 +16,7 @@ class Wizard extends React.Component {
     this.state = {
       currentPage: 0,
       continueEnabled: true,
-      overlay: null
+      overlay: null,
     };
 
     this.showPageInfo = this.props.showPageInfo || true;
@@ -30,7 +30,7 @@ class Wizard extends React.Component {
       {
         back: "Back",
         continue: "Continue",
-        finish: "Finish"
+        finish: "Finish",
       },
       this.props.labels
     );
@@ -40,7 +40,7 @@ class Wizard extends React.Component {
     if (newProps.defaultPage !== prevState.lastDefaultPage) {
       return {
         lastDefaultPage: newProps.defaultPage,
-        currentPage: newProps.defaultPage
+        currentPage: newProps.defaultPage,
       };
     }
     return null;
@@ -49,19 +49,19 @@ class Wizard extends React.Component {
   resetPageState = () => {
     this.setState({
       continueEnabled: true,
-      onContinueValidation: null
+      onContinueValidation: null,
     });
   };
 
   handleContinueEnabled = enabled => {
     this.setState({
-      continueEnabled: enabled
+      continueEnabled: enabled,
     });
   };
 
   handleSetOnContinueValidation = onContinueValidation => {
     this.setState({
-      onContinueValidation
+      onContinueValidation,
     });
   };
 
@@ -69,7 +69,7 @@ class Wizard extends React.Component {
   // Used for things like the Metadata Instructions page.
   setOverlay = overlay => {
     this.setState({
-      overlay
+      overlay,
     });
   };
 
@@ -121,7 +121,7 @@ class Wizard extends React.Component {
     const wizardActions = {
       continue: this.handleContinueClick,
       back: this.handleBackClick,
-      finish: this.handleFinishClick
+      finish: this.handleFinishClick,
     };
 
     let pageInfo = null;
@@ -157,7 +157,7 @@ class Wizard extends React.Component {
             {React.cloneElement(currentPage, {
               wizardEnableContinue: this.handleContinueEnabled,
               wizardSetOnContinueValidation: this.handleSetOnContinueValidation,
-              wizardSetOverlay: this.setOverlay
+              wizardSetOverlay: this.setOverlay,
             })}
           </div>
           {!currentPage.props.skipDefaultButtons && (
@@ -195,20 +195,20 @@ class Wizard extends React.Component {
 Wizard.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.shape({
-      type: Wizard.Page
+      type: Wizard.Page,
     }),
     PropTypes.arrayOf(
       PropTypes.shape({
-        type: Wizard.Page
+        type: Wizard.Page,
       })
-    )
+    ),
   ]).isRequired,
   labels: PropTypes.objectOf(PropTypes.string),
   onComplete: PropTypes.func,
   showPageInfo: PropTypes.bool,
   skipPageInfoNPages: PropTypes.number,
   title: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 // You can use the Page component for basic use cases, or create your own custom page class.
@@ -238,11 +238,11 @@ class Page extends React.Component {
 Page.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.PropTypes.node,
-    PropTypes.arrayOf(PropTypes.node)
+    PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
   onLoad: PropTypes.func,
   // Props are used in Wizard.
-  skipDefaultButtons: PropTypes.bool
+  skipDefaultButtons: PropTypes.bool,
 };
 
 Wizard.Page = Page;
@@ -275,7 +275,7 @@ const Action = ({ action, onAfterAction, children }) => {
 Action.propTypes = {
   action: PropTypes.oneOf(["back", "continue", "finish"]),
   children: PropTypes.node.isRequired,
-  onAfterAction: PropTypes.func
+  onAfterAction: PropTypes.func,
 };
 
 Wizard.Action = Action;

--- a/app/assets/src/components/ui/controls/BulkSampleUploadTable.jsx
+++ b/app/assets/src/components/ui/controls/BulkSampleUploadTable.jsx
@@ -19,7 +19,7 @@ class BulkSampleUploadTable extends React.Component {
       sampleNamesToFiles,
       fileNamesToProgress,
       onRemoved,
-      hideProgressColumn
+      hideProgressColumn,
     } = this.props;
 
     if (isEmpty(sampleNamesToFiles)) return null;
@@ -77,7 +77,7 @@ class BulkSampleUploadTable extends React.Component {
         progress: progress,
         sampleName: sampleName,
         files: filesList,
-        removeIcon: removeIcon
+        removeIcon: removeIcon,
       };
       entries.push(entry);
     }
@@ -99,12 +99,12 @@ class BulkSampleUploadTable extends React.Component {
             progress: "",
             sampleName: "Sample Name",
             files: "Files",
-            removeIcon: ""
+            removeIcon: "",
           }}
           columns={concat(!hideProgressColumn ? ["progress"] : [], [
             "sampleName",
             "files",
-            "removeIcon"
+            "removeIcon",
           ])}
           data={sortedEntries}
         />
@@ -118,7 +118,7 @@ BulkSampleUploadTable.propTypes = {
   sampleNamesToFiles: PropTypes.objectOf(
     PropTypes.arrayOf(
       PropTypes.shape({
-        name: PropTypes.string
+        name: PropTypes.string,
       })
     )
   ),
@@ -127,7 +127,7 @@ BulkSampleUploadTable.propTypes = {
   onRemoved: PropTypes.func,
   hideProgressColumn: PropTypes.bool,
   showCount: PropTypes.bool,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default BulkSampleUploadTable;

--- a/app/assets/src/components/ui/controls/CSVUpload.jsx
+++ b/app/assets/src/components/ui/controls/CSVUpload.jsx
@@ -5,7 +5,7 @@ import { parseCSVBlob } from "~/components/utils/csv";
 
 class CSVUpload extends React.Component {
   state = {
-    file: null
+    file: null,
   };
 
   onChange = accepted => {
@@ -16,7 +16,7 @@ class CSVUpload extends React.Component {
     };
     fileReader.readAsText(accepted[0]);
     this.setState({
-      file: accepted[0]
+      file: accepted[0],
     });
   };
 
@@ -37,7 +37,7 @@ class CSVUpload extends React.Component {
 CSVUpload.propTypes = {
   className: PropTypes.string,
   title: PropTypes.string,
-  onCSV: PropTypes.func.isRequired
+  onCSV: PropTypes.func.isRequired,
 };
 
 export default CSVUpload;

--- a/app/assets/src/components/ui/controls/CategorySearchBox.jsx
+++ b/app/assets/src/components/ui/controls/CategorySearchBox.jsx
@@ -17,7 +17,7 @@ CategorySearchBox.propTypes = {
   rounded: PropTypes.bool,
   initialValue: PropTypes.string,
   onResultSelect: PropTypes.func,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
 };
 
 export default CategorySearchBox;

--- a/app/assets/src/components/ui/controls/Checkbox.jsx
+++ b/app/assets/src/components/ui/controls/Checkbox.jsx
@@ -6,7 +6,7 @@ class Checkbox extends React.Component {
     super(props);
 
     this.state = {
-      isChecked: false
+      isChecked: false,
     };
 
     this.handleClick = this.handleClick.bind(this);
@@ -16,7 +16,7 @@ class Checkbox extends React.Component {
     if (props.checked !== state.oldIsChecked) {
       return {
         isChecked: props.checked,
-        oldIsChecked: props.checked
+        oldIsChecked: props.checked,
       };
     }
     return null;
@@ -52,7 +52,7 @@ class Checkbox extends React.Component {
 }
 
 Checkbox.defaultProps = {
-  checked: false
+  checked: false,
 };
 
 Checkbox.propTypes = {
@@ -60,7 +60,7 @@ Checkbox.propTypes = {
   disabled: PropTypes.bool,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   onChange: PropTypes.func.isRequired,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 export default Checkbox;

--- a/app/assets/src/components/ui/controls/DateInput.jsx
+++ b/app/assets/src/components/ui/controls/DateInput.jsx
@@ -35,7 +35,7 @@ class DateInput extends React.Component {
 DateInput.propTypes = forbidExtraProps({
   className: PropTypes.string,
   onChange: PropTypes.func,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 });
 
 export default DateInput;

--- a/app/assets/src/components/ui/controls/FilePicker.jsx
+++ b/app/assets/src/components/ui/controls/FilePicker.jsx
@@ -7,7 +7,7 @@ import cs from "./file_picker.scss";
 
 class FilePicker extends React.Component {
   state = {
-    file: null
+    file: null,
   };
 
   // Default handler for dropped files being rejected
@@ -21,7 +21,7 @@ class FilePicker extends React.Component {
   onChange = accepted => {
     if (accepted.length > 0) {
       this.setState({
-        file: accepted[0]
+        file: accepted[0],
       });
     }
   };
@@ -33,7 +33,7 @@ class FilePicker extends React.Component {
       onRejected,
       title,
       multiFile,
-      className
+      className,
     } = this.props;
     const file = this.props.file || this.state.file;
     let content;
@@ -83,7 +83,7 @@ FilePicker.propTypes = {
   message: PropTypes.string,
   title: PropTypes.string,
   onRejected: PropTypes.func,
-  multiFile: PropTypes.bool
+  multiFile: PropTypes.bool,
 };
 
 export default FilePicker;

--- a/app/assets/src/components/ui/controls/FilterTag.jsx
+++ b/app/assets/src/components/ui/controls/FilterTag.jsx
@@ -30,5 +30,5 @@ export default class FilterTag extends React.Component {
 FilterTag.propTypes = {
   text: PropTypes.string,
   onClose: PropTypes.func.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
 };

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -13,7 +13,7 @@ class GeoSearchInputBox extends React.Component {
 
     this.state = {
       value: "",
-      usePropValue: true
+      usePropValue: true,
     };
   }
 
@@ -33,19 +33,19 @@ class GeoSearchInputBox extends React.Component {
           r.description = nameParts.slice(1).join(", ");
           r.key = `loc-${r.locationiq_id}`;
           return r;
-        })
+        }),
       };
     }
     // Let users select an unresolved plain text option
     let noMatchName = "Plain Text (No Location Match)";
     categories[noMatchName] = {
       name: noMatchName,
-      results: [{ title: query, name: query }]
+      results: [{ title: query, name: query }],
     };
 
     logAnalyticsEvent("GeoSearchInputBox_location_queried", {
       query: query,
-      numResults: serverSideSuggestions.length
+      numResults: serverSideSuggestions.length,
     });
     return categories;
   };
@@ -69,7 +69,7 @@ class GeoSearchInputBox extends React.Component {
     logAnalyticsEvent("GeoSearchInputBox_result_selected", {
       selected: result.name,
       // Real results will have a description
-      isMatched: !!result.description
+      isMatched: !!result.description,
     });
     onResultSelect && onResultSelect({ result });
   };
@@ -101,7 +101,7 @@ class GeoSearchInputBox extends React.Component {
 GeoSearchInputBox.propTypes = {
   className: PropTypes.string,
   onResultSelect: PropTypes.func,
-  value: PropTypes.object
+  value: PropTypes.object,
 };
 
 export default GeoSearchInputBox;

--- a/app/assets/src/components/ui/controls/Input.jsx
+++ b/app/assets/src/components/ui/controls/Input.jsx
@@ -29,7 +29,7 @@ class Input extends React.Component {
 Input.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onChange: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default Input;

--- a/app/assets/src/components/ui/controls/LiveSearchBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchBox.jsx
@@ -12,7 +12,7 @@ class LiveSearchBox extends React.Component {
       isLoading: false,
       results: [],
       value: this.props.initialValue,
-      selectedResult: null
+      selectedResult: null,
     };
 
     this.lastestTimerId = null;
@@ -22,7 +22,7 @@ class LiveSearchBox extends React.Component {
     if (props.value !== state.prevValue) {
       return {
         prevValue: props.value,
-        value: props.value
+        value: props.value,
       };
     }
     return null;
@@ -45,7 +45,7 @@ class LiveSearchBox extends React.Component {
     this.setState({
       isLoading: false,
       results: [],
-      value: ""
+      value: "",
     });
   };
 
@@ -67,7 +67,7 @@ class LiveSearchBox extends React.Component {
     if (timerId === this.lastestTimerId) {
       this.setState({
         isLoading: false,
-        results: results
+        results: results,
       });
     }
   };
@@ -127,7 +127,7 @@ LiveSearchBox.defaultProps = {
   minChars: 2,
   placeholder: "Search",
   rectangular: false,
-  inputMode: false
+  inputMode: false,
 };
 
 LiveSearchBox.propTypes = {
@@ -142,7 +142,7 @@ LiveSearchBox.propTypes = {
   onSearchChange: PropTypes.func,
   onResultSelect: PropTypes.func,
   rectangular: PropTypes.bool,
-  inputMode: PropTypes.bool
+  inputMode: PropTypes.bool,
 };
 
 export default LiveSearchBox;

--- a/app/assets/src/components/ui/controls/Menu.jsx
+++ b/app/assets/src/components/ui/controls/Menu.jsx
@@ -22,8 +22,8 @@ Menu.propTypes = {
   className: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ])
+    PropTypes.node,
+  ]),
 };
 
 class MenuItem extends React.Component {
@@ -45,8 +45,8 @@ MenuItem.propTypes = {
   className: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ])
+    PropTypes.node,
+  ]),
 };
 
 export { Menu, MenuItem };

--- a/app/assets/src/components/ui/controls/RadioButton.jsx
+++ b/app/assets/src/components/ui/controls/RadioButton.jsx
@@ -23,7 +23,7 @@ class RadioButton extends React.Component {
 RadioButton.propTypes = {
   selected: PropTypes.bool,
   onClick: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default RadioButton;

--- a/app/assets/src/components/ui/controls/SearchBox.jsx
+++ b/app/assets/src/components/ui/controls/SearchBox.jsx
@@ -23,14 +23,14 @@ class SearchBox extends React.Component {
       isLoading: false,
       results: [],
       value: "",
-      selectedResult: null
+      selectedResult: null,
     };
 
     this.state = {
       isLoading: false,
       results: [],
       value: this.props.initialValue,
-      selectedResult: null
+      selectedResult: null,
     };
   }
 
@@ -47,7 +47,7 @@ class SearchBox extends React.Component {
       isLoading: false,
       results: [],
       value: this.state.value, // necessary for closing dropdown but keeping text entered in input
-      selectedResult: null
+      selectedResult: null,
     });
   };
 
@@ -86,7 +86,7 @@ class SearchBox extends React.Component {
 
       this.setState({
         isLoading: false,
-        results: searchResults
+        results: searchResults,
       });
     }, this.delayCheckMatch);
   };
@@ -106,7 +106,7 @@ class SearchBox extends React.Component {
           this.handleSearchChange,
           this.waitHandleSearchChange,
           {
-            leading: true
+            leading: true,
           }
         )}
         results={results}
@@ -135,7 +135,7 @@ SearchBox.propTypes = {
   levelLabel: PropTypes.bool,
   initialValue: PropTypes.string,
   onResultSelect: PropTypes.func,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
 };
 
 export default SearchBox;

--- a/app/assets/src/components/ui/controls/SearchBoxList.jsx
+++ b/app/assets/src/components/ui/controls/SearchBoxList.jsx
@@ -14,7 +14,7 @@ class SearchBoxList extends React.Component {
 
     this.state = {
       filteredOptions: this.sortedOptions,
-      selected
+      selected,
     };
   }
 
@@ -34,7 +34,7 @@ class SearchBoxList extends React.Component {
     this.setState({
       filteredOptions: this.sortedOptions.filter(option =>
         option.label.toLowerCase().includes(filter)
-      )
+      ),
     });
   };
 
@@ -76,7 +76,7 @@ class SearchBoxList extends React.Component {
           {this.state.filteredOptions.map(option => (
             <div
               className={cx(cs.listElement, {
-                active: this.state.selected.has(option.value)
+                active: this.state.selected.has(option.value),
               })}
               key={`option-${option.value}`}
               onClick={() => this.handleOptionClick(option.value)}
@@ -96,17 +96,17 @@ class SearchBoxList extends React.Component {
 }
 
 SearchBoxList.defaultProps = {
-  selected: []
+  selected: [],
 };
 
 SearchBoxList.propTypes = {
   options: PropTypes.array,
   selected: PropTypes.oneOfType([
     PropTypes.instanceOf(Set), // for sets
-    PropTypes.array
+    PropTypes.array,
   ]),
   onChange: PropTypes.func,
-  title: PropTypes.string
+  title: PropTypes.string,
 };
 
 export default SearchBoxList;

--- a/app/assets/src/components/ui/controls/Slider.jsx
+++ b/app/assets/src/components/ui/controls/Slider.jsx
@@ -8,7 +8,7 @@ class Slider extends React.Component {
     this.onChangeParent = this.props.onChange;
 
     this.state = {
-      value: this.props.value
+      value: this.props.value,
     };
 
     this.onChange = this.onChange.bind(this);
@@ -44,7 +44,7 @@ Slider.propTypes = {
   disabled: PropTypes.bool,
   label: PropTypes.string,
   onChange: PropTypes.func,
-  value: PropTypes.number
+  value: PropTypes.number,
 };
 
 export default Slider;

--- a/app/assets/src/components/ui/controls/Tabs.jsx
+++ b/app/assets/src/components/ui/controls/Tabs.jsx
@@ -10,7 +10,7 @@ class Tabs extends React.Component {
 
     this.state = {
       indicatorLeft: null,
-      indicatorWidth: null
+      indicatorWidth: null,
     };
   }
 
@@ -37,7 +37,7 @@ class Tabs extends React.Component {
     if (tab) {
       this.setState({
         indicatorLeft: tab.offsetLeft,
-        indicatorWidth: tab.offsetWidth
+        indicatorWidth: tab.offsetWidth,
       });
     }
   };
@@ -81,14 +81,14 @@ Tabs.propTypes = {
       PropTypes.string.isRequired,
       PropTypes.shape({
         value: PropTypes.string.isRequired,
-        label: PropTypes.node.isRequired
-      })
+        label: PropTypes.node.isRequired,
+      }),
     ])
   ).isRequired,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string,
   className: PropTypes.string,
-  hideBorder: PropTypes.bool
+  hideBorder: PropTypes.bool,
 };
 
 export default Tabs;

--- a/app/assets/src/components/ui/controls/TermsAgreement.jsx
+++ b/app/assets/src/components/ui/controls/TermsAgreement.jsx
@@ -45,7 +45,7 @@ class TermsAgreement extends React.Component {
 
 TermsAgreement.propTypes = {
   onChange: PropTypes.func,
-  checked: PropTypes.bool
+  checked: PropTypes.bool,
 };
 
 export default TermsAgreement;

--- a/app/assets/src/components/ui/controls/Textarea.jsx
+++ b/app/assets/src/components/ui/controls/Textarea.jsx
@@ -30,7 +30,7 @@ class Textarea extends React.Component {
 Textarea.propTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default Textarea;

--- a/app/assets/src/components/ui/controls/UploadBox.jsx
+++ b/app/assets/src/components/ui/controls/UploadBox.jsx
@@ -9,7 +9,7 @@ class UploadBox extends React.Component {
     super(props);
 
     this.state = {
-      uploadRan: false
+      uploadRan: false,
     };
   }
 
@@ -20,7 +20,7 @@ class UploadBox extends React.Component {
         this.setState({ uploadProgress: percent });
       },
       onSuccess: () => this.props.handleSuccess(file),
-      onError: err => this.props.handleFailure(file, err)
+      onError: err => this.props.handleFailure(file, err),
     });
   };
 
@@ -55,7 +55,7 @@ UploadBox.propTypes = {
   startUpload: PropTypes.bool,
   onDrop: PropTypes.func,
   handleSuccess: PropTypes.func,
-  handleFailure: PropTypes.func
+  handleFailure: PropTypes.func,
 };
 
 export default UploadBox;

--- a/app/assets/src/components/ui/controls/buttons/Button.jsx
+++ b/app/assets/src/components/ui/controls/buttons/Button.jsx
@@ -54,11 +54,11 @@ Button.propTypes = forbidExtraProps({
   secondary: PropTypes.bool,
   rounded: PropTypes.bool,
   className: PropTypes.string,
-  hasDropdownArrow: PropTypes.bool
+  hasDropdownArrow: PropTypes.bool,
 });
 
 Button.defaultProps = {
-  rounded: true
+  rounded: true,
 };
 
 export default Button;

--- a/app/assets/src/components/ui/controls/buttons/CompareButton.jsx
+++ b/app/assets/src/components/ui/controls/buttons/CompareButton.jsx
@@ -16,7 +16,7 @@ const CompareButton = ({ disabled, onClick }) => {
 
 CompareButton.propTypes = {
   disabled: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 };
 
 export default CompareButton;

--- a/app/assets/src/components/ui/controls/buttons/DownloadButton.jsx
+++ b/app/assets/src/components/ui/controls/buttons/DownloadButton.jsx
@@ -17,7 +17,7 @@ const DownloadButton = ({ disabled, onClick, ...props }) => {
 
 DownloadButton.propTypes = {
   disabled: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 };
 
 export default DownloadButton;

--- a/app/assets/src/components/ui/controls/buttons/PhylogenyButton.jsx
+++ b/app/assets/src/components/ui/controls/buttons/PhylogenyButton.jsx
@@ -16,7 +16,7 @@ const PhylogenyButton = ({ disabled, onClick }) => {
 
 PhylogenyButton.propTypes = {
   disabled: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 };
 
 export default PhylogenyButton;

--- a/app/assets/src/components/ui/controls/dropdowns/AsyncMultipleDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/AsyncMultipleDropdown.jsx
@@ -9,7 +9,7 @@ class AsyncMultipleDropdown extends React.Component {
 
     this.state = {
       selectedOptions: [],
-      options: []
+      options: [],
     };
   }
 
@@ -18,7 +18,7 @@ class AsyncMultipleDropdown extends React.Component {
       return {
         selectedOptions: props.selectedOptions,
         prevPropsSelectedOptions: props.selectedOptions,
-        options: unionBy("value", state.options, props.selectedOptions)
+        options: unionBy("value", state.options, props.selectedOptions),
       };
     }
     return null;
@@ -42,7 +42,7 @@ class AsyncMultipleDropdown extends React.Component {
 
     this.setState(
       {
-        selectedOptions: newSelectedOptions
+        selectedOptions: newSelectedOptions,
       },
       () => onChange(this.state.selectedOptions)
     );
@@ -84,7 +84,7 @@ class AsyncMultipleDropdown extends React.Component {
 AsyncMultipleDropdown.propTypes = {
   selectedOptions: PropTypes.array,
   onChange: PropTypes.func,
-  onFilterChange: PropTypes.func
+  onFilterChange: PropTypes.func,
 };
 
 export default AsyncMultipleDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -25,7 +25,7 @@ class BareDropdown extends React.Component {
     super(props);
 
     this.state = {
-      filterString: ""
+      filterString: "",
     };
   }
 
@@ -62,7 +62,7 @@ class BareDropdown extends React.Component {
 
     this.setState(
       {
-        filterString
+        filterString,
       },
       () => {
         onFilterChange && onFilterChange(filterString);
@@ -254,7 +254,7 @@ BareDropdown.propTypes = forbidExtraProps({
       value: PropTypes.any,
       text: PropTypes.node,
       // Custom node to render for the option.
-      customNode: PropTypes.node
+      customNode: PropTypes.node,
     })
   ),
   value: PropTypes.any,
@@ -280,11 +280,11 @@ BareDropdown.propTypes = forbidExtraProps({
   fluid: PropTypes.bool,
   direction: PropTypes.string,
   className: PropTypes.string,
-  menuClassName: PropTypes.string
+  menuClassName: PropTypes.string,
 });
 
 BareDropdown.defaultProps = {
-  closeOnClick: true
+  closeOnClick: true,
 };
 
 BareDropdown.Header = BaseDropdown.Header;

--- a/app/assets/src/components/ui/controls/dropdowns/ButtonDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/ButtonDropdown.jsx
@@ -56,7 +56,7 @@ ButtonDropdown.propTypes = {
   primary: PropTypes.bool,
   secondary: PropTypes.bool,
   text: PropTypes.string,
-  direction: PropTypes.oneOf(["left", "right"])
+  direction: PropTypes.oneOf(["left", "right"]),
 };
 
 export default ButtonDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/DownloadButtonDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/DownloadButtonDropdown.jsx
@@ -21,7 +21,7 @@ DownloadButtonDropdown.propTypes = forbidExtraProps({
   disabled: PropTypes.bool,
   options: PropTypes.array,
   onClick: PropTypes.func,
-  direction: PropTypes.oneOf(["left", "right"])
+  direction: PropTypes.oneOf(["left", "right"]),
 });
 
 export default DownloadButtonDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/DownloadIconDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/DownloadIconDropdown.jsx
@@ -30,7 +30,7 @@ DownloadIconDropdown.propTypes = forbidExtraProps({
   disabled: PropTypes.bool,
   options: PropTypes.array,
   onClick: PropTypes.func,
-  direction: PropTypes.oneOf(["left", "right"])
+  direction: PropTypes.oneOf(["left", "right"]),
 });
 
 export default DownloadIconDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
@@ -10,7 +10,7 @@ class Dropdown extends React.Component {
     super(props);
     this.state = {
       value: this.props.value !== undefined ? this.props.value : null,
-      labels: {}
+      labels: {},
     };
   }
 
@@ -36,7 +36,7 @@ class Dropdown extends React.Component {
       labels: this.props.options.reduce((labelMap, option) => {
         labelMap[option.value.toString()] = option.text;
         return labelMap;
-      }, {})
+      }, {}),
     });
   };
 
@@ -107,7 +107,7 @@ Dropdown.propTypes = {
         .isRequired,
       // Optional node element will be rendered instead of text.
       // Text will still be used in the <DropdownTrigger>
-      customNode: PropTypes.node
+      customNode: PropTypes.node,
     })
   ).isRequired,
   // Custom props for rendering items
@@ -120,7 +120,7 @@ Dropdown.propTypes = {
   search: PropTypes.bool,
   menuLabel: PropTypes.string,
   usePortal: PropTypes.bool,
-  withinModal: PropTypes.bool
+  withinModal: PropTypes.bool,
 };
 
 export default Dropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx
@@ -14,7 +14,7 @@ class MultipleDropdown extends React.Component {
 
     this.state = {
       value: this.props.value || [],
-      valueOnOpen: this.props.value || []
+      valueOnOpen: this.props.value || [],
     };
   }
 
@@ -35,7 +35,7 @@ class MultipleDropdown extends React.Component {
     if (props.value !== state.prevPropsValue) {
       return {
         value: props.value,
-        prevPropsValue: props.value
+        prevPropsValue: props.value,
       };
     }
     return null;
@@ -110,7 +110,7 @@ class MultipleDropdown extends React.Component {
     const { checkedOnTop } = this.props;
     if (checkedOnTop)
       this.setState({
-        valueOnOpen: this.state.value.slice()
+        valueOnOpen: this.state.value.slice(),
       });
   };
 
@@ -150,7 +150,7 @@ class MultipleDropdown extends React.Component {
 
 MultipleDropdown.defaultProps = {
   arrowInsideTrigger: true,
-  value: []
+  value: [],
 };
 
 MultipleDropdown.propTypes = {
@@ -165,7 +165,7 @@ MultipleDropdown.propTypes = {
   options: PropTypes.arrayOf(PropTypes.object),
   trigger: PropTypes.node,
   value: PropTypes.array,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default MultipleDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/MultipleNestedDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/MultipleNestedDropdown.jsx
@@ -16,7 +16,7 @@ class MultipleNestedDropdown extends React.Component {
       selectedOptions: this.props.selectedOptions || [],
       selectedSuboptions: this.props.selectedSuboptions || {},
       oldSelectedOptions: [],
-      oldSelectedSuboptions: {}
+      oldSelectedSuboptions: {},
     };
 
     this.suboptionsToOptionMap = {};
@@ -40,7 +40,7 @@ class MultipleNestedDropdown extends React.Component {
         {},
         {
           selectedOptions: props.selectedOptions,
-          oldSelectedOptions: props.selectedOptions
+          oldSelectedOptions: props.selectedOptions,
         }
       );
     }
@@ -54,7 +54,7 @@ class MultipleNestedDropdown extends React.Component {
     ) {
       newState = Object.assign(newState || {}, {
         selectedSuboptions: props.selectedSuboptions,
-        oldSelectedSuboptions: props.selectedSuboptions
+        oldSelectedSuboptions: props.selectedSuboptions,
       });
     }
 
@@ -77,7 +77,7 @@ class MultipleNestedDropdown extends React.Component {
       this.setState(
         prevState => {
           let stateUpdate = {
-            selectedOptions: [...prevState.selectedOptions, optionValue]
+            selectedOptions: [...prevState.selectedOptions, optionValue],
           };
           const optionClicked = this.props.options.find(
             option => option.value == optionValue
@@ -104,7 +104,7 @@ class MultipleNestedDropdown extends React.Component {
           return {
             selectedOptions: prevState.selectedOptions.filter(
               value => value != optionValue
-            )
+            ),
           };
         },
         () =>
@@ -252,7 +252,7 @@ class MultipleNestedDropdown extends React.Component {
         "label",
         "rounded",
         "onChange",
-        "options"
+        "options",
       ],
       this.props
     );
@@ -272,7 +272,7 @@ class MultipleNestedDropdown extends React.Component {
 
 MultipleNestedDropdown.defaultProps = {
   selectedOptions: [],
-  selectedSuboptions: {}
+  selectedSuboptions: {},
 };
 
 MultipleNestedDropdown.propTypes = {
@@ -283,7 +283,7 @@ MultipleNestedDropdown.propTypes = {
   selectedOptions: PropTypes.array,
   selectedSuboptions: PropTypes.object,
   disabled: PropTypes.bool,
-  rounded: PropTypes.bool
+  rounded: PropTypes.bool,
 };
 
 export default MultipleNestedDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/PortalDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/PortalDropdown.jsx
@@ -17,7 +17,7 @@ class PortalDropdown extends React.Component {
   state = {
     open: false,
     // Used to give the menuContainer min-width equal to the trigger element.
-    triggerWidth: null
+    triggerWidth: null,
   };
 
   componentDidMount() {
@@ -40,7 +40,7 @@ class PortalDropdown extends React.Component {
       // Measure the trigger width.
       triggerWidth: this._triggerRef
         ? this._triggerRef.getBoundingClientRect().width
-        : null
+        : null,
     });
     if (this.props.onOpen) {
       this.props.onOpen();
@@ -50,7 +50,7 @@ class PortalDropdown extends React.Component {
   close = () => {
     this._lastTransform = null;
     this.setState({
-      open: false
+      open: false,
     });
     if (this.props.onClose) {
       this.props.onClose();
@@ -93,7 +93,7 @@ class PortalDropdown extends React.Component {
                 onClick={this.toggleOpen}
               >
                 {React.cloneElement(this.props.trigger, {
-                  active: open
+                  active: open,
                 })}
                 {!this.props.hideArrow && (
                   <i className={cx(cs.arrow, this.state.open && cs.active)} />
@@ -110,7 +110,7 @@ class PortalDropdown extends React.Component {
               }
               modifiers={{
                 preventOverflow: { enabled: false },
-                hide: { enabled: false }
+                hide: { enabled: false },
               }}
             >
               {({ ref, style, placement }) => {
@@ -177,11 +177,11 @@ PortalDropdown.propTypes = {
   onClose: PropTypes.func,
   open: PropTypes.bool,
   hideArrow: PropTypes.bool,
-  arrowInsideTrigger: PropTypes.bool
+  arrowInsideTrigger: PropTypes.bool,
 };
 
 PortalDropdown.defaultProps = {
-  direction: "right"
+  direction: "right",
 };
 
 export default PortalDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/ThresholdFilterDropdown.jsx
@@ -26,7 +26,7 @@ class ThresholdFilterDropdown extends React.Component {
 
     this.state = {
       popupIsOpen: false,
-      thresholds: []
+      thresholds: [],
     };
   }
 
@@ -42,7 +42,7 @@ class ThresholdFilterDropdown extends React.Component {
     ) {
       return {
         thresholds: newThresholds,
-        oldThresholds: newThresholds
+        oldThresholds: newThresholds,
       };
     }
     return null;
@@ -99,9 +99,9 @@ class ThresholdFilterDropdown extends React.Component {
           metric: this.metrics[0].value,
           metricDisplay: this.metrics[0].text,
           operator: this.operators[0],
-          value: ""
-        }
-      ]
+          value: "",
+        },
+      ],
     });
   }
 
@@ -121,12 +121,12 @@ class ThresholdFilterDropdown extends React.Component {
       this.props.onApply(newThresholds);
 
       logAnalyticsEvent("ThresholdFilterDropdown_apply-button_clicked", {
-        thresholds: newThresholds.length
+        thresholds: newThresholds.length,
       });
     } else {
       this.setState({ thresholds: this.props.thresholds });
       logAnalyticsEvent("ThresholdFilterDropdown_cancel-button_clicked", {
-        thresholds: this.props.thresholds.length
+        thresholds: this.props.thresholds.length,
       });
     }
   };
@@ -223,7 +223,7 @@ class ThresholdFilterDropdown extends React.Component {
 }
 
 ThresholdFilterDropdown.defaultProps = {
-  thresholds: []
+  thresholds: [],
 };
 
 ThresholdFilterDropdown.propTypes = forbidExtraProps({
@@ -231,7 +231,7 @@ ThresholdFilterDropdown.propTypes = forbidExtraProps({
   label: PropTypes.string,
   thresholds: PropTypes.array,
   onApply: PropTypes.func,
-  options: PropTypes.object
+  options: PropTypes.object,
 });
 
 const ThresholdFilter = ({
@@ -239,7 +239,7 @@ const ThresholdFilter = ({
   metrics,
   operators,
   onChange,
-  onRemove
+  onRemove,
 }) => {
   let { metric, value, operator, metricDisplay } = threshold;
 
@@ -249,7 +249,7 @@ const ThresholdFilter = ({
       metric: newMetric,
       value,
       operator,
-      metricDisplay: newMetricDisplay
+      metricDisplay: newMetricDisplay,
     });
   };
 
@@ -303,17 +303,17 @@ ThresholdFilter.propTypes = forbidExtraProps({
       metric: PropTypes.string,
       value: PropTypes.string,
       operator: PropTypes.string,
-      metricDisplay: PropTypes.string
+      metricDisplay: PropTypes.string,
     })
   ),
   onChange: PropTypes.func,
   onRemove: PropTypes.func,
   operators: PropTypes.array,
-  threshold: PropTypes.object
+  threshold: PropTypes.object,
 });
 
 ThresholdFilterDropdown.defaultProps = {
-  thresholds: []
+  thresholds: [],
 };
 
 export default ThresholdFilterDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/common/CheckboxItem.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/common/CheckboxItem.jsx
@@ -31,7 +31,7 @@ CheckboxItem.propTypes = {
   value: PropTypes.any,
   label: PropTypes.string,
   checked: PropTypes.bool,
-  onOptionClick: PropTypes.func
+  onOptionClick: PropTypes.func,
 };
 
 export default CheckboxItem;

--- a/app/assets/src/components/ui/controls/dropdowns/common/DropdownLabel.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/common/DropdownLabel.jsx
@@ -15,7 +15,7 @@ const DropdownLabel = ({ text, disabled, className }) => (
 DropdownLabel.propTypes = {
   disabled: PropTypes.bool,
   text: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default DropdownLabel;

--- a/app/assets/src/components/ui/controls/dropdowns/common/DropdownTrigger.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/common/DropdownTrigger.jsx
@@ -12,7 +12,7 @@ class DropdownTrigger extends React.Component {
       active,
       disabled,
       className,
-      onClick
+      onClick,
     } = this.props;
     return (
       <div
@@ -41,7 +41,7 @@ DropdownTrigger.propTypes = {
   rounded: PropTypes.bool,
   active: PropTypes.bool,
   disabled: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 };
 
 export default DropdownTrigger;

--- a/app/assets/src/components/ui/icons/AlertIcon.jsx
+++ b/app/assets/src/components/ui/icons/AlertIcon.jsx
@@ -20,7 +20,7 @@ const AlertIcon = props => {
 };
 
 AlertIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default AlertIcon;

--- a/app/assets/src/components/ui/icons/BeeIcon.jsx
+++ b/app/assets/src/components/ui/icons/BeeIcon.jsx
@@ -15,7 +15,7 @@ const BeeIcon = props => {
 };
 
 BeeIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default BeeIcon;

--- a/app/assets/src/components/ui/icons/BulletListIcon.jsx
+++ b/app/assets/src/components/ui/icons/BulletListIcon.jsx
@@ -8,7 +8,7 @@ const BulletListIcon = props => {
 };
 
 BulletListIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default BulletListIcon;

--- a/app/assets/src/components/ui/icons/CatIcon.jsx
+++ b/app/assets/src/components/ui/icons/CatIcon.jsx
@@ -72,7 +72,7 @@ const CatIcon = props => {
 };
 
 CatIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default CatIcon;

--- a/app/assets/src/components/ui/icons/CheckmarkIcon.jsx
+++ b/app/assets/src/components/ui/icons/CheckmarkIcon.jsx
@@ -16,7 +16,7 @@ const CheckmarkIcon = ({ className, size }) => {
 
 CheckmarkIcon.propTypes = {
   className: PropTypes.string,
-  size: PropTypes.string
+  size: PropTypes.string,
 };
 
 export default CheckmarkIcon;

--- a/app/assets/src/components/ui/icons/CompareIcon.jsx
+++ b/app/assets/src/components/ui/icons/CompareIcon.jsx
@@ -23,7 +23,7 @@ const CompareIcon = props => {
 };
 
 CompareIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default CompareIcon;

--- a/app/assets/src/components/ui/icons/CopyIcon.jsx
+++ b/app/assets/src/components/ui/icons/CopyIcon.jsx
@@ -30,7 +30,7 @@ const CopyIcon = props => {
 };
 
 CopyIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default CopyIcon;

--- a/app/assets/src/components/ui/icons/CoverageIcon.jsx
+++ b/app/assets/src/components/ui/icons/CoverageIcon.jsx
@@ -19,7 +19,7 @@ const CoverageIcon = props => {
 };
 
 CoverageIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default CoverageIcon;

--- a/app/assets/src/components/ui/icons/DecipherIcon.jsx
+++ b/app/assets/src/components/ui/icons/DecipherIcon.jsx
@@ -32,7 +32,7 @@ const DecipherIcon = props => {
 };
 
 DecipherIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default DecipherIcon;

--- a/app/assets/src/components/ui/icons/DetectIcon.jsx
+++ b/app/assets/src/components/ui/icons/DetectIcon.jsx
@@ -90,7 +90,7 @@ const DetectIcon = props => {
 };
 
 DetectIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default DetectIcon;

--- a/app/assets/src/components/ui/icons/DiscoverIcon.jsx
+++ b/app/assets/src/components/ui/icons/DiscoverIcon.jsx
@@ -104,7 +104,7 @@ const DiscoverIcon = props => {
 };
 
 DiscoverIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default DiscoverIcon;

--- a/app/assets/src/components/ui/icons/DownloadIcon.jsx
+++ b/app/assets/src/components/ui/icons/DownloadIcon.jsx
@@ -27,7 +27,7 @@ const DownloadIcon = props => {
 };
 
 DownloadIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default DownloadIcon;

--- a/app/assets/src/components/ui/icons/ERCCIcon.jsx
+++ b/app/assets/src/components/ui/icons/ERCCIcon.jsx
@@ -84,7 +84,7 @@ const ERCCIcon = props => {
 };
 
 ERCCIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default ERCCIcon;

--- a/app/assets/src/components/ui/icons/FiltersIcon.jsx
+++ b/app/assets/src/components/ui/icons/FiltersIcon.jsx
@@ -21,7 +21,7 @@ const FiltersIcon = props => {
 };
 
 FiltersIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default FiltersIcon;

--- a/app/assets/src/components/ui/icons/GlobeIcon.jsx
+++ b/app/assets/src/components/ui/icons/GlobeIcon.jsx
@@ -27,7 +27,7 @@ const GlobeIcon = props => {
 };
 
 GlobeIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default GlobeIcon;

--- a/app/assets/src/components/ui/icons/GlobeLinedIcon.jsx
+++ b/app/assets/src/components/ui/icons/GlobeLinedIcon.jsx
@@ -8,7 +8,7 @@ const GlobeLinedIcon = props => {
 };
 
 GlobeLinedIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default GlobeLinedIcon;

--- a/app/assets/src/components/ui/icons/HeatmapIcon.jsx
+++ b/app/assets/src/components/ui/icons/HeatmapIcon.jsx
@@ -34,7 +34,7 @@ const HeatmapIcon = props => {
 };
 
 HeatmapIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default HeatmapIcon;

--- a/app/assets/src/components/ui/icons/HeatmapPrivate.jsx
+++ b/app/assets/src/components/ui/icons/HeatmapPrivate.jsx
@@ -11,7 +11,7 @@ import cs from "./heatmap_private.scss";
  */
 export default class HeatmapPrivate extends Component {
   static propTypes = {
-    className: PropTypes.string
+    className: PropTypes.string,
   };
 
   render() {

--- a/app/assets/src/components/ui/icons/HeatmapPublic.jsx
+++ b/app/assets/src/components/ui/icons/HeatmapPublic.jsx
@@ -11,7 +11,7 @@ import cs from "./heatmap_public.scss";
  */
 export default class HeatmapPublic extends Component {
   static propTypes = {
-    className: PropTypes.string
+    className: PropTypes.string,
   };
 
   render() {

--- a/app/assets/src/components/ui/icons/HumanIcon.jsx
+++ b/app/assets/src/components/ui/icons/HumanIcon.jsx
@@ -148,7 +148,7 @@ const HumanIcon = props => {
 };
 
 HumanIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default HumanIcon;

--- a/app/assets/src/components/ui/icons/Icon.jsx
+++ b/app/assets/src/components/ui/icons/Icon.jsx
@@ -14,7 +14,7 @@ Icon.propTypes = forbidExtraProps({
   name: PropTypes.string,
   size: PropTypes.string,
   className: PropTypes.string,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 });
 
 export default Icon;

--- a/app/assets/src/components/ui/icons/InfoIcon.jsx
+++ b/app/assets/src/components/ui/icons/InfoIcon.jsx
@@ -21,7 +21,7 @@ const InfoIcon = props => {
 };
 
 InfoIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default InfoIcon;

--- a/app/assets/src/components/ui/icons/LoadingIcon.jsx
+++ b/app/assets/src/components/ui/icons/LoadingIcon.jsx
@@ -7,7 +7,7 @@ const LoadingIcon = props => {
 };
 
 LoadingIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default LoadingIcon;

--- a/app/assets/src/components/ui/icons/LockIcon.jsx
+++ b/app/assets/src/components/ui/icons/LockIcon.jsx
@@ -29,7 +29,7 @@ const LockIcon = props => {
 };
 
 LockIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default LockIcon;

--- a/app/assets/src/components/ui/icons/LogoIcon.jsx
+++ b/app/assets/src/components/ui/icons/LogoIcon.jsx
@@ -62,7 +62,7 @@ const LogoIcon = props => {
 };
 
 LogoIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default LogoIcon;

--- a/app/assets/src/components/ui/icons/MosquitoIcon.jsx
+++ b/app/assets/src/components/ui/icons/MosquitoIcon.jsx
@@ -46,7 +46,7 @@ const MosquitoIcon = props => {
 };
 
 MosquitoIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default MosquitoIcon;

--- a/app/assets/src/components/ui/icons/MouseIcon.jsx
+++ b/app/assets/src/components/ui/icons/MouseIcon.jsx
@@ -100,7 +100,7 @@ const MouseIcon = props => {
 };
 
 MouseIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default MouseIcon;

--- a/app/assets/src/components/ui/icons/NoResultsBacteriaIcon.jsx
+++ b/app/assets/src/components/ui/icons/NoResultsBacteriaIcon.jsx
@@ -45,7 +45,7 @@ const NoResultsBacteriaIcon = props => {
 };
 
 NoResultsBacteriaIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default NoResultsBacteriaIcon;

--- a/app/assets/src/components/ui/icons/NoResultsIcon.jsx
+++ b/app/assets/src/components/ui/icons/NoResultsIcon.jsx
@@ -109,7 +109,7 @@ const NoResultsIcon = props => {
 };
 
 NoResultsIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default NoResultsIcon;

--- a/app/assets/src/components/ui/icons/PhyloTreeIcon.jsx
+++ b/app/assets/src/components/ui/icons/PhyloTreeIcon.jsx
@@ -34,7 +34,7 @@ const PhyloTreeIcon = props => {
 };
 
 PhyloTreeIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default PhyloTreeIcon;

--- a/app/assets/src/components/ui/icons/PhyloTreePrivate.jsx
+++ b/app/assets/src/components/ui/icons/PhyloTreePrivate.jsx
@@ -11,7 +11,7 @@ import cs from "./phylo_tree_private.scss";
  */
 export default class PhyloTreePrivate extends Component {
   static propTypes = {
-    className: PropTypes.string
+    className: PropTypes.string,
   };
 
   render() {

--- a/app/assets/src/components/ui/icons/PhyloTreePublic.jsx
+++ b/app/assets/src/components/ui/icons/PhyloTreePublic.jsx
@@ -11,7 +11,7 @@ import cs from "./phylo_tree_public.scss";
  */
 export default class PhyloTreePublic extends Component {
   static propTypes = {
-    className: PropTypes.string
+    className: PropTypes.string,
   };
 
   render() {

--- a/app/assets/src/components/ui/icons/PigIcon.jsx
+++ b/app/assets/src/components/ui/icons/PigIcon.jsx
@@ -97,7 +97,7 @@ const PigIcon = props => {
 };
 
 PigIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default PigIcon;

--- a/app/assets/src/components/ui/icons/PlusIcon.jsx
+++ b/app/assets/src/components/ui/icons/PlusIcon.jsx
@@ -24,7 +24,7 @@ const PlusIcon = props => {
 };
 
 PlusIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default PlusIcon;

--- a/app/assets/src/components/ui/icons/PrivateProjectIcon.jsx
+++ b/app/assets/src/components/ui/icons/PrivateProjectIcon.jsx
@@ -49,7 +49,7 @@ const PrivateProjectIcon = props => {
 };
 
 PrivateProjectIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default PrivateProjectIcon;

--- a/app/assets/src/components/ui/icons/PublicProjectIcon.jsx
+++ b/app/assets/src/components/ui/icons/PublicProjectIcon.jsx
@@ -52,7 +52,7 @@ const PublicProjectIcon = props => {
 };
 
 PublicProjectIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default PublicProjectIcon;

--- a/app/assets/src/components/ui/icons/RemoveIcon.jsx
+++ b/app/assets/src/components/ui/icons/RemoveIcon.jsx
@@ -23,7 +23,7 @@ const RemoveIcon = ({ className, onClick }) => {
 
 RemoveIcon.propTypes = {
   className: PropTypes.string,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 };
 
 export default RemoveIcon;

--- a/app/assets/src/components/ui/icons/SamplePrivateIcon.jsx
+++ b/app/assets/src/components/ui/icons/SamplePrivateIcon.jsx
@@ -67,7 +67,7 @@ const SamplePrivateIcon = props => {
 };
 
 SamplePrivateIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default SamplePrivateIcon;

--- a/app/assets/src/components/ui/icons/SamplePublicIcon.jsx
+++ b/app/assets/src/components/ui/icons/SamplePublicIcon.jsx
@@ -59,7 +59,7 @@ const PublicSampleIcon = props => {
 };
 
 PublicSampleIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default PublicSampleIcon;

--- a/app/assets/src/components/ui/icons/SaveIcon.jsx
+++ b/app/assets/src/components/ui/icons/SaveIcon.jsx
@@ -35,11 +35,11 @@ const SaveIcon = props => {
 
 SaveIcon.propTypes = {
   className: PropTypes.string,
-  popupText: PropTypes.string
+  popupText: PropTypes.string,
 };
 
 SaveIcon.defaultProps = {
-  popupText: "Save"
+  popupText: "Save",
 };
 
 export default SaveIcon;

--- a/app/assets/src/components/ui/icons/TickIcon.jsx
+++ b/app/assets/src/components/ui/icons/TickIcon.jsx
@@ -52,7 +52,7 @@ const TickIcon = props => {
 };
 
 TickIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default TickIcon;

--- a/app/assets/src/components/ui/icons/UserIcon.jsx
+++ b/app/assets/src/components/ui/icons/UserIcon.jsx
@@ -30,7 +30,7 @@ const UserIcon = props => {
 };
 
 UserIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default UserIcon;

--- a/app/assets/src/components/ui/icons/WormIcon.jsx
+++ b/app/assets/src/components/ui/icons/WormIcon.jsx
@@ -18,7 +18,7 @@ const WormIcon = props => {
 };
 
 WormIcon.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
 };
 
 export default WormIcon;

--- a/app/assets/src/components/ui/icons/index.js
+++ b/app/assets/src/components/ui/icons/index.js
@@ -68,14 +68,14 @@ export default {
     WormIcon,
     PublicProjectIcon,
     PrivateProjectIcon,
-    SaveIcon
+    SaveIcon,
   },
   FONT_AWESOME: {
     CheckmarkIcon,
     InsightIcon,
-    LoadingIcon
+    LoadingIcon,
   },
   LOGO: {
-    LogoIcon
-  }
+    LogoIcon,
+  },
 };

--- a/app/assets/src/components/ui/labels/Label.jsx
+++ b/app/assets/src/components/ui/labels/Label.jsx
@@ -12,7 +12,7 @@ const Label = ({
   circular,
   floating,
   text,
-  onClick
+  onClick,
 }) => {
   return (
     <BaseLabel
@@ -35,7 +35,7 @@ Label.propTypes = forbidExtraProps({
   circular: PropTypes.bool,
   floating: PropTypes.bool,
   text: PropTypes.node,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 });
 
 export default Label;

--- a/app/assets/src/components/ui/labels/LoadingLabel.jsx
+++ b/app/assets/src/components/ui/labels/LoadingLabel.jsx
@@ -12,7 +12,7 @@ const LoadingLabel = ({ text }) => {
 };
 
 LoadingLabel.propTypes = {
-  text: PropTypes.string
+  text: PropTypes.string,
 };
 
 export default LoadingLabel;

--- a/app/assets/src/components/ui/labels/PathogenLabel.jsx
+++ b/app/assets/src/components/ui/labels/PathogenLabel.jsx
@@ -12,20 +12,20 @@ export const CATEGORIES = {
     text: BASE_LABEL + " | a",
     color: "red",
     tooltip: "NIAID pathogen priority list | category A",
-    url: NIAID_URL
+    url: NIAID_URL,
   },
   categoryB: {
     text: BASE_LABEL + " | b",
     color: "orange",
     tooltip: "NIAID pathogen priority list | category B",
-    url: NIAID_URL
+    url: NIAID_URL,
   },
   categoryC: {
     text: BASE_LABEL + " | c",
     color: "yellow",
     tooltip: "NIAID pathogen priority list | category C",
-    url: NIAID_URL
-  }
+    url: NIAID_URL,
+  },
 };
 
 const PathogenLabel = ({ type }) => {

--- a/app/assets/src/components/ui/notifications/IssueGroup.jsx
+++ b/app/assets/src/components/ui/notifications/IssueGroup.jsx
@@ -43,7 +43,7 @@ IssueGroup.propTypes = {
   caption: PropTypes.string,
   headers: PropTypes.arrayOf(PropTypes.string),
   rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)),
-  type: PropTypes.oneOf(["error", "warning"])
+  type: PropTypes.oneOf(["error", "warning"]),
 };
 
 export default IssueGroup;

--- a/app/assets/src/components/ui/notifications/ListNotification.jsx
+++ b/app/assets/src/components/ui/notifications/ListNotification.jsx
@@ -16,7 +16,7 @@ class ListNotification extends React.Component {
       className,
       label,
       listItems,
-      listItemName
+      listItemName,
     } = this.props;
     return (
       <Notification
@@ -55,7 +55,7 @@ ListNotification.propTypes = {
   type: PropTypes.oneOf(["success", "info", "warn", "error"]),
   label: PropTypes.node,
   listItems: PropTypes.arrayOf(PropTypes.string),
-  listItemName: PropTypes.string
+  listItemName: PropTypes.string,
 };
 
 export default ListNotification;

--- a/app/assets/src/components/ui/notifications/Notification.jsx
+++ b/app/assets/src/components/ui/notifications/Notification.jsx
@@ -41,7 +41,7 @@ class Notification extends React.Component {
 
 Notification.defaultProps = {
   displayStyle: "elevated",
-  type: "info"
+  type: "info",
 };
 
 Notification.propTypes = {
@@ -49,7 +49,7 @@ Notification.propTypes = {
   children: PropTypes.node,
   displayStyle: PropTypes.oneOf(["flat", "elevated"]),
   onClose: PropTypes.func,
-  type: PropTypes.oneOf(["success", "info", "warn", "error"])
+  type: PropTypes.oneOf(["success", "info", "warn", "error"]),
 };
 
 export default Notification;

--- a/app/assets/src/components/utils/colormaps/CategoricalColormap.js
+++ b/app/assets/src/components/utils/colormaps/CategoricalColormap.js
@@ -6,7 +6,7 @@ export class CategoricalColormap {
       "55C567",
       "BF1464",
       "E58740",
-      "AB4ECC"
+      "AB4ECC",
     ];
 
     this.gradients = this.gradients.map(c => this.hexToDec(c));

--- a/app/assets/src/components/utils/csv.js
+++ b/app/assets/src/components/utils/csv.js
@@ -4,11 +4,11 @@ import Papa from "papaparse";
 // Assumes that the CSV has headers.
 export const parseCSVBlob = blob => {
   const csvData = Papa.parse(blob, {
-    skipEmptyLines: true
+    skipEmptyLines: true,
   }).data;
 
   return {
     headers: head(csvData),
-    rows: tail(csvData)
+    rows: tail(csvData),
   };
 };

--- a/app/assets/src/components/utils/d3/scales/symlog.js
+++ b/app/assets/src/components/utils/d3/scales/symlog.js
@@ -27,7 +27,7 @@ function rescale(range, domain) {
     parts.push({
       domain: d,
       type: d3.scale.log,
-      extent: logScale(Math.abs(d[1] - d[0]) + 1) - logScale(1)
+      extent: logScale(Math.abs(d[1] - d[0]) + 1) - logScale(1),
     });
   }
 
@@ -37,7 +37,7 @@ function rescale(range, domain) {
     parts.push({
       domain: d,
       type: d3.scale.linear,
-      extent: Math.abs(d[1] - d[0]) * (logScale(2) - logScale(1))
+      extent: Math.abs(d[1] - d[0]) * (logScale(2) - logScale(1)),
     });
   }
 
@@ -47,7 +47,7 @@ function rescale(range, domain) {
     parts.push({
       domain: d,
       type: d3.scale.log,
-      extent: logScale(Math.abs(d[1] - d[0]) + 1) - logScale(1)
+      extent: logScale(Math.abs(d[1] - d[0]) + 1) - logScale(1),
     });
   }
 

--- a/app/assets/src/components/utils/propTypes.js
+++ b/app/assets/src/components/utils/propTypes.js
@@ -13,7 +13,7 @@ const TaxonDatabaseStats = PropTypes.shape({
   // Right now, if rpm is 0, it is a number. Otherwise, a string.
   rpm: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   rpm_bg: PropTypes.number,
-  zscore: PropTypes.number.isRequired
+  zscore: PropTypes.number.isRequired,
 });
 
 const Taxon = PropTypes.shape({
@@ -30,42 +30,42 @@ const Taxon = PropTypes.shape({
   species_taxid: PropTypes.number.isRequired,
   tax_id: PropTypes.number.isRequired,
   tax_level: PropTypes.number.isRequired,
-  topScoring: PropTypes.number
+  topScoring: PropTypes.number,
 });
 
 // TODO(mark): Expand signature as more fields of ReportDetails are used in the app.
 const ReportDetails = PropTypes.shape({
-  taxon_fasta_flag: PropTypes.bool.isRequired
+  taxon_fasta_flag: PropTypes.bool.isRequired,
 });
 
 const BackgroundData = PropTypes.shape({
   id: PropTypes.number,
-  name: PropTypes.string
+  name: PropTypes.string,
 });
 
 // TODO(mark): Expand signature as more fields of Sample are used in the app.
 const Sample = PropTypes.shape({
   id: PropTypes.number,
   name: PropTypes.string,
-  host_genome_id: PropTypes.number
+  host_genome_id: PropTypes.number,
 });
 
 const Project = PropTypes.shape({
   id: PropTypes.number.isRequired,
-  name: PropTypes.string.isRequired
+  name: PropTypes.string.isRequired,
 });
 
 const MetadataType = PropTypes.shape({
   key: PropTypes.string,
   dataType: PropTypes.oneOf(["string", "number", "date", "location"]),
-  name: PropTypes.string
+  name: PropTypes.string,
 });
 
 const ERCCComparison = PropTypes.arrayOf(
   PropTypes.shape({
     name: PropTypes.string,
     actual: PropTypes.number,
-    expected: PropTypes.number
+    expected: PropTypes.number,
   })
 );
 
@@ -78,17 +78,17 @@ const PipelineRun = PropTypes.shape({
   adjusted_remaining_reads: PropTypes.number,
   version: PropTypes.shape({
     version: PropTypes.string,
-    alignment_db: PropTypes.string
-  })
+    alignment_db: PropTypes.string,
+  }),
 });
 
 const SummaryStats = PropTypes.shape({
-  last_processed_at: PropTypes.string
+  last_processed_at: PropTypes.string,
 });
 
 const HostGenome = PropTypes.shape({
   id: PropTypes.number,
-  name: PropTypes.string
+  name: PropTypes.string,
 });
 
 const Location = PropTypes.shape({
@@ -101,7 +101,7 @@ const Location = PropTypes.shape({
   name: PropTypes.string,
   sample_ids: PropTypes.arrayOf(PropTypes.number),
   state_name: PropTypes.string,
-  subdivision_name: PropTypes.string
+  subdivision_name: PropTypes.string,
 });
 
 export default {
@@ -116,5 +116,5 @@ export default {
   SummaryStats,
   HostGenome,
   Location,
-  ...PropTypes
+  ...PropTypes,
 };

--- a/app/assets/src/components/utils/structures/Tree.js
+++ b/app/assets/src/components/utils/structures/Tree.js
@@ -41,7 +41,7 @@ export default class Tree {
       // set node's new distance
       [nodeToMove.distance, previousAncestor.distance] = [
         previousAncestor.distance,
-        nodeToMove.distance
+        nodeToMove.distance,
       ];
 
       previousAncestor.children.push(nodeToMove);

--- a/app/assets/src/components/utils/toast.js
+++ b/app/assets/src/components/utils/toast.js
@@ -6,6 +6,6 @@ export const showToast = (component, params = {}) => {
     closeOnClick: false,
     draggable: false,
     hideProgressBar: true,
-    ...params
+    ...params,
   });
 };

--- a/app/assets/src/components/utils/tooltip.js
+++ b/app/assets/src/components/utils/tooltip.js
@@ -11,12 +11,12 @@ export const getTooltipStyle = (location, params = {}) => {
     const right = window.innerWidth - location.left;
     return {
       right: right + buffer,
-      top: location.top + topBufferSign * buffer
+      top: location.top + topBufferSign * buffer,
     };
   } else {
     return {
       left: location.left + buffer,
-      top: location.top + topBufferSign * buffer
+      top: location.top + topBufferSign * buffer,
     };
   }
 };

--- a/app/assets/src/components/views/AlignmentViz.jsx
+++ b/app/assets/src/components/views/AlignmentViz.jsx
@@ -20,7 +20,7 @@ class AlignmentViz extends React.Component {
     this.state = {
       alignmentData: [],
       pipelineRun: null,
-      loading: true
+      loading: true,
     };
   }
 
@@ -30,13 +30,13 @@ class AlignmentViz extends React.Component {
     // TODO(mark): Remove the metadata call once the alignment viz takes assembly into account.
     const [alignmentData, metadata] = await Promise.all([
       getAlignmentData(sampleId, this.alignmentQuery, this.pipelineVersion),
-      getSampleMetadata(sampleId, this.pipelineVersion)
+      getSampleMetadata(sampleId, this.pipelineVersion),
     ]);
 
     this.setState({
       loading: false,
       alignmentData,
-      pipelineRun: metadata.additional_info.pipeline_run
+      pipelineRun: metadata.additional_info.pipeline_run,
     });
   }
 

--- a/app/assets/src/components/views/BulkUploadimportPage/BulkUploadImportPage.jsx
+++ b/app/assets/src/components/views/BulkUploadimportPage/BulkUploadImportPage.jsx
@@ -23,7 +23,7 @@ BulkUploadImportPage.propTypes = {
   projects: PropTypes.arrayOf(PropTypes.Project),
   csrf: PropTypes.string,
   host_genomes: PropTypes.arrayOf(PropTypes.HostGenome),
-  admin: PropTypes.bool
+  admin: PropTypes.bool,
 };
 
 export default BulkUploadImportPage;

--- a/app/assets/src/components/views/CliUserInstructions.jsx
+++ b/app/assets/src/components/views/CliUserInstructions.jsx
@@ -237,7 +237,7 @@ CliUserInstructions.propTypes = {
   trigger: PropTypes.node,
   email: PropTypes.string,
   authToken: PropTypes.string,
-  hostGenomes: PropTypes.array
+  hostGenomes: PropTypes.array,
 };
 
 export default CliUserInstructions;

--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -8,7 +8,7 @@ import {
   Grid,
   Image,
   Message,
-  Divider
+  Divider,
 } from "semantic-ui-react";
 import Container from "../ui/containers/Container";
 import TransparentButton from "../ui/controls/buttons/TransparentButton";
@@ -28,7 +28,7 @@ class Landing extends React.Component {
       email: "",
       institution: "",
       usage: "",
-      submitMessage: ""
+      submitMessage: "",
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -51,8 +51,8 @@ class Landing extends React.Component {
           lastName: this.state.lastName,
           email: this.state.email,
           institution: this.state.institution,
-          usage: this.state.usage
-        }
+          usage: this.state.usage,
+        },
       })
       .then(() => {
         this.setState({
@@ -62,13 +62,13 @@ class Landing extends React.Component {
           institution: "",
           usage: "",
           submitMessage:
-            "Thanks for your interest! Our product team will be in touch about accessing IDseq. If your team is already on IDseq, ask a collaborator to add you to a project to get immediate access."
+            "Thanks for your interest! Our product team will be in touch about accessing IDseq. If your team is already on IDseq, ask a collaborator to add you to a project to get immediate access.",
         });
       })
       .catch(() => {
         this.setState({
           submitMessage:
-            "There was an error submitting the form. Please check required fields and try again."
+            "There was an error submitting the form. Please check required fields and try again.",
         });
       });
   }
@@ -330,7 +330,7 @@ class Landing extends React.Component {
 Landing.propTypes = {
   contactEmail: PropTypes.string.isRequired,
   showBulletin: PropTypes.bool,
-  browserInfo: PropTypes.object
+  browserInfo: PropTypes.object,
 };
 
 export default Landing;

--- a/app/assets/src/components/views/PlaygroundControls.jsx
+++ b/app/assets/src/components/views/PlaygroundControls.jsx
@@ -25,14 +25,14 @@ class PlaygroundControls extends React.Component {
         value: 1,
         suboptions: [
           { text: "suboption a", value: "a" },
-          { text: "suboption b", value: "b" }
-        ]
+          { text: "suboption b", value: "b" },
+        ],
       },
-      { text: "Option 3", value: 2 }
+      { text: "Option 3", value: 2 },
     ];
 
     this.state = {
-      event: ""
+      event: "",
     };
   }
 
@@ -60,7 +60,7 @@ class PlaygroundControls extends React.Component {
                 label={<BetaLabel />}
                 text="Submit"
                 onClick={() => this.setState({ event: "PrimaryButton:Click" })}
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -81,7 +81,7 @@ class PlaygroundControls extends React.Component {
                 onClick={() =>
                   this.setState({ event: "SecondaryButton:Click" })
                 }
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -97,10 +97,10 @@ class PlaygroundControls extends React.Component {
                 disabled
                 onClick={() =>
                   this.setState({
-                    event: "CompareButton:Click: should not show up!"
+                    event: "CompareButton:Click: should not show up!",
                   })
                 }
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -127,7 +127,7 @@ class PlaygroundControls extends React.Component {
                 onClick={option =>
                   this.setState({ event: "DropdownButton:Change", option })
                 }
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -154,7 +154,7 @@ class PlaygroundControls extends React.Component {
                 onClick={option =>
                   this.setState({ event: "DropdownButton:Change", option })
                 }
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -179,7 +179,7 @@ class PlaygroundControls extends React.Component {
                 onClick={option =>
                   this.setState({ event: "DropdownButton:Clicked", option })
                 }
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -204,7 +204,7 @@ class PlaygroundControls extends React.Component {
                 onClick={option =>
                   this.setState({ event: "DropdownButton:Clicked", option })
                 }
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -217,7 +217,7 @@ class PlaygroundControls extends React.Component {
                 onApply={vars => {
                   this.setState({
                     event: "ThresholdFilterDropdown:Apply",
-                    vars
+                    vars,
                   });
                 }}
               />,
@@ -228,10 +228,10 @@ class PlaygroundControls extends React.Component {
                 onApply={vars => {
                   this.setState({
                     event: "ThresholdFilterDropdown:Apply",
-                    vars
+                    vars,
                   });
                 }}
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -254,7 +254,7 @@ class PlaygroundControls extends React.Component {
                 options={this.dropdownOptions}
                 label="Option"
                 onChange={() => this.setState({ event: "Dropdown:Change" })}
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -281,7 +281,7 @@ class PlaygroundControls extends React.Component {
                 onChange={() =>
                   this.setState({ event: "MultipleDropdown:Change" })
                 }
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -297,7 +297,7 @@ class PlaygroundControls extends React.Component {
                 onChange={(a, b) => {
                   this.setState({ event: "MultipleDropdown:Change" });
                 }}
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -328,7 +328,7 @@ class PlaygroundControls extends React.Component {
                 min={0}
                 max={100}
                 value={20}
-              />
+              />,
             ]}
           />
           <ComponentCard
@@ -347,7 +347,7 @@ class PlaygroundControls extends React.Component {
                 label="Checkbox"
                 onChange={() => this.setState({ event: "Checkbox:Change" })}
                 value={1}
-              />
+              />,
             ]}
           />
         </div>
@@ -361,7 +361,7 @@ class PlaygroundControls extends React.Component {
 }
 
 PlaygroundControls.propTypes = {
-  thresholdFilters: PropTypes.object
+  thresholdFilters: PropTypes.object,
 };
 
 const ComponentCard = ({ title, components, width }) => {
@@ -383,7 +383,7 @@ const ComponentCard = ({ title, components, width }) => {
 ComponentCard.propTypes = {
   components: PropTypes.arrayOf(PropTypes.node),
   title: PropTypes.string,
-  width: PropTypes.number
+  width: PropTypes.number,
 };
 
 export default PlaygroundControls;

--- a/app/assets/src/components/views/PlaygroundIcons.jsx
+++ b/app/assets/src/components/views/PlaygroundIcons.jsx
@@ -7,12 +7,16 @@ import cs from "./playground_icons.scss";
 
 class PlaygroundIcons extends React.Component {
   render() {
-    const customIcons = values(Icons.CUSTOM).map(IconComponent => (
-      <IconComponent className={cs.icon} /> /* eslint-disable-line */
-    ));
-    const fontAwesomeIcons = values(Icons.FONT_AWESOME).map(IconComponent => (
-      <IconComponent className={cs.icon} /> /* eslint-disable-line */
-    ));
+    const customIcons = values(Icons.CUSTOM).map(
+      IconComponent => (
+        <IconComponent className={cs.icon} />
+      ) /* eslint-disable-line */
+    );
+    const fontAwesomeIcons = values(Icons.FONT_AWESOME).map(
+      IconComponent => (
+        <IconComponent className={cs.icon} />
+      ) /* eslint-disable-line */
+    );
     const logoIcons = values(Icons.LOGO).map(IconComponent => (
       <IconComponent /* eslint-disable-line */
         className={cx(cs.icon, cs.loadingIcon)}

--- a/app/assets/src/components/views/PlaygroundViz.jsx
+++ b/app/assets/src/components/views/PlaygroundViz.jsx
@@ -10,7 +10,7 @@ const TABS = ["Heatmap"];
 
 export default class PlaygroundViz extends React.Component {
   state = {
-    currentTab: TABS[0]
+    currentTab: TABS[0],
   };
 
   componentDidMount() {
@@ -37,21 +37,21 @@ export default class PlaygroundViz extends React.Component {
           rowLabels: [
             { label: "Row 1" },
             { label: "Row 2" },
-            { label: "Row 3" }
+            { label: "Row 3" },
           ],
           columnLabels: [
             { label: "Column 1" },
             { label: "Column 2" },
             { label: "Column 3" },
             { label: "Column 4" },
-            { label: "Column 5" }
+            { label: "Column 5" },
           ],
-          values: [[0, 1, 2, 3, 4], [1, 2, 3, 4, 5], [2, 3, 4, 5, 6]]
+          values: [[0, 1, 2, 3, 4], [1, 2, 3, 4, 5], [2, 3, 4, 5, 6]],
         },
         // Custom options.
         {
           marginLeft: 0,
-          marginRight: 0
+          marginRight: 0,
         }
       );
 

--- a/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
@@ -7,7 +7,7 @@ import _fp, {
   mapValues,
   sortBy,
   slice,
-  sumBy
+  sumBy,
 } from "lodash/fp";
 import cx from "classnames";
 
@@ -22,7 +22,7 @@ const map = _fp.map.convert({ cap: false });
 
 class LocalSampleFileUpload extends React.Component {
   state = {
-    showInfo: false
+    showInfo: false,
   };
 
   onDrop = acceptedFiles => {
@@ -43,10 +43,10 @@ class LocalSampleFileUpload extends React.Component {
         input_files_attributes: files.map(file => ({
           source_type: "local",
           source: cleanFilePath(file.name),
-          parts: cleanFilePath(file.name)
+          parts: cleanFilePath(file.name),
         })),
         status: "created",
-        client: "web"
+        client: "web",
       }),
       sampleNamesToFiles
     );
@@ -66,11 +66,11 @@ class LocalSampleFileUpload extends React.Component {
   toggleInfo = () => {
     this.setState(
       {
-        showInfo: !this.state.showInfo
+        showInfo: !this.state.showInfo,
       },
       () => {
         logAnalyticsEvent("LocalSampleFileUpload_more-info-toggle_clicked", {
-          showInfo: this.state.showInfo
+          showInfo: this.state.showInfo,
         });
       }
     );
@@ -123,7 +123,7 @@ class LocalSampleFileUpload extends React.Component {
 LocalSampleFileUpload.propTypes = {
   project: PropTypes.Project,
   onChange: PropTypes.func.isRequired,
-  samples: PropTypes.arrayOf(PropTypes.object)
+  samples: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default LocalSampleFileUpload;

--- a/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
@@ -13,17 +13,17 @@ class RemoteSampleFileUpload extends React.Component {
   state = {
     showInfo: false,
     remoteS3Path: "",
-    lastPathChecked: ""
+    lastPathChecked: "",
   };
 
   toggleInfo = () => {
     this.setState(
       {
-        showInfo: !this.state.showInfo
+        showInfo: !this.state.showInfo,
       },
       () => {
         logAnalyticsEvent("RemoteSampleFileUpload_more-info-toggle_clicked", {
-          showInfo: this.state.showInfo
+          showInfo: this.state.showInfo,
         });
       }
     );
@@ -31,35 +31,35 @@ class RemoteSampleFileUpload extends React.Component {
 
   handleRemotePathChange = remoteS3Path => {
     this.setState({
-      remoteS3Path
+      remoteS3Path,
     });
   };
 
   handleConnect = async () => {
     if (!this.props.project) {
       this.setState({
-        error: "Please select a project."
+        error: "Please select a project.",
       });
       return;
     }
 
     this.setState({
       error: "",
-      lastPathChecked: this.state.remoteS3Path
+      lastPathChecked: this.state.remoteS3Path,
     });
 
     try {
       let newSamples = await bulkImportRemoteSamples({
         projectId: this.props.project.id,
         hostGenomeId: "",
-        bulkPath: this.state.remoteS3Path
+        bulkPath: this.state.remoteS3Path,
       });
 
       // Remove any nil files from input_file_attributes.
       // This happens when there is an R2 file without an R1 file.
       newSamples = newSamples.samples.map(sample => ({
         ...sample,
-        input_files_attributes: compact(sample.input_files_attributes)
+        input_files_attributes: compact(sample.input_files_attributes),
       }));
 
       this.props.onChange(newSamples);
@@ -67,21 +67,21 @@ class RemoteSampleFileUpload extends React.Component {
       logAnalyticsEvent("RemoteSampleFileUpload_connect_succeeded", {
         projectId: this.props.project.id,
         bulkPath: this.state.remoteS3Path,
-        newSamples: newSamples.length
+        newSamples: newSamples.length,
       });
     } catch (e) {
       if (e.status.startsWith("No samples imported")) {
         this.setState({
           // TODO (gdingle): we should have an error state for
           // bucket not found as well.
-          error: "No valid samples were found."
+          error: "No valid samples were found.",
         });
       }
 
       logAnalyticsEvent("RemoteSampleFileUpload_connect_failed", {
         projectId: this.props.project.id,
         bulkPath: this.state.remoteS3Path,
-        error: e.status
+        error: e.status,
       });
     }
   };
@@ -149,7 +149,7 @@ class RemoteSampleFileUpload extends React.Component {
 
 RemoteSampleFileUpload.propTypes = {
   project: PropTypes.Project,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
 };
 
 export default RemoteSampleFileUpload;

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -24,13 +24,13 @@ const processMetadataRows = metadataRows =>
 class ReviewStep extends React.Component {
   state = {
     consentChecked: false,
-    submitState: "review"
+    submitState: "review",
   };
 
   onUploadError = error => {
     this.setState({
       submitState: "review",
-      errorMessage: error
+      errorMessage: error,
     });
     this.props.onUploadStatusChange(false);
   };
@@ -40,23 +40,23 @@ class ReviewStep extends React.Component {
 
     this.setState({
       submitState: "submitting",
-      errorMessage: ""
+      errorMessage: "",
     });
 
     // For uploading samples with files on S3
     if (this.props.uploadType === "remote") {
       bulkUploadRemote({
         samples: this.props.samples,
-        metadata: processMetadataRows(this.props.metadata.rows)
+        metadata: processMetadataRows(this.props.metadata.rows),
       })
         .then(response => {
           this.setState({
             submitState: "success",
-            createdSampleIds: response.sample_ids
+            createdSampleIds: response.sample_ids,
           });
           this.props.onUploadComplete();
           logAnalyticsEvent("ReviewStep_remote-upload_succeeded", {
-            createdSampleIds: response.sample_ids.length
+            createdSampleIds: response.sample_ids.length,
           });
         })
         // TODO(mark): Display better errors.
@@ -66,7 +66,7 @@ class ReviewStep extends React.Component {
           console.error("onBulkUploadRemote error:", error);
           this.onUploadError("There were some issues creating your samples.");
           logAnalyticsEvent("ReviewStep_remote-upload_failed", {
-            error
+            error,
           });
         });
     }
@@ -79,11 +79,11 @@ class ReviewStep extends React.Component {
         metadata: processMetadataRows(this.props.metadata.rows),
         onAllUploadsComplete: () => {
           this.setState({
-            submitState: "success"
+            submitState: "success",
           });
           this.props.onUploadComplete();
           logAnalyticsEvent("ReviewStep_local-upload_succeeded", {
-            samples: this.props.samples.length
+            samples: this.props.samples.length,
           });
         },
         onCreateSamplesError: errors => {
@@ -92,7 +92,7 @@ class ReviewStep extends React.Component {
           console.error("onCreateSamplesError:", errors);
           this.onUploadError("There were some issues creating your samples.");
           logAnalyticsEvent("ReviewStep_local-upload_failed", {
-            errors: errors.length
+            errors: errors.length,
           });
         },
         // TODO(mark): Display better errors.
@@ -103,7 +103,7 @@ class ReviewStep extends React.Component {
           this.onUploadError("There were some issues creating your samples.");
           logAnalyticsEvent("ReviewStep_local-upload_failed", {
             fileName: file.name,
-            error
+            error,
           });
         },
         onMarkSampleUploadedError: sampleName => {
@@ -111,9 +111,9 @@ class ReviewStep extends React.Component {
             `Failed to mark sample ${sampleName} as uploaded.`
           );
           logAnalyticsEvent("ReviewStep_local-upload_failed", {
-            sampleName
+            sampleName,
           });
-        }
+        },
       });
     }
   };
@@ -124,7 +124,7 @@ class ReviewStep extends React.Component {
       "Input Files",
       "Host Genome",
       // Omit sample name, which is the first header.
-      ...without(["Sample Name", "sample_name"], this.props.metadata.headers)
+      ...without(["Sample Name", "sample_name"], this.props.metadata.headers),
     ];
   };
 
@@ -148,7 +148,7 @@ class ReviewStep extends React.Component {
               </div>
             ))}
           </div>
-        )
+        ),
       }),
       this.props.samples
     );
@@ -193,7 +193,7 @@ class ReviewStep extends React.Component {
                     this.onLinkClick("uploadSamples");
                     logAnalyticsEvent("ReviewStep_edit-project-link_clicked", {
                       projectId: this.props.project.id,
-                      projectName: this.props.project.name
+                      projectName: this.props.project.name,
                     });
                   }}
                 >
@@ -233,7 +233,7 @@ class ReviewStep extends React.Component {
                     this.onLinkClick("uploadSamples");
                     logAnalyticsEvent("ReviewStep_edit-samples-link_clicked", {
                       projectId: this.props.project.id,
-                      projectName: this.props.project.name
+                      projectName: this.props.project.name,
                     });
                   }}
                 >
@@ -246,7 +246,7 @@ class ReviewStep extends React.Component {
                     this.onLinkClick("uploadMetadata");
                     logAnalyticsEvent("ReviewStep_edit-metadata-link_clicked", {
                       projectId: this.props.project.id,
-                      projectName: this.props.project.name
+                      projectName: this.props.project.name,
                     });
                   }}
                 >
@@ -271,11 +271,11 @@ class ReviewStep extends React.Component {
               onChange={() =>
                 this.setState(
                   {
-                    consentChecked: !this.state.consentChecked
+                    consentChecked: !this.state.consentChecked,
                   },
                   () =>
                     logAnalyticsEvent("ReviewStep_consent-checkbox_checked", {
-                      consentChecked: this.state.consentChecked
+                      consentChecked: this.state.consentChecked,
                     })
                 )
               }
@@ -318,7 +318,7 @@ class ReviewStep extends React.Component {
                 this.uploadSamplesAndMetadata,
                 "ReviewStep_start-upload-button_clicked",
                 {
-                  samples: this.props.samples.length
+                  samples: this.props.samples.length,
                 }
               )}
               rounded={false}
@@ -333,7 +333,7 @@ class ReviewStep extends React.Component {
 ReviewStep.propTypes = {
   metadata: PropTypes.shape({
     headers: PropTypes.arrayOf(PropTypes.string),
-    rows: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any))
+    rows: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)),
   }),
   project: PropTypes.Project,
   samples: PropTypes.arrayOf(
@@ -342,11 +342,11 @@ ReviewStep.propTypes = {
       input_file_attributes: PropTypes.shape({
         name: PropTypes.string,
         source: PropTypes.string,
-        source_type: PropTypes.string
+        source_type: PropTypes.string,
       }),
       name: PropTypes.string,
       project_id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-      status: PropTypes.string
+      status: PropTypes.string,
     })
   ),
   uploadType: PropTypes.string.isRequired,
@@ -358,7 +358,7 @@ ReviewStep.propTypes = {
   // Triggers when we start or stop uploading. Lets the parent know to disable header link.
   onUploadStatusChange: PropTypes.func,
   onStepSelect: PropTypes.func,
-  onUploadComplete: PropTypes.func.isRequired
+  onUploadComplete: PropTypes.func.isRequired,
 };
 
 export default ReviewStep;

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -23,8 +23,8 @@ class SampleUploadFlow extends React.Component {
     stepsEnabled: {
       uploadSamples: true,
       uploadMetadata: false,
-      review: false
-    }
+      review: false,
+    },
   };
 
   componentDidMount() {
@@ -41,7 +41,7 @@ class SampleUploadFlow extends React.Component {
     samples,
     project,
     uploadType,
-    sampleNamesToFiles
+    sampleNamesToFiles,
   }) => {
     this.setState({
       samples,
@@ -49,7 +49,7 @@ class SampleUploadFlow extends React.Component {
       uploadType,
       sampleNamesToFiles,
       currentStep: "uploadMetadata",
-      stepsEnabled: set("uploadMetadata", true, this.state.stepsEnabled)
+      stepsEnabled: set("uploadMetadata", true, this.state.stepsEnabled),
     });
   };
 
@@ -66,14 +66,14 @@ class SampleUploadFlow extends React.Component {
       const hostGenomeId = find(
         [
           "name",
-          get("host_genome", metadataRow) || get("Host Genome", metadataRow)
+          get("host_genome", metadataRow) || get("Host Genome", metadataRow),
         ],
         this.props.host_genomes
       ).id;
 
       return {
         ...sample,
-        host_genome_id: hostGenomeId
+        host_genome_id: hostGenomeId,
       };
     });
 
@@ -88,7 +88,7 @@ class SampleUploadFlow extends React.Component {
       metadata: newMetadata,
       metadataIssues: issues,
       currentStep: "review",
-      stepsEnabled: set("review", true, this.state.stepsEnabled)
+      stepsEnabled: set("review", true, this.state.stepsEnabled),
     });
   };
 
@@ -97,8 +97,8 @@ class SampleUploadFlow extends React.Component {
       stepsEnabled: {
         uploadSamples: true,
         uploadMetadata: false,
-        review: false
-      }
+        review: false,
+      },
     });
   };
 
@@ -107,21 +107,21 @@ class SampleUploadFlow extends React.Component {
       stepsEnabled: {
         uploadSamples: true,
         uploadMetadata: true,
-        review: false
-      }
+        review: false,
+      },
     });
   };
 
   handleStepSelect = step => {
     this.setState({
-      currentStep: step
+      currentStep: step,
     });
   };
 
   getSamplesForMetadataValidation = () => {
     return this.state.samples.map(sample => ({
       name: sample.name,
-      project_id: sample.project_id
+      project_id: sample.project_id,
     }));
   };
 
@@ -168,8 +168,8 @@ class SampleUploadFlow extends React.Component {
       stepsEnabled: {
         uploadSamples: !uploadStatus,
         uploadMetadata: !uploadStatus,
-        review: !uploadStatus
-      }
+        review: !uploadStatus,
+      },
     });
   };
 
@@ -194,7 +194,7 @@ class SampleUploadFlow extends React.Component {
 SampleUploadFlow.propTypes = {
   csrf: PropTypes.string,
   host_genomes: PropTypes.arrayOf(PropTypes.HostGenome),
-  admin: PropTypes.bool
+  admin: PropTypes.bool,
 };
 
 export default SampleUploadFlow;

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
@@ -12,16 +12,16 @@ import cs from "./sample_upload_flow.scss";
 const MENU_OPTIONS = [
   {
     text: "Samples",
-    step: "uploadSamples"
+    step: "uploadSamples",
   },
   {
     text: "Metadata",
-    step: "uploadMetadata"
+    step: "uploadMetadata",
   },
   {
     text: "Review",
-    step: "review"
-  }
+    step: "review",
+  },
 ];
 
 class SampleUploadFlowHeader extends React.Component {
@@ -86,7 +86,7 @@ class SampleUploadFlowHeader extends React.Component {
                       "SampleUploadFlowHeader_step-option_clicked",
                       {
                         step: val.step,
-                        text: val.text
+                        text: val.text,
                       }
                     );
                   }}
@@ -108,7 +108,7 @@ SampleUploadFlowHeader.propTypes = {
   samples: PropTypes.arrayOf(PropTypes.Sample),
   project: PropTypes.Project,
   onStepSelect: PropTypes.func.isRequired,
-  stepsEnabled: PropTypes.objectOf(PropTypes.bool)
+  stepsEnabled: PropTypes.objectOf(PropTypes.bool),
 };
 
 export default SampleUploadFlowHeader;

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -17,12 +17,12 @@ class UploadMetadataStep extends React.Component {
     continueDisabled: true,
     metadata: null,
     issues: null,
-    wasManual: false
+    wasManual: false,
   };
 
   setShowInstructions = showInstructions => {
     this.setState({
-      showInstructions
+      showInstructions,
     });
   };
 
@@ -30,13 +30,13 @@ class UploadMetadataStep extends React.Component {
     this.setState({
       metadata,
       issues,
-      wasManual
+      wasManual,
     });
 
     const metadataValid = metadata && !(issues && issues.errors.length > 0);
 
     this.setState({
-      continueDisabled: !metadataValid
+      continueDisabled: !metadataValid,
     });
   };
 
@@ -45,7 +45,7 @@ class UploadMetadataStep extends React.Component {
     let result = null;
     if (this.state.wasManual) {
       this.setState({
-        issues: null
+        issues: null,
       });
 
       const metadata = this.state.metadata;
@@ -56,19 +56,19 @@ class UploadMetadataStep extends React.Component {
       );
 
       this.setState({
-        issues: result.issues
+        issues: result.issues,
       });
 
       if (metadata && !(result.issues && result.issues.errors.length > 0)) {
         this.props.onUploadMetadata({
           metadata,
-          issues: result.issues
+          issues: result.issues,
         });
       }
     } else {
       this.props.onUploadMetadata({
         metadata: this.state.metadata,
-        issues: this.state.issues
+        issues: this.state.issues,
       });
     }
     logAnalyticsEvent("UploadMetadataStep_continue-button_clicked", {
@@ -77,7 +77,7 @@ class UploadMetadataStep extends React.Component {
       warnings: (result || this.state).issues.warnings.length,
       samples: this.props.samples.length,
       projectId: this.props.project.id,
-      projectName: this.props.project.name
+      projectName: this.props.project.name,
     });
   };
 
@@ -128,7 +128,7 @@ class UploadMetadataStep extends React.Component {
                     "UploadMetadataStep_cancel-button_clicked",
                     {
                       projectId: this.props.project.id,
-                      projectName: this.props.project.name
+                      projectName: this.props.project.name,
                     }
                   )
                 }
@@ -146,17 +146,17 @@ UploadMetadataStep.propTypes = {
   samples: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
-      host_genome_id: PropTypes.number
+      host_genome_id: PropTypes.number,
     })
   ),
   project: PropTypes.shape({
     id: PropTypes.number,
-    name: PropTypes.string
+    name: PropTypes.string,
   }),
   visible: PropTypes.bool,
   // Immediately called when the user changes anything, even before validation has returned.
   // Can be used to disable the header navigation.
-  onDirty: PropTypes.func.isRequired
+  onDirty: PropTypes.func.isRequired,
 };
 
 export default UploadMetadataStep;

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -22,7 +22,7 @@ import {
   zipObject,
   mapKeys,
   mergeWith,
-  uniqBy
+  uniqBy,
 } from "lodash/fp";
 
 import PropTypes from "~/components/utils/propTypes";
@@ -53,22 +53,22 @@ class UploadSampleStep extends React.Component {
     remoteSamples: [],
     removedLocalFiles: [], // Invalid local files that were removed.
     sampleNamesToFiles: {}, // Needed for local samples.
-    validatingSamples: false // Disable the "Continue" button while validating samples.
+    validatingSamples: false, // Disable the "Continue" button while validating samples.
   };
 
   async componentDidMount() {
     const projects = await getProjects({
       domain: "updatable",
-      basic: true
+      basic: true,
     });
 
     this.setState({
-      projects
+      projects,
     });
 
     // Pre-populate the selected project from URL params.
     let urlParams = QueryString.parse(location.search, {
-      arrayFormat: "bracket"
+      arrayFormat: "bracket",
     });
 
     const projectId = parseInt(urlParams.projectId);
@@ -103,42 +103,42 @@ class UploadSampleStep extends React.Component {
   processSamplesForProject = async ({
     samples,
     project,
-    sampleNamesToFiles
+    sampleNamesToFiles,
   }) => {
     const {
       samples: validatedSamples,
-      sampleNamesToFiles: validatedSampleNamesToFiles
+      sampleNamesToFiles: validatedSampleNamesToFiles,
     } = await this.validateSampleNames({
       samples,
       project,
-      sampleNamesToFiles
+      sampleNamesToFiles,
     });
 
     return {
       samples: map(set("project_id", get("id", project)), validatedSamples),
-      sampleNamesToFiles: validatedSampleNamesToFiles
+      sampleNamesToFiles: validatedSampleNamesToFiles,
     };
   };
 
   handleProjectChange = async project => {
     this.props.onDirty();
     this.setState({
-      validatingSamples: true
+      validatingSamples: true,
     });
 
     const [
       { samples: newLocalSamples, sampleNamesToFiles: newSampleNamesToFiles },
-      { samples: newRemoteSamples }
+      { samples: newRemoteSamples },
     ] = await Promise.all([
       this.processSamplesForProject({
         samples: this.state.localSamples,
         project,
-        sampleNamesToFiles: this.state.sampleNamesToFiles
+        sampleNamesToFiles: this.state.sampleNamesToFiles,
       }),
       this.processSamplesForProject({
         samples: this.state.remoteSamples,
-        project
-      })
+        project,
+      }),
     ]);
 
     this.setState({
@@ -146,13 +146,13 @@ class UploadSampleStep extends React.Component {
       validatingSamples: false,
       localSamples: newLocalSamples,
       remoteSamples: newRemoteSamples,
-      sampleNamesToFiles: newSampleNamesToFiles
+      sampleNamesToFiles: newSampleNamesToFiles,
     });
 
     logAnalyticsEvent("UploadSampleStep_project-selector_changed", {
       localSamples: newLocalSamples.length,
       remoteSamples: newRemoteSamples.length,
-      ...this.getAnalyticsContext()
+      ...this.getAnalyticsContext(),
     });
   };
 
@@ -163,7 +163,7 @@ class UploadSampleStep extends React.Component {
     if (!selectedProject || size(samples) <= 0) {
       return Promise.resolve({
         samples,
-        sampleNamesToFiles
+        sampleNamesToFiles,
       });
     }
 
@@ -180,12 +180,12 @@ class UploadSampleStep extends React.Component {
     return {
       samples: samples.map(sample => ({
         ...sample,
-        name: validatedNameMap[sample.name]
+        name: validatedNameMap[sample.name],
       })),
       sampleNamesToFiles: mapKeys(
         name => validatedNameMap[name],
         sampleNamesToFiles
-      )
+      ),
     };
   };
 
@@ -194,13 +194,13 @@ class UploadSampleStep extends React.Component {
   validateSampleNamesAndFiles = async ({
     samples,
     project,
-    sampleNamesToFiles
+    sampleNamesToFiles,
   }) => {
     if (size(samples) <= 0) {
       return Promise.resolve({
         samples,
         sampleNamesToFiles,
-        removedLocalFiles: []
+        removedLocalFiles: [],
       });
     }
 
@@ -209,13 +209,13 @@ class UploadSampleStep extends React.Component {
     const [
       {
         samples: validatedSamples,
-        sampleNamesToFiles: validatedSampleNamesToFiles
+        sampleNamesToFiles: validatedSampleNamesToFiles,
       },
-      areFilesValid
+      areFilesValid,
     ] = await Promise.all([
       // Call validateSampleNames to update sample names.
       this.validateSampleNames({ samples, project, sampleNamesToFiles }),
-      validateSampleFiles(sampleFiles)
+      validateSampleFiles(sampleFiles),
     ]);
 
     const filesValidMap = zipObject(sampleFiles, areFilesValid);
@@ -238,41 +238,41 @@ class UploadSampleStep extends React.Component {
     return {
       samples: filteredSamples,
       sampleNamesToFiles: filteredSampleNamesToFiles,
-      removedLocalFiles: keys(pickBy(fileValid => !fileValid, filesValidMap))
+      removedLocalFiles: keys(pickBy(fileValid => !fileValid, filesValidMap)),
     };
   };
 
   openCreateProject = () => {
     this.setState({
-      createProjectOpen: true
+      createProjectOpen: true,
     });
   };
 
   closeCreateProject = () => {
     this.setState({
-      createProjectOpen: false
+      createProjectOpen: false,
     });
   };
 
   handleProjectCreate = async project => {
     this.props.onDirty();
     this.setState({
-      validatingSamples: true
+      validatingSamples: true,
     });
 
     const [
       { samples: newLocalSamples, sampleNamesToFiles: newSampleNamesToFiles },
-      { samples: newRemoteSamples }
+      { samples: newRemoteSamples },
     ] = await Promise.all([
       this.processSamplesForProject({
         samples: this.state.localSamples,
         project,
-        sampleNamesToFiles: this.state.sampleNamesToFiles
+        sampleNamesToFiles: this.state.sampleNamesToFiles,
       }),
       this.processSamplesForProject({
         samples: this.state.remoteSamples,
-        project
-      })
+        project,
+      }),
     ]);
 
     this.setState({
@@ -282,13 +282,13 @@ class UploadSampleStep extends React.Component {
       createProjectOpen: false,
       localSamples: newLocalSamples,
       remoteSamples: newRemoteSamples,
-      sampleNamesToFiles: newSampleNamesToFiles
+      sampleNamesToFiles: newSampleNamesToFiles,
     });
 
     logAnalyticsEvent("UploadSampleStep_project_created", {
       localSamples: newLocalSamples.length,
       remoteSamples: newRemoteSamples.length,
-      ...this.getAnalyticsContext()
+      ...this.getAnalyticsContext(),
     });
   };
 
@@ -296,7 +296,7 @@ class UploadSampleStep extends React.Component {
     this.props.onDirty();
     this.setState({ currentTab: tab });
     logAnalyticsEvent("UploadSampleStep_tab_changed", {
-      tab
+      tab,
     });
   };
 
@@ -334,16 +334,16 @@ class UploadSampleStep extends React.Component {
     this.props.onDirty();
     this.setState({
       validatingSamples: true,
-      removedLocalFiles: []
+      removedLocalFiles: [],
     });
 
     const {
       samples: validatedLocalSamples,
       sampleNamesToFiles: validatedSampleNamesToFiles,
-      removedLocalFiles
+      removedLocalFiles,
     } = await this.validateSampleNamesAndFiles({
       samples: localSamples,
-      sampleNamesToFiles
+      sampleNamesToFiles,
     });
 
     this.setState({
@@ -361,25 +361,25 @@ class UploadSampleStep extends React.Component {
         validatedSampleNamesToFiles,
         this.state.sampleNamesToFiles
       ),
-      removedLocalFiles
+      removedLocalFiles,
     });
 
     logAnalyticsEvent("UploadSampleStep_local-sample_changed", {
       localSamples: localSamples.length,
       validatedLocalSamples: validatedLocalSamples.length,
       removedLocalFiles: removedLocalFiles.length,
-      ...this.getAnalyticsContext()
+      ...this.getAnalyticsContext(),
     });
   };
 
   handleRemoteSampleChange = async remoteSamples => {
     this.props.onDirty();
     this.setState({
-      validatingSamples: true
+      validatingSamples: true,
     });
 
     const { samples: validatedRemoteSamples } = await this.validateSampleNames({
-      samples: remoteSamples
+      samples: remoteSamples,
     });
 
     this.setState({
@@ -387,13 +387,13 @@ class UploadSampleStep extends React.Component {
       remoteSamples: this.mergeSamples(
         this.state.remoteSamples,
         validatedRemoteSamples
-      )
+      ),
     });
 
     logAnalyticsEvent("UploadSampleStep_remote-sample_changed", {
       remoteSamples: remoteSamples.length,
       validatedRemoteSamples: validatedRemoteSamples.length,
-      ...this.getAnalyticsContext()
+      ...this.getAnalyticsContext(),
     });
   };
 
@@ -407,20 +407,20 @@ class UploadSampleStep extends React.Component {
     if (this.state.currentTab === LOCAL_UPLOAD_TAB) {
       this.setState({
         localSamples: newSamples,
-        sampleNamesToFiles: newSampleNamesToFiles
+        sampleNamesToFiles: newSampleNamesToFiles,
       });
     }
 
     if (this.state.currentTab === REMOTE_UPLOAD_TAB) {
       this.setState({
         remoteSamples: newSamples,
-        sampleNamesToFiles: newSampleNamesToFiles
+        sampleNamesToFiles: newSampleNamesToFiles,
       });
     }
     logAnalyticsEvent("UploadSampleStep_sample_removed", {
       sampleName,
       currentTab: this.state.currentTab,
-      ...this.getAnalyticsContext()
+      ...this.getAnalyticsContext(),
     });
   };
 
@@ -430,7 +430,7 @@ class UploadSampleStep extends React.Component {
         samples: this.state.localSamples,
         project: this.state.selectedProject,
         sampleNamesToFiles: this.state.sampleNamesToFiles,
-        uploadType: "local"
+        uploadType: "local",
       });
     }
 
@@ -438,7 +438,7 @@ class UploadSampleStep extends React.Component {
       this.props.onUploadSamples({
         samples: this.state.remoteSamples,
         project: this.state.selectedProject,
-        uploadType: "remote"
+        uploadType: "remote",
       });
     }
 
@@ -446,7 +446,7 @@ class UploadSampleStep extends React.Component {
       localSamples: this.state.localSamples.length,
       remoteSamples: this.state.remoteSamples.length,
       currentTab: this.state.currentTab,
-      ...this.getAnalyticsContext()
+      ...this.getAnalyticsContext(),
     });
   };
 
@@ -483,7 +483,7 @@ class UploadSampleStep extends React.Component {
     const project = this.state.selectedProject;
     return {
       projectId: project && project.id,
-      projectName: project && project.name
+      projectName: project && project.name,
     };
   };
 
@@ -570,7 +570,7 @@ class UploadSampleStep extends React.Component {
               rounded={false}
               onClick={() =>
                 logAnalyticsEvent("UploadSampleStep_cancel-button_clicked", {
-                  ...this.getAnalyticsContext()
+                  ...this.getAnalyticsContext(),
                 })
               }
             />
@@ -586,7 +586,7 @@ UploadSampleStep.propTypes = {
   // Immediately called when the user changes anything, even before validation has returned.
   // Can be used to disable the header navigation.
   onDirty: PropTypes.func.isRequired,
-  visible: PropTypes.bool
+  visible: PropTypes.bool,
 };
 
 export default UploadSampleStep;

--- a/app/assets/src/components/views/SampleView/PipelineVersionSelect.jsx
+++ b/app/assets/src/components/views/SampleView/PipelineVersionSelect.jsx
@@ -27,7 +27,7 @@ class PipelineVersionSelect extends React.Component {
 
     const options = otherVersions.map(version => ({
       text: `Pipeline v${version}`,
-      value: version
+      value: version,
     }));
 
     return (
@@ -77,7 +77,7 @@ PipelineVersionSelect.propTypes = {
   pipelineRun: PropTypes.PipelineRun,
   pipelineVersions: PropTypes.arrayOf(PropTypes.string),
   lastProcessedAt: PropTypes.string, // Actually a datestring.
-  onPipelineVersionSelect: PropTypes.func.isRequired
+  onPipelineVersionSelect: PropTypes.func.isRequired,
 };
 
 export default PipelineVersionSelect;

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -9,17 +9,17 @@ import { saveVisualization, getCoverageVizSummary } from "~/api";
 import {
   getURLParamString,
   parseUrlParams,
-  copyShortUrlToClipboard
+  copyShortUrlToClipboard,
 } from "~/helpers/url";
 import {
   withAnalytics,
   logAnalyticsEvent,
-  ANALYTICS_EVENT_NAMES
+  ANALYTICS_EVENT_NAMES,
 } from "~/api/analytics";
 import PropTypes from "~/components/utils/propTypes";
 import {
   pipelineVersionHasAssembly,
-  pipelineVersionHasCoverageViz
+  pipelineVersionHasCoverageViz,
 } from "~/components/utils/sample";
 import AMRView from "~/components/AMRView";
 import BasicPopup from "~/components/BasicPopup";
@@ -49,7 +49,7 @@ class SampleView extends React.Component {
       sidebarTaxonModeConfig: null,
       coverageVizDataByTaxon: null,
       nameType: Cookies.get("name_type") || "Scientific name", // "Scientific name" or "Common name"
-      view: "table"
+      view: "table",
     };
 
     this.gsnapFilterStatus = this.generateGsnapFilterStatus();
@@ -74,7 +74,7 @@ class SampleView extends React.Component {
     // frontend events, we keep it for continuity. See
     // https://czi.quip.com/67RCAIiHN0Qc/IDseq-product-analytics-How-to-log
     logAnalyticsEvent(ANALYTICS_EVENT_NAMES.sampleViewed, {
-      sampleId: this.props.sample.id
+      sampleId: this.props.sample.id,
     });
   }
 
@@ -84,7 +84,7 @@ class SampleView extends React.Component {
       const coverageVizSummary = await getCoverageVizSummary(sample.id);
 
       this.setState({
-        coverageVizDataByTaxon: coverageVizSummary
+        coverageVizDataByTaxon: coverageVizSummary,
       });
     }
   };
@@ -133,7 +133,7 @@ class SampleView extends React.Component {
     this.setState({ currentTab: tab });
     const name = tab.replace(/\W+/g, "-").toLowerCase();
     logAnalyticsEvent(`SampleView_tab-${name}_clicked`, {
-      tab: tab
+      tab: tab,
     });
   };
 
@@ -148,12 +148,12 @@ class SampleView extends React.Component {
       this.state.sidebarVisible
     ) {
       this.setState({
-        sidebarVisible: false
+        sidebarVisible: false,
       });
     } else {
       this.setState({
         sidebarMode: "sampleDetails",
-        sidebarVisible: true
+        sidebarVisible: true,
       });
     }
   };
@@ -161,7 +161,7 @@ class SampleView extends React.Component {
   handleTaxonClick = sidebarTaxonModeConfig => {
     if (!sidebarTaxonModeConfig) {
       this.setState({
-        sidebarVisible: false
+        sidebarVisible: false,
       });
       return;
     }
@@ -173,21 +173,21 @@ class SampleView extends React.Component {
         get("taxonId", this.state.sidebarTaxonModeConfig)
     ) {
       this.setState({
-        sidebarVisible: false
+        sidebarVisible: false,
       });
     } else {
       this.setState({
         sidebarMode: "taxonDetails",
         sidebarTaxonModeConfig,
         sidebarVisible: true,
-        coverageVizVisible: false
+        coverageVizVisible: false,
       });
     }
   };
 
   closeSidebar = () => {
     this.setState({
-      sidebarVisible: false
+      sidebarVisible: false,
     });
   };
 
@@ -196,7 +196,7 @@ class SampleView extends React.Component {
 
     if (!params.taxId) {
       this.setState({
-        coverageVizVisible: false
+        coverageVizVisible: false,
       });
       return;
     }
@@ -206,20 +206,20 @@ class SampleView extends React.Component {
       get("taxId", coverageVizParams) === params.taxId
     ) {
       this.setState({
-        coverageVizVisible: false
+        coverageVizVisible: false,
       });
     } else {
       this.setState({
         coverageVizParams: params,
         coverageVizVisible: true,
-        sidebarVisible: false
+        sidebarVisible: false,
       });
     }
   };
 
   closeCoverageViz = () => {
     this.setState({
-      coverageVizVisible: false
+      coverageVizVisible: false,
     });
   };
 
@@ -231,7 +231,7 @@ class SampleView extends React.Component {
   handleMetadataUpdate = (key, newValue) => {
     if (key === "name") {
       this.setState({
-        sampleName: newValue
+        sampleName: newValue,
       });
     }
   };
@@ -406,7 +406,7 @@ class SampleView extends React.Component {
           "pipeline_info.pipeline_version",
           this.props.reportDetails
         ),
-        onMetadataUpdate: this.handleMetadataUpdate
+        onMetadataUpdate: this.handleMetadataUpdate,
       };
     }
     return {};
@@ -429,7 +429,7 @@ class SampleView extends React.Component {
           ...accession,
           // Use snake_case for consistency with other fields.
           taxon_name: taxon.taxonName,
-          taxon_common_name: taxon.taxonCommonName
+          taxon_common_name: taxon.taxonCommonName,
         }),
         speciesBestAccessions
       );
@@ -446,7 +446,7 @@ class SampleView extends React.Component {
           taxId => get([taxId, "num_accessions"], coverageVizDataByTaxon),
           speciesTaxIds
         )
-      )
+      ),
     };
   };
 
@@ -474,7 +474,7 @@ class SampleView extends React.Component {
       taxonCommonName: coverageVizParams.taxCommonName,
       taxonLevel: coverageVizParams.taxLevel,
       alignmentVizUrl: coverageVizParams.alignmentVizUrl,
-      accessionData
+      accessionData,
     };
   };
 
@@ -511,7 +511,7 @@ class SampleView extends React.Component {
       amr,
       reportPresent,
       reportDetails,
-      reportPageParams
+      reportPageParams,
     } = this.props;
 
     const showAMR = amr;
@@ -544,9 +544,9 @@ class SampleView extends React.Component {
                   onClick: () => {
                     window.open(`/samples/${sampleId}`, "_self");
                     logAnalyticsEvent("SampleView_header-title_clicked", {
-                      sampleId
+                      sampleId,
                     });
-                  }
+                  },
                 }))}
               />
               <div className={cs.sampleDetailsLinkContainer}>
@@ -557,7 +557,7 @@ class SampleView extends React.Component {
                     "SampleView_sample-details-link_clicked",
                     {
                       sampleId: sample.id,
-                      sampleName: sample.name
+                      sampleName: sample.name,
                     }
                   )}
                 >
@@ -574,7 +574,7 @@ class SampleView extends React.Component {
                       "SampleView_share-button_clicked",
                       {
                         sampleId: sample.id,
-                        sampleName: sample.name
+                        sampleName: sample.name,
                       }
                     )}
                   />
@@ -591,7 +591,7 @@ class SampleView extends React.Component {
                     "SampleView_save-button_clicked",
                     {
                       sampleId: sample.id,
-                      sampleName: sample.name
+                      sampleName: sample.name,
                     }
                   )}
                 />
@@ -632,7 +632,7 @@ class SampleView extends React.Component {
             "SampleView_details-sidebar_closed",
             {
               sampleId: sample.id,
-              sampleName: sample.name
+              sampleName: sample.name,
             }
           )}
           params={this.getSidebarParams()}
@@ -645,7 +645,7 @@ class SampleView extends React.Component {
               "SampleView_coverage-viz-sidebar_closed",
               {
                 sampleId: sample.id,
-                sampleName: sample.name
+                sampleName: sample.name,
               }
             )}
             params={this.getCoverageVizParams()}
@@ -670,13 +670,13 @@ SampleView.propTypes = {
   reportPageParams: PropTypes.shape({
     pipeline_version: PropTypes.string,
     // TODO (gdingle): standardize on string or number
-    background_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    background_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }),
   amr: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number,
       gene: PropTypes.string,
-      allele: PropTypes.string
+      allele: PropTypes.string,
     })
   ),
   reportPresent: PropTypes.bool,
@@ -688,7 +688,7 @@ SampleView.propTypes = {
   allCategories: PropTypes.arrayOf(
     PropTypes.shape({
       taxid: PropTypes.number,
-      name: PropTypes.string
+      name: PropTypes.string,
     })
   ),
   allBackgrounds: PropTypes.arrayOf(PropTypes.BackgroundData),
@@ -696,11 +696,11 @@ SampleView.propTypes = {
   canSeeAlignViz: PropTypes.bool,
   canEdit: PropTypes.bool,
   hostGenome: PropTypes.shape({
-    name: PropTypes.string
+    name: PropTypes.string,
   }),
   jobStatistics: PropTypes.string,
   sampleStatus: PropTypes.string,
-  savedParamValues: PropTypes.object
+  savedParamValues: PropTypes.object,
 };
 
 export default SampleView;

--- a/app/assets/src/components/views/SampleView/SampleViewControls.jsx
+++ b/app/assets/src/components/views/SampleView/SampleViewControls.jsx
@@ -8,7 +8,7 @@ import DownloadButtonDropdown from "~/components/ui/controls/dropdowns/DownloadB
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import {
   getDownloadDropdownOptions,
-  getLinkInfoForDownloadOption
+  getLinkInfoForDownloadOption,
 } from "~/components/views/report/utils/download";
 
 class SampleViewControls extends React.Component {
@@ -38,7 +38,7 @@ class SampleViewControls extends React.Component {
     location.href = `/home?project_id=${project.id}`;
     logAnalyticsEvent("SampleViewControls_delete-sample-button_clicked", {
       sampleId: sample.id,
-      sampleName: sample.name
+      sampleName: sample.name,
     });
   };
 
@@ -54,7 +54,7 @@ class SampleViewControls extends React.Component {
           .toLowerCase()}_clicked`,
         {
           sampleId: this.props.sample.id,
-          sampleName: this.props.sample.name
+          sampleName: this.props.sample.name,
         }
       );
 
@@ -93,7 +93,7 @@ class SampleViewControls extends React.Component {
     if (this.props.view === "tree") {
       return [
         { text: "Download Taxon Tree as SVG", value: "taxon_svg" },
-        { text: "Download Taxon Tree as PNG", value: "taxon_png" }
+        { text: "Download Taxon Tree as PNG", value: "taxon_png" },
       ];
     }
     return [];
@@ -106,10 +106,10 @@ class SampleViewControls extends React.Component {
       const downloadOptions = [
         {
           text: "Download Report Table (.csv)",
-          value: "download_csv"
+          value: "download_csv",
         },
         ...getDownloadDropdownOptions(pipelineRun),
-        ...this.getImageDownloadOptions()
+        ...this.getImageDownloadOptions(),
       ];
 
       return (
@@ -136,10 +136,10 @@ SampleViewControls.propTypes = {
   reportPageParams: PropTypes.shape({
     pipeline_version: PropTypes.string,
     // TODO (gdingle): standardize on string or number
-    background_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    background_id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   }),
   canEdit: PropTypes.bool,
-  view: PropTypes.string
+  view: PropTypes.string,
 };
 
 export default SampleViewControls;

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -9,14 +9,14 @@ import {
   values,
   omitBy,
   mapValues,
-  isEmpty
+  isEmpty,
 } from "lodash/fp";
 import cx from "classnames";
 
 import {
   Dropdown,
   MultipleNestedDropdown,
-  ThresholdFilterDropdown
+  ThresholdFilterDropdown,
 } from "~ui/controls/dropdowns";
 import { Divider } from "~/components/layout";
 import { logAnalyticsEvent } from "~/api/analytics";
@@ -35,7 +35,7 @@ export default class SamplesHeatmapControls extends React.Component {
 
     this.props.onSelectedOptionsChange({ species: taxonLevel });
     logAnalyticsEvent("SamplesHeatmapControls_taxon-level-select_changed", {
-      taxonLevel
+      taxonLevel,
     });
   };
 
@@ -57,7 +57,7 @@ export default class SamplesHeatmapControls extends React.Component {
     this.props.onSelectedOptionsChange({ categories, subcategories });
     logAnalyticsEvent("SamplesHeatmapControls_category-filter_changed", {
       categories: categories.length,
-      subcategories: subcategories.length
+      subcategories: subcategories.length,
     });
   };
 
@@ -95,7 +95,7 @@ export default class SamplesHeatmapControls extends React.Component {
 
     this.props.onSelectedOptionsChange({ metric });
     logAnalyticsEvent("SamplesHeatmapControls_metric-select_changed", {
-      metric
+      metric,
     });
   };
 
@@ -120,14 +120,14 @@ export default class SamplesHeatmapControls extends React.Component {
 
     this.props.onSelectedOptionsChange({ background });
     logAnalyticsEvent("SamplesHeatmapControls_background-select_changed", {
-      background
+      background,
     });
   };
 
   renderBackgroundSelect() {
     let options = this.props.options.backgrounds.map(background => ({
       text: background.name,
-      value: background.value
+      value: background.value,
     }));
 
     return (
@@ -152,7 +152,7 @@ export default class SamplesHeatmapControls extends React.Component {
     logAnalyticsEvent(
       "SamplesHeatmapControls_threshold-filter-select_applied",
       {
-        filters: filters.length
+        filters: filters.length,
       }
     );
   };
@@ -175,7 +175,7 @@ export default class SamplesHeatmapControls extends React.Component {
 
     this.props.onSelectedOptionsChange({ readSpecificity: specificity });
     logAnalyticsEvent("SamplesHeatmapControls_specificity-filter_changed", {
-      readSpecificity: specificity
+      readSpecificity: specificity,
     });
   };
 
@@ -200,14 +200,14 @@ export default class SamplesHeatmapControls extends React.Component {
 
     this.props.onSelectedOptionsChange({ dataScaleIdx: scaleIdx });
     logAnalyticsEvent("SamplesHeatmapControls_data-scale-select_changed", {
-      dataScaleIdx: scaleIdx
+      dataScaleIdx: scaleIdx,
     });
   };
 
   renderScaleSelect() {
     let options = this.props.options.scales.map((scale, index) => ({
       text: scale[0],
-      value: index
+      value: index,
     }));
 
     return (
@@ -228,7 +228,7 @@ export default class SamplesHeatmapControls extends React.Component {
     logAnalyticsEvent(
       "SamplesHeatmapControls_taxons-per-sample-slider_changed",
       {
-        taxonsPerSample: newValue
+        taxonsPerSample: newValue,
       }
     );
   };
@@ -305,7 +305,7 @@ export default class SamplesHeatmapControls extends React.Component {
                 {
                   value: threshold.value,
                   operator: threshold.operator,
-                  metric: threshold.metric
+                  metric: threshold.metric,
                 }
               );
             }}
@@ -327,7 +327,7 @@ export default class SamplesHeatmapControls extends React.Component {
                 logAnalyticsEvent(
                   "SamplesHeatmapControl_categories-filter_removed",
                   {
-                    category
+                    category,
                   }
                 );
               }}
@@ -351,7 +351,7 @@ export default class SamplesHeatmapControls extends React.Component {
                 logAnalyticsEvent(
                   "SamplesHeatmapControl_categories-filter_removed",
                   {
-                    subcat
+                    subcat,
                   }
                 );
               }}
@@ -395,7 +395,7 @@ SamplesHeatmapControls.propTypes = {
     metrics: PropTypes.arrayOf(
       PropTypes.shape({
         text: PropTypes.string,
-        value: PropTypes.string
+        value: PropTypes.string,
       })
     ),
     categories: PropTypes.arrayOf(PropTypes.string),
@@ -403,19 +403,19 @@ SamplesHeatmapControls.propTypes = {
     backgrounds: PropTypes.arrayOf(
       PropTypes.shape({
         name: PropTypes.string,
-        value: PropTypes.number
+        value: PropTypes.number,
       })
     ),
     taxonLevels: PropTypes.arrayOf(
       PropTypes.shape({
         text: PropTypes.string,
-        value: PropTypes.number
+        value: PropTypes.number,
       })
     ),
     specificityOptions: PropTypes.arrayOf(
       PropTypes.shape({
         text: PropTypes.string,
-        value: PropTypes.number
+        value: PropTypes.number,
       })
     ),
     thresholdFilters: PropTypes.shape({
@@ -423,12 +423,12 @@ SamplesHeatmapControls.propTypes = {
       targets: PropTypes.arrayOf(
         PropTypes.shape({
           text: PropTypes.string,
-          value: PropTypes.string
+          value: PropTypes.string,
         })
-      )
+      ),
     }),
     scales: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
-    taxonsPerSample: PropTypes.objectOf(PropTypes.number)
+    taxonsPerSample: PropTypes.objectOf(PropTypes.number),
   }),
   selectedOptions: PropTypes.shape({
     species: PropTypes.number,
@@ -440,16 +440,16 @@ SamplesHeatmapControls.propTypes = {
       PropTypes.shape({
         metric: PropTypes.string,
         value: PropTypes.string,
-        operator: PropTypes.string
+        operator: PropTypes.string,
       })
     ),
     readSpecificity: PropTypes.number,
     dataScaleIdx: PropTypes.number,
-    taxonsPerSample: PropTypes.number
+    taxonsPerSample: PropTypes.number,
   }),
   onSelectedOptionsChange: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   data: PropTypes.objectOf(
     PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number))
-  )
+  ),
 };

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -11,7 +11,7 @@ import {
   get,
   set,
   isEmpty,
-  find
+  find,
 } from "lodash/fp";
 import DeepEqual from "fast-deep-equal";
 import { StickyContainer, Sticky } from "react-sticky";
@@ -156,7 +156,7 @@ class SamplesHeatmapView extends React.Component {
               this.props.thresholdFilters.targets
             )
           ),
-          ...threshold
+          ...threshold,
         }),
         JSON.parse(urlParams.thresholdFilters)
       );

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -22,7 +22,7 @@ class SamplesHeatmapVis extends React.Component {
       nodeHoverInfo: null,
       columnMetadataLegend: null,
       selectedMetadata: new Set(this.props.defaultMetadata),
-      tooltipLocation: null
+      tooltipLocation: null,
     };
 
     this.heatmap = null;
@@ -35,7 +35,7 @@ class SamplesHeatmapVis extends React.Component {
       { key: "NT.r", label: "NT r (total reads)" },
       { key: "NR.zscore", label: "NR Z Score" },
       { key: "NR.rpm", label: "NR rPM" },
-      { key: "NR.r", label: "NR r (total reads)" }
+      { key: "NR.r", label: "NR r (total reads)" },
     ];
 
     this.metadataTypes = keyBy("key", this.props.metadataTypes);
@@ -47,7 +47,7 @@ class SamplesHeatmapVis extends React.Component {
       {
         rowLabels: this.extractTaxonLabels(),
         columnLabels: this.extractSampleLabels(), // Also includes column metadata.
-        values: this.props.data[this.props.metric]
+        values: this.props.data[this.props.metric],
       },
       {
         scale: this.props.scale,
@@ -65,7 +65,7 @@ class SamplesHeatmapVis extends React.Component {
         onCellClick: this.handleCellClick,
         onAddColumnMetadataClick: this.handleAddColumnMetadataClick,
         columnMetadata: this.getSelectedMetadata(),
-        customColorCallback: this.colorScale
+        customColorCallback: this.colorScale,
       }
     );
     this.heatmap.start();
@@ -78,7 +78,7 @@ class SamplesHeatmapVis extends React.Component {
     }
     if (this.props.sampleDetails !== prevProps.sampleDetails) {
       this.heatmap.updateData({
-        columnLabels: this.extractSampleLabels() // Also includes column metadata.
+        columnLabels: this.extractSampleLabels(), // Also includes column metadata.
       });
     }
   }
@@ -88,7 +88,7 @@ class SamplesHeatmapVis extends React.Component {
       return {
         label: this.props.sampleDetails[id].name,
         metadata: this.props.sampleDetails[id].metadata,
-        id
+        id,
       };
     });
   }
@@ -102,7 +102,7 @@ class SamplesHeatmapVis extends React.Component {
   extractTaxonLabels() {
     return this.props.taxonIds.map(id => {
       return {
-        label: this.props.taxonDetails[id].name
+        label: this.props.taxonDetails[id].name,
       };
     });
   }
@@ -112,8 +112,8 @@ class SamplesHeatmapVis extends React.Component {
       this.setState({
         tooltipLocation: {
           left: currentEvent.pageX,
-          top: currentEvent.pageY
-        }
+          top: currentEvent.pageY,
+        },
       });
     }
   };
@@ -121,7 +121,7 @@ class SamplesHeatmapVis extends React.Component {
   handleNodeHover = node => {
     this.setState({ nodeHoverInfo: this.getTooltipData(node) });
     logAnalyticsEvent("SamplesHeatmapVis_node_hovered", {
-      nodeValue: node.value
+      nodeValue: node.value,
     });
   };
 
@@ -132,11 +132,11 @@ class SamplesHeatmapVis extends React.Component {
   handleColumnMetadataLabelHover = node => {
     const legend = this.heatmap.getColumnMetadataLegend(node.value);
     this.setState({
-      columnMetadataLegend: legend
+      columnMetadataLegend: legend,
     });
     logAnalyticsEvent("SamplesHeatmapVis_column-metadata_hovered", {
       nodeValue: node.value,
-      columnMetadataLegend: legend
+      columnMetadataLegend: legend,
     });
   };
 
@@ -171,7 +171,7 @@ class SamplesHeatmapVis extends React.Component {
         );
         return [
           metric.label,
-          metric.key === this.props.metric ? <b>{value}</b> : value
+          metric.key === this.props.metric ? <b>{value}</b> : value,
         ];
       });
     }
@@ -182,13 +182,13 @@ class SamplesHeatmapVis extends React.Component {
         data: [
           ["Sample", sampleDetails.name],
           ["Taxon", taxonDetails.name],
-          ["Category", taxonDetails.category]
-        ]
+          ["Category", taxonDetails.category],
+        ],
       },
       {
         name: "Values",
-        data: nodeHasData ? values : [["", "Taxon not found in Sample"]]
-      }
+        data: nodeHasData ? values : [["", "Taxon not found in Sample"]],
+      },
     ];
   }
 
@@ -196,16 +196,16 @@ class SamplesHeatmapVis extends React.Component {
     const sampleId = this.props.sampleIds[cell.columnIndex];
     openUrl(`/samples/${sampleId}`, currentEvent);
     logAnalyticsEvent("SamplesHeatmapVis_cell_clicked", {
-      sampleId
+      sampleId,
     });
   };
 
   handleAddColumnMetadataClick = trigger => {
     this.setState({
-      addMetadataTrigger: trigger
+      addMetadataTrigger: trigger,
     });
     logAnalyticsEvent("SamplesHeatmapVis_column-metadata_clicked", {
-      addMetadataTrigger: trigger
+      addMetadataTrigger: trigger,
     });
   };
 
@@ -218,12 +218,12 @@ class SamplesHeatmapVis extends React.Component {
     const current = new Set([...intersection, ...selectedMetadata]);
     this.setState(
       {
-        selectedMetadata: current
+        selectedMetadata: current,
       },
       () => {
         this.heatmap.updateColumnMetadata(this.getSelectedMetadata());
         logAnalyticsEvent("SamplesHeatmapVis_selected-metadata_changed", {
-          selectedMetadata: current.length
+          selectedMetadata: current.length,
         });
       }
     );
@@ -286,7 +286,7 @@ class SamplesHeatmapVis extends React.Component {
       tooltipLocation,
       nodeHoverInfo,
       columnMetadataLegend,
-      addMetadataTrigger
+      addMetadataTrigger,
     } = this.state;
 
     return (
@@ -304,7 +304,7 @@ class SamplesHeatmapVis extends React.Component {
               className={cx(cs.tooltip, nodeHoverInfo && cs.visible)}
               style={getTooltipStyle(tooltipLocation, {
                 buffer: 20,
-                below: true
+                below: true,
               })}
             >
               <DataTooltip data={nodeHoverInfo} />
@@ -316,7 +316,7 @@ class SamplesHeatmapVis extends React.Component {
               className={cx(cs.tooltip, columnMetadataLegend && cs.visible)}
               style={getTooltipStyle(tooltipLocation, {
                 buffer: 20,
-                below: true
+                below: true,
               })}
             >
               {this.renderColumnMetadataLegend(columnMetadataLegend)}
@@ -342,7 +342,7 @@ class SamplesHeatmapVis extends React.Component {
 }
 
 SamplesHeatmapVis.defaultProps = {
-  defaultMetadata: ["collection_location"]
+  defaultMetadata: ["collection_location"],
 };
 
 SamplesHeatmapVis.propTypes = {
@@ -358,7 +358,7 @@ SamplesHeatmapVis.propTypes = {
   sampleIds: PropTypes.array,
   scale: PropTypes.string,
   taxonDetails: PropTypes.object,
-  taxonIds: PropTypes.array
+  taxonIds: PropTypes.array,
 };
 
 export default SamplesHeatmapVis;

--- a/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
@@ -27,13 +27,13 @@ class BaseDiscoveryView extends React.Component {
 
 BaseDiscoveryView.defaultProps = {
   columns: [],
-  data: []
+  data: [],
 };
 
 BaseDiscoveryView.propTypes = {
   columns: PropTypes.array,
   data: PropTypes.array,
-  handleRowClick: PropTypes.func
+  handleRowClick: PropTypes.func,
 };
 
 export default BaseDiscoveryView;

--- a/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
@@ -7,7 +7,7 @@ import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import {
   BaseMultipleFilter,
   BaseSingleFilter,
-  TaxonFilter
+  TaxonFilter,
 } from "~/components/common/filters";
 import FilterTag from "~ui/controls/FilterTag";
 
@@ -26,7 +26,7 @@ class DiscoveryFilters extends React.Component {
       timeSelected: this.props.timeSelected,
       visibilitySelected: this.props.visibilitySelected,
       hostSelected: this.props.hostSelected,
-      tissueSelected: this.props.tissueSelected
+      tissueSelected: this.props.tissueSelected,
     };
   }
 
@@ -47,7 +47,7 @@ class DiscoveryFilters extends React.Component {
         "taxonSelected",
         "timeSelected",
         "tissueSelected",
-        "visibilitySelected"
+        "visibilitySelected",
       ]
     );
 
@@ -64,7 +64,7 @@ class DiscoveryFilters extends React.Component {
         "taxonSelected",
         "timeSelected",
         "tissueSelected",
-        "visibilitySelected"
+        "visibilitySelected",
       ],
       this.state
     );
@@ -76,7 +76,7 @@ class DiscoveryFilters extends React.Component {
     newState[selectedKey] = selected;
     this.setState(newState, this.notifyFilterChangeHandler);
     logAnalyticsEvent(`DiscoveryFilters_${selectedKey.toLowerCase()}_changed`, {
-      selectedKey: selected
+      selectedKey: selected,
     });
   }
 
@@ -118,7 +118,7 @@ class DiscoveryFilters extends React.Component {
               "DiscoveryFilters_tag_removed",
               {
                 value: option.value,
-                text: option.text
+                text: option.text,
               }
             )}
           />
@@ -135,7 +135,7 @@ class DiscoveryFilters extends React.Component {
       taxonSelected,
       timeSelected,
       tissueSelected,
-      visibilitySelected
+      visibilitySelected,
     } = this.state;
 
     const {
@@ -147,7 +147,7 @@ class DiscoveryFilters extends React.Component {
       locationV2,
       time,
       tissue,
-      visibility
+      visibility,
     } = this.props;
 
     return (
@@ -229,7 +229,7 @@ DiscoveryFilters.defaultProps = {
   locationV2: [],
   time: [],
   tissue: [],
-  visibility: []
+  visibility: [],
 };
 
 DiscoveryFilters.propTypes = {
@@ -254,7 +254,7 @@ DiscoveryFilters.propTypes = {
   tissueSelected: PropTypes.array,
   visibilitySelected: PropTypes.string,
 
-  onFilterChange: PropTypes.func
+  onFilterChange: PropTypes.func,
 };
 
 export default DiscoveryFilters;

--- a/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
@@ -40,7 +40,7 @@ class DiscoveryHeader extends React.Component {
     const parsedResult = {
       key: category,
       value: value,
-      text: result.title
+      text: result.title,
     };
 
     onSearchResultSelected &&
@@ -65,7 +65,7 @@ class DiscoveryHeader extends React.Component {
       onTabChange,
       showFilters,
       showStats,
-      tabs
+      tabs,
     } = this.props;
 
     return (
@@ -108,7 +108,7 @@ class DiscoveryHeader extends React.Component {
 
 DiscoveryHeader.defaultProps = {
   filterCount: 0,
-  searchValue: ""
+  searchValue: "",
 };
 
 DiscoveryHeader.propTypes = {
@@ -128,10 +128,10 @@ DiscoveryHeader.propTypes = {
       PropTypes.string.isRequired,
       PropTypes.shape({
         value: PropTypes.string.isRequired,
-        label: PropTypes.node.isRequired
-      })
+        label: PropTypes.node.isRequired,
+      }),
     ])
-  ).isRequired
+  ).isRequired,
 };
 
 export default DiscoveryHeader;

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -19,15 +19,15 @@ export default class DiscoverySidebar extends React.Component {
         numSamples: "",
         numProjects: "",
         avgTotalReads: "",
-        avgAdjustedRemainingReads: ""
+        avgAdjustedRemainingReads: "",
       },
       metadata: {
         host: [],
         tissue: [],
         time: [],
-        location: []
+        location: [],
       },
-      expandedMetadataGroups: new Set()
+      expandedMetadataGroups: new Set(),
     };
   }
 
@@ -38,7 +38,7 @@ export default class DiscoverySidebar extends React.Component {
       projectDimensions,
       projectStats,
       sampleDimensions,
-      sampleStats
+      sampleStats,
     } = newProps;
     if (loading) return prevState;
     const dimensions =
@@ -53,15 +53,15 @@ export default class DiscoverySidebar extends React.Component {
         ),
         avgAdjustedRemainingReads: DiscoverySidebar.formatNumber(
           (sampleStats || {}).avgAdjustedRemainingReads
-        )
+        ),
       },
       metadata: {
         host: DiscoverySidebar.loadDimension(dimensions, "host"),
         tissue: DiscoverySidebar.loadDimension(dimensions, "tissue"),
         location: DiscoverySidebar.loadDimension(dimensions, "location"),
         locationV2: DiscoverySidebar.loadDimension(dimensions, "locationV2"),
-        time: DiscoverySidebar.loadDimension(dimensions, "time_bins")
-      }
+        time: DiscoverySidebar.loadDimension(dimensions, "time_bins"),
+      },
     };
   }
 
@@ -116,7 +116,7 @@ export default class DiscoverySidebar extends React.Component {
                     dateValue: entry.value,
                     dates: dates.length,
                     count: entry.count,
-                    percent
+                    percent,
                   });
                 }}
               >
@@ -184,7 +184,7 @@ export default class DiscoverySidebar extends React.Component {
               logAnalyticsEvent("DiscoverySidebar_show-more-toggle_clicked", {
                 field,
                 extraRows: extraRows.length,
-                linkText
+                linkText,
               });
             }}
           >
@@ -199,7 +199,7 @@ export default class DiscoverySidebar extends React.Component {
     const groups = new Set(this.state.expandedMetadataGroups);
     groups.has(field) ? groups.delete(field) : groups.add(field);
     this.setState({
-      expandedMetadataGroups: groups
+      expandedMetadataGroups: groups,
     });
   }
 
@@ -217,7 +217,7 @@ export default class DiscoverySidebar extends React.Component {
                   value,
                   count,
                   percent,
-                  rows: rows.length
+                  rows: rows.length,
                 });
               }}
             >
@@ -352,7 +352,7 @@ export default class DiscoverySidebar extends React.Component {
 }
 
 DiscoverySidebar.defaultProps = {
-  defaultNumberOfMetadataRows: 4
+  defaultNumberOfMetadataRows: 4,
 };
 
 DiscoverySidebar.propTypes = {
@@ -365,5 +365,5 @@ DiscoverySidebar.propTypes = {
   projectDimensions: PropTypes.array,
   projectStats: PropTypes.object,
   sampleDimensions: PropTypes.array,
-  sampleStats: PropTypes.object
+  sampleStats: PropTypes.object,
 };

--- a/app/assets/src/components/views/discovery/NoResultsBanner.jsx
+++ b/app/assets/src/components/views/discovery/NoResultsBanner.jsx
@@ -11,7 +11,7 @@ const NoResultsBanner = ({ className, message, suggestion, type }) => {
   // This is a hack to associate the event with the parent component, DiscoveryView
   logAnalyticsEvent("DiscoveryView_no-results-banner_displayed", {
     type,
-    message
+    message,
   });
   return (
     <div className={cx(cs.container, className)}>
@@ -28,14 +28,14 @@ const NoResultsBanner = ({ className, message, suggestion, type }) => {
 
 NoResultsBanner.defaultProps = {
   message: "Sorry, no results match your search.",
-  suggestion: "Try another search"
+  suggestion: "Try another search",
 };
 
 NoResultsBanner.propTypes = {
   className: PropTypes.string,
   message: PropTypes.string,
   suggestion: PropTypes.string,
-  type: PropTypes.string
+  type: PropTypes.string,
 };
 
 export default NoResultsBanner;

--- a/app/assets/src/components/views/discovery/TableRenderers.jsx
+++ b/app/assets/src/components/views/discovery/TableRenderers.jsx
@@ -15,7 +15,7 @@ const STATUS_COLOR = {
   complete: "success",
   failed: "error",
   "complete - issue": "warning",
-  "complete*": "warning"
+  "complete*": "warning",
 };
 
 class TableRenderers extends React.Component {
@@ -23,7 +23,7 @@ class TableRenderers extends React.Component {
     cellData: item,
     detailsRenderer,
     nameRenderer,
-    visibilityIconRenderer
+    visibilityIconRenderer,
   }) => {
     let icon = visibilityIconRenderer(item);
     return (
@@ -31,7 +31,7 @@ class TableRenderers extends React.Component {
         <div className={cs.visibility}>
           {icon &&
             React.cloneElement(icon, {
-              className: `${cx(cs.icon, icon.props.className)}`
+              className: `${cx(cs.icon, icon.props.className)}`,
             })}
         </div>
         <div className={cs.itemRightPane}>

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -6,7 +6,7 @@ import {
   getSampleStats,
   getSamples,
   getSamplesLocations,
-  getVisualizations
+  getVisualizations,
 } from "~/api";
 
 const DISCOVERY_DOMAIN_MY_DATA = "my_data";
@@ -17,12 +17,12 @@ const getDiscoverySyncData = async ({ domain, filters, projectId, search }) => {
   try {
     const [projects, visualizations] = await Promise.all([
       getProjects({ domain, filters, projectId, search }),
-      getVisualizations({ domain, filters, search })
+      getVisualizations({ domain, filters, search }),
     ]);
 
     return {
       projects,
-      visualizations
+      visualizations,
     };
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -35,12 +35,12 @@ const getDiscoveryDimensions = async ({
   domain,
   filters,
   projectId,
-  search
+  search,
 }) => {
   try {
     const actions = [
       getSampleDimensions({ domain, filters, projectId, search }),
-      getProjectDimensions({ domain, filters, projectId, search })
+      getProjectDimensions({ domain, filters, projectId, search }),
     ];
     const [sampleDimensions, projectDimensions] = await Promise.all(actions);
     return { sampleDimensions, projectDimensions };
@@ -57,7 +57,7 @@ const getDiscoveryStats = async ({ domain, filters, projectId, search }) => {
       domain,
       filters,
       projectId,
-      search
+      search,
     });
     return { sampleStats };
   } catch (error) {
@@ -77,7 +77,7 @@ const processRawSample = sample => {
       status: get(
         "run_info.result_status_description",
         sample.details
-      ).toLowerCase()
+      ).toLowerCase(),
     },
     collectionLocation: get("metadata.collection_location", sample.details),
     collectionLocationV2: get(
@@ -103,7 +103,7 @@ const processRawSample = sample => {
       percent: get(
         "derived_sample_output.summary_stats.percent_remaining",
         sample.details
-      )
+      ),
     },
     notes: get("db_sample.sample_notes", sample.details),
     nucleotideType: get("metadata.nucleotide_type", sample.details),
@@ -120,7 +120,7 @@ const processRawSample = sample => {
       "derived_sample_output.pipeline_run.total_reads",
       sample.details
     ),
-    totalRuntime: get("run_info.total_runtime", sample.details)
+    totalRuntime: get("run_info.total_runtime", sample.details),
   };
   return row;
 };
@@ -133,7 +133,7 @@ const getDiscoverySamples = async ({
   limit = 100,
   offset = 0,
   listAllIds = false,
-  sampleIds
+  sampleIds,
 } = {}) => {
   const sampleResults = await getSamples({
     domain,
@@ -143,11 +143,11 @@ const getDiscoverySamples = async ({
     limit,
     offset,
     listAllIds,
-    sampleIds
+    sampleIds,
   });
   return {
     samples: map(processRawSample, sampleResults.samples),
-    sampleIds: sampleResults.all_samples_ids
+    sampleIds: sampleResults.all_samples_ids,
   };
 };
 
@@ -155,14 +155,14 @@ const getDiscoveryLocations = async ({
   domain,
   filters,
   projectId,
-  search
+  search,
 }) => {
   try {
     return await getSamplesLocations({
       domain,
       filters,
       projectId,
-      search
+      search,
     });
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -179,5 +179,5 @@ export {
   getDiscoveryLocations,
   getDiscoverySamples,
   getDiscoveryStats,
-  getDiscoverySyncData
+  getDiscoverySyncData,
 };

--- a/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/BaseMap.jsx
@@ -19,8 +19,8 @@ class BaseMap extends React.Component {
         height,
         latitude,
         longitude,
-        zoom
-      }
+        zoom,
+      },
     };
   }
 
@@ -97,7 +97,7 @@ BaseMap.propTypes = {
   viewBounds: PropTypes.objectOf(PropTypes.number),
   tooltip: PropTypes.node,
   markers: PropTypes.array,
-  popups: PropTypes.array
+  popups: PropTypes.array,
 };
 
 BaseMap.defaultProps = {
@@ -116,8 +116,8 @@ BaseMap.defaultProps = {
     // Limit to whole-world view
     minZoom: 0.5,
     // Limit to city-level at most
-    maxZoom: 17
-  }
+    maxZoom: 17,
+  },
 };
 
 export default BaseMap;

--- a/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/CircleMarker.jsx
@@ -39,11 +39,11 @@ CircleMarker.propTypes = {
   size: PropTypes.number,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
 };
 
 CircleMarker.defaultProps = {
-  size: 20
+  size: 20,
 };
 
 export default CircleMarker;

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -15,7 +15,7 @@ class DiscoveryMap extends React.Component {
 
     this.state = {
       tooltip: null,
-      tooltipShouldClose: false
+      tooltipShouldClose: false,
     };
   }
 
@@ -115,7 +115,7 @@ DiscoveryMap.propTypes = {
   mapTilerKey: PropTypes.string,
   onMarkerClick: PropTypes.func,
   onTooltipTitleClick: PropTypes.func,
-  previewedLocationId: PropTypes.number
+  previewedLocationId: PropTypes.number,
 };
 
 export default DiscoveryMap;

--- a/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPlayground.jsx
@@ -24,7 +24,7 @@ class MapPlayground extends React.Component {
       const locId = locData.id;
       const item = {
         sampleName: result.name,
-        sampleId: result.id
+        sampleId: result.id,
       };
       if (locationsToItems.hasOwnProperty(locId)) {
         locationsToItems[locId].items.push(item);
@@ -33,7 +33,7 @@ class MapPlayground extends React.Component {
           lat: parseFloat(locData.lat),
           lng: parseFloat(locData.lng),
           name: locData.name,
-          items: [item]
+          items: [item],
         };
       }
     });
@@ -43,7 +43,7 @@ class MapPlayground extends React.Component {
       viewport: {},
       tooltip: null,
       tooltipShouldClose: false,
-      searchResult: null
+      searchResult: null,
     };
   }
 
@@ -143,7 +143,7 @@ class MapPlayground extends React.Component {
 MapPlayground.propTypes = {
   results: PropTypes.array,
   // Access tokens safe for clients
-  mapTilerKey: PropTypes.string
+  mapTilerKey: PropTypes.string,
 };
 
 export default MapPlayground;

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -18,7 +18,7 @@ export default class MapPreviewSidebar extends React.Component {
     const { initialSelectedSampleIds } = this.props;
 
     this.state = {
-      selectedSampleIds: initialSelectedSampleIds || new Set()
+      selectedSampleIds: initialSelectedSampleIds || new Set(),
     };
 
     this.columns = [
@@ -27,25 +27,25 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         width: 150,
         cellRenderer: cellData => TableRenderers.renderSample(cellData, false),
-        headerClassName: cs.sampleHeader
+        headerClassName: cs.sampleHeader,
       },
       {
         dataKey: "createdAt",
         label: "Uploaded On",
         className: cs.basicCell,
-        cellRenderer: TableRenderers.renderDateWithElapsed
+        cellRenderer: TableRenderers.renderDateWithElapsed,
       },
       {
         dataKey: "host",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       // If you already have access to Maps, just see Location V2 here.
       {
         dataKey: "collectionLocationV2",
         label: "Location",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       {
         dataKey: "totalReads",
@@ -53,14 +53,14 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatNumberWithCommas(rowData[dataKey])
+          TableRenderers.formatNumberWithCommas(rowData[dataKey]),
       },
       {
         dataKey: "nonHostReads",
         label: "Passed Filters",
         flexGrow: 1,
         className: cs.basicCell,
-        cellRenderer: TableRenderers.renderNumberAndPercentage
+        cellRenderer: TableRenderers.renderNumberAndPercentage,
       },
       {
         dataKey: "qcPercent",
@@ -68,7 +68,7 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatPercentage(rowData[dataKey])
+          TableRenderers.formatPercentage(rowData[dataKey]),
       },
       {
         dataKey: "duplicateCompressionRatio",
@@ -76,7 +76,7 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatPercentage(rowData[dataKey])
+          TableRenderers.formatPercentage(rowData[dataKey]),
       },
       {
         dataKey: "erccReads",
@@ -84,24 +84,24 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatNumberWithCommas(rowData[dataKey])
+          TableRenderers.formatNumberWithCommas(rowData[dataKey]),
       },
       {
         dataKey: "notes",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       {
         dataKey: "nucleotideType",
         label: "Nucleotide Type",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       {
         dataKey: "sampleType",
         label: "Sample Type",
         flexGrow: 1,
-        className: cs.basicCell
+        className: cs.basicCell,
       },
       {
         dataKey: "subsampledFraction",
@@ -109,7 +109,7 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatNumber(rowData[dataKey])
+          TableRenderers.formatNumber(rowData[dataKey]),
       },
       {
         dataKey: "totalRuntime",
@@ -117,8 +117,8 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatDuration(rowData[dataKey])
-      }
+          TableRenderers.formatDuration(rowData[dataKey]),
+      },
     ];
   }
 
@@ -140,7 +140,7 @@ export default class MapPreviewSidebar extends React.Component {
     this.setSelectedSampleIds(newSelected);
 
     logAnalyticsEvent("MapPreviewSidebar_row_selected", {
-      selectedSampleIds: newSelected.length
+      selectedSampleIds: newSelected.length,
     });
   };
 
@@ -150,7 +150,7 @@ export default class MapPreviewSidebar extends React.Component {
     onSampleClicked && onSampleClicked({ sample, currentEvent: event });
     logAnalyticsEvent("MapPreviewSidebar_row_clicked", {
       sampleId: sample.id,
-      sampleName: sample.name
+      sampleName: sample.name,
     });
   };
 
@@ -187,7 +187,7 @@ export default class MapPreviewSidebar extends React.Component {
     return [
       {
         label: "Summary",
-        value: "Summary"
+        value: "Summary",
       },
       {
         label: (
@@ -198,8 +198,8 @@ export default class MapPreviewSidebar extends React.Component {
             )}
           </div>
         ),
-        value: "Samples"
-      }
+        value: "Samples",
+      },
     ];
   };
 
@@ -255,7 +255,7 @@ export default class MapPreviewSidebar extends React.Component {
       projectDimensions,
       projectStats,
       sampleDimensions,
-      sampleStats
+      sampleStats,
     } = this.props;
 
     return (
@@ -299,7 +299,7 @@ export default class MapPreviewSidebar extends React.Component {
 MapPreviewSidebar.defaultProps = {
   activeColumns: ["sample"],
   protectedColumns: ["sample"],
-  currentTab: "Summary"
+  currentTab: "Summary",
 };
 
 MapPreviewSidebar.propTypes = {
@@ -319,5 +319,5 @@ MapPreviewSidebar.propTypes = {
   sampleDimensions: PropTypes.array,
   samples: PropTypes.array,
   sampleStats: PropTypes.object,
-  selectableIds: PropTypes.array.isRequired
+  selectableIds: PropTypes.array.isRequired,
 };

--- a/app/assets/src/components/views/discovery/mapping/MapTooltip.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapTooltip.jsx
@@ -15,7 +15,7 @@ class MapTooltip extends React.Component {
       body,
       onMouseEnter,
       onMouseLeave,
-      onTitleClick
+      onTitleClick,
     } = this.props;
 
     return (
@@ -57,7 +57,7 @@ MapTooltip.propTypes = {
   body: PropTypes.string,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
-  onTitleClick: PropTypes.func
+  onTitleClick: PropTypes.func,
 };
 
 export default MapTooltip;

--- a/app/assets/src/components/views/metadata/MetadataDictionary.jsx
+++ b/app/assets/src/components/views/metadata/MetadataDictionary.jsx
@@ -7,7 +7,7 @@ import _fp, {
   partition,
   first,
   get,
-  compact
+  compact,
 } from "lodash/fp";
 import NarrowContainer from "~/components/layout/NarrowContainer";
 import DataTable from "~/components/visualizations/table/DataTable";
@@ -22,7 +22,7 @@ const map = _fp.map.convert({ cap: false });
 const dictionaryHeaders = {
   name: "Name",
   description: "Description",
-  examples: "Examples"
+  examples: "Examples",
 };
 
 const getExamplesForHostGenome = (field, hostGenomeId) =>
@@ -34,13 +34,13 @@ class MetadataDictionary extends React.Component {
   state = {
     officialFields: null,
     hostGenomes: null,
-    currentHostGenome: null
+    currentHostGenome: null,
   };
 
   async componentDidMount() {
     let [officialFields, hostGenomes] = await Promise.all([
       getOfficialMetadataFields(),
-      getAllHostGenomes()
+      getAllHostGenomes(),
     ]);
 
     officialFields = map(
@@ -52,7 +52,7 @@ class MetadataDictionary extends React.Component {
     this.setState({
       officialFields,
       hostGenomes,
-      currentHostGenome: get("id", first(hostGenomes))
+      currentHostGenome: get("id", first(hostGenomes)),
     });
   }
 
@@ -79,7 +79,7 @@ class MetadataDictionary extends React.Component {
           set("name", <div className={cs.required}>{field.name}*</div>, field),
         sortBy("name", requiredFields)
       ),
-      ...sortBy("name", nonrequiredFields)
+      ...sortBy("name", nonrequiredFields),
     ];
   };
 
@@ -95,7 +95,7 @@ class MetadataDictionary extends React.Component {
     const groups = map(
       (fields, name) => ({
         name,
-        fields: this.processFields(fields)
+        fields: this.processFields(fields),
       }),
       groupBy("group", fieldsForHostGenome)
     );
@@ -105,7 +105,7 @@ class MetadataDictionary extends React.Component {
 
   handleHostGenomeChange = id => {
     this.setState({
-      currentHostGenome: id
+      currentHostGenome: id,
     });
   };
 
@@ -114,7 +114,7 @@ class MetadataDictionary extends React.Component {
       "text",
       this.state.hostGenomes.map(hostGenome => ({
         text: hostGenome.name,
-        value: hostGenome.id
+        value: hostGenome.id,
       }))
     );
 

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -41,14 +41,14 @@ class PhyloTreeCreation extends React.Component {
       showErrorTaxonAndProject: false,
       showErrorName: false,
       showErrorSamples: false,
-      treeName: ""
+      treeName: "",
     };
 
     this.phyloTreeHeaders = {
       name: "Phylogenetic Tree",
       user: "Creator",
       last_update: "Last Updated",
-      view: "View"
+      view: "View",
     };
 
     this.projectSamplesHeaders = {
@@ -57,7 +57,7 @@ class PhyloTreeCreation extends React.Component {
       tissue: "Tissue",
       location: "Location",
       date: "Date",
-      reads: "Read Count\n(NT | NR)"
+      reads: "Read Count\n(NT | NR)",
     };
 
     this.otherSamplesHeaders = {
@@ -67,7 +67,7 @@ class PhyloTreeCreation extends React.Component {
       tissue: "Tissue",
       location: "Location",
       date: "Date",
-      reads: "Read Count\n(NT | NR)"
+      reads: "Read Count\n(NT | NR)",
     };
 
     this.skipSelectProjectAndTaxon = this.props.projectId && this.props.taxonId;
@@ -107,8 +107,8 @@ class PhyloTreeCreation extends React.Component {
       .get("/phylo_trees/index.json", {
         params: {
           taxId: this.state.taxonId,
-          projectId: this.state.projectId
-        }
+          projectId: this.state.projectId,
+        },
       })
       .then(response => this.handlePhyloTreeResponse(response))
       .catch(error => {
@@ -123,8 +123,8 @@ class PhyloTreeCreation extends React.Component {
       .get("/phylo_trees/new.json", {
         params: {
           taxId: this.state.taxonId,
-          projectId: this.state.projectId
-        }
+          projectId: this.state.projectId,
+        },
       })
       .then(response => this.handleNewTreeContextResponse(response))
       .catch(error => {
@@ -151,13 +151,13 @@ class PhyloTreeCreation extends React.Component {
     if (!phyloTrees || !Array.isArray(phyloTrees) || phyloTrees.length === 0) {
       this.setState({
         skipListTrees: true,
-        phyloTreesLoaded: true
+        phyloTreesLoaded: true,
       });
     } else {
       this.setState({
         phyloTrees: this.parsePhyloTreeData(response.data.phyloTrees),
         phyloTreesLoaded: true,
-        taxonName: (data.taxon || {}).name
+        taxonName: (data.taxon || {}).name,
       });
     }
   }
@@ -170,14 +170,14 @@ class PhyloTreeCreation extends React.Component {
       console.error("Error loading samples data");
     } else if (samplesData.length === 0) {
       this.setState({
-        samplesLoaded: true
+        samplesLoaded: true,
       });
     } else {
       let parsedTables = this.parseProjectSamplesData(samplesData);
       this.setState({
         projectSamples: parsedTables.projectSamples,
         otherSamples: parsedTables.otherSamples,
-        samplesLoaded: true
+        samplesLoaded: true,
       });
     }
   }
@@ -185,7 +185,7 @@ class PhyloTreeCreation extends React.Component {
   handleProjectSearchContextResponse(response) {
     this.setState({
       projectList: response.data,
-      projectsLoaded: true
+      projectsLoaded: true,
     });
   }
 
@@ -199,7 +199,7 @@ class PhyloTreeCreation extends React.Component {
       selectedProjectSamples: new Set(),
       otherSamples: [],
       selectedOtherSamples: new Set(),
-      otherSamplesFilter: ""
+      otherSamplesFilter: "",
     });
   }
 
@@ -213,7 +213,7 @@ class PhyloTreeCreation extends React.Component {
       selectedProjectSamples: new Set(),
       otherSamples: [],
       selectedOtherSamples: new Set(),
-      otherSamplesFilter: ""
+      otherSamplesFilter: "",
     });
   }
 
@@ -222,7 +222,7 @@ class PhyloTreeCreation extends React.Component {
       name: row.name,
       user: (row.user || {}).name,
       last_update: <Moment fromNow date={row.updated_at} />,
-      view: <a href={`/phylo_trees/index?treeId=${row.id}`}>View</a>
+      view: <a href={`/phylo_trees/index?treeId=${row.id}`}>View</a>,
     }));
   }
 
@@ -248,9 +248,9 @@ class PhyloTreeCreation extends React.Component {
           }`,
           rawReads: {
             nt: (row.taxid_reads || {}).NT || 0,
-            nr: (row.taxid_reads || {}).NR || 0
+            nr: (row.taxid_reads || {}).NR || 0,
           },
-          pipelineRunId: row.pipeline_run_id
+          pipelineRunId: row.pipeline_run_id,
         };
         if (row.project_id === this.state.projectId) {
           projectSamples.push(entry);
@@ -297,7 +297,7 @@ class PhyloTreeCreation extends React.Component {
   handleCreation() {
     if (!this.isNumberOfSamplesValid()) {
       this.setState({
-        showErrorSamples: true
+        showErrorSamples: true,
       });
       return false;
     }
@@ -319,7 +319,7 @@ class PhyloTreeCreation extends React.Component {
         taxId: this.state.taxonId,
         taxName: this.state.taxonName,
         pipelineRunIds: pipelineRunIds,
-        authenticity_token: this.props.csrf
+        authenticity_token: this.props.csrf,
       })
       .then(response => {
         let phyloTreeId = response.data.phylo_tree_id;
@@ -350,7 +350,7 @@ class PhyloTreeCreation extends React.Component {
     const result = await validatePhyloTreeName(treeName);
     this.setState({
       treeName: result.sanitizedName,
-      treeNameValid: result.valid
+      treeNameValid: result.valid,
     });
     return result.valid;
   };
@@ -368,7 +368,7 @@ class PhyloTreeCreation extends React.Component {
       otherSamples,
       projectSamples,
       selectedProjectSamples,
-      selectedOtherSamples
+      selectedOtherSamples,
     } = this.state;
 
     const getReadsArray = (samples, indices, readType) =>
@@ -449,7 +449,7 @@ class PhyloTreeCreation extends React.Component {
       "tissue",
       "location",
       "date",
-      "reads"
+      "reads",
     ];
     const otherSamplesColumns = [
       "name",
@@ -458,7 +458,7 @@ class PhyloTreeCreation extends React.Component {
       "tissue",
       "location",
       "date",
-      "reads"
+      "reads",
     ];
     let options = {
       listTrees: (
@@ -514,7 +514,7 @@ class PhyloTreeCreation extends React.Component {
                 serverSearchAction="choose_taxon"
                 serverSearchActionArgs={{
                   args: "species,genus",
-                  project_id: this.state.projectId
+                  project_id: this.state.projectId,
                 }}
                 onResultSelect={this.handleSelectTaxon}
                 initialValue={this.state.taxonName}
@@ -631,7 +631,7 @@ class PhyloTreeCreation extends React.Component {
             {this.renderNotifications()}
           </div>
         </Wizard.Page>
-      )
+      ),
     };
     return options[action];
   }
@@ -660,7 +660,7 @@ class PhyloTreeCreation extends React.Component {
           onComplete={this.handleComplete}
           defaultPage={this.state.defaultPage}
           labels={{
-            finish: "Create Tree"
+            finish: "Create Tree",
           }}
         >
           {this.getPages()}
@@ -679,7 +679,7 @@ PhyloTreeCreation.propTypes = {
   projectId: PropTypes.number,
   projectName: PropTypes.string,
   taxonId: PropTypes.number,
-  taxonName: PropTypes.string
+  taxonName: PropTypes.string,
 };
 
 export default PhyloTreeCreation;

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreationModal.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreationModal.jsx
@@ -23,7 +23,7 @@ PhyloTreeCreationModal.propTypes = forbidExtraProps({
   projectId: PropTypes.number,
   projectName: PropTypes.string,
   taxonId: PropTypes.number,
-  taxonName: PropTypes.string
+  taxonName: PropTypes.string,
 });
 
 export default PhyloTreeCreationModal;

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeDownloadButton.jsx
@@ -12,11 +12,11 @@ class PhyloTreeDownloadButton extends React.Component {
 
     this.dataOptions = [
       { text: "VCF", value: "vcf" },
-      { text: "SNP annotations", value: "snp_annotations" }
+      { text: "SNP annotations", value: "snp_annotations" },
     ];
     this.imageOptions = [
       { text: "SVG", value: "svg" },
-      { text: "PNG", value: "png" }
+      { text: "PNG", value: "png" },
     ];
     this.download = this.download.bind(this);
     this.svgSaver = new SvgSaver();
@@ -40,7 +40,7 @@ class PhyloTreeDownloadButton extends React.Component {
     logAnalyticsEvent("PhyloTreeDownloadButton_option_clicked", {
       option,
       treeName: this.props.tree.name,
-      treeId: this.props.tree.id
+      treeId: this.props.tree.id,
     });
   }
 
@@ -65,7 +65,7 @@ class PhyloTreeDownloadButton extends React.Component {
 }
 
 PhyloTreeDownloadButton.propTypes = {
-  tree: PropTypes.object
+  tree: PropTypes.object,
 };
 
 export default PhyloTreeDownloadButton;

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeVis.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeVis.jsx
@@ -14,12 +14,12 @@ const getAbsentName = attribute =>
 const EXTRA_DROPDOWN_OPTIONS = [
   {
     text: "Project Name",
-    value: "project_name"
+    value: "project_name",
   },
   {
     text: "Host Genome Name",
-    value: "host_genome_name"
-  }
+    value: "host_genome_name",
+  },
 ];
 
 class PhyloTreeVis extends React.Component {
@@ -34,7 +34,7 @@ class PhyloTreeVis extends React.Component {
       sidebarVisible: false,
       metadataFields: [],
       selectedMetadataType:
-        props.defaultMetadata || EXTRA_DROPDOWN_OPTIONS[0].value
+        props.defaultMetadata || EXTRA_DROPDOWN_OPTIONS[0].value,
     };
 
     (this.newick = props.newick),
@@ -43,7 +43,7 @@ class PhyloTreeVis extends React.Component {
 
     this.ncbiFields = [
       { name: "country", label: "Country" },
-      { name: "collection_date", label: "Collection Date" }
+      { name: "collection_date", label: "Collection Date" },
     ];
   }
 
@@ -60,7 +60,7 @@ class PhyloTreeVis extends React.Component {
       tooltipContainer: this.tooltipContainer,
       onNodeTextClick: this.handleNodeClick,
       onNodeHover: this.handleNodeHover,
-      scaleLabel: "Relative distance"
+      scaleLabel: "Relative distance",
     });
     this.treeVis.update();
 
@@ -94,7 +94,7 @@ class PhyloTreeVis extends React.Component {
     let metadataFields = await getSampleMetadataFields(sampleIds);
 
     this.setState({
-      metadataFields
+      metadataFields,
     });
   };
 
@@ -116,13 +116,13 @@ class PhyloTreeVis extends React.Component {
 
   handleSidebarClose = () => {
     this.setState({
-      sidebarVisible: false
+      sidebarVisible: false,
     });
   };
 
   handleMetadataTypeChange = (selectedMetadataType, name) => {
     this.setState({
-      selectedMetadataType
+      selectedMetadataType,
     });
 
     // This path will be used by lodash.get on the node data.
@@ -133,7 +133,7 @@ class PhyloTreeVis extends React.Component {
     this.treeVis.updateOptions({
       colorGroupAttribute: path,
       colorGroupLegendTitle: name,
-      colorGroupAbsentName: getAbsentName(selectedMetadataType)
+      colorGroupAbsentName: getAbsentName(selectedMetadataType),
     });
     this.props.afterSelectedMetadataChange(selectedMetadataType);
   };
@@ -162,9 +162,9 @@ class PhyloTreeVis extends React.Component {
           name: "NCBI Reference",
           data: this.ncbiFields.map(f => [
             f.label,
-            this.getFieldValue(f) || "-"
-          ])
-        }
+            this.getFieldValue(f) || "-",
+          ]),
+        },
       ];
     }
 
@@ -176,18 +176,18 @@ class PhyloTreeVis extends React.Component {
           ...SAMPLE_METADATA_FIELDS.map(key => {
             return [
               get("name", find(["key", key], this.state.metadataFields)) || key,
-              this.getMetadataFieldValue(key) || "-"
+              this.getMetadataFieldValue(key) || "-",
             ];
-          })
-        ]
-      }
+          }),
+        ],
+      },
     ];
   }
 
   getMetadataDropdownOptions = () => {
     const metadataOptions = this.state.metadataFields.map(metadataType => ({
       text: metadataType.name,
-      value: metadataType.key
+      value: metadataType.key,
     }));
 
     return sortBy(
@@ -239,7 +239,7 @@ PhyloTreeVis.propTypes = {
   onMetadataUpdate: PropTypes.func,
   phyloTreeId: PropTypes.number,
   onSampleNodeClick: PropTypes.func,
-  defaultMetadata: PropTypes.string
+  defaultMetadata: PropTypes.string,
 };
 
 export default PhyloTreeVis;

--- a/app/assets/src/components/views/phylo_tree/constants.js
+++ b/app/assets/src/components/views/phylo_tree/constants.js
@@ -11,13 +11,13 @@ export const SAMPLE_FIELDS = [
   {
     name: "created_at",
     label: "Upload Date",
-    parser: DateParser
-  }
+    parser: DateParser,
+  },
 ];
 
 export const SAMPLE_METADATA_FIELDS = [
   "collection_location",
   "collection_date",
   "sample_type",
-  "nucleotide_type"
+  "nucleotide_type",
 ];

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -26,36 +26,36 @@ class ProjectsView extends React.Component {
               {
                 nameRenderer: this.nameRenderer,
                 detailsRenderer: this.detailsRenderer,
-                visibilityIconRenderer: this.visibilityIconRenderer
+                visibilityIconRenderer: this.visibilityIconRenderer,
               }
             )
           ),
         headerClassName: cs.projectHeader,
-        sortFunction: p => (p.name || "").toLowerCase()
+        sortFunction: p => (p.name || "").toLowerCase(),
       },
       {
         dataKey: "created_at",
         label: "Created On",
         width: 120,
-        cellRenderer: TableRenderers.renderDateWithElapsed
+        cellRenderer: TableRenderers.renderDateWithElapsed,
       },
       {
         dataKey: "hosts",
         width: 200,
         disableSort: true,
-        cellRenderer: TableRenderers.renderList
+        cellRenderer: TableRenderers.renderList,
       },
       {
         dataKey: "tissues",
         width: 200,
         disableSort: true,
-        cellRenderer: TableRenderers.renderList
+        cellRenderer: TableRenderers.renderList,
       },
       {
         dataKey: "number_of_samples",
         width: 140,
-        label: "No. of Samples"
-      }
+        label: "No. of Samples",
+      },
     ];
   }
 
@@ -85,7 +85,7 @@ class ProjectsView extends React.Component {
     onProjectSelected && onProjectSelected({ project });
     logAnalyticsEvent("ProjectsView_row_clicked", {
       projectId: project.id,
-      projectName: project.name
+      projectName: project.name,
     });
   };
 
@@ -97,7 +97,7 @@ class ProjectsView extends React.Component {
           project: pick(
             ["name", "description", "owner", "public_access"],
             project
-          )
+          ),
         },
         pick(
           ["id", "created_at", "hosts", "tissues", "number_of_samples"],
@@ -117,12 +117,12 @@ class ProjectsView extends React.Component {
 }
 
 ProjectsView.defaultProps = {
-  projects: []
+  projects: [],
 };
 
 ProjectsView.propTypes = {
   projects: PropTypes.array,
-  onProjectSelected: PropTypes.func
+  onProjectSelected: PropTypes.func,
 };
 
 export default ProjectsView;

--- a/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
+++ b/app/assets/src/components/views/report/ReportTable/DetailCells.jsx
@@ -18,7 +18,7 @@ export default class DetailCells extends React.Component {
       backgroundData,
       showAssemblyColumns,
       handleMouseEnter,
-      handleMouseLeave
+      handleMouseLeave,
     } = this.props;
 
     return taxons.map(taxInfo => (
@@ -95,5 +95,5 @@ DetailCells.propTypes = {
   backgroundData: PropTypes.BackgroundData,
   showAssemblyColumns: PropTypes.bool,
   handleMouseEnter: PropTypes.func,
-  handleMouseLeave: PropTypes.func
+  handleMouseLeave: PropTypes.func,
 };

--- a/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
+++ b/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
@@ -13,7 +13,7 @@ import cs from "./hover_actions.scss";
 
 class HoverActions extends React.Component {
   state = {
-    phyloTreeCreationModalOpen: false
+    phyloTreeCreationModalOpen: false,
   };
 
   handlePhyloModalOpen = () => {
@@ -38,8 +38,8 @@ class HoverActions extends React.Component {
         enabled: this.props.ncbiEnabled,
         disabledMessage: "NCBI Taxonomy Not Found",
         params: {
-          taxId: this.props.taxId
-        }
+          taxId: this.props.taxId,
+        },
       },
       {
         message: "FASTA Download",
@@ -49,8 +49,8 @@ class HoverActions extends React.Component {
         disabledMessage: "FASTA Download Not Available",
         params: {
           taxId: this.props.taxId,
-          taxLevel: this.props.taxLevel
-        }
+          taxLevel: this.props.taxLevel,
+        },
       },
       {
         message: "Contigs Download",
@@ -59,8 +59,8 @@ class HoverActions extends React.Component {
         enabled: this.props.contigVizEnabled,
         disabledMessage: "No Contigs Available",
         params: {
-          taxId: this.props.taxId
-        }
+          taxId: this.props.taxId,
+        },
       },
       hasCoverageViz
         ? {
@@ -74,8 +74,8 @@ class HoverActions extends React.Component {
               taxId: this.props.taxId,
               taxLevel: this.props.taxLevel === 1 ? "species" : "genus",
               taxName: this.props.taxName,
-              taxCommonName: this.props.taxCommonName
-            }
+              taxCommonName: this.props.taxCommonName,
+            },
           }
         : {
             message: "Alignment Visualization",
@@ -87,8 +87,8 @@ class HoverActions extends React.Component {
             params: {
               taxId: this.props.taxId,
               taxLevel: this.props.taxLevel === 1 ? "species" : "genus",
-              taxName: this.props.taxName
-            }
+              taxName: this.props.taxName,
+            },
           },
       {
         message: (
@@ -100,8 +100,8 @@ class HoverActions extends React.Component {
         handleClick: this.handlePhyloModalOpen,
         enabled: this.props.phyloTreeEnabled,
         disabledMessage:
-          "Phylogenetic Analysis Not Available - requires 100+ reads in NT/NR"
-      }
+          "Phylogenetic Analysis Not Available - requires 100+ reads in NT/NR",
+      },
     ];
   };
 
@@ -161,7 +161,7 @@ class HoverActions extends React.Component {
       taxName,
       projectId,
       projectName,
-      className
+      className,
     } = this.props;
 
     return (
@@ -203,7 +203,7 @@ HoverActions.propTypes = {
   onContigVizClick: PropTypes.func.isRequired,
   phyloTreeEnabled: PropTypes.bool,
   onPhyloTreeModalOpened: PropTypes.func,
-  pipelineVersion: PropTypes.string
+  pipelineVersion: PropTypes.string,
 };
 
 export default HoverActions;

--- a/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
+++ b/app/assets/src/components/views/report/ReportTable/ReportTable.jsx
@@ -20,8 +20,8 @@ export default class ReportTable extends React.Component {
       taxonName,
       taxonValues: {
         NT: taxInfo.NT,
-        NR: taxInfo.NR
-      }
+        NR: taxInfo.NR,
+      },
     });
   };
 
@@ -40,7 +40,7 @@ export default class ReportTable extends React.Component {
       collapseTable,
       countType,
       setCountType,
-      showAssemblyColumns
+      showAssemblyColumns,
     } = this.props;
 
     return (
@@ -183,5 +183,5 @@ ReportTable.propTypes = {
   showAssemblyColumns: PropTypes.bool,
   onTaxonClick: PropTypes.func,
   handleMouseEnter: PropTypes.func,
-  handleMouseLeave: PropTypes.func
+  handleMouseLeave: PropTypes.func,
 };

--- a/app/assets/src/components/views/report/filters/BackgroundModelFilter.jsx
+++ b/app/assets/src/components/views/report/filters/BackgroundModelFilter.jsx
@@ -10,7 +10,7 @@ const BackgroundModelFilter = ({ allBackgrounds, value, onChange }) => {
   });
   if (backgroundOptions.length == 0) {
     backgroundOptions = [
-      { text: "No background models to display", value: -1 }
+      { text: "No background models to display", value: -1 },
     ];
     disabled = true;
   }
@@ -29,7 +29,7 @@ const BackgroundModelFilter = ({ allBackgrounds, value, onChange }) => {
 BackgroundModelFilter.propTypes = {
   allBackgrounds: PropTypes.arrayOf(PropTypes.BackgroundData),
   value: PropTypes.number,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
 };
 
 export default BackgroundModelFilter;

--- a/app/assets/src/components/views/report/filters/CategoryFilter.jsx
+++ b/app/assets/src/components/views/report/filters/CategoryFilter.jsx
@@ -9,7 +9,7 @@ const CategoryFilter = ({
   categoryChildParent,
   selectedCategories,
   selectedSubcategories,
-  onChange
+  onChange,
 }) => {
   let options = [];
   allCategories.forEach(category => {
@@ -19,7 +19,7 @@ const CategoryFilter = ({
     (categoryParentChild[category.name] || []).forEach(subcategory => {
       suboptions.push({
         text: subcategory,
-        value: subcategory
+        value: subcategory,
       });
     });
     if (suboptions.length > 0) {
@@ -53,7 +53,7 @@ CategoryFilter.propTypes = {
   allCategories: PropTypes.arrayOf(
     PropTypes.shape({
       taxid: PropTypes.number,
-      name: PropTypes.string
+      name: PropTypes.string,
     })
   ).isRequired,
   categoryParentChild: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.string))
@@ -61,7 +61,7 @@ CategoryFilter.propTypes = {
   categoryChildParent: PropTypes.objectOf(PropTypes.string).isRequired,
   selectedCategories: PropTypes.arrayOf(PropTypes.string).isRequired,
   selectedSubcategories: PropTypes.arrayOf(PropTypes.string).isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
 };
 
 export default CategoryFilter;

--- a/app/assets/src/components/views/report/filters/MetricPicker.jsx
+++ b/app/assets/src/components/views/report/filters/MetricPicker.jsx
@@ -21,9 +21,9 @@ MetricPicker.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string,
-      value: PropTypes.string
+      value: PropTypes.string,
     })
-  )
+  ),
 };
 
 export default MetricPicker;

--- a/app/assets/src/components/views/report/filters/MinContigSizeFilter.jsx
+++ b/app/assets/src/components/views/report/filters/MinContigSizeFilter.jsx
@@ -12,14 +12,14 @@ class MinContigSizeFilter extends React.Component {
   state = {
     value: this.props.value,
     error: "",
-    previousValue: this.props.value
+    previousValue: this.props.value,
   };
 
   componentDidUpdate(prevProps) {
     if (prevProps.value !== this.props.value) {
       this.setState({
         value: this.props.value,
-        previousValue: this.props.value
+        previousValue: this.props.value,
       });
     }
   }
@@ -35,11 +35,11 @@ class MinContigSizeFilter extends React.Component {
       // Reset back to the previous value.
       this.setState({
         value: this.state.previousValue,
-        error: "Size must be at least 4."
+        error: "Size must be at least 4.",
       });
     } else {
       this.setState({
-        error: ""
+        error: "",
       });
       if (this.props.onChange) {
         this.props.onChange(newValue);
@@ -98,7 +98,7 @@ class MinContigSizeFilter extends React.Component {
 
 MinContigSizeFilter.propTypes = {
   value: PropTypes.number,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
 };
 
 export default MinContigSizeFilter;

--- a/app/assets/src/components/views/report/filters/NameTypeFilter.jsx
+++ b/app/assets/src/components/views/report/filters/NameTypeFilter.jsx
@@ -5,7 +5,7 @@ import Dropdown from "../../../ui/controls/dropdowns/Dropdown";
 
 const NAME_TYPE_OPTIONS = [
   { text: "Scientific", value: "Scientific name" },
-  { text: "Common", value: "Common name" }
+  { text: "Common", value: "Common name" },
 ];
 
 const NameTypeFilter = ({ value, onChange }) => {
@@ -22,7 +22,7 @@ const NameTypeFilter = ({ value, onChange }) => {
 
 NameTypeFilter.propTypes = {
   value: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
 };
 
 export default NameTypeFilter;

--- a/app/assets/src/components/views/report/filters/ReportSearchBox.jsx
+++ b/app/assets/src/components/views/report/filters/ReportSearchBox.jsx
@@ -7,7 +7,7 @@ const ReportSearchBox = ({
   searchKeysInSample,
   searchKey,
   onSelect,
-  onChange
+  onChange,
 }) => {
   return (
     <li className="search-box genus-autocomplete-container">
@@ -27,7 +27,7 @@ const ReportSearchBox = ({
               backgroundColor: highlighted ? "#eee" : "transparent",
               fontFamily: "'Helvetica Neue', Arial, Helvetica, sans-serif",
               fontSize: "1rem",
-              overflow: "hidden"
+              overflow: "hidden",
             }}
           >
             {item[0]}
@@ -47,7 +47,7 @@ ReportSearchBox.propTypes = {
   searchKeysInSample: PropTypes.arrayOf(PropTypes.array).isRequired,
   searchKey: PropTypes.string.isRequired,
   onSelect: PropTypes.func.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
 };
 
 export default ReportSearchBox;

--- a/app/assets/src/components/views/report/filters/SpecificityFilter.jsx
+++ b/app/assets/src/components/views/report/filters/SpecificityFilter.jsx
@@ -5,7 +5,7 @@ import Dropdown from "../../../ui/controls/dropdowns/Dropdown";
 
 const SPECIFICITY_OPTIONS = [
   { text: "All", value: 0 },
-  { text: "Specific Only", value: 1 }
+  { text: "Specific Only", value: 1 },
 ];
 
 const SpecificityFilter = ({ value, onChange }) => {
@@ -22,7 +22,7 @@ const SpecificityFilter = ({ value, onChange }) => {
 
 SpecificityFilter.propTypes = {
   value: PropTypes.number.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
 };
 
 export default SpecificityFilter;

--- a/app/assets/src/components/views/report/utils/download.js
+++ b/app/assets/src/components/views/report/utils/download.js
@@ -17,7 +17,7 @@ const getDownloadOptions = pipelineRun => {
     assembled && NON_HOST_CONTIGS_LABEL,
     assembled && NON_HOST_CONTIGS_MAPPING_LABEL,
     stageTwoComplete && UNMAPPED_READS_LABEL,
-    RESULTS_FOLDER_LABEL
+    RESULTS_FOLDER_LABEL,
   ]);
 };
 
@@ -27,7 +27,7 @@ export const getDownloadDropdownOptions = pipelineRun => {
 
   return downloadOptions.map(option => ({
     text: option,
-    value: option
+    value: option,
   }));
 };
 
@@ -38,30 +38,30 @@ const getDownloadLinkInfoMap = (sampleId, pipelineRun) => ({
     path: `/samples/${sampleId}/nonhost_fasta?pipeline_version=${
       pipelineRun.pipeline_version
     }`,
-    newPage: false
+    newPage: false,
   },
   [NON_HOST_CONTIGS_LABEL]: {
     path: `/samples/${sampleId}/contigs_fasta?pipeline_version=${
       pipelineRun.pipeline_version
     }`,
-    newPage: false
+    newPage: false,
   },
   [NON_HOST_CONTIGS_MAPPING_LABEL]: {
     path: `/samples/${sampleId}/contigs_summary?pipeline_version=${
       pipelineRun.pipeline_version
     }`,
-    newPage: false
+    newPage: false,
   },
   [UNMAPPED_READS_LABEL]: {
     path: `/samples/${sampleId}/unidentified_fasta?pipeline_version=${
       pipelineRun.pipeline_version
     }`,
-    newPage: false
+    newPage: false,
   },
   [RESULTS_FOLDER_LABEL]: {
     path: `/samples/${sampleId}/results_folder`,
-    newPage: true
-  }
+    newPage: true,
+  },
 });
 
 export const getLinkInfoForDownloadOption = (option, sampleId, pipelineRun) =>
@@ -75,6 +75,6 @@ export const getDownloadLinks = (sampleId, pipelineRun) => {
   return downloadOptions.map(option => ({
     label: option,
     path: downloadLinkInfoMap[option].path,
-    newPage: downloadLinkInfoMap[option].newPage
+    newPage: downloadLinkInfoMap[option].newPage,
   }));
 };

--- a/app/assets/src/components/views/report/utils/taxon.js
+++ b/app/assets/src/components/views/report/utils/taxon.js
@@ -163,7 +163,7 @@ export const addContigCountsToTaxonomyDetails = (
       [contigCount.taxid, contigCount.count_type],
       {
         contigs: contigCount.contigs,
-        contigreads: contigCount.contig_reads
+        contigreads: contigCount.contig_reads,
       },
       contigCountsMap
     );
@@ -175,7 +175,7 @@ export const addContigCountsToTaxonomyDetails = (
       contigCountsMap[detail.tax_id]
         ? {
             ...detail,
-            summaryContigCounts: contigCountsMap[detail.tax_id]
+            summaryContigCounts: contigCountsMap[detail.tax_id],
           }
         : omit("summaryContigCounts", detail)
   );

--- a/app/assets/src/components/views/samples/CollectionModal.jsx
+++ b/app/assets/src/components/views/samples/CollectionModal.jsx
@@ -19,7 +19,7 @@ class CollectionModal extends React.Component {
       backgroundCreationResponse: null,
       backgroundDescription: null,
       backgroundName: null,
-      modalOpen: false
+      modalOpen: false,
     };
   }
 
@@ -78,12 +78,12 @@ class CollectionModal extends React.Component {
       backgroundCreationResponse = await createBackground({
         name: backgroundName,
         description: backgroundDescription,
-        sampleIds: Array.from(selectedSampleIds)
+        sampleIds: Array.from(selectedSampleIds),
       });
     } catch (_) {
       backgroundCreationResponse = {
         status: "error",
-        message: "Something went wrong."
+        message: "Something went wrong.",
       };
     }
     this.setState({ backgroundCreationResponse });
@@ -112,7 +112,7 @@ class CollectionModal extends React.Component {
               this.handleCreateBackground,
               "CollectionModal_create-collection-button_clicked",
               {
-                selectedSampleIds: this.props.selectedSampleIds.length
+                selectedSampleIds: this.props.selectedSampleIds.length,
               }
             )}
           />
@@ -188,7 +188,7 @@ class CollectionModal extends React.Component {
 
 CollectionModal.defaultProps = {
   maxSamplesShown: 10,
-  numDescriptionRows: 7
+  numDescriptionRows: 7,
 };
 
 CollectionModal.propTypes = {
@@ -196,7 +196,7 @@ CollectionModal.propTypes = {
   numDescriptionRows: PropTypes.number,
   fetchedSamples: PropTypes.array,
   selectedSampleIds: PropTypes.instanceOf(Set),
-  trigger: PropTypes.node.isRequired
+  trigger: PropTypes.node.isRequired,
 };
 
 export default CollectionModal;

--- a/app/assets/src/components/views/samples/MetadataUploadModal/Instructions.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/Instructions.jsx
@@ -67,7 +67,7 @@ class UploadInstructions extends React.Component {
 UploadInstructions.propTypes = {
   onClose: PropTypes.func.isRequired,
   standalone: PropTypes.bool,
-  size: PropTypes.oneOf(["small"])
+  size: PropTypes.oneOf(["small"]),
 };
 
 export default UploadInstructions;

--- a/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
@@ -20,24 +20,24 @@ class MetadataUploadModal extends React.Component {
   state = {
     metadata: null,
     issues: null,
-    projectSamples: null
+    projectSamples: null,
   };
 
   async componentDidMount() {
     const projectSamples = await getSamplesV1({
       project_id: this.props.project.id,
-      basic: true
+      basic: true,
     });
 
     this.setState({
-      projectSamples
+      projectSamples,
     });
   }
 
   handleMetadataChange = ({ metadata, issues }) => {
     this.setState({
       metadata,
-      issues
+      issues,
     });
   };
 
@@ -67,7 +67,7 @@ class MetadataUploadModal extends React.Component {
       logAnalyticsEvent("MetadataUploadModal_modal_error", {
         projectId: this.props.project.id,
         projectSamples: this.state.projectSamples.length,
-        errors: response.errors.length
+        errors: response.errors.length,
       });
     } else {
       showToast(
@@ -77,13 +77,13 @@ class MetadataUploadModal extends React.Component {
           </Notification>
         ),
         {
-          autoClose: 3000
+          autoClose: 3000,
         }
       );
 
       logAnalyticsEvent("MetadataUploadModal_modal_success", {
         projectId: this.props.project.id,
-        projectSamples: this.state.projectSamples.length
+        projectSamples: this.state.projectSamples.length,
       });
     }
   };
@@ -141,8 +141,8 @@ MetadataUploadModal.propTypes = {
   onClose: PropTypes.func,
   project: PropTypes.shape({
     id: PropTypes.number,
-    name: PropTypes.string
-  })
+    name: PropTypes.string,
+  }),
 };
 
 export default MetadataUploadModal;

--- a/app/assets/src/components/views/samples/MetadataUploadModal/ReviewPage.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/ReviewPage.jsx
@@ -21,7 +21,7 @@ class ReviewPage extends React.Component {
 }
 
 ReviewPage.propTypes = {
-  metadata: PropTypes.object
+  metadata: PropTypes.object,
 };
 
 export default ReviewPage;

--- a/app/assets/src/components/views/samples/MetadataUploadModal/UploadPage.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/UploadPage.jsx
@@ -10,7 +10,7 @@ class UploadPage extends React.Component {
     showInstructions: false,
     metadata: null,
     wasManual: false,
-    issues: null
+    issues: null,
   };
 
   componentDidMount() {
@@ -26,7 +26,7 @@ class UploadPage extends React.Component {
   verifyMetadata = async () => {
     if (this.state.wasManual) {
       this.setState({
-        issues: null
+        issues: null,
       });
 
       const result = await validateManualMetadataForProject(
@@ -35,7 +35,7 @@ class UploadPage extends React.Component {
       );
 
       this.setState({
-        issues: result.issues
+        issues: result.issues,
       });
 
       return (
@@ -49,7 +49,7 @@ class UploadPage extends React.Component {
   handleMetadataChange = ({ metadata, issues, wasManual }) => {
     this.setState({
       wasManual,
-      metadata
+      metadata,
     });
     this.props.onMetadataChange({ metadata, issues });
 
@@ -88,12 +88,12 @@ UploadPage.propTypes = {
   onMetadataChange: PropTypes.func.isRequired,
   project: PropTypes.shape({
     id: PropTypes.number,
-    name: PropTypes.string
+    name: PropTypes.string,
   }),
   wizardEnableContinue: PropTypes.func,
   wizardSetOnContinueValidation: PropTypes.func,
   wizardSetOverlay: PropTypes.func,
-  samples: PropTypes.arrayOf(PropTypes.Sample)
+  samples: PropTypes.arrayOf(PropTypes.Sample),
 };
 
 export default UploadPage;

--- a/app/assets/src/components/views/samples/PipelineStatusFilter.jsx
+++ b/app/assets/src/components/views/samples/PipelineStatusFilter.jsx
@@ -7,20 +7,20 @@ import cs from "./pipeline_status_filter.scss";
 const STATUS_OPTIONS = [
   {
     name: "In Progress",
-    class: "uploading"
+    class: "uploading",
   },
   {
     name: "Complete",
-    class: "complete"
+    class: "complete",
   },
   {
     name: "Failed",
-    class: "failed"
+    class: "failed",
   },
   {
     name: "All",
-    class: "all"
-  }
+    class: "all",
+  },
 ];
 
 class PipelineStatusFilter extends React.Component {
@@ -58,7 +58,7 @@ class PipelineStatusFilter extends React.Component {
 
 PipelineStatusFilter.propTypes = {
   className: PropTypes.string,
-  onStatusFilterSelect: PropTypes.func
+  onStatusFilterSelect: PropTypes.func,
 };
 
 export default PipelineStatusFilter;

--- a/app/assets/src/components/views/samples/ProjectSettingsModal/ProjectSettingsModal.jsx
+++ b/app/assets/src/components/views/samples/ProjectSettingsModal/ProjectSettingsModal.jsx
@@ -17,7 +17,7 @@ class ProjectSettingsModal extends React.Component {
     super(props);
 
     this.state = {
-      modalOpen: false
+      modalOpen: false,
     };
   }
 
@@ -30,7 +30,7 @@ class ProjectSettingsModal extends React.Component {
     axios
       .put(`/projects/${project.id}.json`, {
         public_access: true,
-        authenticity_token: csrf
+        authenticity_token: csrf,
       })
       .then(() => {
         onProjectPublished();
@@ -43,7 +43,7 @@ class ProjectSettingsModal extends React.Component {
       nextPublicSampleDate,
       onUserAdded,
       project,
-      users
+      users,
     } = this.props;
 
     return (
@@ -55,7 +55,7 @@ class ProjectSettingsModal extends React.Component {
             "ProjectSettingsModal_open-link_click",
             {
               projectId: project.id,
-              projectName: project.name
+              projectName: project.name,
             }
           )}
         >
@@ -70,7 +70,7 @@ class ProjectSettingsModal extends React.Component {
               "ProjectSettingsModal_close-modal_clicked",
               {
                 projectId: project.id,
-                projectName: project.name
+                projectName: project.name,
               }
             )}
             className={cs.projectSettingsModal}
@@ -97,7 +97,7 @@ class ProjectSettingsModal extends React.Component {
                           "ProjectSettingsModal_public-button_confirmed",
                           {
                             projectId: project.id,
-                            projectName: project.name
+                            projectName: project.name,
                           }
                         )}
                         project={project}
@@ -135,10 +135,10 @@ ProjectSettingsModal.propTypes = {
   project: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,
-    public_access: PropTypes.oneOfType([PropTypes.bool, PropTypes.number])
+    public_access: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   }).isRequired,
   nextPublicSampleDate: PropTypes.string,
-  users: PropTypes.array
+  users: PropTypes.array,
 };
 
 export default ProjectSettingsModal;

--- a/app/assets/src/components/views/samples/ProjectSettingsModal/PublicProjectConfirmationModal.jsx
+++ b/app/assets/src/components/views/samples/ProjectSettingsModal/PublicProjectConfirmationModal.jsx
@@ -9,7 +9,7 @@ class PublicProjectConfirmationModal extends React.Component {
     super(props);
 
     this.state = {
-      modalOpen: false
+      modalOpen: false,
     };
   }
 
@@ -86,9 +86,9 @@ PublicProjectConfirmationModal.propTypes = {
   project: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,
-    public_access: PropTypes.oneOfType([PropTypes.bool, PropTypes.number])
+    public_access: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   }).isRequired,
-  trigger: PropTypes.node
+  trigger: PropTypes.node,
 };
 
 export default PublicProjectConfirmationModal;

--- a/app/assets/src/components/views/samples/ProjectSettingsModal/UserManagementForm.jsx
+++ b/app/assets/src/components/views/samples/ProjectSettingsModal/UserManagementForm.jsx
@@ -18,7 +18,7 @@ class UserManagementForm extends React.Component {
       name: "",
       email: "",
       statusMessage: "",
-      statusClass: null
+      statusClass: null,
     };
   }
 
@@ -28,19 +28,19 @@ class UserManagementForm extends React.Component {
 
     const fieldsValidation = {
       email: StringHelper.validateEmail(email),
-      name: StringHelper.validateName(name)
+      name: StringHelper.validateName(name),
     };
 
     if (Object.values(fieldsValidation).every(valid => !!valid)) {
       this.setState({
         statusClass: cs.infoMessage,
-        statusMessage: "Sending invitation"
+        statusMessage: "Sending invitation",
       });
       axios
         .put(`/projects/${project.id}}/add_user`, {
           user_name_to_add: name,
           user_email_to_add: email,
-          authenticity_token: csrf
+          authenticity_token: csrf,
         })
         .then(() => {
           onUserAdded(name, email);
@@ -48,7 +48,7 @@ class UserManagementForm extends React.Component {
             statusClass: cs.successMessage,
             statusMessage: "Invitation sent! User added.",
             name: "",
-            email: ""
+            email: "",
           });
         });
     } else {
@@ -58,7 +58,7 @@ class UserManagementForm extends React.Component {
 
       this.setState({
         statusClass: cs.errorMessage,
-        statusMessage: `Invalid ${invalidFieldsString} address`
+        statusMessage: `Invalid ${invalidFieldsString} address`,
       });
     }
   };
@@ -67,7 +67,7 @@ class UserManagementForm extends React.Component {
     this.setState({
       name,
       statusClass: cs.infoMessage,
-      statusMessage: ""
+      statusMessage: "",
     });
   };
 
@@ -75,7 +75,7 @@ class UserManagementForm extends React.Component {
     this.setState({
       email,
       statusClass: cs.infoMessage,
-      statusMessage: ""
+      statusMessage: "",
     });
   };
 
@@ -146,9 +146,9 @@ UserManagementForm.propTypes = {
   project: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,
-    public_access: PropTypes.oneOfType([PropTypes.bool, PropTypes.number])
+    public_access: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   }).isRequired,
-  users: PropTypes.array
+  users: PropTypes.array,
 };
 
 export default UserManagementForm;

--- a/app/assets/src/components/views/samples/PublicSampleNotification.jsx
+++ b/app/assets/src/components/views/samples/PublicSampleNotification.jsx
@@ -50,7 +50,7 @@ class PublicSampleNotification extends React.Component {
 PublicSampleNotification.propTypes = {
   projectName: PropTypes.string.isRequired,
   samples: PropTypes.array.isRequired,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
 };
 
 export default PublicSampleNotification;

--- a/app/assets/src/components/views/samples/ReportsDownloader.js
+++ b/app/assets/src/components/views/samples/ReportsDownloader.js
@@ -9,11 +9,11 @@ export default class ReportsDownloader {
     projectId = "all",
     onDownloadFail = null,
     downloadOption,
-    selectedSampleIds
+    selectedSampleIds,
   }) {
     this.nanobar = new Nanobar({
       id: "prog-bar",
-      class: "prog-bar"
+      class: "prog-bar",
     });
 
     this.projectId = projectId || "all";
@@ -36,7 +36,7 @@ export default class ReportsDownloader {
           this.scheduleCheckReportDownload({
             result,
             statusAction,
-            retrieveAction
+            retrieveAction,
           });
         }
       })
@@ -94,7 +94,7 @@ export default class ReportsDownloader {
         this.generateReport({
           makeAction: "make_project_reports_csv",
           statusAction: "project_reports_csv_status",
-          retrieveAction: "send_project_reports_csv"
+          retrieveAction: "send_project_reports_csv",
         });
         break;
       }
@@ -102,7 +102,7 @@ export default class ReportsDownloader {
         this.generateReport({
           makeAction: "make_host_gene_counts",
           statusAction: "host_gene_counts_status",
-          retrieveAction: "send_host_gene_counts"
+          retrieveAction: "send_host_gene_counts",
         });
         break;
       }

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -406,7 +406,7 @@ class SamplesView extends React.Component {
       mapPreviewedLocationId,
       mapTilerKey,
       onMapMarkerClick,
-      onMapTooltipTitleClick
+      onMapTooltipTitleClick,
     } = this.props;
     return (
       <div className={cs.map}>

--- a/app/assets/src/components/views/samples/TableColumnHeader.jsx
+++ b/app/assets/src/components/views/samples/TableColumnHeader.jsx
@@ -13,7 +13,7 @@ class TableColumnHeader extends React.Component {
       columnOptions,
       columnMap,
       onColumnOptionSelect,
-      tooltip
+      tooltip,
     } = this.props;
 
     let trigger = (
@@ -31,7 +31,7 @@ class TableColumnHeader extends React.Component {
 
     const options = columnOptions.map(option => ({
       value: option,
-      text: columnMap[option].display_name
+      text: columnMap[option].display_name,
     }));
 
     return (
@@ -53,10 +53,10 @@ TableColumnHeader.propTypes = {
   columnOptions: PropTypes.arrayOf(PropTypes.string),
   columnMap: PropTypes.objectOf(
     PropTypes.shape({
-      display_name: PropTypes.string.isRequired
+      display_name: PropTypes.string.isRequired,
     })
   ),
-  onColumnOptionSelect: PropTypes.func
+  onColumnOptionSelect: PropTypes.func,
 };
 
 export default TableColumnHeader;

--- a/app/assets/src/components/views/samples/constants.js
+++ b/app/assets/src/components/views/samples/constants.js
@@ -3,54 +3,54 @@ import { keys } from "lodash/fp";
 export const SAMPLE_TABLE_COLUMNS = {
   total_reads: {
     display_name: "Total reads",
-    type: "pipeline_data"
+    type: "pipeline_data",
   },
   nonhost_reads: {
     display_name: "Passed filters",
-    type: "pipeline_data"
+    type: "pipeline_data",
   },
   total_ercc_reads: {
     display_name: "ERCC reads",
-    type: "pipeline_data"
+    type: "pipeline_data",
   },
   fraction_subsampled: {
     display_name: "Subsampled fraction",
-    type: "pipeline_data"
+    type: "pipeline_data",
   },
   quality_control: {
     display_name: "Passed QC",
     tooltip: "Passed quality control",
-    type: "pipeline_data"
+    type: "pipeline_data",
   },
   compression_ratio: {
     display_name: "DCR",
     tooltip: "Duplicate compression ratio",
-    type: "pipeline_data"
+    type: "pipeline_data",
   },
   pipeline_status: {
     display_name: "Status",
-    type: "pipeline_data"
+    type: "pipeline_data",
   },
   nucleotide_type: {
     display_name: "Nucleotide type",
-    type: "metadata"
+    type: "metadata",
   },
   collection_location: {
     display_name: "Collection Location",
-    type: "metadata"
+    type: "metadata",
   },
   host_genome: {
     display_name: "Host",
-    type: "sampleMetadata"
+    type: "sampleMetadata",
   },
   sample_type: {
     display_name: "Sample type",
-    type: "metadata"
+    type: "metadata",
   },
   notes: {
     display_name: "Notes",
-    type: "sampleMetadata"
-  }
+    type: "sampleMetadata",
+  },
 };
 
 export const INITIAL_COLUMNS = [
@@ -60,7 +60,7 @@ export const INITIAL_COLUMNS = [
   "compression_ratio",
   "host_genome",
   "collection_location",
-  "pipeline_status"
+  "pipeline_status",
 ];
 
 export const ALL_COLUMNS = keys(SAMPLE_TABLE_COLUMNS);

--- a/app/assets/src/components/views/samples/notifications.jsx
+++ b/app/assets/src/components/views/samples/notifications.jsx
@@ -12,7 +12,7 @@ const publicSampleNotification = (samples, projectName, onClose) => {
       />
     ),
     {
-      onClose
+      onClose,
     }
   );
 };
@@ -37,7 +37,7 @@ const publicSampleNotificationsByProject = samples => {
           JSON.stringify(
             new Set([
               ...JSON.parse(localStorage.getItem("dismissedPublicSamples")),
-              ...projectSamples.map(sample => sample.id)
+              ...projectSamples.map(sample => sample.id),
             ])
           )
         );

--- a/app/assets/src/components/views/samples/utils.js
+++ b/app/assets/src/components/views/samples/utils.js
@@ -15,7 +15,7 @@ export const getSampleTableData = sample => {
   const {
     derived_sample_output: derivedOutput,
     db_sample: dbSample,
-    metadata
+    metadata,
   } = sample;
 
   const data = {
@@ -42,7 +42,7 @@ export const getSampleTableData = sample => {
     nucleotide_type: get("nucleotide_type", metadata),
     collection_location: get("collection_location", metadata),
     host_genome: get("host_genome_name", dbSample),
-    notes: get("sample_notes", dbSample)
+    notes: get("sample_notes", dbSample),
   };
 
   return data;

--- a/app/assets/src/components/views/visualizations/VisualizationsView.jsx
+++ b/app/assets/src/components/views/visualizations/VisualizationsView.jsx
@@ -30,29 +30,29 @@ class VisualizationsView extends React.Component {
               {
                 nameRenderer: this.nameRenderer,
                 detailsRenderer: this.detailsRenderer,
-                visibilityIconRenderer: this.visibilityIconRenderer
+                visibilityIconRenderer: this.visibilityIconRenderer,
               }
             )
           ),
         headerClassName: cs.visualizationHeader,
-        sortFunction: p => p.updated_at
+        sortFunction: p => p.updated_at,
       },
       {
         dataKey: "updated_at",
         label: "Updated On",
         width: 120,
-        cellRenderer: TableRenderers.renderDate
+        cellRenderer: TableRenderers.renderDate,
       },
       {
         dataKey: "project_name",
         width: 280, // big enough for "mBAL-PLASMA and Medical Detectives"
-        label: "Project"
+        label: "Project",
       },
       {
         dataKey: "samples_count",
         width: 140,
-        label: "Samples"
-      }
+        label: "Samples",
+      },
     ];
   }
 
@@ -63,7 +63,7 @@ class VisualizationsView extends React.Component {
   visibilityIconRenderer = visualization => {
     const {
       visualization_type: visualizationType,
-      publicAccess
+      publicAccess,
     } = visualization;
     if (visualizationType == "heatmap") {
       return publicAccess ? (
@@ -99,7 +99,7 @@ class VisualizationsView extends React.Component {
     logAnalyticsEvent("VisualizationsView_row_clicked", {
       visualizationType: rowData.visualization.visualization_type,
       visualizationId: rowData.id,
-      url
+      url,
     });
   };
 
@@ -111,7 +111,7 @@ class VisualizationsView extends React.Component {
           visualization: pick(
             ["user_name", "visualization_type", "name", "publicAccess"],
             visualization
-          )
+          ),
         },
         pick(
           ["id", "updated_at", "project_name", "samples_count"],
@@ -131,11 +131,11 @@ class VisualizationsView extends React.Component {
 }
 
 VisualizationsView.defaultProps = {
-  visualizations: []
+  visualizations: [],
 };
 
 VisualizationsView.propTypes = {
-  visualizations: PropTypes.array
+  visualizations: PropTypes.array,
 };
 
 export default VisualizationsView;

--- a/app/assets/src/components/visualizations/GenomeViz.js
+++ b/app/assets/src/components/visualizations/GenomeViz.js
@@ -18,19 +18,19 @@ export default class GenomeViz {
       top: 0,
       right: 0,
       bottom: 0,
-      left: 0
+      left: 0,
     };
 
     this.size = {
       width: container.clientWidth || 800,
-      height: container.clientHeight || 400
+      height: container.clientHeight || 400,
     };
 
     this.options = Object.assign(
       {
         colors: null,
         hoverBuffer: 5,
-        hoverDarkenFactor: 0.25
+        hoverDarkenFactor: 0.25,
       },
       options
     );

--- a/app/assets/src/components/visualizations/Histogram.js
+++ b/app/assets/src/components/visualizations/Histogram.js
@@ -19,12 +19,12 @@ export default class Histogram {
       top: 20,
       right: 40,
       bottom: 40,
-      left: 40
+      left: 40,
     };
 
     this.size = {
       width: container.clientWidth || 800,
-      height: container.clientHeight || 400
+      height: container.clientHeight || 400,
     };
 
     this.options = Object.assign(
@@ -38,7 +38,7 @@ export default class Histogram {
         // If true, the data is already binned, i.e. the data is an array of
         // { x0, length }
         skipBin: false,
-        hoverBuffer: 5
+        hoverBuffer: 5,
       },
       options
     );

--- a/app/assets/src/components/visualizations/dendrogram/Dendogram.js
+++ b/app/assets/src/components/visualizations/dendrogram/Dendogram.js
@@ -15,17 +15,17 @@ const VIZ_MARGINS = {
   // includes root label on the left of the node
   left: 250,
   // includes leaf nodes labels
-  right: 150
+  right: 150,
 };
 
 const SCALE_POS = {
   top: 48,
-  left: 250
+  left: 250,
 };
 
 const LEGEND_POS = {
   top: 20,
-  left: 16
+  left: 16,
 };
 
 export default class Dendogram {
@@ -53,7 +53,7 @@ export default class Dendogram {
         tooltipContainer: null,
         scaleLabel: null,
         // This is needed for downloading PNG and SVG on solid background
-        svgBackgroundColor: "white"
+        svgBackgroundColor: "white",
       },
       options || {}
     );
@@ -61,14 +61,14 @@ export default class Dendogram {
     // sizes
     this.minTreeSize = {
       width: 600,
-      height: 500
+      height: 500,
     };
 
     this.margins = VIZ_MARGINS;
 
     this.nodeSize = {
       width: 1,
-      height: 25
+      height: 25,
     };
 
     this._highlighted = new Set();
@@ -394,7 +394,7 @@ export default class Dendogram {
         ticks.push({
           id: i + 1,
           y: yMin + i * stepSize,
-          multiplier: i % 2 ? undefined : i * multiplier / 2
+          multiplier: i % 2 ? undefined : i * multiplier / 2,
         });
       }
       return ticks;

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -67,7 +67,7 @@ export default class Heatmap {
         // The signature of customColor is customColor(value, data_node, originalColor, colors, colorNoValue)
         customColorCallback: null,
         colors: null,
-        colorNoValue: "#eaeaea"
+        colorNoValue: "#eaeaea",
       },
       options
     );
@@ -188,7 +188,7 @@ export default class Heatmap {
       max: Math.max(
         d3.max(this.data.values, array => d3.max(array)),
         this.options.nullValue
-      )
+      ),
     };
 
     this.scaleLimits = {
@@ -199,7 +199,7 @@ export default class Heatmap {
       max:
         this.options.scaleMax || this.options.scaleMax === 0
           ? this.options.scaleMax
-          : this.limits.max
+          : this.limits.max,
     };
 
     this.cells = [];
@@ -209,7 +209,7 @@ export default class Heatmap {
           id: `${i},${j}`,
           rowIndex: i,
           columnIndex: j,
-          value: this.data.values[i][j]
+          value: this.data.values[i][j],
         });
       }
     }
@@ -269,7 +269,7 @@ export default class Heatmap {
           this.columnClusterHeight) /
           this.rowLabels.length,
         this.options.minCellHeight
-      )
+      ),
     };
 
     this.width =
@@ -971,7 +971,7 @@ export default class Heatmap {
       const handleAddColumnMetadataClick = () => {
         this.options.onAddColumnMetadataClick(addMetadataTrigger.node(), {
           x: this.rowLabelsWidth - 10,
-          y: yPos
+          y: yPos,
         });
       };
 
@@ -1204,7 +1204,7 @@ export default class Heatmap {
       )
     ) {
       return Object.assign({}, this.metadataColors[value], {
-        Unknown: this.options.colorNoValue
+        Unknown: this.options.colorNoValue,
       });
     } else {
       return this.metadataColors[value];

--- a/app/assets/src/components/visualizations/legends/SequentialLegend.js
+++ b/app/assets/src/components/visualizations/legends/SequentialLegend.js
@@ -21,7 +21,7 @@ export default class HeatmapLegend {
         levels: 10,
         cellHeight: 20,
         cellWidth: null,
-        fontSize: "9pt"
+        fontSize: "9pt",
       },
       options
     );

--- a/app/assets/src/components/visualizations/legends/SequentialLegendVis.jsx
+++ b/app/assets/src/components/visualizations/legends/SequentialLegendVis.jsx
@@ -12,7 +12,7 @@ class SequentialLegendVis extends React.Component {
     this.legend = new SequentialLegend(this.legendContainer, {
       scale: this.props.scale,
       min: this.props.min,
-      max: this.props.max
+      max: this.props.max,
     });
     this.legend.update();
   }
@@ -33,7 +33,7 @@ class SequentialLegendVis extends React.Component {
 SequentialLegendVis.propTypes = {
   max: PropTypes.number,
   min: PropTypes.number,
-  scale: PropTypes.string
+  scale: PropTypes.string,
 };
 
 export default SequentialLegendVis;

--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -4,7 +4,7 @@ import {
   AutoSizer,
   Column,
   SortIndicator,
-  Table as VirtualizedTable
+  Table as VirtualizedTable,
 } from "react-virtualized";
 import "react-virtualized/styles.css";
 import cx from "classnames";
@@ -32,7 +32,7 @@ class BaseTable extends React.Component {
     // TOOD: move this to componentDidUpdate and remove from state?
     this.state = {
       activeColumns: this.props.initialActiveColumns,
-      columns: this.setDefaults(this.props.columns)
+      columns: this.setDefaults(this.props.columns),
     };
   }
 
@@ -76,7 +76,7 @@ class BaseTable extends React.Component {
     this.setState({ activeColumns: concat(protectedColumns, selectedColumns) });
     logAnalyticsEvent("BaseTable_column-selector_changed", {
       selectedColumns: selectedColumns.length,
-      protectedColumns: protectedColumns.length
+      protectedColumns: protectedColumns.length,
     });
   };
 
@@ -88,7 +88,7 @@ class BaseTable extends React.Component {
       .filter(column => !includes(column.dataKey, protectedColumns))
       .map(column => ({
         value: column.dataKey,
-        text: column.label
+        text: column.label,
       }));
 
     const value = difference(activeColumns, protectedColumns);
@@ -249,13 +249,13 @@ BaseTable.defaultProps = {
   defaultHeaderHeight: 50,
   defaultRowHeight: 30,
   defaultSelectColumnWidth: 30,
-  selected: new Set()
+  selected: new Set(),
 };
 
 BaseTable.propTypes = {
   columns: PropTypes.arrayOf(
     PropTypes.shape({
-      dataKey: PropTypes.string.isRequired
+      dataKey: PropTypes.string.isRequired,
     })
   ).isRequired,
   defaultCellRenderer: PropTypes.func,
@@ -271,7 +271,7 @@ BaseTable.propTypes = {
   protectedColumns: PropTypes.arrayOf(PropTypes.string),
   forwardRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   ]),
   rowClassName: PropTypes.string,
   rowGetter: PropTypes.func.isRequired,
@@ -287,7 +287,7 @@ BaseTable.propTypes = {
   selected: PropTypes.instanceOf(Set),
   onSelectRow: PropTypes.func,
   onSelectAllRows: PropTypes.func,
-  selectAllChecked: PropTypes.bool
+  selectAllChecked: PropTypes.bool,
 };
 
 export default BaseTable;

--- a/app/assets/src/components/visualizations/table/DataTable.jsx
+++ b/app/assets/src/components/visualizations/table/DataTable.jsx
@@ -13,7 +13,7 @@ class DataTable extends React.Component {
       filter: "",
       selectedRows: new Set(this.props.selectedRows || []),
       originalData: this.props.data,
-      indexedData: DataTable.indexData(this.props.data)
+      indexedData: DataTable.indexData(this.props.data),
     };
 
     this.handleCheckBoxChange = this.handleCheckBoxChange.bind(this);
@@ -199,16 +199,16 @@ DataTable.propTypes = {
   selectedRows: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.number),
     // allow Set = TODO: replace by custom function
-    PropTypes.object
+    PropTypes.object,
   ]),
   striped: PropTypes.bool,
   // TODO(mark): Make column width sizing more robust.
   columnWidth: PropTypes.number,
-  getColumnWidth: PropTypes.func
+  getColumnWidth: PropTypes.func,
 };
 
 DataTable.defaultProps = {
-  striped: true
+  striped: true,
 };
 
 export default DataTable;

--- a/app/assets/src/components/visualizations/table/InfiniteTable.jsx
+++ b/app/assets/src/components/visualizations/table/InfiniteTable.jsx
@@ -24,7 +24,7 @@ class InfiniteTable extends React.Component {
     this.rows = [];
     this.loadedRowsMap = [];
     this.state = {
-      rowCount: this.props.rowCount
+      rowCount: this.props.rowCount,
     };
   }
 
@@ -142,7 +142,7 @@ InfiniteTable.defaultProps = {
   minimumBatchSize: 50,
   // should be at least as high as the minimumBatchSize
   rowCount: 50,
-  threshold: 50
+  threshold: 50,
 };
 
 InfiniteTable.propTypes = {
@@ -156,7 +156,7 @@ InfiniteTable.propTypes = {
   onSelectRow: PropTypes.func,
   onSelectAllRows: PropTypes.func,
   rowCount: PropTypes.number,
-  threshold: PropTypes.number
+  threshold: PropTypes.number,
 };
 
 export default InfiniteTable;

--- a/app/assets/src/components/visualizations/table/Table.jsx
+++ b/app/assets/src/components/visualizations/table/Table.jsx
@@ -10,14 +10,14 @@ class Table extends React.Component {
     super(props);
     this.state = {
       sortBy: this.props.sortBy,
-      sortDirection: this.props.sortDirection || SortDirection.ASC
+      sortDirection: this.props.sortDirection || SortDirection.ASC,
     };
   }
 
   handleSort = ({ sortBy, sortDirection }) => {
     this.setState({
       sortBy,
-      sortDirection
+      sortDirection,
     });
   };
 
@@ -58,7 +58,7 @@ class Table extends React.Component {
             [
               columnSortFunction
                 ? row => columnSortFunction(row[sortBy])
-                : sortBy
+                : sortBy,
             ],
             [sortDirection === SortDirection.ASC ? "asc" : "desc"],
             this.props.data
@@ -87,13 +87,13 @@ class Table extends React.Component {
 
 Table.defaultProps = {
   data: [],
-  selected: new Set()
+  selected: new Set(),
 };
 
 Table.propTypes = {
   columns: PropTypes.arrayOf(
     PropTypes.shape({
-      dataKey: PropTypes.string.isRequired
+      dataKey: PropTypes.string.isRequired,
     })
   ).isRequired,
   data: PropTypes.array,
@@ -103,7 +103,7 @@ Table.propTypes = {
   selected: PropTypes.instanceOf(Set),
   sortable: PropTypes.bool,
   sortBy: PropTypes.string,
-  sortDirection: PropTypes.string
+  sortDirection: PropTypes.string,
 };
 
 export default Table;

--- a/app/assets/src/helpers/url.js
+++ b/app/assets/src/helpers/url.js
@@ -10,7 +10,7 @@ import {
   flow,
   map,
   flatten,
-  join
+  join,
 } from "lodash/fp";
 import { shortenUrl } from "~/api";
 import copy from "copy-to-clipboard";
@@ -23,7 +23,7 @@ export const resetUrl = () => {
 // See also parseUrlParams in SamplesHeatmapView
 export const parseUrlParams = () => {
   let urlParams = QueryString.parse(location.search, {
-    arrayFormat: "bracket"
+    arrayFormat: "bracket",
   });
   for (var key in urlParams) {
     try {

--- a/app/assets/src/index.jsx
+++ b/app/assets/src/index.jsx
@@ -18,7 +18,7 @@ if (!function f() {}.name) {
       var name = (this.toString().match(/^function\s*([^\s(]+)/) || [])[1];
       Object.defineProperty(this, "name", { value: name });
       return name;
-    }
+    },
   });
 }
 


### PR DESCRIPTION
# Description

To avoid noise in other PRs when the new prettier rule is applied, I applied it once to all jsx and js files. 

```
find . -name '*.js' | xargs prettier --trailing-comma es5 --write
find . -name '*.jsx' | xargs prettier --trailing-comma es5 --write
```

# Note

If we want other prettier non-default rules, such as line length, now would be a good time to apply those as well. 

# Test

open http://localhost:3000/
click around
see no errors