### PR TITLE
[Locations] Add smarter name-shortening before saving

### DIFF
--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -31,7 +31,7 @@ module LocationHelper
 
   def self.truncate_name(name)
     # Shorten long names so they look a little better downstream (e.g. in dropdown filters). Try to take the first 2 + last 2 parts, or just the first + last 2 parts.
-    max_chars = 30
+    max_chars = Location::DEFAULT_MAX_NAME_LENGTH
     if name.size > max_chars
       parts = name.split(", ")
       if parts.size >= 4

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -40,7 +40,7 @@ module LocationHelper
     name.gsub(%r{[;%_^<>\/?\\]}, "")
   end
 
-  # Note: Use Location#shorten_name on the object for a shorter name before saving.
+  # TODO(jsheu): Remove this if the name shortening in adapt_location_iq_response is sufficient.
   def self.truncate_name(name)
     # Shorten long names so they look a little better downstream (e.g. in dropdown filters). Try to take the first 2 + last 2 parts, or just the first + last 2 parts.
     max_chars = Location::DEFAULT_MAX_NAME_LENGTH

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -5,7 +5,7 @@ module LocationHelper
     geo_level = ["city", "county", "state", "country"].each do |n|
       break n if address[n]
     end || ""
-    {
+    loc = {
       name: body["display_name"],
       geo_level: geo_level,
       country_name: address["country"] || "",
@@ -22,6 +22,7 @@ module LocationHelper
       osm_type: body["osm_type"],
       locationiq_id: body["place_id"].to_i
     }
+    Location.shorten_name(loc)
   end
 
   # Light sanitization with SQL/HTML/JS injections in mind
@@ -29,6 +30,7 @@ module LocationHelper
     name.gsub(%r{[;%_^<>\/?\\]}, "")
   end
 
+  # Note: Use Location#shorten_name on the object for a shorter name before saving.
   def self.truncate_name(name)
     # Shorten long names so they look a little better downstream (e.g. in dropdown filters). Try to take the first 2 + last 2 parts, or just the first + last 2 parts.
     max_chars = Location::DEFAULT_MAX_NAME_LENGTH

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -28,7 +28,7 @@ module LocationHelper
       # The first field in the address response may have a useful place name like 'university'
       parts = [address.first[1]]
       fields = [:city_name, :subdivision_name, :state_name, :country_name]
-      parts += fields.map { |f| loc[f] if loc[f].present? }
+      parts += fields.map { |f| loc[f] if loc[f].present? }.compact
       loc[:name] = parts.uniq.join(", ")
     end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -96,16 +96,4 @@ class Location < ApplicationRecord
 
     location
   end
-
-  # Shorten to just City, Subdivision, State, Country if the name is long.
-  # Note this will work on ActiveRecord objects and hashes.
-  def self.shorten_name(location)
-    if location[:name].present? && location[:name].size > DEFAULT_MAX_NAME_LENGTH
-      fields = [:city_name, :subdivision_name, :state_name, :country_name]
-      parts = fields.map {|f| location[f] if location[f].present? }
-      location[:name] = parts.join(", ")
-    end
-    # No 'save' here so make sure the caller saves ActiveRecord objects.
-    location
-  end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -13,6 +13,7 @@ class Location < ApplicationRecord
     :lat,
     :lng
   ].freeze
+  DEFAULT_MAX_NAME_LENGTH = 30
 
   # Base request to LocationIQ API
   def self.location_api_request(endpoint_query)
@@ -94,5 +95,13 @@ class Location < ApplicationRecord
     end
 
     location
+  end
+
+  def self.shorten_name(location)
+    if location.name.size > DEFAULT_MAX_NAME_LENGTH
+      puts "long"
+    end
+
+    # No 'save' here so make sure the caller saves.
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -97,11 +97,15 @@ class Location < ApplicationRecord
     location
   end
 
+  # Shorten to just City, Subdivision, State, Country if the name is long.
+  # Note this will work on ActiveRecord objects and hashes.
   def self.shorten_name(location)
-    if location.name.size > DEFAULT_MAX_NAME_LENGTH
-      puts "long"
+    if location[:name].present? && location[:name].size > DEFAULT_MAX_NAME_LENGTH
+      fields = [:city_name, :subdivision_name, :state_name, :country_name]
+      parts = fields.map {|f| location[f] if location[f].present? }
+      location[:name] = parts.join(", ")
     end
-
-    # No 'save' here so make sure the caller saves.
+    # No 'save' here so make sure the caller saves ActiveRecord objects.
+    location
   end
 end

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -130,7 +130,6 @@ class Metadatum < ApplicationRecord
     # trusting user input, we'll potentially re-fetch location details based on the API and OSM IDs.
     location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
     location = Location.check_and_restrict_specificity(location, sample.host_genome_name)
-    location = Location.shorten_name(location)
     location.save!
 
     # At this point, discard raw_value (too long to store anyway)

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -130,6 +130,7 @@ class Metadatum < ApplicationRecord
     # trusting user input, we'll potentially re-fetch location details based on the API and OSM IDs.
     location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
     location = Location.check_and_restrict_specificity(location, sample.host_genome_name)
+    location = Location.shorten_name(location)
     location.save!
 
     # At this point, discard raw_value (too long to store anyway)

--- a/spec/helpers/location_helper_spec.rb
+++ b/spec/helpers/location_helper_spec.rb
@@ -1,6 +1,8 @@
 # See deprecated test/helpers/location_helper_test.rb
 
 require "rails_helper"
+require_relative "../../test/test_helpers/location_test_helper.rb"
+include LocationTestHelper
 
 RSpec.describe LocationHelper, type: :helper do
   describe "#sanitize_name" do
@@ -79,5 +81,15 @@ RSpec.describe LocationHelper, type: :helper do
 
   describe "#filter_by_name" do
     pending "add test for filtering by location names (with Factories)"
+  end
+
+  describe "#adapt_location_iq_response" do
+    it "formats a response for a short city name without subdivision" do
+      expected = LocationTestHelper::FORMATTED_GEOSEARCH_DHAKA_RESPONSE[0].symbolize_keys
+      puts expected
+      result = LocationHelper.adapt_location_iq_response(LocationTestHelper::API_GEOSEARCH_DHAKA_RESPONSE[0])
+      puts "actual: ", result
+      expect(result).to eq(expected)
+    end
   end
 end

--- a/spec/helpers/location_helper_spec.rb
+++ b/spec/helpers/location_helper_spec.rb
@@ -84,11 +84,15 @@ RSpec.describe LocationHelper, type: :helper do
   end
 
   describe "#adapt_location_iq_response" do
-    it "formats a response for a short city name without subdivision" do
+    it "formats a response for a city name without subdivision" do
       expected = LocationTestHelper::FORMATTED_GEOSEARCH_DHAKA_RESPONSE[0].symbolize_keys
-      puts expected
       result = LocationHelper.adapt_location_iq_response(LocationTestHelper::API_GEOSEARCH_DHAKA_RESPONSE[0])
-      puts "actual: ", result
+      expect(result).to eq(expected)
+    end
+
+    it "formats a response for a short country name without truncation" do
+      expected = LocationTestHelper::FORMATTED_GEOSEARCH_UGANDA_RESPONSE[0].symbolize_keys
+      result = LocationHelper.adapt_location_iq_response(LocationTestHelper::API_GEOSEARCH_UGANDA_RESPONSE[0])
       expect(result).to eq(expected)
     end
   end

--- a/test/test_helpers/location_test_helper.rb
+++ b/test/test_helpers/location_test_helper.rb
@@ -9,6 +9,7 @@ module LocationTestHelper
       "lon" => -122.45,
       "display_name" => "University of California, San Francisco, Parnassus Avenue, Inner Sunset, San Francisco, San Francisco City and County, California, 94131, USA",
       "address" => {
+        "university" => "University of California, San Francisco",
         "city" => "San Francisco",
         "county" => "San Francisco City and County",
         "state" => "California",
@@ -21,7 +22,7 @@ module LocationTestHelper
 
   FORMATTED_GEOSEARCH_RESPONSE = [
     {
-      "name" => "University of California, San Francisco, Parnassus Avenue, Inner Sunset, San Francisco, San Francisco City and County, California, 94131, USA",
+      "name" => "University of California, San Francisco, San Francisco, San Francisco City and County, California, USA",
       "geo_level" => "city",
       "country_name" => "USA",
       "state_name" => "California",

--- a/test/test_helpers/location_test_helper.rb
+++ b/test/test_helpers/location_test_helper.rb
@@ -69,4 +69,37 @@ module LocationTestHelper
       }
     }
   ].freeze
+  API_GEOSEARCH_DHAKA_RESPONSE = [
+    {
+      "place_id" => "46003496",
+      "osm_type" => "node",
+      "osm_id" => "3442474911",
+      "lat" => 23.76,
+      # LocationIQ uses 'lon'
+      "lon" => 90.38,
+      "display_name" => "Dhaka, Dhaka Division, 12, Bangladesh",
+      "address" => {
+        "city" => "Dhaka",
+        "state" => "Dhaka Division",
+        "country" => "Bangladesh",
+        "country_code" => "bd"
+      }
+    }
+  ].freeze
+  FORMATTED_GEOSEARCH_DHAKA_RESPONSE = [
+    {
+      "name" => "Dhaka, Dhaka Division, Bangladesh",
+      "geo_level" => "city",
+      "country_name" => "Bangladesh",
+      "state_name" => "Dhaka Division",
+      "subdivision_name" => "",
+      "city_name" => "Dhaka",
+      "lat" => 23.76,
+      "lng" => 90.38,
+      "country_code" => "bd",
+      "osm_id" => 3_442_474_911,
+      "osm_type" => "node",
+      "locationiq_id" => 46_003_496
+    }
+  ].freeze
 end

--- a/test/test_helpers/location_test_helper.rb
+++ b/test/test_helpers/location_test_helper.rb
@@ -75,7 +75,6 @@ module LocationTestHelper
       "osm_type" => "node",
       "osm_id" => "3442474911",
       "lat" => 23.76,
-      # LocationIQ uses 'lon'
       "lon" => 90.38,
       "display_name" => "Dhaka, Dhaka Division, 12, Bangladesh",
       "address" => {
@@ -100,6 +99,36 @@ module LocationTestHelper
       "osm_id" => 3_442_474_911,
       "osm_type" => "node",
       "locationiq_id" => 46_003_496
+    }
+  ].freeze
+  API_GEOSEARCH_UGANDA_RESPONSE = [
+    {
+      "place_id" => "214342685",
+      "osm_type" => "relation",
+      "osm_id" => "192796",
+      "lat" => 1.53,
+      "lon" => 32.22,
+      "display_name" => "Uganda",
+      "address" => {
+        "country" => "Uganda",
+        "country_code" => "ug"
+      }
+    }
+  ].freeze
+  FORMATTED_GEOSEARCH_UGANDA_RESPONSE = [
+    {
+      "name" => "Uganda",
+      "geo_level" => "country",
+      "country_name" => "Uganda",
+      "state_name" => "",
+      "subdivision_name" => "",
+      "city_name" => "",
+      "lat" => 1.53,
+      "lng" => 32.22,
+      "country_code" => "ug",
+      "osm_id" => 192_796,
+      "osm_type" => "relation",
+      "locationiq_id" => 214_342_685
     }
   ].freeze
 end


### PR DESCRIPTION
# Description

- We get some really long display_names from the provider, so we can just save the first address field (sometimes a place name or a special categorization like 'university') and the city/subdivision/state/country.

# Notes

- Before: "Chania, Chania Municipality, Chania Regional Unit, Region of Crete, Crete, 73135, Greece"
- After: "Chania, Chania Municipality, Crete, Greece"

- Before: "University of California, San Francisco, Parnassus Avenue, Inner Sunset, San Francisco, San Francisco City and County, California, 94131, USA"
- After: "University of California, San Francisco, San Francisco, San Francisco City and County, California, USA"

# Tests
- See tests.