### PR TITLE
[Maps] Add more analytics tracking

### DIFF
--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -33,29 +33,29 @@ class DiscoveryMap extends React.Component {
     logAnalyticsEvent("DiscoveryMap_marker_clicked", { locationId });
   };
 
-  handleMarkerMouseEnter = hoverInfo => {
+  handleMarkerMouseEnter = locationInfo => {
     const { currentTab } = this.props;
 
     // ex: samples -> Sample
     const noun = upperFirst(currentTab).slice(0, -1);
-    const title = `${hoverInfo.pointCount} ${noun}${
-      hoverInfo.pointCount > 1 ? "s" : ""
+    const title = `${locationInfo.pointCount} ${noun}${
+      locationInfo.pointCount > 1 ? "s" : ""
     }`;
     const tooltip = (
       <MapTooltip
-        lat={hoverInfo.lat}
-        lng={hoverInfo.lng}
+        lat={locationInfo.lat}
+        lng={locationInfo.lng}
         title={title}
-        body={hoverInfo.name}
+        body={locationInfo.name}
         onMouseEnter={this.handleTooltipMouseEnter}
         onMouseLeave={this.handleMarkerMouseLeave}
-        onTitleClick={() => this.handleTooltipTitleClick(hoverInfo)}
+        onTitleClick={() => this.handleTooltipTitleClick(locationInfo)}
       />
     );
     this.setState({ tooltip, tooltipShouldClose: false });
 
     logAnalyticsEvent("DiscoveryMap_marker_hovered", {
-      locationId: hoverInfo.id,
+      locationId: locationInfo.id,
     });
   };
 
@@ -72,12 +72,12 @@ class DiscoveryMap extends React.Component {
     this.setState({ tooltipShouldClose: false });
   };
 
-  handleTooltipTitleClick = hoverInfo => {
+  handleTooltipTitleClick = locationInfo => {
     const { onTooltipTitleClick } = this.props;
-    onTooltipTitleClick && onTooltipTitleClick(hoverInfo.id);
+    onTooltipTitleClick && onTooltipTitleClick(locationInfo.id);
 
     logAnalyticsEvent("DiscoveryMap_tooltip-title_clicked", {
-      locationId: hoverInfo.id,
+      locationId: locationInfo.id,
     });
   };
 
@@ -87,16 +87,16 @@ class DiscoveryMap extends React.Component {
     logAnalyticsEvent("DiscoveryMap_blank-area_clicked");
   };
 
-  renderMarker = markerData => {
+  renderMarker = locationInfo => {
     const { currentTab, previewedLocationId } = this.props;
     const { viewport } = this.state;
-    const id = markerData.id;
-    const name = markerData.name;
-    const lat = parseFloat(markerData.lat);
-    const lng = parseFloat(markerData.lng);
+    const id = locationInfo.id;
+    const name = locationInfo.name;
+    const lat = parseFloat(locationInfo.lat);
+    const lng = parseFloat(locationInfo.lng);
     const idsField = currentTab === "samples" ? "sample_ids" : "project_ids";
-    if (!markerData[idsField]) return;
-    const pointCount = markerData[idsField].length;
+    if (!locationInfo[idsField]) return;
+    const pointCount = locationInfo[idsField].length;
     const minSize = 10;
     // Scale based on the zoom and point count (zoomed-in = higher zoom)
     // Log1.5 of the count looked nice visually for not getting too large with many points.
@@ -106,7 +106,7 @@ class DiscoveryMap extends React.Component {
     );
 
     return (
-      <Marker key={`marker-${markerData.id}`} latitude={lat} longitude={lng}>
+      <Marker key={`marker-${locationInfo.id}`} latitude={lat} longitude={lng}>
         <CircleMarker
           active={id === previewedLocationId}
           size={markerSize}

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -27,12 +27,10 @@ class DiscoveryMap extends React.Component {
     logAnalyticsEvent("DiscoveryMap_viewport_updated");
   };
 
-  handleMarkerClick = id => {
+  handleMarkerClick = locationId => {
     const { onMarkerClick } = this.props;
-    onMarkerClick && onMarkerClick(id);
-    logAnalyticsEvent("DiscoveryMap_marker_clicked", {
-      locationId: id,
-    });
+    onMarkerClick && onMarkerClick(locationId);
+    logAnalyticsEvent("DiscoveryMap_marker_clicked", { locationId });
   };
 
   handleMarkerMouseEnter = hoverInfo => {

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -250,6 +250,12 @@ export default class MapPreviewSidebar extends React.Component {
     logAnalyticsEvent("MapPreviewSidebar_select-all-rows_clicked");
   };
 
+  handleTabChange = tab => {
+    const { onTabChange } = this.props;
+    onTabChange && onTabChange(tab);
+    logAnalyticsEvent("MapPreviewSidebar_tab_clicked", { tab });
+  };
+
   setSelectedSampleIds = selectedSampleIds => {
     const { onSelectionUpdate } = this.props;
     this.setState({ selectedSampleIds });
@@ -388,13 +394,13 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   render() {
-    const { className, currentTab, onTabChange } = this.props;
+    const { className, currentTab } = this.props;
     return (
       <div className={cx(className, cs.sidebar)}>
         <Tabs
           className={cs.tabs}
           hideBorder
-          onChange={onTabChange}
+          onChange={this.handleTabChange}
           tabs={this.computeTabs()}
           value={currentTab}
         />


### PR DESCRIPTION
# Description
- This adds more analytics tracking to the main map interactions. If you see more actions you think are missing, let me know.

# Tests
- Open up the map, click around to trigger these event handlers. See events in the Segment debugger (e.g. using staging key).