### PR TITLE
[MetadataTab] Optimize the use of RequestContext

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -181,34 +181,32 @@ class MetadataTab extends React.Component {
               />
             </div>
           )}
-        {validKeys.map(key => (
+        {
           <RequestContext.Consumer>
-            {requestContext => {
-              // Don't show collection_location_v2 unless you have maps in requestContext
-              // allowedFeatures.
-              // TODO(jsheu): Migrate all to location_v2 after release
-              if (
-                key === "collection_location_v2" &&
-                !(
-                  requestContext &&
-                  requestContext.allowedFeatures &&
-                  requestContext.allowedFeatures.includes("maps")
-                )
-              ) {
-                return null;
-              }
+            {({ allowedFeatures } = {}) => {
+              return validKeys.map(key => {
+                // Don't show collection_location_v2 unless you have maps in requestContext
+                // allowedFeatures.
+                // TODO(jsheu): Migrate all to location_v2 after release
+                if (
+                  key === "collection_location_v2" &&
+                  !(allowedFeatures && allowedFeatures.includes("maps"))
+                ) {
+                  return null;
+                }
 
-              return (
-                <div className={cs.field} key={metadataTypes[key].key}>
-                  <div className={cs.label}>{metadataTypes[key].name}</div>
-                  {isSectionEditing
-                    ? this.renderInput(metadataTypes[key])
-                    : this.renderMetadataType(metadataTypes[key])}
-                </div>
-              );
+                return (
+                  <div className={cs.field} key={metadataTypes[key].key}>
+                    <div className={cs.label}>{metadataTypes[key].name}</div>
+                    {isSectionEditing
+                      ? this.renderInput(metadataTypes[key])
+                      : this.renderMetadataType(metadataTypes[key])}
+                  </div>
+                );
+              });
             }}
           </RequestContext.Consumer>
-        ))}
+        }
       </div>
     );
   };


### PR DESCRIPTION
# Description

- Per Tiago's suggestion of moving out the call to RequestContext.Consumer to avoid repeating the getter work within a loop. Also does `{ allowedFeatures } = {}` to populate the default value from an empty object.

# Notes

![Screen Shot 2019-06-18 at 10 01 52 AM](https://user-images.githubusercontent.com/5652739/59704435-f871f400-91b0-11e9-9f3a-579a37b4109c.png)

# Tests
- Go to a heatmap, click on a sample name to pull up the metadata tab, click around the accordions and metadata.