### PR TITLE
[Heatmap] Tweak bug fix for location_v2 fields

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -184,17 +184,20 @@ class MetadataTab extends React.Component {
         {validKeys.map(key => (
           <RequestContext.Consumer>
             {requestContext => {
-              if (requestContext) {
-                const { allowedFeatures } = requestContext;
-                // TODO(jsheu): Migrate all to location_v2 after release
-                if (
-                  key === "collection_location_v2" &&
-                  allowedFeatures &&
-                  !allowedFeatures.includes("maps")
-                ) {
-                  return null;
-                }
+              // Don't show collection_location_v2 unless you have maps in requestContext
+              // allowedFeatures.
+              // TODO(jsheu): Migrate all to location_v2 after release
+              if (
+                key === "collection_location_v2" &&
+                !(
+                  requestContext &&
+                  requestContext.allowedFeatures &&
+                  requestContext.allowedFeatures.includes("maps")
+                )
+              ) {
+                return null;
               }
+
               return (
                 <div className={cs.field} key={metadataTypes[key].key}>
                   <div className={cs.label}>{metadataTypes[key].name}</div>

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -183,16 +183,17 @@ class MetadataTab extends React.Component {
           )}
         {validKeys.map(key => (
           <RequestContext.Consumer>
-            {props => {
-              if (!props) return null;
-
-              const { allowedFeatures } = props;
-              // TODO(jsheu): Migrate all to location_v2 after release
-              if (
-                key === "collection_location_v2" &&
-                !allowedFeatures.includes("maps")
-              ) {
-                return null;
+            {requestContext => {
+              if (requestContext) {
+                const { allowedFeatures } = requestContext;
+                // TODO(jsheu): Migrate all to location_v2 after release
+                if (
+                  key === "collection_location_v2" &&
+                  allowedFeatures &&
+                  !allowedFeatures.includes("maps")
+                ) {
+                  return null;
+                }
               }
               return (
                 <div className={cs.field} key={metadataTypes[key].key}>

--- a/app/views/samples/heatmap.html.erb
+++ b/app/views/samples/heatmap.html.erb
@@ -5,6 +5,7 @@
   react_component(
     'SamplesHeatmapView',
     JSON.parse('<%= raw escape_json(@visualization_data) %>'),
-    'SamplesHeatmapView_page'
+    'SamplesHeatmapView_page',
+    JSON.parse('<%= raw escape_json(request_context)%>')
   );
 <% end %>

--- a/app/views/visualizations/visualization.html.erb
+++ b/app/views/visualizations/visualization.html.erb
@@ -6,5 +6,6 @@
     'SamplesHeatmapView',
     JSON.parse('<%= raw escape_json(@visualization_data) %>'),
     'SamplesHeatmapView_page',
+    JSON.parse('<%= raw escape_json(request_context)%>')
   );
 <% end %>


### PR DESCRIPTION
# Description
- This fixes a previous fix so that we get the requestContext passed in where it was supposed to show up + the location_v2 fields as well.

# Notes
- Previous to this commit it will return early and not show the other fields.
![Screen Shot 2019-06-17 at 4 33 57 PM](https://user-images.githubusercontent.com/5652739/59644019-f7dd4d00-911f-11e9-85a6-b7896effe999.png)
- After:
![Screen Shot 2019-06-17 at 4 34 34 PM](https://user-images.githubusercontent.com/5652739/59644136-7f2ac080-9120-11e9-9af5-01653c2126f1.png)

# Tests
- Go to a heatmap, click on the sample name, see the right sidebar, verify that you see all the fields there and contents in the accordions.