### PR TITLE
Additional information for pipeline viz endpoint

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -969,7 +969,6 @@ class SamplesController < ApplicationController
   end
 
   # GET /samples/:id/stage_results
-  # GET /samples/:id/stage_results.json
   def stage_results
     pipeline_run = @sample.first_pipeline_run
     feature_allowed = current_user.allowed_feature_list.include?("pipeline_viz")
@@ -977,7 +976,7 @@ class SamplesController < ApplicationController
       stage_info = {}
       pipeline_run.pipeline_run_stages.each do |stage|
         if stage.name != "Experimental" || current_user.admin?
-          stage_info[stage.name] = stage.dag_json.nil? ? {} : JSON.parse(stage.dag_json)
+          stage_info[stage.name] = JSON.PARSE(stage.dag_json || "{}")
           stage_info[stage.name][:job_status] = stage.job_status
         end
       end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -976,7 +976,7 @@ class SamplesController < ApplicationController
       stage_info = {}
       pipeline_run.pipeline_run_stages.each do |stage|
         if stage.name != "Experimental" || current_user.admin?
-          stage_info[stage.name] = JSON.PARSE(stage.dag_json || "{}")
+          stage_info[stage.name] = JSON.parse(stage.dag_json || "{}")
           stage_info[stage.name][:job_status] = stage.job_status
         end
       end

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -60,6 +60,16 @@ RSpec.describe SamplesController, type: :controller do
         expect(response).to have_http_status 401
       end
     end
+
+    describe "GET pipeline stage results from sample with no pipeline stages" do
+      it "cannot see stage results" do
+        project = create(:public_project)
+        sample = create(:sample, project: project)
+        get :stage_results, params: { id: sample.id }
+
+        expect(response).to have_http_status 404
+      end
+    end
   end
 
   # Non-admin, aka Joe, specific behavior
@@ -115,6 +125,16 @@ RSpec.describe SamplesController, type: :controller do
         expect do
           get :stage_results, params: { id: private_sample.id }
         end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe "GET pipeline stage results from sample with no pipeline stages (nonadmin)" do
+      it "cannot see stage results" do
+        project = create(:project, users: [@joe])
+        sample = create(:sample, project: project)
+        get :stage_results, params: { id: sample.id }
+
+        expect(response).to have_http_status 404
       end
     end
 

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -16,10 +16,13 @@ RSpec.describe SamplesController, type: :controller do
   }]
 
   expected_stage_results = {
-    "Host Filtering" => { key1: "value1" },
-    "GSNAPL/RAPSEARCH alignment" => { key2: "value2" },
-    "Post Processing" => { key3: "value3" },
-    "Experimental" => { key4: "value4" }
+    "pipeline_version" => "1.0",
+    "stages" => {
+      "Host Filtering" => { key1: "value1", job_status: "COMPLETED" },
+      "GSNAPL/RAPSEARCH alignment" => { key2: "value2", job_status: "COMPLETED" },
+      "Post Processing" => { key3: "value3", job_status: "COMPLETED" },
+      "Experimental" => { key4: "value4", job_status: "COMPLETED" }
+    }
   }
 
   # Admin specific behavior
@@ -72,13 +75,13 @@ RSpec.describe SamplesController, type: :controller do
         sample = create(:sample, project: project,
                                  pipeline_runs_data: [{ pipeline_run_stages_data: pipeline_run_stages_data }])
         expected_stage_results_no_experimental = expected_stage_results.clone()
-        expected_stage_results_no_experimental.delete "Experimental"
+        expected_stage_results_no_experimental["stages"].delete "Experimental"
 
         get :stage_results, params: { id: sample.id }
 
         json_response = JSON.parse(response.body)["pipeline_stage_results"]
         expect(json_response).to include_json(expected_stage_results_no_experimental)
-        expect(json_response).not_to include_json(Experimental: { key4: "value4" })
+        expect(json_response["stages"]).not_to include_json(Experimental: { key4: "value4" })
         expect(json_response.keys).to contain_exactly(
           *expected_stage_results_no_experimental.keys
         )
@@ -91,13 +94,13 @@ RSpec.describe SamplesController, type: :controller do
         sample = create(:sample, project: project,
                                  pipeline_runs_data: [{ pipeline_run_stages_data: pipeline_run_stages_data }])
         expected_stage_results_no_experimental = expected_stage_results.clone()
-        expected_stage_results_no_experimental.delete "Experimental"
+        expected_stage_results_no_experimental["stages"].delete "Experimental"
 
         get :stage_results, params: { id: sample.id }
 
         json_response = JSON.parse(response.body)["pipeline_stage_results"]
         expect(json_response).to include_json(expected_stage_results_no_experimental)
-        expect(json_response).not_to include_json(Experimental: { key4: "value4" })
+        expect(json_response["stages"]).not_to include_json(Experimental: { key4: "value4" })
         expect(json_response.keys).to contain_exactly(
           *expected_stage_results_no_experimental.keys
         )

--- a/spec/factories/pipeline_run_stages.rb
+++ b/spec/factories/pipeline_run_stages.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     # Post Processing, Experimental
     step_number { 1 }
     name { "Host Filtering" }
+    job_status { "COMPLETED" }
     dag_json do
       {
         output_dir_s3: "s3:gc/someBucket/samples/theProjectId/theSampleId/results",

--- a/spec/factories/pipeline_runs.rb
+++ b/spec/factories/pipeline_runs.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :pipeline_run, class: PipelineRun do
+    pipeline_version { 1.0 }
+
     transient do
       # Arrays of entries to create for their respective properties:
       # taxon_counts, amr_counts, output_states, pipeline_run_stage

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -11,9 +11,6 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     @sample_human_existing_metadata_joe_project = samples(:sample_human_existing_metadata_joe_project)
     @sample_human_existing_metadata_expired = samples(:sample_human_existing_metadata_expired)
     @deletable_sample = samples(:deletable_sample)
-    @public_pipeline_run_sample = samples(:public_sample_with_pipeline_stages)
-    @public_pipeline_run = pipeline_runs(:public_sample_run_with_pipeline_stages)
-    @private_pipeline_run_sample = samples(:private_sample_with_pipeline_stages)
     @project = projects(:one)
     @user = users(:one)
     @user.authentication_token = 'sdfsdfsdff'
@@ -21,8 +18,6 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     @user_params = { 'user[email]' => @user.email, 'user[password]' => 'password' }
     @user_nonadmin = users(:joe)
     @user_nonadmin_params = { 'user[email]' => @user_nonadmin.email, 'user[password]' => 'password' }
-    @user_pipeline_viz_disabled = users(:admin)
-    @user_pipeline_viz_disabled_params = { 'user[email]' => @user_pipeline_viz_disabled.email, 'user[password]' => 'password' }
   end
 
   test 'should get index' do
@@ -206,54 +201,6 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
       delete sample_url(@deletable_sample)
     end
     assert_redirected_to samples_url
-  end
-
-  test 'admin sees all pipeline stage results' do
-    post user_session_path, params: @user_params
-    get stage_results_sample_url(@public_pipeline_run_sample), as: :json
-    assert_response :success
-
-    results = @response.parsed_body["pipeline_stage_results"]
-    stage_data = results["stages"]
-    assert_equal 4, stage_data.length
-    assert_not_nil stage_data["Experimental"]
-    @public_pipeline_run.pipeline_run_stages.each do |stage|
-      expected = JSON.parse stage.dag_json
-      expected["job_status"] = stage.job_status
-      assert_equal expected, stage_data[stage.name]
-    end
-  end
-
-  test 'joe cannot see pipeline experimental stage results' do
-    post user_session_path, params: @user_nonadmin_params
-    get stage_results_sample_url(@public_pipeline_run_sample), as: :json
-    assert_response :success
-
-    results = @response.parsed_body["pipeline_stage_results"]
-    stage_data = results["stages"]
-    assert_equal 3, stage_data.length
-    @public_pipeline_run.pipeline_run_stages.each do |stage|
-      if stage.name == "Experimental"
-        assert_nil stage_data["Experimental"]
-      else
-        expected = JSON.parse stage.dag_json
-        expected["job_status"] = stage.job_status
-        assert_equal expected, stage_data[stage.name]
-      end
-    end
-  end
-
-  test 'joe cannot fetch pipeline stage results for another user\'s private samples' do
-    post user_session_path, params: @user_nonadmin_params
-    assert_raises(ActiveRecord::RecordNotFound) do
-      get stage_results_sample_url(@private_pipeline_run_sample)
-    end
-  end
-
-  test 'cannot see stage results if pipeline viz flag disabled' do
-    post user_session_path, params: @user_pipeline_viz_disabled_params
-    get stage_results_sample_url(@public_pipeline_run_sample)
-    assert_response 401
   end
 
   test 'joe can fetch metadata for a public sample' do

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -214,10 +214,13 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     results = @response.parsed_body["pipeline_stage_results"]
-    assert_equal 4, results.length
-    assert_not_nil results["Experimental"]
+    stage_data = results["stages"]
+    assert_equal 4, stage_data.length
+    assert_not_nil stage_data["Experimental"]
     @public_pipeline_run.pipeline_run_stages.each do |stage|
-      assert_equal JSON.parse(stage.dag_json), results[stage.name]
+      expected = JSON.parse stage.dag_json
+      expected["job_status"] = stage.job_status
+      assert_equal expected, stage_data[stage.name]
     end
   end
 
@@ -227,12 +230,15 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     results = @response.parsed_body["pipeline_stage_results"]
-    assert_equal 3, results.length
+    stage_data = results["stages"]
+    assert_equal 3, stage_data.length
     @public_pipeline_run.pipeline_run_stages.each do |stage|
       if stage.name == "Experimental"
-        assert_nil results["Experimental"]
+        assert_nil stage_data["Experimental"]
       else
-        assert_equal JSON.parse(stage.dag_json), results[stage.name]
+        expected = JSON.parse stage.dag_json
+        expected["job_status"] = stage.job_status
+        assert_equal expected, stage_data[stage.name]
       end
     end
   end


### PR DESCRIPTION
# Additional information for pipeline viz endpoint

Adds the following information to the `stage_results` endpoint for pipeline visualization:
* Pipeline version
* Job status for each stage

# Notes

* Pipeline version needed for file matching for edges in front end ([see TODO here](https://github.com/chanzuckerberg/idseq-web/pull/2340/files#diff-749f700b60f6b84cf7f1ce76d874bff2R150)) + informing user of variations of pipeline due to version
* Job status for each stage also for front end: knowing which stage to expand initially ([see TODO here](https://github.com/chanzuckerberg/idseq-web/pull/2340/files#diff-749f700b60f6b84cf7f1ce76d874bff2R295))

# Tests

Updated both rails tests and rspec tests that are related to modified endpoint

