### PR TITLE
Add front-end for Basespace integration.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,7 @@ end
 
 group :test do
   gem 'rspec-json_expectations'
+  gem "webmock", "~> 3.6"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -794,6 +794,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     deep_cloneable (2.4.0)
       activerecord (>= 3.1.0, < 6)
@@ -854,9 +856,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    guard-rubocop (1.3.0)
-      guard (~> 2.0)
-      rubocop (~> 0.20)
+    hashdiff (0.4.0)
     hashie (3.6.0)
     health_check (3.0.0)
       railties (>= 5.0)
@@ -1059,13 +1059,12 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.16.0)
-      rubocop (>= 0.49.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     rufus-scheduler (3.5.2)
       fugit (~> 1.1, >= 1.1.5)
+    safe_yaml (1.0.5)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -1125,6 +1124,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.6.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -1161,7 +1164,6 @@ DEPENDENCIES
   flamegraph
   guard (~> 2.15)
   guard-rspec (~> 4.7)
-  guard-rubocop (~> 1.3)
   health_check (>= 2.7.0)
   honeycomb-rails (>= 0.8.1)
   http-2
@@ -1188,7 +1190,6 @@ DEPENDENCIES
   rspec-json_expectations
   rspec-rails (>= 3.7.2)
   rubocop (= 0.49.1)
-  rubocop-rspec
   selenium-webdriver
   shortener
   silencer
@@ -1200,6 +1201,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   useragent
   web-console (>= 3.5.1)
+  webmock (~> 3.6)
   will_paginate
 
 BUNDLED WITH

--- a/app/assets/src/api/basespace.js
+++ b/app/assets/src/api/basespace.js
@@ -1,0 +1,19 @@
+import { get } from "./core";
+
+export const getBasespaceProjects = accessToken =>
+  get("/basespace/projects", {
+    params: {
+      access_token: accessToken,
+    },
+  });
+
+export const getSamplesForBasespaceProject = (
+  accessToken,
+  basespaceProjectId
+) =>
+  get("/basespace/samples_for_project", {
+    params: {
+      access_token: accessToken,
+      basespace_project_id: basespaceProjectId,
+    },
+  });

--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -4,9 +4,17 @@ import {
   markSampleUploaded,
   uploadFileToUrlWithRetries,
 } from "~/api";
+import { map } from "lodash/fp";
 
 import { bulkUploadWithMetadata } from "~/api/metadata";
 import { putWithCSRF } from "./core";
+
+// TODO(mark): Implement back-end for basespace sample uploading.
+export const bulkUploadBasespace = async ({ samples, metadata }) => {
+  return {
+    sample_ids: map("id", samples),
+  };
+};
 
 export const bulkUploadRemote = ({ samples, metadata }) =>
   metadata

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -74,7 +74,12 @@ class Header extends React.Component {
   };
 
   render() {
-    const { adminUser, userSignedIn, ...userMenuProps } = this.props;
+    const {
+      adminUser,
+      userSignedIn,
+      disableNavigation,
+      ...userMenuProps
+    } = this.props;
 
     return (
       userSignedIn && (
@@ -86,8 +91,10 @@ class Header extends React.Component {
               </a>
             </div>
             <div className={cs.fill} />
-            <MainMenu adminUser={adminUser} />
-            <UserMenuDropDown adminUser={adminUser} {...userMenuProps} />
+            {!disableNavigation && <MainMenu adminUser={adminUser} />}
+            {!disableNavigation && (
+              <UserMenuDropDown adminUser={adminUser} {...userMenuProps} />
+            )}
           </div>
           {
             // Initialize the toast container - can be done anywhere (has absolute positioning)
@@ -102,6 +109,7 @@ class Header extends React.Component {
 Header.propTypes = {
   adminUser: PropTypes.bool,
   userSignedIn: PropTypes.bool,
+  disableNavigation: PropTypes.bool,
 };
 
 const UserMenuDropDown = ({

--- a/app/assets/src/components/ui/notifications/notification.scss
+++ b/app/assets/src/components/ui/notifications/notification.scss
@@ -21,6 +21,7 @@
   .icon {
     flex-grow: 0;
     margin-right: 14px;
+    height: 20px;
 
     svg {
       width: 20px;
@@ -30,6 +31,11 @@
       font-size: 16px;
       color: $success;
     }
+  }
+
+  .content {
+    // Helps to center single-line text vertically.
+    margin-top: 1px;
   }
 
   .actions {

--- a/app/assets/src/components/utils/format.js
+++ b/app/assets/src/components/utils/format.js
@@ -2,3 +2,19 @@ export const formatPercent = number => `${(100 * number).toFixed(1)}%`;
 
 export const limitToRange = (number, min, max) =>
   Math.min(max, Math.max(min, number));
+
+// Converts file sizes to readable format.
+// Example: 1234 to 1.2 kb
+export const formatFileSize = bytes =>
+  formatWithUnits(bytes, 1024, ["B", "kB", "MB", "GB", "TB", "PB"]);
+
+export const formatWithUnits = (number, unitFactor, units) => {
+  let unitIndex = 0;
+
+  while (Math.abs(number) >= unitFactor && unitIndex < units.length - 1) {
+    number /= unitFactor;
+    unitIndex++;
+  }
+
+  return `${unitIndex > 0 ? number.toFixed(1) : number} ${units[unitIndex]}`;
+};

--- a/app/assets/src/components/utils/links.js
+++ b/app/assets/src/components/utils/links.js
@@ -31,4 +31,22 @@ const openUrlWithTimeout = link => {
   }, 2000);
 };
 
-export { openUrl, openUrlInNewTab, downloadStringToFile, openUrlWithTimeout };
+// Opens a new popup window centered to the current window.
+const openUrlInPopupWindow = (url, windowName, windowWidth, windowHeight) => {
+  const left = window.screenLeft + (window.outerWidth - windowWidth) / 2;
+  const top = window.screenTop + (window.outerHeight - windowHeight) / 2;
+
+  return window.open(
+    url,
+    windowName,
+    `left=${left},top=${top},width=${windowWidth},height=${windowHeight},menubar=no,toolbar=no`
+  );
+};
+
+export {
+  openUrl,
+  openUrlInNewTab,
+  downloadStringToFile,
+  openUrlWithTimeout,
+  openUrlInPopupWindow,
+};

--- a/app/assets/src/components/views/BasespaceIntegration.jsx
+++ b/app/assets/src/components/views/BasespaceIntegration.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+import PropTypes from "~/components/utils/propTypes";
+import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
+import { logAnalyticsEvent } from "~/api/analytics";
+
+import cs from "./basespace_integration.scss";
+
+export default class BasespaceIntegration extends React.Component {
+  componentDidMount() {
+    const { accessToken } = this.props;
+    if (window.opener && accessToken) {
+      window.opener.postMessage(
+        {
+          basespaceAccessToken: this.props.accessToken,
+        },
+        window.location.origin
+      );
+    }
+
+    // Log whether an access token was returned.
+    if (accessToken) {
+      logAnalyticsEvent("BasespaceIntegration_authorization_succeeded");
+    } else {
+      logAnalyticsEvent("BasespaceIntegration_authorization_failed");
+    }
+  }
+
+  closeWindow = () => {
+    window.close();
+  };
+
+  render() {
+    const { accessToken } = this.props;
+    return (
+      <div className={cs.basespaceIntegration}>
+        <div className={cs.content}>
+          {accessToken ? (
+            <div>
+              <div className={cs.message}>
+                You&apos;ve successfully authorized IDseq to connect to
+                Basespace!
+              </div>
+              <div className={cs.smallMessage}>
+                You can now return to the IDseq Upload page.
+              </div>
+            </div>
+          ) : (
+            <div className={cs.error}>
+              Something went wrong when trying to connect to Basespace. Please
+              <a className={cs.helpLink} href="mailto:help@idseq.net">
+                &nbsp;contact us
+              </a>{" "}
+              for help.
+            </div>
+          )}
+          <PrimaryButton
+            text="Close Window"
+            rounded={false}
+            onClick={this.closeWindow}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+BasespaceIntegration.propTypes = {
+  accessToken: PropTypes.string,
+};

--- a/app/assets/src/components/views/SampleUploadFlow/BasespaceSampleImport.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/BasespaceSampleImport.jsx
@@ -1,0 +1,221 @@
+import React from "react";
+import { set, isEmpty, map, get, head, find } from "lodash/fp";
+
+import PropTypes from "~/components/utils/propTypes";
+import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
+import Dropdown from "~ui/controls/dropdowns/Dropdown";
+import LoadingIcon from "~ui/icons/LoadingIcon";
+import Notification from "~ui/notifications/Notification";
+import {
+  getBasespaceProjects,
+  getSamplesForBasespaceProject,
+} from "~/api/basespace";
+import { withAnalytics } from "~/api/analytics";
+
+import { openBasespaceOAuthPopup } from "./utils";
+import cs from "./basespace_sample_import.scss";
+
+export default class BasespaceSampleImport extends React.Component {
+  state = {
+    basespaceProjects: null,
+    selectedProjectId: null,
+    loadingSamples: false,
+    error: "",
+    errorType: "",
+  };
+
+  componentDidMount() {
+    const { accessToken } = this.props;
+    window.addEventListener("message", this.handleMessageEvent);
+    if (accessToken) {
+      this.fetchBasespaceProjects(accessToken);
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("message", this.handleMessageEvent);
+  }
+
+  handleMessageEvent = async event => {
+    const { onAccessTokenChange } = this.props;
+    if (
+      event.source === this._window &&
+      event.origin === window.location.origin &&
+      event.data.basespaceAccessToken
+    ) {
+      const accessToken = event.data.basespaceAccessToken;
+      this.fetchBasespaceProjects(accessToken);
+      onAccessTokenChange(accessToken);
+    }
+  };
+
+  handleProjectSelect = projectId => {
+    this.setState({
+      selectedProjectId: projectId,
+    });
+  };
+
+  requestBasespaceBrowseGlobalPermissions = () => {
+    const { basespaceClientId, basespaceOauthRedirectUri } = this.props;
+
+    this._window = openBasespaceOAuthPopup({
+      client_id: basespaceClientId,
+      redirect_uri: basespaceOauthRedirectUri,
+      scope: "browse+global",
+    });
+  };
+
+  getProjectOptions = () => {
+    const { basespaceProjects } = this.state;
+
+    return map(
+      project => ({
+        value: project.id,
+        text: project.name,
+      }),
+      basespaceProjects
+    );
+  };
+
+  fetchBasespaceProjects = async accessToken => {
+    const projects = await getBasespaceProjects(accessToken);
+    this.setState({
+      basespaceProjects: projects,
+      selectedProjectId: get("id", head(projects)),
+    });
+  };
+
+  fetchSamplesForBasespaceProject = async () => {
+    const { selectedProjectId, basespaceProjects } = this.state;
+    const { onChange, accessToken, project } = this.props;
+
+    if (!this.props.project) {
+      this.setState({
+        error: "Please select a project.",
+        errorType: "error",
+      });
+      return;
+    } else {
+      this.setState({
+        error: "",
+      });
+    }
+
+    this.setState({ loadingSamples: true });
+
+    let samples = await getSamplesForBasespaceProject(
+      accessToken,
+      selectedProjectId
+    );
+
+    this.setState({ loadingSamples: false });
+
+    const currentProjectName = get(
+      "name",
+      find(["id", selectedProjectId], basespaceProjects)
+    );
+
+    if (samples.error) {
+      this.setState({
+        error: `There was an error accessing project ${currentProjectName}. Please contact us for help.`,
+        errorType: "error",
+      });
+      return;
+    }
+
+    // Add the current project id to each sample.
+    samples = map(set("project_id", project.id), samples);
+
+    if (isEmpty(samples)) {
+      this.setState({
+        error: `No valid samples could be found in project ${currentProjectName}`,
+        errorType: "warn",
+      });
+    }
+
+    onChange(samples);
+  };
+
+  renderConnectButton = () => {
+    return (
+      <React.Fragment>
+        <div className={cs.helpText}>
+          Please connect to Basespace and authorize IDseq to view your projects
+          and samples.
+        </div>
+        <PrimaryButton
+          text="Connect to Basespace"
+          rounded={false}
+          onClick={withAnalytics(
+            this.requestBasespaceBrowseGlobalPermissions,
+            "BasespaceSampleImport_connect-btn_clicked",
+            {}
+          )}
+        />
+      </React.Fragment>
+    );
+  };
+
+  renderProjectSelect = () => {
+    const { selectedProjectId, loadingSamples, error, errorType } = this.state;
+    return (
+      <React.Fragment>
+        <div className={cs.label}>Select Basespace Project</div>
+        <div className={cs.projectSelectContainer}>
+          <Dropdown
+            placeholder="Project"
+            fluid
+            floating
+            scrolling
+            options={this.getProjectOptions()}
+            onChange={this.handleProjectSelect}
+            value={selectedProjectId}
+          />
+          <PrimaryButton
+            text="Connect to Project"
+            rounded={false}
+            onClick={withAnalytics(
+              this.fetchSamplesForBasespaceProject,
+              "BasespaceSampleImport_connect-project-btn_clicked",
+              {}
+            )}
+            className={cs.connectProjectButton}
+          />
+        </div>
+        {loadingSamples && (
+          <div className={cs.loadingMessage}>
+            <LoadingIcon className={cs.loadingIcon} />
+            <span>Loading samples...</span>
+          </div>
+        )}
+        {this.state.error && (
+          <Notification
+            type={errorType}
+            displayStyle="flat"
+            className={cs.notification}
+          >
+            {error}
+          </Notification>
+        )}
+      </React.Fragment>
+    );
+  };
+
+  render() {
+    const { accessToken } = this.props;
+    return (
+      <div className={cs.basespaceSampleImport}>
+        {accessToken ? this.renderProjectSelect() : this.renderConnectButton()}
+      </div>
+    );
+  }
+}
+
+BasespaceSampleImport.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  accessToken: PropTypes.string,
+  onAccessTokenChange: PropTypes.func.isRequired,
+  project: PropTypes.Project,
+  basespaceClientId: PropTypes.string.isRequired,
+  basespaceOauthRedirectUri: PropTypes.string.isRequired,
+};

--- a/app/assets/src/components/views/SampleUploadFlow/BasespaceSampleUploadTable.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/BasespaceSampleUploadTable.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { flow, sortBy, size, isEmpty, map } from "lodash/fp";
+
+import DataTable from "~/components/visualizations/table/DataTable";
+import RemoveIcon from "~/components/ui/icons/RemoveIcon";
+import PropTypes from "~/components/utils/propTypes";
+import { formatFileSize } from "~/components/utils/format";
+import { withAnalytics } from "~/api/analytics";
+import cs from "./basespace_sample_upload_table.scss";
+
+const TABLE_COLUMN_WIDTHS = {
+  name: 500,
+  basespace_project_name: 400,
+  file_size: 100,
+  remove_icon: 20,
+};
+
+export default class BasespaceSampleUploadTable extends React.Component {
+  render() {
+    const { samples, onSampleRemove } = this.props;
+
+    if (isEmpty(samples)) return null;
+
+    const data = flow(
+      map(sample => ({
+        ...sample,
+        file_size: formatFileSize(sample.file_size),
+        remove_icon: (
+          <RemoveIcon
+            onClick={withAnalytics(
+              () => onSampleRemove(sample.name),
+              "BasepaceSampleUploadTable_remove-sample-btn_clicked",
+              {
+                numSample: samples.length,
+              }
+            )}
+            className={cs.removeIcon}
+          />
+        ),
+      })),
+      sortBy("name")
+    )(samples);
+
+    return (
+      <div className={cs.basespaceSampleUploadTable}>
+        <div className={cs.detectedMsg}>
+          <span className={cs.count}>
+            {size(samples)} samples detected.&nbsp;
+          </span>
+          Remove samples you do not want to upload.
+        </div>
+        <DataTable
+          headers={{
+            name: "Sample Name",
+            basespace_project_name: "Basespace Project",
+            file_type: "File Type",
+            file_size: "File Size",
+          }}
+          columns={[
+            "name",
+            "basespace_project_name",
+            "file_size",
+            "file_type",
+            "remove_icon",
+          ]}
+          data={data}
+          getColumnWidth={column => TABLE_COLUMN_WIDTHS[column] || ""}
+          className={cs.table}
+        />
+      </div>
+    );
+  }
+}
+
+BasespaceSampleUploadTable.propTypes = {
+  samples: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      file_size: PropTypes.number,
+      file_type: PropTypes.string,
+    })
+  ),
+  onSampleRemove: PropTypes.func.isRequired,
+};

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -1,19 +1,45 @@
 import React from "react";
 import cx from "classnames";
-import { get, without, map, keyBy, flow, mapValues, omit } from "lodash/fp";
+import {
+  pick,
+  get,
+  without,
+  map,
+  keyBy,
+  flow,
+  mapValues,
+  omit,
+} from "lodash/fp";
 
 import DataTable from "~/components/visualizations/table/DataTable";
 import PropTypes from "~/components/utils/propTypes";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import SecondaryButton from "~/components/ui/controls/buttons/SecondaryButton";
 import TermsAgreement from "~ui/controls/TermsAgreement";
-import { bulkUploadLocalWithMetadata, bulkUploadRemote } from "~/api/upload";
+import {
+  bulkUploadLocalWithMetadata,
+  bulkUploadRemote,
+  bulkUploadBasespace,
+} from "~/api/upload";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import PublicProjectIcon from "~ui/icons/PublicProjectIcon";
 import PrivateProjectIcon from "~ui/icons/PrivateProjectIcon";
 import LoadingIcon from "~ui/icons/LoadingIcon";
+import { formatFileSize } from "~/components/utils/format";
 
 import cs from "./sample_upload_flow.scss";
+
+const BASESPACE_SAMPLE_FIELDS = [
+  "name",
+  "project_id",
+  "host_genome_id",
+  "basespace_project_id",
+  "basespace_access_token",
+  "basespace_dataset_id",
+];
+
+const REVIEWSTEP_UPLOAD_FAILED = "ReviewStep_upload_failed";
+const REVIEWSTEP_UPLOAD_SUCCEEDED = "ReviewStep_upload_succeeded";
 
 const processMetadataRows = metadataRows =>
   flow(
@@ -36,54 +62,76 @@ class ReviewStep extends React.Component {
   };
 
   uploadSamplesAndMetadata = () => {
-    this.props.onUploadStatusChange(true);
+    const {
+      onUploadStatusChange,
+      onUploadComplete,
+      uploadType,
+      samples,
+      sampleNamesToFiles,
+      metadata,
+    } = this.props;
+
+    onUploadStatusChange(true);
 
     this.setState({
       submitState: "submitting",
       errorMessage: "",
     });
 
-    // For uploading samples with files on S3
-    if (this.props.uploadType === "remote") {
-      bulkUploadRemote({
-        samples: this.props.samples,
-        metadata: processMetadataRows(this.props.metadata.rows),
+    // For uploading samples with files on S3 or Basespace
+    if (uploadType === "remote" || uploadType === "basespace") {
+      let bulkUploadFn = bulkUploadRemote;
+      let bulkUploadFnName = "bulkUploadRemote";
+      let samplesToUpload = samples;
+
+      if (uploadType === "basespace") {
+        bulkUploadFn = bulkUploadBasespace;
+        bulkUploadFnName = "bulkUploadBasespace";
+        samplesToUpload = map(pick(BASESPACE_SAMPLE_FIELDS), samplesToUpload);
+      }
+
+      bulkUploadFn({
+        samples: samplesToUpload,
+        metadata: processMetadataRows(metadata.rows),
       })
         .then(response => {
           this.setState({
             submitState: "success",
             createdSampleIds: response.sample_ids,
           });
-          this.props.onUploadComplete();
-          logAnalyticsEvent("ReviewStep_remote-upload_succeeded", {
+          onUploadComplete();
+          logAnalyticsEvent(REVIEWSTEP_UPLOAD_SUCCEEDED, {
             createdSampleIds: response.sample_ids.length,
+            uploadType,
           });
         })
         // TODO(mark): Display better errors.
         // For example, some samples may have successfully saved, but not others. Should explain to user.
         .catch(error => {
           // eslint-disable-next-line no-console
-          console.error("onBulkUploadRemote error:", error);
+          console.error(`${bulkUploadFnName} error:`, error);
           this.onUploadError("There were some issues creating your samples.");
-          logAnalyticsEvent("ReviewStep_remote-upload_failed", {
+          logAnalyticsEvent(REVIEWSTEP_UPLOAD_FAILED, {
             error,
+            uploadType,
           });
         });
     }
     // For uploading samples with local files
-    if (this.props.uploadType === "local") {
+    if (uploadType === "local") {
       // TODO(mark): Handle progress indicators in UI.
       bulkUploadLocalWithMetadata({
-        samples: this.props.samples,
-        sampleNamesToFiles: this.props.sampleNamesToFiles,
-        metadata: processMetadataRows(this.props.metadata.rows),
+        samples,
+        sampleNamesToFiles: sampleNamesToFiles,
+        metadata: processMetadataRows(metadata.rows),
         onAllUploadsComplete: () => {
           this.setState({
             submitState: "success",
           });
-          this.props.onUploadComplete();
-          logAnalyticsEvent("ReviewStep_local-upload_succeeded", {
-            samples: this.props.samples.length,
+          onUploadComplete();
+          logAnalyticsEvent(REVIEWSTEP_UPLOAD_SUCCEEDED, {
+            samples: samples.length,
+            uploadType,
           });
         },
         onCreateSamplesError: errors => {
@@ -91,8 +139,9 @@ class ReviewStep extends React.Component {
           // eslint-disable-next-line no-console
           console.error("onCreateSamplesError:", errors);
           this.onUploadError("There were some issues creating your samples.");
-          logAnalyticsEvent("ReviewStep_local-upload_failed", {
+          logAnalyticsEvent(REVIEWSTEP_UPLOAD_FAILED, {
             errors: errors.length,
+            uploadType,
           });
         },
         // TODO(mark): Display better errors.
@@ -101,17 +150,19 @@ class ReviewStep extends React.Component {
           // eslint-disable-next-line no-console
           console.error("onUploadError:", error);
           this.onUploadError("There were some issues creating your samples.");
-          logAnalyticsEvent("ReviewStep_local-upload_failed", {
+          logAnalyticsEvent(REVIEWSTEP_UPLOAD_FAILED, {
             fileName: file.name,
             error,
+            uploadType,
           });
         },
         onMarkSampleUploadedError: sampleName => {
           this.onUploadError(
             `Failed to mark sample ${sampleName} as uploaded.`
           );
-          logAnalyticsEvent("ReviewStep_local-upload_failed", {
+          logAnalyticsEvent(REVIEWSTEP_UPLOAD_FAILED, {
             sampleName,
+            uploadType,
           });
         },
       });
@@ -119,28 +170,44 @@ class ReviewStep extends React.Component {
   };
 
   getDataHeaders = () => {
-    return [
-      "Sample Name",
-      "Input Files",
-      "Host Genome",
-      // Omit sample name, which is the first header.
-      ...without(["Sample Name", "sample_name"], this.props.metadata.headers),
-    ];
+    const { uploadType } = this.props;
+    // Omit sample name, which is the first header.
+    const metadataHeaders = without(
+      ["Sample Name", "sample_name"],
+      this.props.metadata.headers
+    );
+    if (uploadType !== "basespace") {
+      return ["Sample Name", "Input Files", "Host Genome", ...metadataHeaders];
+    } else {
+      return [
+        "Sample Name",
+        "Basespace Project",
+        "File Size",
+        "File Type",
+        "Host Genome",
+        ...metadataHeaders,
+      ];
+    }
   };
 
   getDataRows = () => {
+    const { uploadType } = this.props;
     const metadataBySample = keyBy(
       row => row["Sample Name"] || row.sample_name,
       this.props.metadata.rows
     );
     const hostGenomesById = keyBy("id", this.props.hostGenomes);
 
-    return map(
-      sample => ({
+    const assembleDataForSample = sample => {
+      const sampleData = {
         ...metadataBySample[sample.name],
         "Sample Name": <div className={cs.sampleName}>{sample.name}</div>,
         "Host Genome": get("name", hostGenomesById[sample.host_genome_id]),
-        "Input Files": (
+      };
+
+      // We display different columns if the uploadType is basespace.
+      if (uploadType !== "basespace") {
+        sampleData["Input Files"] = (
           <div className={cs.files}>
             {sample.input_files_attributes.map(file => (
               <div key={file.source} className={cs.file}>
@@ -148,10 +215,17 @@ class ReviewStep extends React.Component {
               </div>
             ))}
           </div>
-        ),
-      }),
-      this.props.samples
-    );
+        );
+      } else {
+        (sampleData["File Size"] = formatFileSize(sample.file_size)),
+          (sampleData["File Type"] = sample.file_type);
+        sampleData["Basespace Project"] = sample.basespace_project_name;
+      }
+
+      return sampleData;
+    };
+
+    return map(assembleDataForSample, this.props.samples);
   };
 
   linksEnabled = () => this.state.submitState === "review";
@@ -194,6 +268,7 @@ class ReviewStep extends React.Component {
                     logAnalyticsEvent("ReviewStep_edit-project-link_clicked", {
                       projectId: this.props.project.id,
                       projectName: this.props.project.name,
+                      uploadType: this.props.uploadType,
                     });
                   }}
                 >
@@ -234,6 +309,7 @@ class ReviewStep extends React.Component {
                     logAnalyticsEvent("ReviewStep_edit-samples-link_clicked", {
                       projectId: this.props.project.id,
                       projectName: this.props.project.name,
+                      uploadType: this.props.uploadType,
                     });
                   }}
                 >
@@ -247,6 +323,7 @@ class ReviewStep extends React.Component {
                     logAnalyticsEvent("ReviewStep_edit-metadata-link_clicked", {
                       projectId: this.props.project.id,
                       projectName: this.props.project.name,
+                      uploadType: this.props.uploadType,
                     });
                   }}
                 >
@@ -304,7 +381,13 @@ class ReviewStep extends React.Component {
                   text="Go to Project"
                   rounded={false}
                   onClick={() =>
-                    logAnalyticsEvent("ReviewStep_go-to-project-button_clicked")
+                    logAnalyticsEvent(
+                      "ReviewStep_go-to-project-button_clicked",
+                      {
+                        projectId: this.props.project.id,
+                        projectName: this.props.project.name,
+                      }
+                    )
                   }
                 />
               </a>
@@ -319,6 +402,7 @@ class ReviewStep extends React.Component {
                 "ReviewStep_start-upload-button_clicked",
                 {
                   samples: this.props.samples.length,
+                  uploadType: this.props.uploadType,
                 }
               )}
               rounded={false}
@@ -347,6 +431,10 @@ ReviewStep.propTypes = {
       name: PropTypes.string,
       project_id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       status: PropTypes.string,
+      // Basespace samples only.
+      file_size: PropTypes.number,
+      file_type: PropTypes.string,
+      basespace_project_name: PropTypes.string,
     })
   ),
   uploadType: PropTypes.string.isRequired,

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -68,7 +68,7 @@ class SampleUploadFlow extends React.Component {
           "name",
           get("host_genome", metadataRow) || get("Host Genome", metadataRow),
         ],
-        this.props.host_genomes
+        this.props.hostGenomes
       ).id;
 
       return {
@@ -134,6 +134,9 @@ class SampleUploadFlow extends React.Component {
           onDirty={this.samplesChanged}
           onUploadSamples={this.handleUploadSamples}
           visible={this.state.currentStep === "uploadSamples"}
+          basespaceClientId={this.props.basespaceClientId}
+          basespaceOauthRedirectUri={this.props.basespaceOauthRedirectUri}
+          admin={this.props.admin}
         />
         {this.state.samples && (
           <UploadMetadataStep
@@ -152,7 +155,7 @@ class SampleUploadFlow extends React.Component {
               uploadType={this.state.uploadType}
               project={this.state.project}
               sampleNamesToFiles={this.state.sampleNamesToFiles}
-              hostGenomes={this.props.host_genomes}
+              hostGenomes={this.props.hostGenomes}
               visible={this.state.currentStep === "review"}
               onUploadStatusChange={this.onUploadStatusChange}
               onStepSelect={this.handleStepSelect}
@@ -193,8 +196,10 @@ class SampleUploadFlow extends React.Component {
 
 SampleUploadFlow.propTypes = {
   csrf: PropTypes.string,
-  host_genomes: PropTypes.arrayOf(PropTypes.HostGenome),
+  hostGenomes: PropTypes.arrayOf(PropTypes.HostGenome),
   admin: PropTypes.bool,
+  basespaceClientId: PropTypes.string.isRequired,
+  basespaceOauthRedirectUri: PropTypes.string.isRequired,
 };
 
 export default SampleUploadFlow;

--- a/app/assets/src/components/views/SampleUploadFlow/basespace_sample_import.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/basespace_sample_import.scss
@@ -1,0 +1,39 @@
+@import "~styles/themes/colors";
+@import "~styles/themes/typography";
+
+.basespaceSampleImport {
+  .projectSelectContainer {
+    display: flex;
+  }
+
+  .helpText {
+    @include font-body-xxs;
+    margin-bottom: 10px;
+    color: $medium-grey;
+  }
+
+  .connectProjectButton {
+    width: 180px;
+    margin-left: 10px;
+  }
+
+  .label {
+    @include font-header-s;
+    margin-bottom: 5px;
+  }
+
+  .loadingMessage {
+    @include font-body-xxs;
+    color: $medium-grey;
+    margin-top: 5px;
+    margin-left: 2px;
+
+    span {
+      margin-left: 5px;
+    }
+  }
+
+  .notification {
+    margin-top: 10px;
+  }
+}

--- a/app/assets/src/components/views/SampleUploadFlow/basespace_sample_upload_table.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/basespace_sample_upload_table.scss
@@ -1,0 +1,33 @@
+@import "~styles/themes/typography";
+@import "~styles/themes/colors";
+
+.basespaceSampleUploadTable {
+  .detectedMsg {
+    @include font-body-xs;
+    margin-top: 30px;
+    margin-bottom: 10px;
+    color: $dark-grey;
+
+    .count {
+      @include font-header-xs;
+      color: $black;
+    }
+  }
+
+  .removeIcon {
+    cursor: pointer;
+    opacity: 0.3;
+    width: 10px;
+    margin-top: 5px;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  .table {
+    tbody {
+      max-height: 500px;
+    }
+  }
+}

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -28,6 +28,12 @@
   .controls {
     margin: 30px 0 60px;
 
+    .helpText {
+      @include font-body-xxs;
+      margin-bottom: 10px;
+      color: $medium-grey;
+    }
+
     .continueButton {
       margin-right: 10px;
     }

--- a/app/assets/src/components/views/SampleUploadFlow/utils.js
+++ b/app/assets/src/components/views/SampleUploadFlow/utils.js
@@ -1,0 +1,21 @@
+import { getURLParamString } from "~/helpers/url";
+import { openUrlInPopupWindow } from "~/components/utils/links";
+
+const BASESPACE_OAUTH_URL = "https://basespace.illumina.com/oauth/authorize";
+const BASESPACE_OAUTH_WINDOW_NAME = "BASESPACE_OAUTH_WINDOW";
+const BASESPACE_OAUTH_WINDOW_WIDTH = 1000;
+const BASESPACE_OAUTH_WINDOW_HEIGHT = 600;
+
+export const openBasespaceOAuthPopup = params => {
+  const urlParams = getURLParamString({
+    ...params,
+    response_type: "code",
+  });
+
+  return openUrlInPopupWindow(
+    `${BASESPACE_OAUTH_URL}?${urlParams}`,
+    BASESPACE_OAUTH_WINDOW_NAME,
+    BASESPACE_OAUTH_WINDOW_WIDTH,
+    BASESPACE_OAUTH_WINDOW_HEIGHT
+  );
+};

--- a/app/assets/src/components/views/basespace_integration.scss
+++ b/app/assets/src/components/views/basespace_integration.scss
@@ -1,0 +1,37 @@
+@import "~styles/themes/typography";
+@import "~styles/themes/colors";
+
+.basespaceIntegration {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 50px);
+
+  .content {
+    text-align: center;
+
+    .message {
+      @include font-body-m;
+      margin-bottom: 5px;
+      max-width: 350px;
+    }
+
+    .smallMessage {
+      @include font-body-xxs;
+      color: $medium-grey;
+      margin-bottom: 15px;
+      max-width: 350px;
+    }
+
+    .error {
+      @include font-body-m;
+      margin-bottom: 15px;
+      max-width: 400px;
+    }
+
+    .helpLink {
+      // Override header.scss.
+      color: $primary-light !important;
+    }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :check_rack_mini_profiler
   before_action :check_browser
   before_action :set_current_context_for_logging!
+  before_action :set_application_view_variables
 
   include Consul::Controller
 
@@ -34,6 +35,10 @@ class ApplicationController < ActionController::Base
     super
     payload[:remote_ip] = request.remote_ip
     payload[:user_id] = current_user.try(:id) if current_user
+  end
+
+  def disable_header_navigation
+    @disable_header_navigation = true
   end
 
   protected
@@ -92,6 +97,10 @@ class ApplicationController < ActionController::Base
     if current_user && current_user.admin?
       Rack::MiniProfiler.authorize_request
     end
+  end
+
+  def set_application_view_variables
+    @disable_header_navigation = false
   end
 
   # Set current user and request to global for use in logging in ActiveRecord.

--- a/app/controllers/basespace_controller.rb
+++ b/app/controllers/basespace_controller.rb
@@ -1,0 +1,138 @@
+BASESPACE_OAUTH_URL = ["https://api.basespace.illumina.com/v1pre3/oauthv2/token",
+                       BASESPACE_CURRENT_PROJECTS_URL = "https://api.basespace.illumina.com/v1pre3/users/current/projects".freeze].freeze
+BASESPACE_PROJECT_DATASETS_URL = "https://api.basespace.illumina.com/v2/projects/%s/datasets".freeze
+# The maximum number of items to fetch from a Basespace API endpoint at one time.
+# If we don't set this, it defaults to 10.
+# TODO(mark): Implement a way to automatically fetch additional pages if necessary.
+BASESPACE_PAGE_SIZE = 1024
+
+class BasespaceController < ApplicationController
+  include HttpHelper
+
+  before_action :admin_required
+
+  def oauth
+    disable_header_navigation
+    @access_token = nil
+
+    if params[:code] &&
+       ENV["BASESPACE_OAUTH_REDIRECT_URI"] &&
+       ENV["BASESPACE_CLIENT_ID"] &&
+       ENV["BASESPACE_CLIENT_SECRET"]
+      response = HttpHelper.post_json(
+        "https://api.basespace.illumina.com/v1pre3/oauthv2/token",
+        "code" => params[:code],
+        "redirect_uri" => ENV["BASESPACE_OAUTH_REDIRECT_URI"],
+        "client_id" => ENV["BASESPACE_CLIENT_ID"],
+        "client_secret" => ENV["BASESPACE_CLIENT_SECRET"],
+        "grant_type" => "authorization_code"
+      )
+
+      if response.present?
+        @access_token = response["access_token"]
+      end
+    end
+  end
+
+  def projects
+    access_token = params[:access_token]
+
+    if access_token.nil?
+      render json: {
+        error: "basespace access token required"
+      }
+      return
+    end
+
+    # 1024 is the maximum limit allowed by Basespace.
+    # If users reach this limit, we will need to implement multiple requests to fetch all the projects.
+    response = HttpHelper.get_json(
+      BASESPACE_CURRENT_PROJECTS_URL,
+      { limit: BASESPACE_PAGE_SIZE },
+      "Authorization" => "Bearer #{access_token}"
+    )
+
+    if response.nil? || response["Response"].nil? || response["Response"]["Items"].nil?
+      render json: {
+        error: "unable to fetch data from basespace"
+      }
+      return
+    end
+
+    # Just return selected fields.
+    formatted_projects = response["Response"]["Items"].map do |dataset|
+      {
+        id: dataset["Id"],
+        name: dataset["Name"]
+      }
+    end
+
+    render json: formatted_projects
+  end
+
+  def samples_for_project
+    access_token = params[:access_token]
+    basespace_project_id = params[:basespace_project_id]
+
+    if access_token.nil?
+      render json: {
+        error: "basespace access token required"
+      }
+      return
+    end
+
+    if basespace_project_id.nil?
+      render json: {
+        error: "basespace project id required"
+      }
+      return
+    end
+
+    # 1024 is the maximum limit allowed by Basespace.
+    # If users reach this limit, we will need to implement multiple requests to fetch all the samples.
+    response = HttpHelper.get_json(
+      BASESPACE_PROJECT_DATASETS_URL % basespace_project_id,
+      { limit: BASESPACE_PAGE_SIZE },
+      "Authorization" => "Bearer #{access_token}"
+    )
+
+    if response.nil? || response["Items"].nil?
+      render json: {
+        error: "unable to fetch data from basespace"
+      }
+      return
+    end
+
+    # Just return selected fields.
+    formatted_samples = response["Items"].map do |dataset|
+      {
+        basespace_dataset_id: dataset["Id"],
+        name: dataset["Name"],
+        file_size: dataset["TotalSize"],
+        file_type: get_dataset_file_type(dataset),
+        basespace_project_id: basespace_project_id,
+        basespace_project_name: dataset["Project"]["Name"]
+      }
+    end
+
+    # Remove all non-FASTQ files.
+    # We will add other file types as we encounter them.
+    formatted_samples = formatted_samples.select { |dataset| dataset[:file_type].present? }
+
+    render json: formatted_samples
+  end
+
+  private
+
+  def get_dataset_file_type(dataset)
+    if dataset["DatasetType"].present? && dataset["DatasetType"]["Name"].downcase.include?("fastq")
+      if dataset["Attributes"].present? && dataset["Attributes"]["common_fastq"].present? && dataset["Attributes"]["common_fastq"]["IsPairedEnd"] == true
+        return "Paired-end FASTQ"
+      else
+        return "Single-end FASTQ"
+      end
+    end
+
+    return nil
+  end
+end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1025,6 +1025,8 @@ class SamplesController < ApplicationController
   def upload
     @projects = current_power.updatable_projects
     @host_genomes = host_genomes_list || nil
+    @basespace_client_id = ENV["BASESPACE_CLIENT_ID"] || nil
+    @basespace_oauth_redirect_uri = ENV["BASESPACE_OAUTH_REDIRECT_URI"] || nil
   end
 
   # GET /samples/1/edit

--- a/app/helpers/http_helper.rb
+++ b/app/helpers/http_helper.rb
@@ -1,0 +1,57 @@
+require "net/http"
+
+module HttpHelper
+  def self.post_json(url, body)
+    uri = URI.parse(url)
+    request = Net::HTTP::Post.new(uri)
+    request.content_type = "application/json"
+    request.body = JSON.dump(body)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == "https"
+
+    response = http.request(request)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      Rails.logger.warn("POST request to #{url} failed: #{response.message}")
+      return nil
+    end
+
+    begin
+      # Parse the body as JSON and return it.
+      JSON.parse(response.body)
+    rescue JSON::ParserError
+      Rails.logger.warn("POST response from #{url} was not valid JSON")
+      return nil
+    end
+  end
+
+  def self.get_json(url, params, headers)
+    uri = URI.parse(url)
+    request = Net::HTTP::Get.new(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == "https"
+
+    # Add headers
+    headers.each do |key, value|
+      request[key] = value
+    end
+
+    # Add params to url
+    uri.query = URI.encode_www_form(params)
+
+    response = http.request(request)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      Rails.logger.warn("GET request to #{url} failed: #{response.message}")
+      return nil
+    end
+
+    begin
+      # Parse the body as JSON and return it.
+      JSON.parse(response.body)
+    rescue JSON::ParserError
+      Rails.logger.warn("GET response from #{url} was not valid JSON")
+      return nil
+    end
+  end
+end

--- a/app/views/basespace/oauth.html.erb
+++ b/app/views/basespace/oauth.html.erb
@@ -1,0 +1,5 @@
+<%= javascript_tag do %>
+  react_component('BasespaceIntegration', {
+    accessToken: "<%= @access_token %>",
+  }, 'page_content');
+<% end %>

--- a/app/views/layouts/_page_header.html.erb
+++ b/app/views/layouts/_page_header.html.erb
@@ -8,7 +8,8 @@
         signInEndpoint: '<%=new_user_session_path%>',
         signOutEndpoint: '<%=destroy_user_session_path%>',
         userName: '<%= current_user.name %>',
-        userSignedIn: true
+        userSignedIn: true,
+        disableNavigation: <%= @disable_header_navigation %>,
       }, 'page_header', JSON.parse('<%= raw escape_json(request_context)%>'))
 
 

--- a/app/views/samples/upload.html.erb
+++ b/app/views/samples/upload.html.erb
@@ -2,8 +2,10 @@
   <%= javascript_tag do %>
     react_component('SampleUploadFlow', {
       csrf: '<%= form_authenticity_token %>',
-      host_genomes: JSON.parse('<%= raw escape_json(@host_genomes) %>'),
-      admin: JSON.parse('<%= raw escape_json(current_user.admin) %>')
+      hostGenomes: JSON.parse('<%= raw escape_json(@host_genomes) %>'),
+      admin: JSON.parse('<%= raw escape_json(current_user.admin) %>'),
+      basespaceClientId: '<%= @basespace_client_id %>',
+      basespaceOauthRedirectUri: '<%= @basespace_oauth_redirect_uri %>',
     }, 'upload_page');
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,10 @@ Rails.application.routes.draw do
   get 'amr_heatmap/amr_counts.json', to: 'amr_heatmap#amr_counts'
   get 'amr_heatmap', to: 'amr_heatmap#index'
 
+  get 'basespace/oauth', to: 'basespace#oauth'
+  get 'basespace/projects', to: 'basespace#projects'
+  get 'basespace/samples_for_project', to: 'basespace#samples_for_project'
+
   resources :host_genomes
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ x-web-variables: &web-variables
   ? SEGMENT_RUBY_ID
   ? LOCATION_IQ_API_KEY
   ? MAPTILER_API_KEY
+  ? BASESPACE_CLIENT_ID
+  ? BASESPACE_CLIENT_SECRET
+  ? BASESPACE_OAUTH_REDIRECT_URI
 
 x-aws-variables: &aws-variables
   ? AWS_ACCESS_KEY_ID

--- a/package-lock.json
+++ b/package-lock.json
@@ -5627,8 +5627,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5649,14 +5648,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5671,20 +5668,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5801,8 +5795,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5814,7 +5807,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5829,7 +5821,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5837,14 +5828,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5863,7 +5852,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5951,8 +5939,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5964,7 +5951,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6050,8 +6036,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6087,7 +6072,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6107,7 +6091,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6151,14 +6134,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/spec/controllers/basespace_controller_spec.rb
+++ b/spec/controllers/basespace_controller_spec.rb
@@ -1,0 +1,273 @@
+require 'rails_helper'
+
+BASESPACE_PAIRED_END_FASTQ_SAMPLE = {
+  "Id" => "1",
+  "Name" => "Sample 1",
+  "TotalSize" => 1000,
+  "Project" => {
+    "Name" => "Mock Project"
+  },
+  "DatasetType" => {
+    "Name" => "Illumina Fastq"
+  },
+  "Attributes" => {
+    "common_fastq" => {
+      "IsPairedEnd" => true
+    }
+  }
+}.freeze
+
+BASESPACE_SINGLE_END_FASTQ_SAMPLE = {
+  "Id" => "2",
+  "Name" => "Sample 2",
+  "TotalSize" => 1001,
+  "Project" => {
+    "Name" => "Mock Project"
+  },
+  "DatasetType" => {
+    "Name" => "Illumina Fastq"
+  },
+  "Attributes" => {
+    "common_fastq" => {
+      "IsPairedEnd" => false
+    }
+  }
+}.freeze
+
+BASESPACE_NON_FASTQ_SAMPLE = {
+  "Id" => "1",
+  "Name" => "Sample 1",
+  "TotalSize" => 1000,
+  "Project" => {
+    "Name" => "Mock Project"
+  },
+  "DatasetType" => {
+    "Name" => "Common Files"
+  },
+  "Attributes" => {}
+}.freeze
+
+RSpec.describe BasespaceController, type: :controller do
+  create_users
+
+  context "Admin user" do
+    before do
+      sign_in @admin
+    end
+
+    describe "GET oauth" do
+      let(:access_token) { "12345" }
+
+      before do
+        allow(HttpHelper).to receive(:post_json).and_return("access_token" => access_token)
+        allow(ENV).to receive(:[]).with("BASESPACE_OAUTH_REDIRECT_URI").and_return("MOCK_URI")
+        allow(ENV).to receive(:[]).with("BASESPACE_CLIENT_ID").and_return("MOCK_ID")
+        allow(ENV).to receive(:[]).with("BASESPACE_CLIENT_SECRET").and_return("MOCK_SECRET")
+      end
+
+      it "renders the oauth template" do
+        get :oauth, params: { code: "MOCK_CODE" }
+        expect(response).to render_template("oauth")
+      end
+
+      it "assigns view variables correctly" do
+        get :oauth, params: { code: "MOCK_CODE" }
+        expect(assigns(:access_token)).to eq(access_token)
+      end
+
+      context "when no code param is provided" do
+        it "assigns view variables correctly" do
+          get :oauth, params: {}
+          expect(response).to render_template("oauth")
+          expect(assigns(:access_token)).to eq(nil)
+        end
+      end
+    end
+
+    describe "GET projects" do
+      before do
+        allow(HttpHelper).to receive(:get_json)
+          .and_return(
+            "Response" => {
+              "Items" => [
+                {
+                  "Id" => "1",
+                  "Name" => "Project 1"
+                },
+                {
+                  "Id" => "2",
+                  "Name" => "Project 2"
+                }
+              ]
+            }
+          )
+      end
+
+      it "returns projects" do
+        get :projects, params: { access_token: "123" }
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to include_json(
+          [
+            {
+              "id" => "1",
+              "name" => "Project 1"
+            },
+            {
+              "id" => "2",
+              "name" => "Project 2"
+            }
+          ]
+        )
+      end
+
+      context "when no access token is provided" do
+        it "returns an error" do
+          get :projects, params: {}
+
+          json_response = JSON.parse(response.body)
+          expect(json_response).to include_json(error: "basespace access token required")
+        end
+      end
+
+      context "when response is nil" do
+        before do
+          allow(HttpHelper).to receive(:get_json)
+            .and_return(nil)
+        end
+
+        it "returns an error" do
+          get :projects, params: { access_token: "123" }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response).to include_json(error: "unable to fetch data from basespace")
+        end
+      end
+    end
+
+    describe "GET samples_for_project" do
+      before do
+        allow(HttpHelper).to receive(:get_json).and_return(
+          "Items" => [
+            BASESPACE_PAIRED_END_FASTQ_SAMPLE,
+            BASESPACE_SINGLE_END_FASTQ_SAMPLE
+          ]
+        )
+      end
+
+      it "returns samples for project" do
+        get :samples_for_project, params: { access_token: "123", basespace_project_id: 77 }
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to include_json(
+          [
+            {
+              "basespace_dataset_id" => "1",
+              "name" => "Sample 1",
+              "file_size" => 1000,
+              "file_type" => "Paired-end FASTQ",
+              "basespace_project_id" => "77",
+              "basespace_project_name" => "Mock Project"
+            },
+            {
+              "basespace_dataset_id" => "2",
+              "name" => "Sample 2",
+              "file_size" => 1001,
+              "file_type" => "Single-end FASTQ",
+              "basespace_project_id" => "77",
+              "basespace_project_name" => "Mock Project"
+            }
+          ]
+        )
+      end
+
+      context "when some samples are non-fastq" do
+        before do
+          allow(HttpHelper).to receive(:get_json).and_return(
+            "Items" => [
+              BASESPACE_NON_FASTQ_SAMPLE,
+              BASESPACE_SINGLE_END_FASTQ_SAMPLE
+            ]
+          )
+        end
+
+        it "filters out non-fastq samples" do
+          get :samples_for_project, params: { access_token: "123", basespace_project_id: 77 }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response).to include_json(
+            [
+              {
+                "basespace_dataset_id" => "2",
+                "name" => "Sample 2",
+                "file_size" => 1001,
+                "file_type" => "Single-end FASTQ",
+                "basespace_project_id" => "77",
+                "basespace_project_name" => "Mock Project"
+              }
+            ]
+          )
+        end
+      end
+
+      context "when no access token is provided" do
+        it "returns an error" do
+          get :samples_for_project, params: { basespace_project_id: 77 }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response).to include_json("error" => "basespace access token required")
+        end
+      end
+
+      context "when no basespace project id is provided" do
+        it "returns an error" do
+          get :samples_for_project, params: { access_token: "123" }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response).to include_json("error" => "basespace project id required")
+        end
+      end
+
+      context "when response is nil" do
+        before do
+          allow(HttpHelper).to receive(:get_json)
+            .and_return(nil)
+        end
+
+        it "returns an error" do
+          get :samples_for_project, params: { access_token: "123", basespace_project_id: 77 }
+
+          json_response = JSON.parse(response.body)
+          expect(json_response).to include_json(error: "unable to fetch data from basespace")
+        end
+      end
+    end
+  end
+
+  context "non-admin user" do
+    before do
+      sign_in @joe
+    end
+
+    describe "GET oauth" do
+      it "should redirect to the root" do
+        get :oauth, params: { code: "MOCK_CODE" }
+        expect(response).to redirect_to("/")
+      end
+    end
+
+    describe "GET projects" do
+      it "should redirect to the root" do
+        get :projects, params: { access_token: "123" }
+        expect(response).to redirect_to("/")
+      end
+    end
+
+    describe "GET samples_for_project" do
+      it "should redirect to the root" do
+        get :samples_for_project, params: { basespace_project_id: 77 }
+        expect(response).to redirect_to("/")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,3 +98,4 @@ RSpec.configure do |config|
 end
 
 require "rspec/json_expectations"
+require 'webmock/rspec'


### PR DESCRIPTION
Guarded with admin-only.
Add "Upload with Basespace" option to Upload Sample options.
Add pop-up window for Basespace OAuth integration.
Add alternate components to render Basespace sample metadata in upload flow.
Add projects and samples_for_project endpoints that proxy to Basespace API.
Add metrics instrumentation.

# Screenshots

![Screen Shot 2019-06-24 at 5 18 35 PM](https://user-images.githubusercontent.com/837004/60060215-78fa8e00-96a4-11e9-8cac-56c349c6c3f8.png)
![Screen Shot 2019-06-24 at 5 18 39 PM](https://user-images.githubusercontent.com/837004/60060218-7a2bbb00-96a4-11e9-91af-ec84c3a1c413.png)
![Screen Shot 2019-06-24 at 5 20 04 PM](https://user-images.githubusercontent.com/837004/60060219-7bf57e80-96a4-11e9-99da-55b698efe12a.png)
![Screen Shot 2019-06-24 at 5 20 11 PM](https://user-images.githubusercontent.com/837004/60060220-7d26ab80-96a4-11e9-8911-b93acc0220d2.png)
![Screen Shot 2019-06-24 at 5 20 24 PM](https://user-images.githubusercontent.com/837004/60060222-7ef06f00-96a4-11e9-8b56-dbe3d3f54c82.png)
![Screen Shot 2019-06-24 at 5 20 44 PM](https://user-images.githubusercontent.com/837004/60060225-80219c00-96a4-11e9-8367-2c9817f8630f.png)

# Tests

Include tests for basespace_controller and http_helper.

Verified that Basespace upload flow succeeds and passes the expected object.
Verified that changing projects after the samples are selected re-validates the sample names.
Verified that picking samples from multiple projects works as expected (and the auth pop-up requests permissions from all projects). 
Verify that non-admin users don't see the Basespace tab and can't access the endpoints.