### PR TITLE
[IDSEQ-1075] [Maps] Fix visual styles according to Designs

### DIFF
--- a/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
@@ -15,6 +15,7 @@ class BaseDiscoveryView extends React.Component {
       columns,
       data,
       handleRowClick,
+      headerClassName,
       initialActiveColumns,
       protectedColumns,
       rowClassName,
@@ -25,7 +26,8 @@ class BaseDiscoveryView extends React.Component {
       <Table
         columns={columns}
         data={data}
-        defaultRowHeight={rowHeight || 68}
+        defaultRowHeight={rowHeight}
+        headerClassName={headerClassName}
         initialActiveColumns={initialActiveColumns}
         onRowClick={handleRowClick}
         protectedColumns={protectedColumns}
@@ -39,12 +41,14 @@ class BaseDiscoveryView extends React.Component {
 BaseDiscoveryView.defaultProps = {
   columns: [],
   data: [],
+  rowHeight: 68,
 };
 
 BaseDiscoveryView.propTypes = {
   columns: PropTypes.array,
   data: PropTypes.array,
   handleRowClick: PropTypes.func,
+  headerClassName: PropTypes.string,
   initialActiveColumns: PropTypes.arrayOf(PropTypes.string),
   protectedColumns: PropTypes.arrayOf(PropTypes.string),
   rowClassName: PropTypes.string,

--- a/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import cx from "classnames";
 
 import { Table } from "~/components/visualizations/table";
 // CSS file must be loaded after any elements you might want to override
@@ -16,17 +17,19 @@ class BaseDiscoveryView extends React.Component {
       handleRowClick,
       initialActiveColumns,
       protectedColumns,
+      rowClassName,
+      rowHeight,
     } = this.props;
 
     return (
       <Table
         columns={columns}
         data={data}
-        defaultRowHeight={68}
+        defaultRowHeight={rowHeight || 68}
         initialActiveColumns={initialActiveColumns}
         onRowClick={handleRowClick}
         protectedColumns={protectedColumns}
-        rowClassName={cs.tableDataRow}
+        rowClassName={cx(rowClassName, cs.tableDataRow)}
         sortable
       />
     );
@@ -44,6 +47,8 @@ BaseDiscoveryView.propTypes = {
   handleRowClick: PropTypes.func,
   initialActiveColumns: PropTypes.arrayOf(PropTypes.string),
   protectedColumns: PropTypes.arrayOf(PropTypes.string),
+  rowClassName: PropTypes.string,
+  rowHeight: PropTypes.number,
 };
 
 export default BaseDiscoveryView;

--- a/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/BaseDiscoveryView.jsx
@@ -31,7 +31,7 @@ class BaseDiscoveryView extends React.Component {
         initialActiveColumns={initialActiveColumns}
         onRowClick={handleRowClick}
         protectedColumns={protectedColumns}
-        rowClassName={cx(rowClassName, cs.tableDataRow)}
+        rowClassName={cx(cs.tableDataRow, rowClassName)}
         sortable
       />
     );

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -608,6 +608,7 @@ class DiscoveryView extends React.Component {
     const { mapSidebarTab } = this.state;
     this.setState(
       {
+        currentDisplay: "table",
         currentTab: "samples",
         mapSidebarTab: mapSidebarTab === "summary" ? mapSidebarTab : "samples",
         project,
@@ -615,6 +616,7 @@ class DiscoveryView extends React.Component {
         search: null,
       },
       () => {
+        this.clearMapPreview();
         this.updateBrowsingHistory();
         this.refreshDataFromProjectChange();
       }

--- a/app/assets/src/components/views/discovery/discovery_view.scss
+++ b/app/assets/src/components/views/discovery/discovery_view.scss
@@ -34,7 +34,7 @@
         display: flex;
         flex-direction: column;
         flex: 1 1 auto;
-        padding: 16px 0 0 0;
+        padding-top: 11px;
       }
     }
 

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -374,10 +374,12 @@ export default class MapPreviewSidebar extends React.Component {
     return (
       <BaseDiscoveryView
         columns={this.projectColumns}
-        initialActiveColumns={["project", "number_of_samples"]}
-        protectedColumns={["project"]}
         data={data}
         handleRowClick={this.handleProjectRowClick}
+        initialActiveColumns={["project", "number_of_samples"]}
+        protectedColumns={["project"]}
+        rowClassName={cs.projectRow}
+        rowHeight={50}
       />
     );
   };

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -267,7 +267,7 @@ export default class MapPreviewSidebar extends React.Component {
     const count = (tab === "samples" ? samples : projects || []).length;
     return [
       {
-        label: "Summary",
+        label: <span className={cs.tabLabel}>Summary</span>,
         value: "summary",
       },
       {

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -38,6 +38,7 @@ export default class MapPreviewSidebar extends React.Component {
         flexGrow: 1,
         width: 150,
         cellRenderer: cellData => TableRenderers.renderSample(cellData, false),
+        className: cs.sample,
         headerClassName: cs.sampleHeader,
       },
       {
@@ -158,6 +159,7 @@ export default class MapPreviewSidebar extends React.Component {
             )
           ),
         headerClassName: cs.projectHeader,
+        className: cs.project,
         sortFunction: p => (p.name || "").toLowerCase(),
       },
       {
@@ -309,6 +311,7 @@ export default class MapPreviewSidebar extends React.Component {
             ref={infiniteTable => (this.infiniteTable = infiniteTable)}
             rowClassName={cs.sampleRow}
             rowCount={batchSize}
+            selectableColumnClassName={cs.selectColumn}
             selectableKey="id"
             selectAllChecked={selectAllChecked}
             selected={selectedSampleIds}

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -298,6 +298,7 @@ export default class MapPreviewSidebar extends React.Component {
           <InfiniteTable
             columns={this.sampleColumns}
             defaultRowHeight={rowHeight}
+            headerClassName={cs.tableHeader}
             initialActiveColumns={["sample"]}
             minimumBatchSize={batchSize}
             onLoadRows={this.handleLoadSampleRows}
@@ -306,7 +307,7 @@ export default class MapPreviewSidebar extends React.Component {
             onSelectRow={this.handleSelectRow}
             protectedColumns={["sample"]}
             ref={infiniteTable => (this.infiniteTable = infiniteTable)}
-            rowClassName={cs.tableDataRow}
+            rowClassName={cs.sampleRow}
             rowCount={batchSize}
             selectableKey="id"
             selectAllChecked={selectAllChecked}
@@ -378,6 +379,7 @@ export default class MapPreviewSidebar extends React.Component {
         handleRowClick={this.handleProjectRowClick}
         initialActiveColumns={["project", "number_of_samples"]}
         protectedColumns={["project"]}
+        headerClassName={cs.tableHeader}
         rowClassName={cs.projectRow}
         rowHeight={50}
       />

--- a/app/assets/src/components/views/discovery/mapping/base_map.scss
+++ b/app/assets/src/components/views/discovery/mapping/base_map.scss
@@ -1,4 +1,5 @@
 @import url("https://api.tiles.mapbox.com/mapbox-gl-js/v0.42.0/mapbox-gl.css");
+@import "~styles/themes/elements";
 
 .mapContainer {
   display: block;
@@ -10,9 +11,9 @@
     position: absolute;
     bottom: 50px;
     right: 15px;
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+    box-shadow: $box-shadow-dropdown-menu;
 
-    button {
+    :global(.mapboxgl-ctrl-icon) {
       width: 25px;
       height: 25px;
 

--- a/app/assets/src/components/views/discovery/mapping/base_map.scss
+++ b/app/assets/src/components/views/discovery/mapping/base_map.scss
@@ -10,8 +10,12 @@
     position: absolute;
     bottom: 50px;
     right: 15px;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
 
     button {
+      width: 25px;
+      height: 25px;
+
       &:focus {
         // Override materialize.css
         background-color: transparent !important;
@@ -20,6 +24,6 @@
   }
 
   :global(.mapboxgl-ctrl-attrib) {
-    right: 8px;
+    right: 5px;
   }
 }

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -81,7 +81,7 @@
 
 .projectRow {
   margin-left: 0;
-  padding: 6px 0;
+  padding: 5px 0;
 
   :global(.ReactVirtualized) {
     &__Table {

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -56,19 +56,11 @@
   padding: 10px 0;
   margin-left: 0;
 
-  .tableHeader {
+  .sample,
+  .tableHeader,
+  .selectColumn {
     margin-left: 0;
-  }
-
-  // Override defaults
-  &:global(.ReactVirtualized),
-  :global(.ReactVirtualized) {
-    &__Table {
-      &__rowColumn {
-        margin-left: 0;
-        margin-right: 5px;
-      }
-    }
+    margin-right: 5px;
   }
 }
 
@@ -87,12 +79,8 @@
   margin-left: 0;
   padding: 5px 0;
 
-  :global(.ReactVirtualized) {
-    &__Table {
-      &__rowColumn {
-        margin-left: 5px;
-        margin-right: 5px;
-      }
-    }
+  .project {
+    margin-left: 5px;
+    margin-right: 5px;
   }
 }

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -27,7 +27,7 @@
   }
 
   .tabs {
-    margin: 15px 10px;
+    margin: 15px 10px 5px;
 
     .tabLabel {
       @include font-header-xs;

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -52,16 +52,13 @@
   margin-left: 0;
 
   // Override defaults
-  &:global(.ReactVirtualized) {
+  &:global(.ReactVirtualized),
+  :global(.ReactVirtualized) {
     &__Table {
       &__headerRow {
         padding: 5px 0;
       }
-    }
-  }
 
-  :global(.ReactVirtualized) {
-    &__Table {
       &__rowColumn,
       &__headerColumn {
         margin-left: 0;

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -46,7 +46,11 @@
   }
 }
 
-.tableDataRow {
+.tableHeader {
+  padding: 5px 0;
+}
+
+.sampleRow {
   align-items: flex-start;
   padding: 10px 0;
   margin-left: 0;
@@ -55,10 +59,6 @@
   &:global(.ReactVirtualized),
   :global(.ReactVirtualized) {
     &__Table {
-      &__headerRow {
-        padding: 5px 0;
-      }
-
       &__rowColumn,
       &__headerColumn {
         margin-left: 0;

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -30,7 +30,7 @@
     margin: 15px 10px;
 
     .tabLabel {
-      font-size: $font-size-h6;
+      @include font-header-xs;
       margin-right: 10px;
     }
 
@@ -49,6 +49,13 @@
 .tableDataRow {
   align-items: flex-start;
   padding: 11px 0;
+  margin-left: 0;
+
+  // Override defaults
+  :global(.ReactVirtualized__Table__rowColumn),
+  :global(.ReactVirtualized__Table__headerColumn) {
+    margin-left: 0;
+  }
 }
 
 .basicCell {

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -48,6 +48,7 @@
 
 .tableHeader {
   padding: 5px 0;
+  margin-left: 0;
 }
 
 .sampleRow {
@@ -55,12 +56,15 @@
   padding: 10px 0;
   margin-left: 0;
 
+  .tableHeader {
+    margin-left: 0;
+  }
+
   // Override defaults
   &:global(.ReactVirtualized),
   :global(.ReactVirtualized) {
     &__Table {
-      &__rowColumn,
-      &__headerColumn {
+      &__rowColumn {
         margin-left: 0;
         margin-right: 5px;
       }
@@ -85,8 +89,7 @@
 
   :global(.ReactVirtualized) {
     &__Table {
-      &__rowColumn,
-      &__headerColumn {
+      &__rowColumn {
         margin-left: 5px;
         margin-right: 5px;
       }

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -81,3 +81,18 @@
 .projectHeader {
   text-align: left;
 }
+
+.projectRow {
+  margin-left: 0;
+  padding: 6px 0;
+
+  :global(.ReactVirtualized) {
+    &__Table {
+      &__rowColumn,
+      &__headerColumn {
+        margin-left: 5px;
+        margin-right: 5px;
+      }
+    }
+  }
+}

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -48,13 +48,26 @@
 
 .tableDataRow {
   align-items: flex-start;
-  padding: 11px 0;
+  padding: 10px 0;
   margin-left: 0;
 
   // Override defaults
-  :global(.ReactVirtualized__Table__rowColumn),
-  :global(.ReactVirtualized__Table__headerColumn) {
-    margin-left: 0;
+  &:global(.ReactVirtualized) {
+    &__Table {
+      &__headerRow {
+        padding: 5px 0;
+      }
+    }
+  }
+
+  :global(.ReactVirtualized) {
+    &__Table {
+      &__rowColumn,
+      &__headerColumn {
+        margin-left: 0;
+        margin-right: 5px;
+      }
+    }
   }
 }
 

--- a/app/assets/src/components/views/discovery/mapping/map_tooltip.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_tooltip.scss
@@ -41,10 +41,10 @@ $tooltip-tip-size: 8px;
     }
 
     .content {
-      padding: 15px;
+      padding: 12px;
 
       .title {
-        @include font-header-s;
+        @include font-header-xs;
 
         &.hoverable {
           &:hover {
@@ -54,7 +54,7 @@ $tooltip-tip-size: 8px;
       }
 
       .body {
-        @include font-body-s;
+        @include font-body-xs;
       }
     }
   }

--- a/app/assets/src/components/views/projects/projects_view.scss
+++ b/app/assets/src/components/views/projects/projects_view.scss
@@ -1,3 +1,4 @@
+@import "~styles/themes/colors";
 @import "~styles/themes/elements";
 
 .projectHeader {
@@ -18,5 +19,6 @@
     flex: 1 0 auto;
     display: flex;
     flex-direction: column;
+    border-top: 2px solid $lightest-grey;
   }
 }

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -79,7 +79,9 @@
       .icon {
         fill: $light-grey;
         flex: 0 0 auto;
-        width: 22px;
+        height: 21px;
+        width: 21px;
+        vertical-align: middle;
 
         &:not(.disabled) {
           cursor: pointer;
@@ -87,13 +89,11 @@
         }
 
         &.save {
-          margin-top: 1px;
           width: 21px;
         }
 
         &.heatmap {
           margin-left: 4px;
-          margin-top: 1px;
         }
 
         &.download {

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -38,7 +38,7 @@
 .samplesToolbar {
   display: flex;
   align-items: center;
-  margin-bottom: 12px;
+  margin-bottom: 11px;
 
   .fluidBlank {
     flex: 1 1 auto;
@@ -62,7 +62,7 @@
 
   .separator {
     flex: 0 0 auto;
-    height: 100%;
+    height: 27px;
     margin: 0 20px;
     border-right: 1px solid $medium-grey;
   }

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -15,6 +15,10 @@
     flex-direction: column;
   }
 
+  .map {
+    border-top: 2px solid $lightest-grey;
+  }
+
   .note {
     flex: 0 0 auto;
   }

--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -145,10 +145,11 @@ class BaseTable extends React.Component {
       defaultHeaderHeight,
       defaultRowHeight,
       defaultSelectColumnWidth,
+      forwardRef,
+      headerClassName,
       initialActiveColumns,
       onRowClick,
       onRowsRendered,
-      forwardRef,
       onSort,
       rowClassName,
       rowCount,
@@ -169,7 +170,7 @@ class BaseTable extends React.Component {
           {({ width, height }) => (
             <VirtualizedTable
               gridClassName={cs.grid}
-              headerClassName={cs.header}
+              headerClassName={cx(cs.header, headerClassName)}
               headerHeight={defaultHeaderHeight}
               height={height}
               onRowsRendered={onRowsRendered}
@@ -263,6 +264,7 @@ BaseTable.propTypes = {
   defaultHeaderHeight: PropTypes.number,
   defaultRowHeight: PropTypes.number,
   defaultSelectColumnWidth: PropTypes.number,
+  headerClassName: PropTypes.string,
   // Set of dataKeys of columns to be shown by default
   initialActiveColumns: PropTypes.arrayOf(PropTypes.string),
   onRowClick: PropTypes.func,

--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -155,6 +155,7 @@ class BaseTable extends React.Component {
       rowCount,
       rowGetter,
       rowRenderer,
+      selectableColumnClassName,
       selectableKey,
       sortable,
       sortBy,
@@ -193,7 +194,7 @@ class BaseTable extends React.Component {
             >
               {selectableKey && (
                 <Column
-                  className={cs.selectableColumn}
+                  className={selectableColumnClassName}
                   dataKey={selectableKey}
                   headerRenderer={this.renderSelectableHeader}
                   cellRenderer={this.renderSelectableCell}
@@ -283,6 +284,7 @@ BaseTable.propTypes = {
   sortBy: PropTypes.string,
   sortDirection: PropTypes.string,
 
+  selectableColumnClassName: PropTypes.string,
   // make the table selectable, by setting a selectable key
   // the tables will check for the selectable key in the selected set/array
   selectableKey: PropTypes.string,

--- a/app/assets/src/styles/themes/_typography.scss
+++ b/app/assets/src/styles/themes/_typography.scss
@@ -65,7 +65,7 @@ $font-weight-heavy: 800;
 @mixin font-header-xs {
   font-size: 13px;
   line-height: 20px;
-  font-weight: 600;
+  font-weight: $font-weight-semibold;
   letter-spacing: 0.3px;
 }
 

--- a/app/views/phylo_trees/index.html.erb
+++ b/app/views/phylo_trees/index.html.erb
@@ -5,6 +5,7 @@
       taxon: JSON.parse('<%= raw escape_json(@taxon) %>'),
       phyloTrees: JSON.parse('<%= raw escape_json(@phylo_trees) %>'),
       allowedFeatures: JSON.parse('<%= raw escape_json(@current_user.allowed_feature_list) %>'),
-    }, 'PhyloTreeListView_page');
+    }, 'PhyloTreeListView_page',
+    JSON.parse('<%= raw escape_json(request_context)%>'));
   <% end %>
 </div>


### PR DESCRIPTION
### Description
- See full list here: https://jira.czi.team/browse/IDSEQ-1075
- Assorted design fixes according to mock here: https://chanzuckerberg.invisionapp.com/d/main#/console/17624454/365364533/preview
- Tighten up map sidebar styles for the sample/project rows
- Adjust styles of the tables, map controls, tooltips, and font sizes.
- Last change is adding RequestContext to PhyloTreeListView (so that it can be properly loaded for its metadata sidebar). Last one!
- Also change it so that in the MapPreviewSidebar, when you select a project, it'll exit the map view and exit preview mode to take you to the whole samples list.

### Demo
![Screen Shot 2019-06-18 at 6 28 13 PM](https://user-images.githubusercontent.com/5652739/59730402-16fade00-91f7-11e9-8988-580c7f024a10.png)
![Screen Shot 2019-06-18 at 6 28 20 PM](https://user-images.githubusercontent.com/5652739/59730409-19f5ce80-91f7-11e9-9d6c-aac731ba102e.png)
![Screen Shot 2019-06-18 at 6 30 19 PM](https://user-images.githubusercontent.com/5652739/59730424-29751780-91f7-11e9-867a-ac95d146c043.png)

### Tests
- Go to the data discovery views, go to the map, select locations, observe the updated visual styles above.