### PR TITLE
tweak rapsearch concurrency and chunk size for r5d.metal

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -32,9 +32,9 @@ class PipelineRun < ApplicationRecord
                         "paired-end" => "s3://idseq-database/adapter_sequences/illumina_TruSeq3-PE-2_NexteraPE-PE.fasta" }.freeze
 
   GSNAP_CHUNK_SIZE = 60_000
-  RAPSEARCH_CHUNK_SIZE = 20_000
+  RAPSEARCH_CHUNK_SIZE = 80_000
   GSNAP_MAX_CONCURRENT = 2
-  RAPSEARCH_MAX_CONCURRENT = 4
+  RAPSEARCH_MAX_CONCURRENT = 8
   MAX_CHUNKS_IN_FLIGHT = 32
 
   SORTED_TAXID_ANNOTATED_FASTA = 'taxid_annot_sorted_nt.fasta'.freeze


### PR DESCRIPTION
Deploy this on prod ONLY AFTER deploying the matching idseq-infra change.

```
  SERVER      CHUNK     CHUNK           PARALLEL      COST           COST REDUCTION
  TYPE         SIZE     ELAPSED TIME    CHUNKS        (READS         FACTOR (UNITS OF
             (READS)    (SECONDS)       PER SERVER    PER DOLLAR)    1/i3.metal)
  -----------------------------------------------------------------------------

  r5d.metal   80,000       555             8          600,774        4.82

  r5d.metal   40,000       454             8          368,000        2.95

  i3.metal    20,000       463             4          124,655        1.00
```