### PR TITLE
[Maps] Port over all the current map functions to the Projects tab

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -269,18 +269,23 @@ BareDropdown.propTypes = forbidExtraProps({
   withinModal: PropTypes.bool,
 
   // Props directly passed to semantic-ui.
-  trigger: PropTypes.node.isRequired,
-  onOpen: PropTypes.func,
-  onClose: PropTypes.func,
-  open: PropTypes.bool,
   children: PropTypes.node,
-  floating: PropTypes.bool,
-  disabled: PropTypes.bool,
-  selectOnBlur: PropTypes.bool,
-  fluid: PropTypes.bool,
-  direction: PropTypes.string,
   className: PropTypes.string,
+  direction: PropTypes.string,
+  disabled: PropTypes.bool,
+  floating: PropTypes.bool,
+  fluid: PropTypes.bool,
   menuClassName: PropTypes.string,
+  onBlur: PropTypes.func,
+  onClick: PropTypes.func,
+  onClose: PropTypes.func,
+  onFocus: PropTypes.func,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  onOpen: PropTypes.func,
+  open: PropTypes.bool,
+  selectOnBlur: PropTypes.bool,
+  trigger: PropTypes.node.isRequired,
 });
 
 BareDropdown.defaultProps = {

--- a/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
@@ -10,16 +10,17 @@ class BaseDiscoveryView extends React.Component {
   // between views that use it (at the time of this comment, ProjectsView and VisualizationsView)
   // We might be able to get rid of it once we implement dynamic row height on the tables.
   render() {
-    const { columns, data, handleRowClick } = this.props;
+    const { columns, data, handleRowClick, initialActiveColumns } = this.props;
 
     return (
       <Table
-        sortable
-        data={data}
         columns={columns}
+        data={data}
         defaultRowHeight={68}
+        initialActiveColumns={initialActiveColumns}
         onRowClick={handleRowClick}
         rowClassName={cs.tableDataRow}
+        sortable
       />
     );
   }
@@ -34,6 +35,7 @@ BaseDiscoveryView.propTypes = {
   columns: PropTypes.array,
   data: PropTypes.array,
   handleRowClick: PropTypes.func,
+  initialActiveColumns: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default BaseDiscoveryView;

--- a/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
@@ -10,7 +10,13 @@ class BaseDiscoveryView extends React.Component {
   // between views that use it (at the time of this comment, ProjectsView and VisualizationsView)
   // We might be able to get rid of it once we implement dynamic row height on the tables.
   render() {
-    const { columns, data, handleRowClick, initialActiveColumns } = this.props;
+    const {
+      columns,
+      data,
+      handleRowClick,
+      initialActiveColumns,
+      protectedColumns,
+    } = this.props;
 
     return (
       <Table
@@ -19,6 +25,7 @@ class BaseDiscoveryView extends React.Component {
         defaultRowHeight={68}
         initialActiveColumns={initialActiveColumns}
         onRowClick={handleRowClick}
+        protectedColumns={protectedColumns}
         rowClassName={cs.tableDataRow}
         sortable
       />
@@ -36,6 +43,7 @@ BaseDiscoveryView.propTypes = {
   data: PropTypes.array,
   handleRowClick: PropTypes.func,
   initialActiveColumns: PropTypes.arrayOf(PropTypes.string),
+  protectedColumns: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default BaseDiscoveryView;

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -822,8 +822,7 @@ class DiscoveryView extends React.Component {
     return (
       <div className={cs.rightPane}>
         {showStats &&
-          currentTab === "samples" &&
-          currentDisplay === "map" && (
+          (currentDisplay === "map" ? (
             <MapPreviewSidebar
               allowedFeatures={allowedFeatures}
               currentTab={mapSidebarTab}
@@ -838,6 +837,7 @@ class DiscoveryView extends React.Component {
                   ? computedProjectDimensions
                   : mapSidebarProjectDimensions
               }
+              projects={projects}
               projectStats={
                 isEmpty(mapSidebarSampleStats)
                   ? projectStats
@@ -859,10 +859,7 @@ class DiscoveryView extends React.Component {
               }
               selectableIds={mapPreviewedSampleIds}
             />
-          )}
-        {showStats &&
-          ((currentTab === "samples" && currentDisplay === "table") ||
-            currentTab === "projects") && (
+          ) : (
             <DiscoverySidebar
               allowedFeatures={allowedFeatures}
               currentTab={currentTab}
@@ -872,7 +869,7 @@ class DiscoveryView extends React.Component {
               sampleDimensions={computedSampleDimensions}
               sampleStats={filteredSampleStats}
             />
-          )}
+          ))}
       </div>
     );
   };
@@ -959,8 +956,10 @@ class DiscoveryView extends React.Component {
                       currentDisplay={currentDisplay}
                       currentTab={currentTab}
                       mapLocationData={mapLocationData}
+                      mapPreviewedLocationId={mapPreviewedLocationId}
                       mapTilerKey={mapTilerKey}
                       onDisplaySwitch={this.handleDisplaySwitch}
+                      onMapMarkerClick={this.handleMapMarkerClick}
                       onProjectSelected={this.handleProjectSelected}
                       projects={projects}
                     />

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -957,6 +957,7 @@ class DiscoveryView extends React.Component {
                     <ProjectsView
                       allowedFeatures={allowedFeatures}
                       currentDisplay={currentDisplay}
+                      mapTilerKey={mapTilerKey}
                       onDisplaySwitch={this.handleDisplaySwitch}
                       onProjectSelected={this.handleProjectSelected}
                       projects={projects}

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -135,7 +135,6 @@ class DiscoveryView extends React.Component {
     this.resetDataFromInitialLoad();
 
     window.onpopstate = () => {
-      console.log("back was pressed");
       this.setState(history.state, () => {
         this.resetDataFromInitialLoad();
       });
@@ -234,7 +233,6 @@ class DiscoveryView extends React.Component {
   };
 
   resetDataFromInitialLoad = () => {
-    console.log("initial load");
     const { project } = this.state;
     this.resetData({
       callback: () => {
@@ -242,8 +240,8 @@ class DiscoveryView extends React.Component {
         //   - load (A) non-filtered dimensions, (C) filtered stats, (D) filtered locations, and (E) synchronous table data
         this.refreshDimensions();
         this.refreshFilteredStats();
-        this.refreshSynchronousData();
         this.refreshFilteredLocations();
+        this.refreshSynchronousData();
         //   * if filter or project is set
         //     - load (B) filtered dimensions
         (this.getFilterCount() || project) && this.refreshFilteredDimensions();
@@ -252,7 +250,6 @@ class DiscoveryView extends React.Component {
   };
 
   resetDataFromFilterChange = () => {
-    console.log("filter change");
     const { project } = this.state;
     this.resetData({
       callback: () => {
@@ -269,7 +266,6 @@ class DiscoveryView extends React.Component {
   };
 
   refreshDataFromProjectChange = () => {
-    console.log("project change");
     this.resetData({
       callback: () => {
         // * On project selected
@@ -308,6 +304,7 @@ class DiscoveryView extends React.Component {
         loadingProjects: false,
         loadingVisualizations: false,
       },
+      // Uses 'projects'
       this.refreshMapPreviewedProjects
     );
   };
@@ -396,10 +393,10 @@ class DiscoveryView extends React.Component {
       search,
     });
 
-    this.setState(
-      { mapLocationData, loadingLocations: false },
-      this.refreshMapPreviewedSamples
-    );
+    this.setState({ mapLocationData, loadingLocations: false }, () => {
+      this.refreshMapPreviewedSamples();
+      this.refreshMapPreviewedProjects();
+    });
   };
 
   computeTabs = () => {
@@ -447,6 +444,7 @@ class DiscoveryView extends React.Component {
       });
     });
 
+    // Set to match 'samples' or 'projects'
     if (mapSidebarTab !== "summary")
       this.setState({ mapSidebarTab: currentTab });
   };
@@ -722,9 +720,10 @@ class DiscoveryView extends React.Component {
   };
 
   handleMapTooltipTitleClick = locationId => {
-    this.setState({ mapPreviewedLocationId: locationId }, () =>
-      this.refreshMapPreviewedSamples()
-    );
+    this.setState({ mapPreviewedLocationId: locationId }, () => {
+      this.refreshMapPreviewedSamples();
+      this.refreshMapPreviewedProjects();
+    });
   };
 
   handleMapMarkerClick = locationId => {
@@ -733,7 +732,10 @@ class DiscoveryView extends React.Component {
         mapPreviewedLocationId: locationId,
         showStats: true,
       },
-      this.refreshMapPreviewedSamples
+      () => {
+        this.refreshMapPreviewedSamples();
+        this.refreshMapPreviewedProjects();
+      }
     );
   };
 
@@ -800,6 +802,8 @@ class DiscoveryView extends React.Component {
     const { mapLocationData, mapPreviewedLocationId, projects } = this.state;
 
     if (!mapPreviewedLocationId) return;
+
+    console.log("the projects I see are: ", projects);
 
     const projectIds = mapLocationData[mapPreviewedLocationId].project_ids;
     const mapPreviewedProjects = at(projectIds, keyBy("id", projects));

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -957,6 +957,8 @@ class DiscoveryView extends React.Component {
                     <ProjectsView
                       allowedFeatures={allowedFeatures}
                       currentDisplay={currentDisplay}
+                      currentTab={currentTab}
+                      mapLocationData={mapLocationData}
                       mapTilerKey={mapTilerKey}
                       onDisplaySwitch={this.handleDisplaySwitch}
                       onProjectSelected={this.handleProjectSelected}

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -955,8 +955,9 @@ class DiscoveryView extends React.Component {
                 <div className={cs.tableContainer}>
                   <div className={cs.dataContainer}>
                     <ProjectsView
-                      projects={projects}
+                      allowedFeatures={allowedFeatures}
                       onProjectSelected={this.handleProjectSelected}
+                      projects={projects}
                     />
                   </div>
                   {!projects.length &&

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -956,6 +956,8 @@ class DiscoveryView extends React.Component {
                   <div className={cs.dataContainer}>
                     <ProjectsView
                       allowedFeatures={allowedFeatures}
+                      currentDisplay={currentDisplay}
+                      onDisplaySwitch={this.handleDisplaySwitch}
                       onProjectSelected={this.handleProjectSelected}
                       projects={projects}
                     />

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -720,10 +720,18 @@ class DiscoveryView extends React.Component {
   };
 
   handleMapTooltipTitleClick = locationId => {
-    this.setState({ mapPreviewedLocationId: locationId }, () => {
-      this.refreshMapPreviewedSamples();
-      this.refreshMapPreviewedProjects();
-    });
+    const { currentTab } = this.state;
+    this.setState(
+      {
+        mapPreviewedLocationId: locationId,
+        mapSidebarTab: currentTab,
+        showStats: true,
+      },
+      () => {
+        this.refreshMapPreviewedSamples();
+        this.refreshMapPreviewedProjects();
+      }
+    );
   };
 
   handleMapMarkerClick = locationId => {
@@ -802,8 +810,6 @@ class DiscoveryView extends React.Component {
     const { mapLocationData, mapPreviewedLocationId, projects } = this.state;
 
     if (!mapPreviewedLocationId) return;
-
-    console.log("the projects I see are: ", projects);
 
     const projectIds = mapLocationData[mapPreviewedLocationId].project_ids;
     const mapPreviewedProjects = at(projectIds, keyBy("id", projects));
@@ -1000,6 +1006,7 @@ class DiscoveryView extends React.Component {
                       onDisplaySwitch={this.handleDisplaySwitch}
                       onMapMarkerClick={this.handleMapMarkerClick}
                       onProjectSelected={this.handleProjectSelected}
+                      onMapTooltipTitleClick={this.handleMapTooltipTitleClick}
                       projects={projects}
                     />
                   </div>

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -103,7 +103,10 @@ class DiscoveryMap extends React.Component {
       <BaseMap
         mapTilerKey={mapTilerKey}
         updateViewport={this.updateViewport}
-        markers={Object.values(mapLocationData).map(this.renderMarker)}
+        markers={
+          mapLocationData &&
+          Object.values(mapLocationData).map(this.renderMarker)
+        }
         tooltip={tooltip}
       />
     );

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Marker } from "react-map-gl";
-import { get } from "lodash/fp";
+import { get, upperFirst } from "lodash/fp";
 
 import PropTypes from "~/components/utils/propTypes";
 import BaseMap from "~/components/views/discovery/mapping/BaseMap";
@@ -29,7 +29,11 @@ class DiscoveryMap extends React.Component {
   };
 
   handleMarkerMouseEnter = hoverInfo => {
-    const title = `${hoverInfo.pointCount} Sample${
+    const { currentTab } = this.props;
+
+    // ex: samples -> Sample
+    const noun = upperFirst(currentTab).slice(0, -1);
+    const title = `${hoverInfo.pointCount} ${noun}${
       hoverInfo.pointCount > 1 ? "s" : ""
     }`;
     const tooltip = (
@@ -65,13 +69,14 @@ class DiscoveryMap extends React.Component {
   };
 
   renderMarker = markerData => {
-    const { previewedLocationId } = this.props;
+    const { currentTab, previewedLocationId } = this.props;
     const { viewport } = this.state;
     const id = markerData.id;
     const name = markerData.name;
     const lat = parseFloat(markerData.lat);
     const lng = parseFloat(markerData.lng);
-    const pointCount = markerData.sample_ids.length;
+    const idsField = currentTab === "samples" ? "sample_ids" : "project_ids";
+    const pointCount = markerData[idsField].length;
     const minSize = 12;
     // Scale based on the zoom and point count (zoomed-in = higher zoom)
     // Log1.5 of the count looked nice visually for not getting too large with many points.
@@ -113,7 +118,13 @@ class DiscoveryMap extends React.Component {
   }
 }
 
+DiscoveryMap.defaultProps = {
+  currentTab: "samples",
+};
+
 DiscoveryMap.propTypes = {
+  currentDisplay: PropTypes.string,
+  currentTab: PropTypes.string.isRequired,
   mapLocationData: PropTypes.objectOf(PropTypes.Location),
   mapTilerKey: PropTypes.string,
   onMarkerClick: PropTypes.func,

--- a/app/assets/src/components/views/discovery/mapping/MapToggle.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapToggle.jsx
@@ -1,0 +1,43 @@
+import PropTypes from "prop-types";
+import React from "react";
+import cx from "classnames";
+
+import { Menu, MenuItem } from "~ui/controls/Menu";
+
+import cs from "./map_toggle.scss";
+
+const DISPLAYS = ["table", "map"];
+
+class MapToggle extends React.Component {
+  render() {
+    const { currentDisplay, onDisplaySwitch } = this.props;
+    return (
+      <div className={cs.displaySwitcher}>
+        <Menu compact className={cs.switcherMenu}>
+          {DISPLAYS.map(display => (
+            <MenuItem
+              className={cs.menuItem}
+              active={currentDisplay === display}
+              onClick={() => onDisplaySwitch(display)}
+            >
+              <i
+                className={cx(
+                  "fa",
+                  display === "map" ? "fa-globe" : "fa-list-ul",
+                  cs.icon
+                )}
+              />
+            </MenuItem>
+          ))}
+        </Menu>
+      </div>
+    );
+  }
+}
+
+MapToggle.propTypes = {
+  currentDisplay: PropTypes.string,
+  onDisplaySwitch: PropTypes.func,
+};
+
+export default MapToggle;

--- a/app/assets/src/components/views/discovery/mapping/MapToggle.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapToggle.jsx
@@ -12,23 +12,25 @@ class MapToggle extends React.Component {
   render() {
     const { currentDisplay, onDisplaySwitch } = this.props;
     return (
-      <Menu compact className={cs.switcherMenu}>
-        {DISPLAYS.map(display => (
-          <MenuItem
-            className={cs.menuItem}
-            active={currentDisplay === display}
-            onClick={() => onDisplaySwitch(display)}
-          >
-            <i
-              className={cx(
-                "fa",
-                display === "map" ? "fa-globe" : "fa-list-ul",
-                cs.icon
-              )}
-            />
-          </MenuItem>
-        ))}
-      </Menu>
+      <div className={cs.displaySwitcher}>
+        <Menu compact className={cs.switcherMenu}>
+          {DISPLAYS.map(display => (
+            <MenuItem
+              className={cs.menuItem}
+              active={currentDisplay === display}
+              onClick={() => onDisplaySwitch(display)}
+            >
+              <i
+                className={cx(
+                  "fa",
+                  display === "map" ? "fa-globe" : "fa-list-ul",
+                  cs.icon
+                )}
+              />
+            </MenuItem>
+          ))}
+        </Menu>
+      </div>
     );
   }
 }

--- a/app/assets/src/components/views/discovery/mapping/MapToggle.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapToggle.jsx
@@ -12,25 +12,23 @@ class MapToggle extends React.Component {
   render() {
     const { currentDisplay, onDisplaySwitch } = this.props;
     return (
-      <div className={cs.displaySwitcher}>
-        <Menu compact className={cs.switcherMenu}>
-          {DISPLAYS.map(display => (
-            <MenuItem
-              className={cs.menuItem}
-              active={currentDisplay === display}
-              onClick={() => onDisplaySwitch(display)}
-            >
-              <i
-                className={cx(
-                  "fa",
-                  display === "map" ? "fa-globe" : "fa-list-ul",
-                  cs.icon
-                )}
-              />
-            </MenuItem>
-          ))}
-        </Menu>
-      </div>
+      <Menu compact className={cs.switcherMenu}>
+        {DISPLAYS.map(display => (
+          <MenuItem
+            className={cs.menuItem}
+            active={currentDisplay === display}
+            onClick={() => onDisplaySwitch(display)}
+          >
+            <i
+              className={cx(
+                "fa",
+                display === "map" ? "fa-globe" : "fa-list-ul",
+                cs.icon
+              )}
+            />
+          </MenuItem>
+        ))}
+      </Menu>
     );
   }
 }

--- a/app/assets/src/components/views/discovery/mapping/MapToggle.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapToggle.jsx
@@ -19,6 +19,7 @@ class MapToggle extends React.Component {
               className={cs.menuItem}
               active={currentDisplay === display}
               onClick={() => onDisplaySwitch(display)}
+              key={`item-${display}`}
             >
               <i
                 className={cx(

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -57,6 +57,7 @@
   margin-top: 2px;
 }
 
-.sampleHeader {
+.sampleHeader,
+.projectHeader {
   text-align: left;
 }

--- a/app/assets/src/components/views/discovery/mapping/map_toggle.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_toggle.scss
@@ -1,21 +1,23 @@
 @import "~styles/themes/colors";
 
-.switcherMenu {
-  margin: 0;
-  min-height: 25px;
-  border-radius: 7px;
-  box-shadow: none;
+.displaySwitcher {
+  .switcherMenu {
+    margin: 0;
+    min-height: 25px;
+    border-radius: 7px;
+    box-shadow: none;
 
-  .menuItem {
-    padding: 5px 15px;
+    .menuItem {
+      padding: 5px 15px;
 
-    .icon {
-      font-size: 15px;
-    }
+      .icon {
+        font-size: 15px;
+      }
 
-    &:global(.active) {
-      // Important due to a { color: inherit !important; } in header.scss.
-      color: $primary-light !important;
+      &:global(.active) {
+        // Important due to a { color: inherit !important; } in header.scss.
+        color: $primary-light !important;
+      }
     }
   }
 }

--- a/app/assets/src/components/views/discovery/mapping/map_toggle.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_toggle.scss
@@ -1,0 +1,23 @@
+@import "~styles/themes/colors";
+
+.displaySwitcher {
+  .switcherMenu {
+    margin: 0;
+    min-height: 25px;
+    border-radius: 7px;
+    box-shadow: none;
+
+    .menuItem {
+      padding: 5px 15px;
+
+      .icon {
+        font-size: 15px;
+      }
+
+      &:global(.active) {
+        // Important due to a { color: inherit !important; } in header.scss.
+        color: $primary-light !important;
+      }
+    }
+  }
+}

--- a/app/assets/src/components/views/discovery/mapping/map_toggle.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_toggle.scss
@@ -1,23 +1,21 @@
 @import "~styles/themes/colors";
 
-.displaySwitcher {
-  .switcherMenu {
-    margin: 0;
-    min-height: 25px;
-    border-radius: 7px;
-    box-shadow: none;
+.switcherMenu {
+  margin: 0;
+  min-height: 25px;
+  border-radius: 7px;
+  box-shadow: none;
 
-    .menuItem {
-      padding: 5px 15px;
+  .menuItem {
+    padding: 5px 15px;
 
-      .icon {
-        font-size: 15px;
-      }
+    .icon {
+      font-size: 15px;
+    }
 
-      &:global(.active) {
-        // Important due to a { color: inherit !important; } in header.scss.
-        color: $primary-light !important;
-      }
+    &:global(.active) {
+      // Important due to a { color: inherit !important; } in header.scss.
+      color: $primary-light !important;
     }
   }
 }

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -4,10 +4,12 @@ import React from "react";
 
 import { logAnalyticsEvent } from "~/api/analytics";
 import BaseDiscoveryView from "~/components/views/discovery/BaseDiscoveryView";
+import DiscoveryMap from "~/components/views/discovery/mapping/DiscoveryMap";
 import MapToggle from "~/components/views/discovery/mapping/MapToggle";
 import TableRenderers from "~/components/views/discovery/TableRenderers";
 import PrivateProjectIcon from "~ui/icons/PrivateProjectIcon";
 import PublicProjectIcon from "~ui/icons/PublicProjectIcon";
+
 // CSS file must be loaded after any elements you might want to override
 import cs from "./projects_view.scss";
 
@@ -93,18 +95,25 @@ class ProjectsView extends React.Component {
   renderDisplaySwitcher = () => {
     const { currentDisplay, onDisplaySwitch } = this.props;
     return (
-      <MapToggle
-        currentDisplay={currentDisplay}
-        onDisplaySwitch={display => {
-          onDisplaySwitch(display);
-          logAnalyticsEvent(`ProjectsView_${display}-switch_clicked`);
-        }}
-      />
+      <div className={cs.displaySwitcher}>
+        <MapToggle
+          currentDisplay={currentDisplay}
+          onDisplaySwitch={display => {
+            onDisplaySwitch(display);
+            logAnalyticsEvent(`ProjectsView_${display}-switch_clicked`);
+          }}
+        />
+      </div>
     );
   };
 
   render() {
-    const { allowedFeatures, projects } = this.props;
+    const {
+      allowedFeatures,
+      currentDisplay,
+      mapTilerKey,
+      projects,
+    } = this.props;
     let data = projects.map(project => {
       return merge(
         {
@@ -125,11 +134,23 @@ class ProjectsView extends React.Component {
         {allowedFeatures &&
           allowedFeatures.includes("maps") &&
           this.renderDisplaySwitcher()}
-        <BaseDiscoveryView
-          columns={this.columns}
-          data={data}
-          handleRowClick={this.handleRowClick}
-        />
+        {currentDisplay === "table" ? (
+          <BaseDiscoveryView
+            columns={this.columns}
+            data={data}
+            handleRowClick={this.handleRowClick}
+          />
+        ) : (
+          <div className={cs.map}>
+            <DiscoveryMap
+              // mapLocationData={mapLocationData}
+              mapTilerKey={mapTilerKey}
+              // onMarkerClick={onMapMarkerClick}
+              // onTooltipTitleClick={onMapTooltipTitleClick}
+              // previewedLocationId={mapPreviewedLocationId}
+            />
+          </div>
+        )}
       </div>
     );
   }
@@ -143,6 +164,7 @@ ProjectsView.defaultProps = {
 ProjectsView.propTypes = {
   allowedFeatures: PropTypes.array,
   currentDisplay: PropTypes.string.isRequired,
+  mapTilerKey: PropTypes.string,
   onDisplaySwitch: PropTypes.func,
   onProjectSelected: PropTypes.func,
   projects: PropTypes.array,

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -113,7 +113,9 @@ class ProjectsView extends React.Component {
       currentDisplay,
       currentTab,
       mapLocationData,
+      mapPreviewedLocationId,
       mapTilerKey,
+      onMapMarkerClick,
       projects,
     } = this.props;
     let data = projects.map(project => {
@@ -148,9 +150,9 @@ class ProjectsView extends React.Component {
               currentTab={currentTab}
               mapLocationData={mapLocationData}
               mapTilerKey={mapTilerKey}
-              // onMarkerClick={onMapMarkerClick}
+              onMarkerClick={onMapMarkerClick}
               // onTooltipTitleClick={onMapTooltipTitleClick}
-              // previewedLocationId={mapPreviewedLocationId}
+              previewedLocationId={mapPreviewedLocationId}
             />
           </div>
         )}
@@ -169,8 +171,10 @@ ProjectsView.propTypes = {
   currentDisplay: PropTypes.string.isRequired,
   currentTab: PropTypes.string.isRequired,
   mapLocationData: PropTypes.objectOf(PropTypes.Location),
+  mapPreviewedLocationId: PropTypes.number,
   mapTilerKey: PropTypes.string,
   onDisplaySwitch: PropTypes.func,
+  onMapMarkerClick: PropTypes.func,
   onProjectSelected: PropTypes.func,
   projects: PropTypes.array,
 };

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -90,7 +90,7 @@ class ProjectsView extends React.Component {
   };
 
   render() {
-    const { projects } = this.props;
+    const { allowedFeatures, projects } = this.props;
     let data = projects.map(project => {
       return merge(
         {
@@ -107,11 +107,16 @@ class ProjectsView extends React.Component {
     });
 
     return (
-      <BaseDiscoveryView
-        columns={this.columns}
-        data={data}
-        handleRowClick={this.handleRowClick}
-      />
+      <div className={cs.container}>
+        {/*{allowedFeatures &&*/}
+        {/*allowedFeatures.includes("maps") &&*/}
+        {/*this.renderDisplaySwitcher()}*/}
+        <BaseDiscoveryView
+          columns={this.columns}
+          data={data}
+          handleRowClick={this.handleRowClick}
+        />
+      </div>
     );
   }
 }
@@ -121,6 +126,7 @@ ProjectsView.defaultProps = {
 };
 
 ProjectsView.propTypes = {
+  allowedFeatures: PropTypes.array,
   projects: PropTypes.array,
   onProjectSelected: PropTypes.func,
 };

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -95,7 +95,7 @@ class ProjectsView extends React.Component {
   renderDisplaySwitcher = () => {
     const { currentDisplay, onDisplaySwitch } = this.props;
     return (
-      <div className={cs.displaySwitcher}>
+      <div className={cs.toggleContainer}>
         <MapToggle
           currentDisplay={currentDisplay}
           onDisplaySwitch={display => {

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -1,12 +1,13 @@
-import React from "react";
-import PropTypes from "prop-types";
 import { find, merge, pick } from "lodash/fp";
+import PropTypes from "prop-types";
+import React from "react";
 
 import { logAnalyticsEvent } from "~/api/analytics";
+import BaseDiscoveryView from "~/components/views/discovery/BaseDiscoveryView";
+import MapToggle from "~/components/views/discovery/mapping/MapToggle";
+import TableRenderers from "~/components/views/discovery/TableRenderers";
 import PrivateProjectIcon from "~ui/icons/PrivateProjectIcon";
 import PublicProjectIcon from "~ui/icons/PublicProjectIcon";
-import BaseDiscoveryView from "~/components/views/discovery/BaseDiscoveryView";
-import TableRenderers from "~/components/views/discovery/TableRenderers";
 // CSS file must be loaded after any elements you might want to override
 import cs from "./projects_view.scss";
 
@@ -89,6 +90,19 @@ class ProjectsView extends React.Component {
     });
   };
 
+  renderDisplaySwitcher = () => {
+    const { currentDisplay, onDisplaySwitch } = this.props;
+    return (
+      <MapToggle
+        currentDisplay={currentDisplay}
+        onDisplaySwitch={display => {
+          onDisplaySwitch(display);
+          logAnalyticsEvent(`ProjectsView_${display}-switch_clicked`);
+        }}
+      />
+    );
+  };
+
   render() {
     const { allowedFeatures, projects } = this.props;
     let data = projects.map(project => {
@@ -108,9 +122,9 @@ class ProjectsView extends React.Component {
 
     return (
       <div className={cs.container}>
-        {/*{allowedFeatures &&*/}
-        {/*allowedFeatures.includes("maps") &&*/}
-        {/*this.renderDisplaySwitcher()}*/}
+        {allowedFeatures &&
+          allowedFeatures.includes("maps") &&
+          this.renderDisplaySwitcher()}
         <BaseDiscoveryView
           columns={this.columns}
           data={data}
@@ -122,13 +136,16 @@ class ProjectsView extends React.Component {
 }
 
 ProjectsView.defaultProps = {
+  currentDisplay: "table",
   projects: [],
 };
 
 ProjectsView.propTypes = {
   allowedFeatures: PropTypes.array,
-  projects: PropTypes.array,
+  currentDisplay: PropTypes.string.isRequired,
+  onDisplaySwitch: PropTypes.func,
   onProjectSelected: PropTypes.func,
+  projects: PropTypes.array,
 };
 
 export default ProjectsView;

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -116,6 +116,7 @@ class ProjectsView extends React.Component {
       mapPreviewedLocationId,
       mapTilerKey,
       onMapMarkerClick,
+      onMapTooltipTitleClick,
       projects,
     } = this.props;
     let data = projects.map(project => {
@@ -151,7 +152,7 @@ class ProjectsView extends React.Component {
               mapLocationData={mapLocationData}
               mapTilerKey={mapTilerKey}
               onMarkerClick={onMapMarkerClick}
-              // onTooltipTitleClick={onMapTooltipTitleClick}
+              onTooltipTitleClick={onMapTooltipTitleClick}
               previewedLocationId={mapPreviewedLocationId}
             />
           </div>
@@ -175,6 +176,7 @@ ProjectsView.propTypes = {
   mapTilerKey: PropTypes.string,
   onDisplaySwitch: PropTypes.func,
   onMapMarkerClick: PropTypes.func,
+  onMapTooltipTitleClick: PropTypes.func,
   onProjectSelected: PropTypes.func,
   projects: PropTypes.array,
 };

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -1,8 +1,8 @@
-import { find, merge, pick } from "lodash/fp";
-import PropTypes from "prop-types";
 import React from "react";
+import { find, merge, pick } from "lodash/fp";
 
 import { logAnalyticsEvent } from "~/api/analytics";
+import PropTypes from "~/components/utils/propTypes";
 import BaseDiscoveryView from "~/components/views/discovery/BaseDiscoveryView";
 import DiscoveryMap from "~/components/views/discovery/mapping/DiscoveryMap";
 import MapToggle from "~/components/views/discovery/mapping/MapToggle";
@@ -111,6 +111,8 @@ class ProjectsView extends React.Component {
     const {
       allowedFeatures,
       currentDisplay,
+      currentTab,
+      mapLocationData,
       mapTilerKey,
       projects,
     } = this.props;
@@ -143,7 +145,8 @@ class ProjectsView extends React.Component {
         ) : (
           <div className={cs.map}>
             <DiscoveryMap
-              // mapLocationData={mapLocationData}
+              currentTab={currentTab}
+              mapLocationData={mapLocationData}
               mapTilerKey={mapTilerKey}
               // onMarkerClick={onMapMarkerClick}
               // onTooltipTitleClick={onMapTooltipTitleClick}
@@ -164,6 +167,8 @@ ProjectsView.defaultProps = {
 ProjectsView.propTypes = {
   allowedFeatures: PropTypes.array,
   currentDisplay: PropTypes.string.isRequired,
+  currentTab: PropTypes.string.isRequired,
+  mapLocationData: PropTypes.objectOf(PropTypes.Location),
   mapTilerKey: PropTypes.string,
   onDisplaySwitch: PropTypes.func,
   onProjectSelected: PropTypes.func,

--- a/app/assets/src/components/views/projects/projects_view.scss
+++ b/app/assets/src/components/views/projects/projects_view.scss
@@ -1,3 +1,10 @@
 .projectHeader {
   text-align: left;
 }
+
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  flex: 1 0 auto;
+}

--- a/app/assets/src/components/views/projects/projects_view.scss
+++ b/app/assets/src/components/views/projects/projects_view.scss
@@ -7,4 +7,14 @@
   flex-direction: column;
   height: 100%;
   flex: 1 0 auto;
+
+  .displaySwitcher {
+    margin-bottom: 10px;
+  }
+
+  .map {
+    flex: 1 0 auto;
+    display: flex;
+    flex-direction: column;
+  }
 }

--- a/app/assets/src/components/views/projects/projects_view.scss
+++ b/app/assets/src/components/views/projects/projects_view.scss
@@ -8,7 +8,7 @@
   height: 100%;
   flex: 1 0 auto;
 
-  .displaySwitcher {
+  .toggleContainer {
     margin-bottom: 10px;
   }
 

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -373,15 +373,13 @@ class SamplesView extends React.Component {
   renderDisplaySwitcher = () => {
     const { currentDisplay, onDisplaySwitch } = this.props;
     return (
-      <div className={cs.displaySwitcher}>
-        <MapToggle
-          currentDisplay={currentDisplay}
-          onDisplaySwitch={display => {
-            onDisplaySwitch(display);
-            logAnalyticsEvent(`SamplesView_${display}-switch_clicked`);
-          }}
-        />
-      </div>
+      <MapToggle
+        currentDisplay={currentDisplay}
+        onDisplaySwitch={display => {
+          onDisplaySwitch(display);
+          logAnalyticsEvent(`SamplesView_${display}-switch_clicked`);
+        }}
+      />
     );
   };
 

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -16,9 +16,9 @@ import HeatmapIcon from "~ui/icons/HeatmapIcon";
 import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";
 import SaveIcon from "~ui/icons/SaveIcon";
 import Label from "~ui/labels/Label";
-import csTableRenderer from "../discovery/table_renderers.scss";
 
 import cs from "./samples_view.scss";
+import csTableRenderer from "../discovery/table_renderers.scss";
 
 class SamplesView extends React.Component {
   constructor(props) {
@@ -373,13 +373,15 @@ class SamplesView extends React.Component {
   renderDisplaySwitcher = () => {
     const { currentDisplay, onDisplaySwitch } = this.props;
     return (
-      <MapToggle
-        currentDisplay={currentDisplay}
-        onDisplaySwitch={display => {
-          onDisplaySwitch(display);
-          logAnalyticsEvent(`SamplesView_${display}-switch_clicked`);
-        }}
-      />
+      <div className={cs.displaySwitcher}>
+        <MapToggle
+          currentDisplay={currentDisplay}
+          onDisplaySwitch={display => {
+            onDisplaySwitch(display);
+            logAnalyticsEvent(`SamplesView_${display}-switch_clicked`);
+          }}
+        />
+      </div>
     );
   };
 

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -5,22 +5,20 @@ import React from "react";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import PropTypes from "~/components/utils/propTypes";
 import DiscoveryMap from "~/components/views/discovery/mapping/DiscoveryMap";
+import MapToggle from "~/components/views/discovery/mapping/MapToggle";
 import TableRenderers from "~/components/views/discovery/TableRenderers";
 import PhyloTreeCreationModal from "~/components/views/phylo_tree/PhyloTreeCreationModal";
 import CollectionModal from "~/components/views/samples/CollectionModal";
 import ReportsDownloader from "~/components/views/samples/ReportsDownloader";
 import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 import { DownloadIconDropdown } from "~ui/controls/dropdowns";
-import { Menu, MenuItem } from "~ui/controls/Menu";
 import HeatmapIcon from "~ui/icons/HeatmapIcon";
 import PhyloTreeIcon from "~ui/icons/PhyloTreeIcon";
 import SaveIcon from "~ui/icons/SaveIcon";
 import Label from "~ui/labels/Label";
-
-import cs from "./samples_view.scss";
 import csTableRenderer from "../discovery/table_renderers.scss";
 
-const DISPLAYS = ["table", "map"];
+import cs from "./samples_view.scss";
 
 class SamplesView extends React.Component {
   constructor(props) {
@@ -375,28 +373,13 @@ class SamplesView extends React.Component {
   renderDisplaySwitcher = () => {
     const { currentDisplay, onDisplaySwitch } = this.props;
     return (
-      <div className={cs.displaySwitcher}>
-        <Menu compact className={cs.switcherMenu}>
-          {DISPLAYS.map(display => (
-            <MenuItem
-              className={cs.menuItem}
-              active={currentDisplay === display}
-              onClick={withAnalytics(
-                () => onDisplaySwitch(display),
-                `SamplesView_${display}-switch_clicked`
-              )}
-            >
-              <i
-                className={cx(
-                  "fa",
-                  display === "map" ? "fa-globe" : "fa-list-ul",
-                  cs.icon
-                )}
-              />
-            </MenuItem>
-          ))}
-        </Menu>
-      </div>
+      <MapToggle
+        currentDisplay={currentDisplay}
+        onDisplaySwitch={display => {
+          onDisplaySwitch(display);
+          logAnalyticsEvent(`SamplesView_${display}-switch_clicked`);
+        }}
+      />
     );
   };
 

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -98,6 +98,9 @@
       }
     }
   }
+
+  .displaySwitcher {
+  }
 }
 
 .sampleHeader {

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -98,9 +98,6 @@
       }
     }
   }
-
-  .displaySwitcher {
-  }
 }
 
 .sampleHeader {

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -98,28 +98,6 @@
       }
     }
   }
-
-  .displaySwitcher {
-    .switcherMenu {
-      margin: 0;
-      min-height: 25px;
-      border-radius: 7px;
-      box-shadow: none;
-
-      .menuItem {
-        padding: 5px 15px;
-
-        .icon {
-          font-size: 15px;
-        }
-
-        &:global(.active) {
-          // Important due to a { color: inherit !important; } in header.scss.
-          color: $primary-light !important;
-        }
-      }
-    }
-  }
 }
 
 .sampleHeader {

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -80,16 +80,23 @@ class LocationsController < ApplicationController
     # (a) Filter to samples with collection_location_v2 and non-nil location_id.
     # (b) Pluck location_id, id, and location fields.
     # (c) Map and zip the fields to a hash to convert the plucked array to an object with keys.
-    # (d) Group and key by the location_id and add a list of sample_ids to the location attributes
+    # (d) Group and key by the location_id.
+    # (e) Add lists of sample_ids and project_ids to the location attributes.
+    #
     # Final result is a hash of hashes for frontend lookups.
     location_fields = [:name, :geo_level, :country_name, :state_name, :subdivision_name, :city_name, :lat, :lng]
     location_data = samples
                     .includes(metadata: [:location, :metadata_field])
                     .where(metadata: { metadata_fields: { name: "collection_location_v2" } })
                     .where.not(metadata: { location_id: nil })
-                    .pluck(:location_id, :id, *location_fields.map { |f| "locations.#{f}" })
-                    .map { |p| [:id, :sample_id, *location_fields].zip(p).to_h }
-                    .group_by { |h| h[:id] }.map { |k, v| [k, v[0].except(:sample_id).merge(sample_ids: v.map { |h| h[:sample_id] })] }.to_h
+                    .pluck(:location_id, :id, :project_id, *location_fields.map { |f| "locations.#{f}" })
+                    .map { |p| [:id, :sample_id, :project_id, *location_fields].zip(p).to_h }
+                    .group_by { |h| h[:id] }
+                    .map do |k, v|
+                      [k, v[0].except(:sample_id, :project_id)
+                              .merge(sample_ids: v.map { |h| h[:sample_id] })
+                              .merge(project_ids: v.map { |h| h[:project_id] }.uniq)]
+                    end.to_h
 
     respond_to do |format|
       format.json do

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -309,7 +309,7 @@ class CheckPipelineRuns
   end
 end
 
-task "pipeline_monitor", [:duration] => :environment do |_t, args|
+task  "pipeline_monitor", [:duration] => :environment do |_t, args|
   trap('SIGTERM') do
     CheckPipelineRuns.shutdown_requested = true
   end

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -309,7 +309,7 @@ class CheckPipelineRuns
   end
 end
 
-task  "pipeline_monitor", [:duration] => :environment do |_t, args|
+task "pipeline_monitor", [:duration] => :environment do |_t, args|
   trap('SIGTERM') do
     CheckPipelineRuns.shutdown_requested = true
   end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -76,7 +76,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     results = JSON.parse(@response.body)
     loc = locations(:swamp)
     actual_object = results[loc.id.to_s]
-    expected_object = { "id" => loc.id, "name" => loc.name, "geo_level" => loc.geo_level, "country_name" => loc.country_name, "state_name" => loc.state_name, "subdivision_name" => loc.subdivision_name, "city_name" => loc.city_name, "lat" => loc.lat.to_s, "lng" => loc.lng.to_s, "sample_ids" => [samples(:joe_project_sample_mosquito).id, samples(:joe_sample).id] }
+    expected_object = { "id" => loc.id, "name" => loc.name, "geo_level" => loc.geo_level, "country_name" => loc.country_name, "state_name" => loc.state_name, "subdivision_name" => loc.subdivision_name, "city_name" => loc.city_name, "lat" => loc.lat.to_s, "lng" => loc.lng.to_s, "sample_ids" => [samples(:joe_project_sample_mosquito).id, samples(:joe_sample).id], "project_ids" => [projects(:joe_project).id] }
 
     assert_equal actual_object, expected_object
   end


### PR DESCRIPTION
### Description
- Port over the map features to the Projects tab, including the projects preview sidebar. Projects show up under every location at which they have a sample.
- Add project_ids to the samples_locations endpoint.
- Fix some prop type warnings in BareDropdown.
- Standardize the map sidebar tab names as lowercase "samples"/"projects"/"summary".
- projectColumns in MapPreviewSidebar mostly copied from ProjectsView.
- Moved the map toggle into a new MapToggle component.

### Demo
![Jun-13-2019 17-03-37](https://user-images.githubusercontent.com/5652739/59475328-c9016700-8dff-11e9-8fee-d0cea8cf362f.gif)
![Jun-13-2019 17-04-13](https://user-images.githubusercontent.com/5652739/59475330-cacb2a80-8dff-11e9-8e05-79c60be5571a.gif)
![Jun-13-2019 17-29-15](https://user-images.githubusercontent.com/5652739/59475511-d10dd680-8e00-11e9-91ca-99f41b6aa93d.gif)

### Testing
- Go to data discovery, go to the Projects tab, go to the map view, see your projects, click around the map marker and the tooltip title and play around with the sidebar and filters.