### PR TITLE
[Maps] Add a manual rake task for reference in migrating to locationV2 + bug fix for OSM ID integer limit

### DIFF
--- a/db/migrate/20190612205949_fix_location_osm_id_limit.rb
+++ b/db/migrate/20190612205949_fix_location_osm_id_limit.rb
@@ -1,0 +1,10 @@
+class FixLocationOsmIdLimit < ActiveRecord::Migration[5.1]
+  def up
+    # As of now there are 5 billion nodes in OSM (https://wiki.openstreetmap.org/wiki/Stats#In_summary) so limit 5 here gives us max 9,223,372,036,854,775,807 (https://gist.github.com/icyleaf/9089250).
+    change_column :locations, :osm_id, :integer, limit: 5
+  end
+
+  def down
+    change_column :locations, :osm_id, :integer, limit: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_531_162_647) do
+ActiveRecord::Schema.define(version: 20_190_612_205_949) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -149,7 +149,7 @@ ActiveRecord::Schema.define(version: 20_190_531_162_647) do
     t.string "state_name", limit: 100, default: "", null: false, comment: "State (or equivalent) of this location if available"
     t.string "subdivision_name", limit: 100, default: "", null: false, comment: "Second-level administrative division (e.g. county/district/division/province/etc.) of this location if available"
     t.string "city_name", limit: 100, default: "", null: false, comment: "City (or equivalent) of this location if available"
-    t.integer "osm_id", comment: "OpenStreetMap ID for traceability. May change at any time."
+    t.bigint "osm_id", comment: "OpenStreetMap ID for traceability. May change at any time."
     t.integer "locationiq_id", comment: "Data provider API ID for traceability."
     t.decimal "lat", precision: 10, scale: 6, comment: "The latitude of this location if available"
     t.decimal "lng", precision: 10, scale: 6, comment: "The longitude of this location if available"

--- a/lib/tasks/migrate_to_location_v2.rake
+++ b/lib/tasks/migrate_to_location_v2.rake
@@ -8,49 +8,49 @@ task migrate_to_location_v2: :environment do
 
   Metadatum.where(key: "collection_location").each do |location_v1|
     sample = location_v1.sample
-    if sample
-      location_v2 = location_v1.sample.metadata.find_by(key: key_v2)
-      unless location_v2
-        # Make the new Metadatum entry
-        new_datum = Metadatum.new(metadata_field: MetadataField.find_by(name: key_v2), key: key_v2, sample: sample)
+    next unless sample
 
-        # Sub _ to , for some coordinates
-        location_v1_name = location_v1.string_validated_value.gsub(/_/, ",")
-        location_v2_value = location_v1_name
-        if geosearch_cache.key?(location_v1_name)
-          location_v2_value = geosearch_cache[location_v1_name]
-        else
-          # Do a geosearch for the user input
-          success, resp = Location.geosearch(location_v1_name)
-          unless success
-            log << "Geosearch failed at Sample \##{sample.id}: #{location_v1_name}. Check API limits. Stopping now."
-            break
-          end
+    location_v2 = location_v1.sample.metadata.find_by(key: key_v2)
+    next unless location_v2
 
-          if resp[0]
-            # Find or create a Location entry
-            resp = LocationHelper.adapt_location_iq_response(resp[0])
-            location = Location.find_by(name: resp[:name]) || Location.new_from_params(resp)
-            location.save!
-            location_v2_value = location
-          end
-          geosearch_cache[location_v1_name] = location_v2_value
-        end
+    # Make the new Metadatum entry
+    new_datum = Metadatum.new(metadata_field: MetadataField.find_by(name: key_v2), key: key_v2, sample: sample)
 
-        # Set the location_v2 value
-        if location_v2_value.is_a?(Location)
-          new_datum.location = location_v2_value
-          log << "Sample \##{sample.id}: Matched \"#{location_v1_name}\" => \"#{location_v2_value.name}\""
-          if sample.host_genome_name == "Human"
-            log << "^ Human sample. Please correct specificity if needed."
-          end
-        else
-          new_datum.string_validated_value = location_v2_value
-          log << "Sample \##{sample.id}: No results. Set to plain text: #{location_v2_value}"
-        end
-        new_datum.save!(validate: false)
+    # Sub _ to , for some coordinates
+    location_v1_name = location_v1.string_validated_value.tr('_', ',')
+    location_v2_value = location_v1_name
+    if geosearch_cache.key?(location_v1_name)
+      location_v2_value = geosearch_cache[location_v1_name]
+    else
+      # Do a geosearch for the user input
+      success, resp = Location.geosearch(location_v1_name)
+      unless success
+        log << "Geosearch failed at Sample \##{sample.id}: #{location_v1_name}. Check API limits. Stopping now."
+        break
       end
+
+      if resp[0]
+        # Find or create a Location entry
+        resp = LocationHelper.adapt_location_iq_response(resp[0])
+        location = Location.find_by(name: resp[:name]) || Location.new_from_params(resp)
+        location.save!
+        location_v2_value = location
+      end
+      geosearch_cache[location_v1_name] = location_v2_value
     end
+
+    # Set the location_v2 value
+    if location_v2_value.is_a?(Location)
+      new_datum.location = location_v2_value
+      log << "Sample \##{sample.id}: Matched \"#{location_v1_name}\" => \"#{location_v2_value.name}\""
+      if sample.host_genome_name == "Human"
+        log << "^ Human sample. Please correct specificity if needed."
+      end
+    else
+      new_datum.string_validated_value = location_v2_value
+      log << "Sample \##{sample.id}: No results. Set to plain text: #{location_v2_value}"
+    end
+    new_datum.save!(validate: false)
   end
   puts log.join("\n")
 end

--- a/lib/tasks/migrate_to_location_v2.rake
+++ b/lib/tasks/migrate_to_location_v2.rake
@@ -1,0 +1,56 @@
+# MANUAL TASK ONLY. Don't invoke this in code. Adapt as needed.
+# This task is for migrating location_v1 Metadata (plain text only) to location_v1 Metadata and Location objects (new objects to represent rich location information).
+
+task migrate_to_location_v2: :environment do
+  key_v2 = "collection_location_v2"
+  log = ["Results below. Please correct incorrect matches manually:"]
+  geosearch_cache = {}
+
+  Metadatum.where(key: "collection_location").each do |location_v1|
+    sample = location_v1.sample
+    if sample
+      location_v2 = location_v1.sample.metadata.find_by(key: key_v2)
+      unless location_v2
+        # Make the new Metadatum entry
+        new_datum = Metadatum.new(metadata_field: MetadataField.find_by(name: key_v2), key: key_v2, sample: sample)
+
+        # Sub _ to , for some coordinates
+        location_v1_name = location_v1.string_validated_value.gsub(/_/, ",")
+        location_v2_value = location_v1_name
+        if geosearch_cache.key?(location_v1_name)
+          location_v2_value = geosearch_cache[location_v1_name]
+        else
+          # Do a geosearch for the user input
+          success, resp = Location.geosearch(location_v1_name)
+          unless success
+            log << "Geosearch failed at Sample \##{sample.id}: #{location_v1_name}. Check API limits. Stopping now."
+            break
+          end
+
+          if resp[0]
+            # Find or create a Location entry
+            resp = LocationHelper.adapt_location_iq_response(resp[0])
+            location = Location.find_by(name: resp[:name]) || Location.new_from_params(resp)
+            location.save!
+            location_v2_value = location
+          end
+          geosearch_cache[location_v1_name] = location_v2_value
+        end
+
+        # Set the location_v2 value
+        if location_v2_value.is_a?(Location)
+          new_datum.location = location_v2_value
+          log << "Sample \##{sample.id}: Matched \"#{location_v1_name}\" => \"#{location_v2_value.name}\""
+          if sample.host_genome_name == "Human"
+            log << "^ Human sample. Please correct specificity if needed."
+          end
+        else
+          new_datum.string_validated_value = location_v2_value
+          log << "Sample \##{sample.id}: No results. Set to plain text: #{location_v2_value}"
+        end
+        new_datum.save!(validate: false)
+      end
+    end
+  end
+  puts log.join("\n")
+end


### PR DESCRIPTION
### Description
- Bug fix for location saving because OSM IDs currently go up to 5 billion, so we needed to change to bigint to save those.
- Adds a manual rake task (mostly for reference) for populating location_v2 values. This can help us do a first pass but will probably still need a lot of correction. Also while our provider contract is not finalized, we have an API rate limit of 2 requests/second.

### Test and Reproduce
- Open up local console and create a Location with an osm_id of a billion.
- Try out the rake task by running `docker-compose run web "rake migrate_to_location_v2"`