### PR TITLE
Save Country+State geographical levels on all locations and load them

### DIFF
--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -26,7 +26,6 @@ module LocationHelper
       country_name: address[country_key] || "",
       state_name: address[state_key] || "",
       subdivision_name: address[subdivision_key] || "",
-      # Normalize extra provider fields to city. normalizecity param doesn't work all the time.
       city_name: address[city_key] || "",
       # Round coordinates to enhance privacy
       lat: body["lat"] ? body["lat"].to_f.round(2) : nil,

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -14,6 +14,8 @@ module LocationHelper
                   Location::STATE_LEVEL
                 elsif country_key
                   Location::COUNTRY_LEVEL
+                else
+                  ""
                 end
 
     loc = {

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -92,4 +92,9 @@ module LocationHelper
     samples.where(metadata: { string_validated_value: query })
            .or(samples.where(metadata: { locations: { name: query } }))
   end
+
+  def self.set_parent_ids(location, parent_level_ids)
+    parent_level_ids.each { |level, id| location["#{level}_id"] = id }
+    location
+  end
 end

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -103,13 +103,4 @@ module LocationHelper
     samples.where(metadata: { string_validated_value: query })
            .or(samples.where(metadata: { locations: { name: query } }))
   end
-
-  def self.set_parent_ids(location, parent_level_ids)
-    parent_level_ids.each do |level, id|
-      if Location::GEO_LEVELS.index(level) <= Location::GEO_LEVELS.index(location.geo_level)
-        location["#{level}_id"] = id
-      end
-    end
-    location
-  end
 end

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -94,7 +94,11 @@ module LocationHelper
   end
 
   def self.set_parent_ids(location, parent_level_ids)
-    parent_level_ids.each { |level, id| location["#{level}_id"] = id }
+    parent_level_ids.each do |level, id|
+      if Location::GEO_LEVELS.index(level) <= Location::GEO_LEVELS.index(location.geo_level)
+        location["#{level}_id"] = id
+      end
+    end
     location
   end
 end

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -2,9 +2,12 @@ module LocationHelper
   # Adapter function to munge responses from Location IQ API to our format
   def self.adapt_location_iq_response(body)
     address = body["address"]
-    geo_level = ["city", "county", "state", "country"].each do |n|
+    geo_level = %w[city county state country].each do |n|
       break n if address[n]
     end || ""
+    if geo_level == "county"
+      geo_level = Location::SUBDIVISION_LEVEL
+    end
 
     loc = {
       name: body["display_name"],

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -2,10 +2,12 @@ module LocationHelper
   # Adapter function to munge responses from Location IQ API to our format
   def self.adapt_location_iq_response(body)
     address = body["address"]
+
     country_key = Location::COUNTRY_NAMES.find { |k| address.include?(k) }
     state_key = Location::STATE_NAMES.find { |k| address.include?(k) }
     subdivision_key = Location::SUBDIVISION_NAMES.find { |k| address.include?(k) }
     city_key = Location::CITY_NAMES.find { |k| address.key?(k) }
+
     geo_level = if city_key
                   Location::CITY_LEVEL
                 elsif subdivision_key

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -32,7 +32,7 @@ class Location < ApplicationRecord
     raise "No location API key" unless ENV["LOCATION_IQ_API_KEY"]
 
     query_url = "#{LOCATION_IQ_BASE_URL}/#{endpoint_query}&key=#{ENV['LOCATION_IQ_API_KEY']}&format=json"
-    uri = URI.parse(query_url)
+    uri = URI.parse(URI.escape(query_url))
     request = Net::HTTP::Get.new(uri)
     resp = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
       http.request(request)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -18,6 +18,8 @@ class Location < ApplicationRecord
   COUNTRY_LEVEL = "country".freeze
   STATE_LEVEL = "state".freeze
   SUBDIVISION_LEVEL = "subdivision".freeze
+  CITY_LEVEL = "city".freeze
+  GEO_LEVELS = [COUNTRY_LEVEL, STATE_LEVEL, SUBDIVISION_LEVEL, CITY_LEVEL].freeze
 
   # Base request to LocationIQ API
   def self.location_api_request(endpoint_query)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -147,6 +147,8 @@ class Location < ApplicationRecord
 
     location = set_parent_ids(location, present_parent_level_ids)
     location.save!
+
+    location
   end
 
   # Identify missing Country or State location levels. Even for levels below State, clustering is
@@ -166,6 +168,7 @@ class Location < ApplicationRecord
     )
     present_parents = country_match.or(state_match)
     present_parent_levels = present_parents.pluck(:geo_level)
+
     missing_parent_levels = []
     if !present_parent_levels.include?(COUNTRY_LEVEL) && location.country_name.present?
       missing_parent_levels << COUNTRY_LEVEL

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -154,8 +154,6 @@ class Location < ApplicationRecord
   # Identify missing Country or State location levels. Even for levels below State, clustering is
   # only at Country+State for now.
   def self.present_and_missing_parents(location)
-    return [] if location.geo_level == COUNTRY_LEVEL
-
     # Find if the Country or State level is missing
     country_match = Location.where(
       geo_level: COUNTRY_LEVEL,
@@ -170,7 +168,7 @@ class Location < ApplicationRecord
     present_parent_levels = present_parents.pluck(:geo_level)
 
     missing_parent_levels = []
-    if !present_parent_levels.include?(COUNTRY_LEVEL) && location.country_name.present?
+    if !present_parent_levels.include?(COUNTRY_LEVEL) && location.country_name.present? && location.geo_level != COUNTRY_LEVEL
       missing_parent_levels << COUNTRY_LEVEL
     end
     if !present_parent_levels.include?(STATE_LEVEL) && location.state_name.present? && location.geo_level != STATE_LEVEL

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -104,7 +104,8 @@ class Location < ApplicationRecord
   def self.check_and_fetch_parents(location)
     # Do a fetch for the missing levels
     to_create = []
-    missing_parent_levels(location).each do |level|
+    missing_parents = missing_parent_levels(location)
+    missing_parents.each do |level|
       if level == COUNTRY_LEVEL
         success, resp = geosearch_by_levels(location.country_name)
       else
@@ -144,6 +145,7 @@ class Location < ApplicationRecord
     present_parents = parents.inject(:or).pluck(:geo_level)
 
     missing_parents = [COUNTRY_LEVEL, STATE_LEVEL]
+    missing_parents.delete(location.geo_level)
     missing_parents.delete(COUNTRY_LEVEL) if location.country_name == ""
     missing_parents.delete(STATE_LEVEL) if location.state_name == ""
     missing_parents -= present_parents

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -119,9 +119,11 @@ class Location < ApplicationRecord
       result = LocationHelper.adapt_location_iq_response(resp[0])
       new_location = new_from_params(result)
       new_location.save!
-
+      new_location.update_attribute("#{level}_id", new_location.id)
       location["#{level}_id"] = new_location.id
     end
+
+    # Need to also set the other one's country_id or state_id. Which means doing the country one first.
 
     location["#{location.geo_level}_id"] = location.id
     location.save!

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -168,7 +168,7 @@ class Location < ApplicationRecord
 
     missing_parent_levels = []
     [COUNTRY_LEVEL, STATE_LEVEL].each do |level|
-      if !present_parent_levels.include?(level) && location.country_name.present? && location.geo_level != level
+      if !present_parent_levels.include?(level) && location["#{level}_name"].present? && location.geo_level != level
         missing_parent_levels << level
       end
     end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -17,6 +17,7 @@ class Location < ApplicationRecord
 
   COUNTRY_LEVEL = "country".freeze
   STATE_LEVEL = "state".freeze
+  SUBDIVISION_LEVEL = "subdivision".freeze
 
   # Base request to LocationIQ API
   def self.location_api_request(endpoint_query)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -121,11 +121,12 @@ class Location < ApplicationRecord
       new_location.save!
 
       # Set id fields
-      new_location.update("#{level}_id" => new_location.id)
-      location["#{level}_id"] = new_location.id
+      new_location["#{level}_id"] = new_location.id
       if level == STATE_LEVEL
         new_location.country_id = location.country_id
       end
+      new_location.save!
+      location["#{level}_id"] = new_location.id
     end
 
     location["#{location.geo_level}_id"] = location.id
@@ -133,7 +134,7 @@ class Location < ApplicationRecord
   end
 
   # Identify missing Country or State location levels. Even for levels below State, clustering is
-  # only at State+Country for now.
+  # only at Country+State for now.
   def self.missing_parent_levels(location)
     return [] if location.geo_level == COUNTRY_LEVEL
 
@@ -149,7 +150,7 @@ class Location < ApplicationRecord
     )
     present_parents = country_match.or(state_match).pluck(:geo_level)
     missing_parents = []
-    if !present_parents.include?(COUNTRY_LEVEL) && location.country_name.present? && location.geo_level != COUNTRY_LEVEL
+    if !present_parents.include?(COUNTRY_LEVEL) && location.country_name.present?
       missing_parents << COUNTRY_LEVEL
     end
     if !present_parents.include?(STATE_LEVEL) && location.state_name.present? && location.geo_level != STATE_LEVEL

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -120,6 +120,7 @@ class Location < ApplicationRecord
   # Note: We are clustering at Country+State for now so Subdivision+City ids may be nil.
   def self.check_and_fetch_parents(location)
     present_parent_level_ids, missing_parent_levels = present_and_missing_parents(location)
+    location.save! unless location.id
     present_parent_level_ids[location.geo_level] = location.id
 
     missing_parent_levels.each do |level|
@@ -145,10 +146,7 @@ class Location < ApplicationRecord
       new_location.save!
     end
 
-    location = set_parent_ids(location, present_parent_level_ids)
-    location.save!
-
-    location
+    set_parent_ids(location, present_parent_level_ids)
   end
 
   # Identify missing Country or State location levels. Even for levels below State, clustering is

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -141,11 +141,11 @@ class Location < ApplicationRecord
 
       # Set id fields
       present_parent_level_ids[level] = new_location.id
-      new_location = LocationHelper.set_parent_ids(new_location, present_parent_level_ids)
+      new_location = set_parent_ids(new_location, present_parent_level_ids)
       new_location.save!
     end
 
-    location = LocationHelper.set_parent_ids(location, present_parent_level_ids)
+    location = set_parent_ids(location, present_parent_level_ids)
     location.save!
   end
 
@@ -176,5 +176,14 @@ class Location < ApplicationRecord
 
     present_parent_level_ids = present_parents.map { |p| [p.geo_level, p.id] }.to_h
     [present_parent_level_ids, missing_parent_levels]
+  end
+
+  def self.set_parent_ids(location, parent_level_ids)
+    parent_level_ids.each do |level, id|
+      if Location::GEO_LEVELS.index(level) <= Location::GEO_LEVELS.index(location.geo_level)
+        location["#{level}_id"] = id
+      end
+    end
+    location
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -100,6 +100,10 @@ class Location < ApplicationRecord
   def self.check_and_restrict_specificity(location, host_genome_name)
     # We don't want Human locations with city
     if host_genome_name == "Human" && location.city_name.present?
+      # Return our existing entry if found
+      existing = Location.find_by(country_name: location.country_name, state_name: location.state_name, subdivision_name: location.subdivision_name, city_name: "")
+      return existing if existing
+
       # Redo the search for just the subdivision/state/country
       success, resp = geosearch_by_levels(location.country_name, location.state_name, location.subdivision_name)
       unless success && !resp.empty?

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -21,6 +21,12 @@ class Location < ApplicationRecord
   CITY_LEVEL = "city".freeze
   GEO_LEVELS = [COUNTRY_LEVEL, STATE_LEVEL, SUBDIVISION_LEVEL, CITY_LEVEL].freeze
 
+  # See https://wiki.openstreetmap.org/wiki/Key:place
+  COUNTRY_NAMES = %w[country].freeze
+  STATE_NAMES = %w[state province region].freeze
+  SUBDIVISION_NAMES = %w[county state_district district].freeze
+  CITY_NAMES = %w[city city_distrct locality town borough municipality village hamlet quarter neighbourhood suburb].freeze
+
   # Base request to LocationIQ API
   def self.location_api_request(endpoint_query)
     raise "No location API key" unless ENV["LOCATION_IQ_API_KEY"]

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -103,7 +103,6 @@ class Location < ApplicationRecord
 
   def self.check_and_fetch_parents(location)
     # Do a fetch for the missing levels
-    to_create = []
     missing_parents = missing_parent_levels(location)
     missing_parents.each do |level|
       if level == COUNTRY_LEVEL
@@ -118,10 +117,14 @@ class Location < ApplicationRecord
       end
 
       result = LocationHelper.adapt_location_iq_response(resp[0])
-      to_create << new_from_params(result)
+      new_location = new_from_params(result)
+      new_location.save!
+
+      location["#{level}_id"] = new_location.id
     end
 
-    Location.import! to_create
+    location["#{location.geo_level}_id"] = location.id
+    location.save!
   end
 
   def self.missing_parent_levels(location)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -17,10 +17,6 @@ class Location < ApplicationRecord
 
   COUNTRY_LEVEL = "country".freeze
   STATE_LEVEL = "state".freeze
-  SUBDIVISION_LEVEL = "subdivision".freeze
-  CITY_LEVEL = "city".freeze
-  PLACE_LEVEL = "place".freeze
-  GEO_LEVELS = [PLACE_LEVEL, CITY_LEVEL, SUBDIVISION_LEVEL, STATE_LEVEL, COUNTRY_LEVEL].freeze
 
   # Base request to LocationIQ API
   def self.location_api_request(endpoint_query)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -11,7 +11,11 @@ class Location < ApplicationRecord
     :subdivision_name,
     :city_name,
     :lat,
-    :lng
+    :lng,
+    :country_id,
+    :state_id,
+    :subdivision_id,
+    :city_id
   ].freeze
   DEFAULT_MAX_NAME_LENGTH = 30
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -26,6 +26,7 @@ class Location < ApplicationRecord
   GEO_LEVELS = [COUNTRY_LEVEL, STATE_LEVEL, SUBDIVISION_LEVEL, CITY_LEVEL].freeze
 
   # See https://wiki.openstreetmap.org/wiki/Key:place
+  # Normalize extra provider fields to each of our levels.
   COUNTRY_NAMES = %w[country].freeze
   STATE_NAMES = %w[state province region].freeze
   SUBDIVISION_NAMES = %w[county state_district district].freeze
@@ -166,11 +167,10 @@ class Location < ApplicationRecord
     present_parent_levels = present_parents.pluck(:geo_level)
 
     missing_parent_levels = []
-    if !present_parent_levels.include?(COUNTRY_LEVEL) && location.country_name.present? && location.geo_level != COUNTRY_LEVEL
-      missing_parent_levels << COUNTRY_LEVEL
-    end
-    if !present_parent_levels.include?(STATE_LEVEL) && location.state_name.present? && location.geo_level != STATE_LEVEL
-      missing_parent_levels << STATE_LEVEL
+    [COUNTRY_LEVEL, STATE_LEVEL].each do |level|
+      if !present_parent_levels.include?(level) && location.country_name.present? && location.geo_level != level
+        missing_parent_levels << level
+      end
     end
 
     present_parent_level_ids = present_parents.map { |p| [p.geo_level, p.id] }.to_h

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -141,6 +141,7 @@ class Metadatum < ApplicationRecord
     self.location_id = location.id
   rescue => err
     LogUtil.log_err_and_airbrake("Failed to save location metadatum: #{err.message}")
+    LogUtil.log_backtrace(err)
     errors.add(:raw_value, MetadataValidationErrors::INVALID_LOCATION)
   end
 

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -131,8 +131,8 @@ class Metadatum < ApplicationRecord
     location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
     location = Location.check_and_restrict_specificity(location, sample.host_genome_name)
     unless location.id
+      location = Location.check_and_fetch_parents(location)
       location.save!
-      Location.check_and_fetch_parents(location)
     end
 
     # At this point, discard raw_value (too long to store anyway)

--- a/db/migrate/20190621224648_add_location_level_ids.rb
+++ b/db/migrate/20190621224648_add_location_level_ids.rb
@@ -1,4 +1,15 @@
 class AddLocationLevelIds < ActiveRecord::Migration[5.1]
-  def change
+  def up
+    add_column :locations, :country_id, :integer
+    add_column :locations, :state_id, :integer
+    add_column :locations, :subdivision_id, :integer
+    add_column :locations, :city_id, :integer
+  end
+
+  def down
+    remove_column :locations, :country_id
+    remove_column :locations, :state_id
+    remove_column :locations, :subdivision_id
+    remove_column :locations, :city_id
   end
 end

--- a/db/migrate/20190621224648_add_location_level_ids.rb
+++ b/db/migrate/20190621224648_add_location_level_ids.rb
@@ -1,9 +1,9 @@
 class AddLocationLevelIds < ActiveRecord::Migration[5.1]
   def up
-    add_column :locations, :country_id, :integer
-    add_column :locations, :state_id, :integer
-    add_column :locations, :subdivision_id, :integer
-    add_column :locations, :city_id, :integer
+    add_column :locations, :country_id, :integer, comment: "ID of the country entry in our database"
+    add_column :locations, :state_id, :integer, comment: "ID of the state entry in our database"
+    add_column :locations, :subdivision_id, :integer, comment: "ID of the subdivision entry in our database"
+    add_column :locations, :city_id, :integer, comment: "ID of the city entry in our database"
   end
 
   def down

--- a/db/migrate/20190621224648_add_location_level_ids.rb
+++ b/db/migrate/20190621224648_add_location_level_ids.rb
@@ -1,0 +1,4 @@
+class AddLocationLevelIds < ActiveRecord::Migration[5.1]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -156,6 +156,10 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "osm_type", limit: 10, default: "", null: false, comment: "OpenStreetMap type (Node, Way, or Relation) to use OSM ID"
+    t.integer "country_id", comment: "ID of the country entry in our database"
+    t.integer "state_id", comment: "ID of the state entry in our database"
+    t.integer "subdivision_id", comment: "ID of the subdivision entry in our database"
+    t.integer "city_id", comment: "ID of the city entry in our database"
     t.index ["country_name", "state_name", "subdivision_name", "city_name"], name: "index_locations_levels", comment: "Index for lookup within regions. Composite works for any left subset of columns."
     t.index ["geo_level"], name: "index_locations_on_geo_level", comment: "Index for lookup by level of specificity"
     t.index ["locationiq_id"], name: "index_locations_on_locationiq_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_621_224_648) do
+ActiveRecord::Schema.define(version: 20_190_612_205_949) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20_190_621_224_648) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define(version: 20_190_621_224_648) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 20_190_621_224_648) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type"
+    t.string "source_type", null: false
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -156,10 +156,10 @@ ActiveRecord::Schema.define(version: 20_190_621_224_648) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "osm_type", limit: 10, default: "", null: false, comment: "OpenStreetMap type (Node, Way, or Relation) to use OSM ID"
-    t.integer "country_id"
-    t.integer "state_id"
-    t.integer "subdivision_id"
-    t.integer "city_id"
+    t.integer "country_id", comment: "ID of the country entry in our database"
+    t.integer "state_id", comment: "ID of the state entry in our database"
+    t.integer "subdivision_id", comment: "ID of the subdivision entry in our database"
+    t.integer "city_id", comment: "ID of the city entry in our database"
     t.index ["country_name", "state_name", "subdivision_name", "city_name"], name: "index_locations_levels", comment: "Index for lookup within regions. Composite works for any left subset of columns."
     t.index ["geo_level"], name: "index_locations_on_geo_level", comment: "Index for lookup by level of specificity"
     t.index ["locationiq_id"], name: "index_locations_on_locationiq_id"
@@ -168,7 +168,7 @@ ActiveRecord::Schema.define(version: 20_190_621_224_648) do
   end
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "key", null: false, collation: "latin1_swedish_ci"
+    t.string "key", null: false
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9
@@ -322,7 +322,7 @@ ActiveRecord::Schema.define(version: 20_190_621_224_648) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1, default: 0
+    t.integer "public_access", limit: 1
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -440,15 +440,14 @@ ActiveRecord::Schema.define(version: 20_190_621_224_648) do
     t.integer "family_taxid", default: -300, null: false
     t.integer "is_phage", limit: 1, default: 0, null: false
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
-    t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
   end
 
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
     t.string "title"
-    t.text "summary", limit: 16_777_215
-    t.text "description", limit: 16_777_215
+    t.text "summary"
+    t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -538,11 +537,11 @@ ActiveRecord::Schema.define(version: 20_190_621_224_648) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email"
+    t.string "email", default: "", null: false
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password"
+    t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_612_205_949) do
+ActiveRecord::Schema.define(version: 20_190_621_224_648) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
     t.index ["sample_id"], name: "index_backgrounds_samples_on_sample_id"
   end
 
-  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "contigs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.bigint "pipeline_run_id"
     t.string "name"
     t.text "sequence", limit: 4_294_967_295
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", null: false
+    t.string "name"
     t.text "s3_star_index_path"
     t.text "s3_bowtie2_index_path"
     t.bigint "default_background_id"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type", null: false
+    t.string "source_type"
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -156,6 +156,10 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "osm_type", limit: 10, default: "", null: false, comment: "OpenStreetMap type (Node, Way, or Relation) to use OSM ID"
+    t.integer "country_id"
+    t.integer "state_id"
+    t.integer "subdivision_id"
+    t.integer "city_id"
     t.index ["country_name", "state_name", "subdivision_name", "city_name"], name: "index_locations_levels", comment: "Index for lookup within regions. Composite works for any left subset of columns."
     t.index ["geo_level"], name: "index_locations_on_geo_level", comment: "Index for lookup by level of specificity"
     t.index ["locationiq_id"], name: "index_locations_on_locationiq_id"
@@ -164,7 +168,7 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
   end
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "key", null: false
+    t.string "key", null: false, collation: "latin1_swedish_ci"
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9
@@ -318,7 +322,7 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1
+    t.integer "public_access", limit: 1, default: 0
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.index ["name"], name: "index_projects_on_name", unique: true
@@ -436,14 +440,15 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
     t.integer "family_taxid", default: -300, null: false
     t.integer "is_phage", limit: 1, default: 0, null: false
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
+    t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
   end
 
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
     t.string "title"
-    t.text "summary"
-    t.text "description"
+    t.text "summary", limit: 16_777_215
+    t.text "description", limit: 16_777_215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -533,11 +538,11 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email", default: "", null: false
+    t.string "email"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password", default: "", null: false
+    t.string "encrypted_password"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -156,10 +156,6 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "osm_type", limit: 10, default: "", null: false, comment: "OpenStreetMap type (Node, Way, or Relation) to use OSM ID"
-    t.integer "country_id", comment: "ID of the country entry in our database"
-    t.integer "state_id", comment: "ID of the state entry in our database"
-    t.integer "subdivision_id", comment: "ID of the subdivision entry in our database"
-    t.integer "city_id", comment: "ID of the city entry in our database"
     t.index ["country_name", "state_name", "subdivision_name", "city_name"], name: "index_locations_levels", comment: "Index for lookup within regions. Composite works for any left subset of columns."
     t.index ["geo_level"], name: "index_locations_on_geo_level", comment: "Index for lookup by level of specificity"
     t.index ["locationiq_id"], name: "index_locations_on_locationiq_id"

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -76,7 +76,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     results = JSON.parse(@response.body)
     loc = locations(:swamp)
     actual_object = results[loc.id.to_s]
-    expected_object = { "id" => loc.id, "name" => loc.name, "geo_level" => loc.geo_level, "country_name" => loc.country_name, "state_name" => loc.state_name, "subdivision_name" => loc.subdivision_name, "city_name" => loc.city_name, "lat" => loc.lat.to_s, "lng" => loc.lng.to_s, "sample_ids" => [samples(:joe_project_sample_mosquito).id, samples(:joe_sample).id], "project_ids" => [projects(:joe_project).id] }
+    expected_object = { "id" => loc.id, "name" => loc.name, "geo_level" => loc.geo_level, "country_name" => loc.country_name, "state_name" => loc.state_name, "subdivision_name" => loc.subdivision_name, "city_name" => loc.city_name, "lat" => loc.lat.to_s, "lng" => loc.lng.to_s, "country_id" => nil, "state_id" => nil, "subdivision_id" => nil, "city_id" => nil, "sample_ids" => [samples(:joe_project_sample_mosquito).id, samples(:joe_sample).id], "project_ids" => [projects(:joe_project).id] }
 
     assert_equal actual_object, expected_object
   end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -54,7 +54,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     results = JSON.parse(@response.body)
-    assert_equal 2, results.count
+    assert_equal 3, results.count
     assert_includes @response.body, locations(:swamp).name
   end
 
@@ -79,6 +79,18 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     expected_object = { "id" => loc.id, "name" => loc.name, "geo_level" => loc.geo_level, "country_name" => loc.country_name, "state_name" => loc.state_name, "subdivision_name" => loc.subdivision_name, "city_name" => loc.city_name, "lat" => loc.lat.to_s, "lng" => loc.lng.to_s, "country_id" => nil, "state_id" => nil, "subdivision_id" => nil, "city_id" => nil, "sample_ids" => [samples(:joe_project_sample_mosquito).id, samples(:joe_sample).id], "project_ids" => [projects(:joe_project).id] }
 
     assert_equal actual_object, expected_object
+  end
+
+  test "user can load location data including Country and State parent levels" do
+    post user_session_path, params: @user_params
+    get sample_locations_locations_path, as: :json
+    assert_response :success
+
+    results = JSON.parse(@response.body)
+    loc = locations(:kurigram)
+    assert_includes results.keys, loc.id.to_s
+    assert_includes results.keys, loc.country_id.to_s
+    assert_includes results.keys, loc.state_id.to_s
   end
 
   test "disallowed users cannot access sample_locations" do

--- a/test/controllers/projects_metadata_upload_test.rb
+++ b/test/controllers/projects_metadata_upload_test.rb
@@ -230,6 +230,6 @@ class ProjectsMetadataUploadTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_equal 0, @response.parsed_body['errors'].length
-    assert_equal 3, Metadatum.where(sample_id: @joe_project_sample_a.id).length
+    assert_equal 4, Metadatum.where(sample_id: @joe_project_sample_a.id).length
   end
 end

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -31,3 +31,24 @@ sf_county:
   state_name: "California"
   subdivision_name: "San Francisco City and County"
   locationiq_id: 214379825
+
+bangladesh:
+  name: "Bangladesh"
+  geo_level: "country"
+  country_name: "Bangladesh"
+  locationiq_id: 214341060
+
+rangpur:
+  name: "Rangpur Division, Bangladesh"
+  geo_level: "state"
+  country_name: "Bangladesh"
+  state_name: "Rangpur Division"
+  locationiq_id: 214799782
+
+columbus:
+  name: "Columbus, Franklin County, Ohio, USA"
+  geo_level: "city"
+  country_name: "USA"
+  state_name: "Ohio"
+  subdivision_name: "Franklin County"
+  city_name: "Columbus"

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -34,16 +34,30 @@ sf_county:
 
 bangladesh:
   name: "Bangladesh"
+  id: 2
   geo_level: "country"
   country_name: "Bangladesh"
   locationiq_id: 214341060
 
 rangpur:
   name: "Rangpur Division, Bangladesh"
+  id: 3
   geo_level: "state"
   country_name: "Bangladesh"
   state_name: "Rangpur Division"
   locationiq_id: 214799782
+
+kurigram:
+  name: "Kurigram, Kurigram District, Rangpur Division, Bangladesh"
+  id: 4
+  geo_level: "city"
+  country_name: "Bangladesh"
+  state_name: "Rangpur Division"
+  subdivision_name: "Kurigram District"
+  city_name: "Kurigram"
+  country_id: 2
+  state_id: 3
+  city_id: 4
 
 columbus:
   name: "Columbus, Franklin County, Ohio, USA"

--- a/test/fixtures/metadata.yml
+++ b/test/fixtures/metadata.yml
@@ -85,3 +85,10 @@ sample_human_collection_location_v2:
   metadata_field: collection_location_v2
   location_id: 1
   sample: joe_sample
+
+sample_collection_location_v2_kurigram:
+  key: "collection_location_v2"
+  raw_value: "{\"locationiq_id\":\"123\",\"osm_id\":\"321\",\"osm_type\":\"Way\"}"
+  metadata_field: collection_location_v2
+  location_id: 4
+  sample: joe_project_sampleA

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -130,10 +130,12 @@ class LocationTest < ActiveSupport::TestCase
     api_response = [true, LocationTestHelper::API_GEOSEARCH_SF_COUNTY_RESPONSE]
     mock = MiniTest::Mock.new
     mock.expect(:call, api_response, [bad_location.country_name, bad_location.state_name, bad_location.subdivision_name])
-    Location.stub :geosearch_by_levels, mock do
-      Location.stub :new_from_params, locations(:sf_county) do
-        new_location = Location.check_and_restrict_specificity(bad_location, "Human")
-        assert_equal locations(:sf_county), new_location
+    Location.stub :find_by, nil do
+      Location.stub :geosearch_by_levels, mock do
+        Location.stub :new_from_params, locations(:sf_county) do
+          new_location = Location.check_and_restrict_specificity(bad_location, "Human")
+          assert_equal locations(:sf_county), new_location
+        end
       end
     end
     assert mock.verify

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -215,5 +215,35 @@ class LocationTest < ActiveSupport::TestCase
     present_parent_level_ids, missing_parent_levels = Location.present_and_missing_parents(original)
     assert_equal ["state"], present_parent_level_ids.keys
     assert_equal ["country"], missing_parent_levels
+
+    original = locations(:bangladesh)
+    present_parent_level_ids, missing_parent_levels = Location.present_and_missing_parents(original)
+    assert_equal ["country"], present_parent_level_ids.keys
+    assert_equal [], missing_parent_levels
+
+    original = locations(:columbus)
+    present_parent_level_ids, missing_parent_levels = Location.present_and_missing_parents(original)
+    assert_equal [], present_parent_level_ids.keys
+    assert_equal %w[country state], missing_parent_levels
+  end
+
+  test "should fill in parent ids on a Location" do
+    original = locations(:swamp)
+    parent_level_ids = { "country" => 10, "state" => 20, "subdivision" => 30, "city" => 40 }
+    result = Location.set_parent_ids(original, parent_level_ids)
+    assert_equal 10, result.country_id
+    assert_equal 20, result.state_id
+    assert_equal 30, result.subdivision_id
+    assert_equal 40, result.city_id
+  end
+
+  test "should not fill in a geo level id below a Location's actual level" do
+    original = locations(:california)
+    parent_level_ids = { "country" => 10, "state" => 20, "subdivision" => 30, "city" => 40 }
+    result = Location.set_parent_ids(original, parent_level_ids)
+    assert_equal 10, result.country_id
+    assert_equal 20, result.state_id
+    assert_nil result.subdivision_id
+    assert_nil result.city_id
   end
 end

--- a/test/test_helpers/location_test_helper.rb
+++ b/test/test_helpers/location_test_helper.rb
@@ -85,6 +85,20 @@ module LocationTestHelper
       }
     }
   ].freeze
+  API_GEOSEARCH_USA_RESPONSE = [
+    {
+      "place_id" => "214325471",
+      "osm_type" => "relation",
+      "osm_id" => "148838",
+      "lat" => 39.78,
+      "lon" => -100.45,
+      "display_name" => "USA",
+      "address" => {
+        "country" => "USA",
+        "country_code" => "us"
+      }
+    }
+  ].freeze
   FORMATTED_GEOSEARCH_DHAKA_RESPONSE = [
     {
       "name" => "Dhaka, Dhaka Division, Bangladesh",


### PR DESCRIPTION
# Description
- Add extra geosearching and saving for all Country and State levels when you save a Location. We agreed to skip Subdivison/City for now to simplify implementation and stay under provider per-second rate limits.
- Add extra_parents to LocationsController#sample_locations endpoint response. Frontend clustering is to-be-implemented so this may change.
- Better implementation of determining geo_levels based on a variety of similar OpenStreetMap names for similar levels.
- Add country_id/state_id/subdivision_id/city_id columns to Locations. This is for more efficient read comparisons so you can go straight to a parent or child level.
- Update tests.

# Notes
- Example of a merged sample_locations response with USA + California:
![Screen Shot 2019-06-25 at 11 16 26 AM](https://user-images.githubusercontent.com/5652739/60138599-d0116900-975f-11e9-86cd-8915d05a33bd.png)

# Tests
- See tests