### PR TITLE
[Maps] Fix height of samples tables on maps sidebar.

### DIFF
--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -5,12 +5,12 @@
   font-size: 12px;
   width: 300px;
   overflow-y: scroll;
-  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   .container {
     display: flex;
     flex-direction: column;
-    height: 100%;
     flex: 1 0 auto;
 
     .table {
@@ -28,6 +28,7 @@
 
   .tabs {
     margin: 15px 10px 5px;
+    flex: 1 0 30px;
 
     .tabLabel {
       @include font-header-xs;

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -5,6 +5,7 @@
   font-size: 12px;
   width: 300px;
   overflow-y: scroll;
+  height: 100%;
   display: flex;
   flex-direction: column;
 

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -29,7 +29,7 @@
 
   .tabs {
     margin: 15px 10px 5px;
-    flex: 1 0 30px;
+    flex: 0 0 auto;
 
     .tabLabel {
       @include font-header-xs;


### PR DESCRIPTION
# Description

The height of the samples table used to be 100%, which would make a scrollbar appear. This was to not having into account the height of the tabs.
Heights are now set using flex layout components.

![Jun-25-2019 13-43-39](https://user-images.githubusercontent.com/37312125/60132038-8de02b80-974f-11e9-805c-7a6275d4a65b.gif)
