### PR TITLE
fix wording about filters

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -1252,7 +1252,9 @@ class PipelineSampleReport extends React.Component {
   render() {
     const filter_stats = `${
       this.state.rows_passing_filters
-    } rows passing filters, out of ${this.state.rows_total} total rows.`;
+    } rows passing the above filters, out of ${
+      this.state.rows_total
+    } total rows.`;
 
     let truncation_stats =
       this.report_details && this.report_details.pipeline_info.truncated
@@ -1267,11 +1269,11 @@ class PipelineSampleReport extends React.Component {
       subsampled_reads &&
       subsampled_reads <
         this.report_details.pipeline_info.adjusted_remaining_reads
-        ? "Randomly subsampled to " +
+        ? "The total was randomly subsampled to " +
           subsampled_reads +
           " out of " +
           this.report_details.pipeline_info.adjusted_remaining_reads +
-          " reads passing filters."
+          " reads passing host and quality filters."
         : "";
     const disable_filter = this.anyFilterSet() ? (
       <span


### PR DESCRIPTION
Following a user request, I realized the wording on the report page is very confusing. The first occurrence of "filters" refers to the threshold controls on the page. The second occurrence refers to the host filtering steps in the pipeline.

Old wording:
![image](https://user-images.githubusercontent.com/16944816/59872184-11fc7280-934e-11e9-86f7-1b14c1b27713.png)
