### PR TITLE
Clarify read labels in coverage viz.

### DIFF
--- a/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
@@ -54,8 +54,9 @@ const METRIC_COLUMNS = [
     },
     {
       key: "alignedReads",
-      name: "Aligned Reads",
-      tooltip: "Number of reads for which this accession was the best match.",
+      name: "Aligned Loose Reads",
+      tooltip:
+        "Number of reads for which this accession was the best match. Only includes reads which did not assemble into a contig.",
     },
   ],
   [

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/utils.js
@@ -24,7 +24,7 @@ export const getHistogramTooltipData = memoize(
           ["Coverage Depth", `${coverageObj[1]}x`],
           ["Coverage Breadth", formatPercent(coverageObj[2])],
           ["Overlapping Contigs", coverageObj[3]],
-          ["Overlapping Reads", coverageObj[4]],
+          ["Overlapping Loose Reads", coverageObj[4]],
         ],
       },
     ];
@@ -51,14 +51,14 @@ export const getGenomeVizTooltipData = memoize((accessionData, dataIndex) => {
     name = "Aggregated Contigs and Reads";
     counts = [
       ["# Contigs", numContigs],
-      ["# Reads", numReads],
+      ["# Loose Reads", numReads],
       ["Contig Read Count", hitObj[2]],
     ];
   } else if (numReads > 1) {
-    name = "Aggregated Reads";
-    counts = [["# Reads", numReads]];
+    name = "Aggregated Loose Reads";
+    counts = [["# Loose Reads", numReads]];
   } else if (numReads == 1) {
-    name = "Read";
+    name = "Loose Read";
   } else if (numContigs > 1) {
     name = "Aggregated Contigs";
     counts = [["# Contigs", numContigs], ["Contig Read Count", hitObj[2]]];


### PR DESCRIPTION

Add "loose" to read label and updated on-hover tooltip to clarify that only
unassembled reads were included.

# Description

![Screen Shot 2019-06-24 at 5 55 48 PM](https://user-images.githubusercontent.com/837004/60061268-5454e500-96a9-11e9-940e-5f44682eec2e.png)


