### PR TITLE
Batch autoscaling (IDSEQ-237)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - docker-compose run webtest "rails test"
   - docker-compose run webtest "rake db:drop db:create db:migrate db:reset"
   - docker-compose run webtest "rspec"
+  - docker-compose run --rm webtest "pip install mock; python -m unittest discover -v -s /app/test/ -p 'test_*.py'"
   - brakeman --no-pager || true
 env:
   global:

--- a/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_preview_sidebar.scss
@@ -6,11 +6,12 @@
   width: 300px;
   overflow-y: scroll;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 
   .container {
     display: flex;
     flex-direction: column;
-    height: 100%;
     flex: 1 0 auto;
 
     .table {
@@ -28,6 +29,7 @@
 
   .tabs {
     margin: 15px 10px 5px;
+    flex: 0 0 auto;
 
     .tabLabel {
       @include font-header-xs;

--- a/app/jobs/autoscaling.py
+++ b/app/jobs/autoscaling.py
@@ -9,6 +9,8 @@ from operator import itemgetter
 from functools import wraps
 from collections import defaultdict, Counter
 import dateutil.parser
+import batch_autoscaling
+
 
 DEBUG = False
 
@@ -144,6 +146,15 @@ def autoscaling_update(config):
             print "{num_to_discard} instances have finished draining and can be discarded: {instances_to_discard}.".format(num_to_discard=num_to_discard, instances_to_discard=instances_to_discard)
         else:
             print "No instances are ready to move from 'draining' to 'discarded' state."
+
+        print "Autoscaling batches:"
+        response_batch_autoscaling = batch_autoscaling.autoscale_compute_environments(config['batch_configurations'])
+        print json.dumps(response_batch_autoscaling, default=_default_json_serializer)
+
+
+def _default_json_serializer(obj):
+    '''Default serializer that returns string <<non-sertializable: TYPE_NAME>> for that type'''
+    return "<<non-serializable: {type_name}>>".format(type_name=str(type(obj)))
 
 class ASG(object):
     r'''

--- a/app/jobs/autoscaling.py
+++ b/app/jobs/autoscaling.py
@@ -147,10 +147,10 @@ def autoscaling_update(config):
         else:
             print "No instances are ready to move from 'draining' to 'discarded' state."
 
-        if 'batch_configurations' in config:
-            print "Autoscaling batches:"
-            response_batch_autoscaling = batch_autoscaling.autoscale_compute_environments(config['batch_configurations'], dry_run=True)
-            print json.dumps(response_batch_autoscaling, default=_default_json_serializer)
+    if 'batch_configurations' in config:
+        print "Autoscaling batches:"
+        response_batch_autoscaling = batch_autoscaling.autoscale_compute_environments(config['batch_configurations'], dry_run=True)
+        print json.dumps(response_batch_autoscaling, default=_default_json_serializer)
 
 
 def _default_json_serializer(obj):

--- a/app/jobs/autoscaling.py
+++ b/app/jobs/autoscaling.py
@@ -147,9 +147,10 @@ def autoscaling_update(config):
         else:
             print "No instances are ready to move from 'draining' to 'discarded' state."
 
-        print "Autoscaling batches:"
-        response_batch_autoscaling = batch_autoscaling.autoscale_compute_environments(config['batch_configurations'])
-        print json.dumps(response_batch_autoscaling, default=_default_json_serializer)
+        if 'batch_configurations' in config:
+            print "Autoscaling batches:"
+            response_batch_autoscaling = batch_autoscaling.autoscale_compute_environments(config['batch_configurations'])
+            print json.dumps(response_batch_autoscaling, default=_default_json_serializer)
 
 
 def _default_json_serializer(obj):

--- a/app/jobs/autoscaling.py
+++ b/app/jobs/autoscaling.py
@@ -149,7 +149,7 @@ def autoscaling_update(config):
 
     if 'batch_configurations' in config:
         print "Autoscaling batches:"
-        response_batch_autoscaling = batch_autoscaling.autoscale_compute_environments(config['batch_configurations'], dry_run=True)
+        response_batch_autoscaling = batch_autoscaling.autoscale_compute_environments(config['batch_configurations'])
         print json.dumps(response_batch_autoscaling, default=_default_json_serializer)
 
 

--- a/app/jobs/autoscaling.py
+++ b/app/jobs/autoscaling.py
@@ -149,7 +149,7 @@ def autoscaling_update(config):
 
         if 'batch_configurations' in config:
             print "Autoscaling batches:"
-            response_batch_autoscaling = batch_autoscaling.autoscale_compute_environments(config['batch_configurations'])
+            response_batch_autoscaling = batch_autoscaling.autoscale_compute_environments(config['batch_configurations'], dry_run=True)
             print json.dumps(response_batch_autoscaling, default=_default_json_serializer)
 
 

--- a/app/jobs/batch_autoscaling.py
+++ b/app/jobs/batch_autoscaling.py
@@ -1,0 +1,78 @@
+import sys
+import boto3
+
+def get_compute_environment_capacity(compute_environment_name, region):
+    batch_client = boto3.client('batch', region_name=region)
+    response = batch_client.describe_compute_environments(computeEnvironments=[compute_environment_name])
+    compute_resources = response['computeEnvironments'][0]['computeResources']
+    return {'minvCpus': compute_resources['minvCpus'], 'maxvCpus': compute_resources['maxvCpus']}
+
+
+def set_compute_environment_min_capacity(vcpu_min_capacity, compute_environment_name, region):
+    batch_client = boto3.client('batch', region_name=region)
+    batch_client.update_compute_environment(computeEnvironment=compute_environment_name, computeResources={'minvCpus': vcpu_min_capacity})
+
+
+def check_pending_jobs_counts(queue_name, region, job_status_list=('SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING', 'RUNNING')):
+    return {job_status: get_jobs_count(queue_name, region, job_status) for job_status in job_status_list}
+
+
+def autoscale_compute_environments(batch_configurations):
+    results = []
+    for bc in batch_configurations:
+        try:
+            process_results = process_batch_configuration(bc)
+            results.append({'batch_configuration': bc, 'process_results': process_results})
+        except Exception as e:
+            error_type = str(type(e))
+            error_args = e.args
+            results.append({ 'batch_configuration': bc, "error_type": error_type, "error_args": error_args})
+    return results
+
+
+def process_batch_configuration(batch_configuration):
+    job_vcpus, queue_name, region = (batch_configuration[i] for i in ('vcpus', 'queue_name', 'region'))
+    compute_environment_name = find_compute_environment_name(queue_name, region)
+    current_capacity = get_compute_environment_capacity(compute_environment_name, region)
+    current_vcpu_min, current_vcpu_max = (current_capacity[i] for i in ('minvCpus', 'maxvCpus'))
+
+    pending_jobs_counts = check_pending_jobs_counts(queue_name, region)
+    total_jobs_count = sum(pending_jobs_counts.values())
+    total_jobs_vcpu = total_jobs_count * job_vcpus
+
+    new_vcpu_min = min(total_jobs_vcpu, current_vcpu_max)
+
+    if new_vcpu_min != current_vcpu_min:
+        changed = True
+        set_compute_environment_min_capacity(new_vcpu_min, compute_environment_name, region)
+    else:
+        changed = False
+
+    return {
+        'current_vcpu_max': current_vcpu_max,
+        'total_jobs_count': total_jobs_count,
+        'total_jobs_vcpu': total_jobs_vcpu,
+        'old_vcpu_min': current_vcpu_min,
+        'new_vcpu_min': new_vcpu_min,
+        'changed': changed
+    }
+
+
+def get_jobs_count(queue_name, region, job_status):
+    batch_client = boto3.client('batch', region_name=region)
+    response = batch_client.list_jobs(jobQueue=queue_name,
+                                      maxResults=10000,
+                                      jobStatus=job_status)
+    return len(response['jobSummaryList'])
+
+
+def find_compute_environment_name(job_queues_name, region):
+    batch_client = boto3.client('batch', region_name=region)
+    response = batch_client.describe_job_queues(jobQueues=[job_queues_name])
+    job_queue_description = response['jobQueues'][0]
+    compute_environment_order = job_queue_description['computeEnvironmentOrder']
+    if len(compute_environment_order) > 1:
+        raise Exception('Batch queue {queue_name} has more than one compute environment. Not supported by autoscaler.py')
+    compute_environment_arn = compute_environment_order[0]['computeEnvironment']
+    compute_environment_name = compute_environment_arn.split('/')[1]
+    return compute_environment_name

--- a/app/jobs/batch_autoscaling.py
+++ b/app/jobs/batch_autoscaling.py
@@ -13,7 +13,7 @@ def set_compute_environment_min_capacity(vcpu_min_capacity, compute_environment_
     batch_client.update_compute_environment(computeEnvironment=compute_environment_name, computeResources={'minvCpus': vcpu_min_capacity})
 
 
-def check_pending_jobs_counts(queue_name, region, job_status_list=('SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING', 'RUNNING')):
+def check_pending_jobs_counts(queue_name, region, job_status_list=('RUNNABLE', 'STARTING', 'RUNNING')):
     return {job_status: get_jobs_count(queue_name, region, job_status) for job_status in job_status_list}
 
 

--- a/app/jobs/batch_autoscaling.py
+++ b/app/jobs/batch_autoscaling.py
@@ -17,7 +17,7 @@ def get_compute_environment_configuration(compute_environment_name, region):
 def _get_scaling_permission(compute_environment_arn, compute_resources):
     scaling_permission = 'tags' in compute_resources and SCALING_PERMISSION_TAG in compute_resources['tags']
     if not scaling_permission:
-        scaling_permission = compute_environment_arn in (s.strip() for s in os.getenv(SCALING_PERMISSION_ENV_VAR, '').split(','))
+        scaling_permission = any(s for s in (s.strip() for s in os.getenv(SCALING_PERMISSION_ENV_VAR, '').split(',')) if s in compute_environment_arn)
     return scaling_permission
 
 def _set_compute_environment_min_capacity(vcpu_min_capacity, compute_environment_name, region):

--- a/app/jobs/batch_autoscaling.py
+++ b/app/jobs/batch_autoscaling.py
@@ -1,63 +1,68 @@
+import traceback
 import boto3
 
-def get_compute_environment_capacity(compute_environment_name, region):
+SCALING_PERMISSION_TAG = 'IDSeqEnvsThatCanScale'
+
+def get_compute_environment_configuration(compute_environment_name, region):
     batch_client = boto3.client('batch', region_name=region)
     response = batch_client.describe_compute_environments(computeEnvironments=[compute_environment_name])
     compute_resources = response['computeEnvironments'][0]['computeResources']
-    return {'minvCpus': compute_resources['minvCpus'], 'maxvCpus': compute_resources['maxvCpus']}
+    scaling_permission = 'tags' in compute_resources and SCALING_PERMISSION_TAG in compute_resources['tags']
+    return {'minvCpus': compute_resources['minvCpus'], 'maxvCpus': compute_resources['maxvCpus'], 'scaling_permission': scaling_permission}
 
 
-def set_compute_environment_min_capacity(vcpu_min_capacity, compute_environment_name, region):
+def _set_compute_environment_min_capacity(vcpu_min_capacity, compute_environment_name, region):
     batch_client = boto3.client('batch', region_name=region)
     batch_client.update_compute_environment(computeEnvironment=compute_environment_name, computeResources={'minvCpus': vcpu_min_capacity})
 
 
-def check_pending_jobs_counts(queue_name, region, job_status_list=('RUNNABLE', 'STARTING', 'RUNNING')):
-    return {job_status: get_jobs_count(queue_name, region, job_status) for job_status in job_status_list}
+def _check_pending_jobs_counts(queue_name, region, job_status_list=('RUNNING', 'STARTING', 'RUNNABLE')):
+    return {job_status: _get_jobs_count(queue_name, region, job_status) for job_status in job_status_list}
 
 
-def autoscale_compute_environments(batch_configurations, dry_run=False):
+def autoscale_compute_environments(batch_configurations):
     results = []
     for bc in batch_configurations:
         try:
-            process_results = process_batch_configuration(bc, dry_run)
+            process_results = process_batch_configuration(bc)
             results.append({'batch_configuration': bc, 'process_results': process_results})
         except Exception as e:
             error_type = str(type(e))
             error_args = e.args
-            results.append({'batch_configuration': bc, "error_type": error_type, "error_args": error_args})
+            results.append({'batch_configuration': bc, "error_type": error_type, "error_args": error_args, "traceback": traceback.format_exc(e)})
     return results
 
 
-def process_batch_configuration(batch_configuration, dry_run=False):
-    job_vcpus, queue_name, region = (batch_configuration[i] for i in ('vcpus', 'queue_name', 'region'))
-    compute_environment_name = find_compute_environment_name(queue_name, region)
-    current_capacity = get_compute_environment_capacity(compute_environment_name, region)
-    current_vcpu_min, current_vcpu_max = (current_capacity[i] for i in ('minvCpus', 'maxvCpus'))
-
-    pending_jobs_counts = check_pending_jobs_counts(queue_name, region)
+def calc_auto_scaling_recommendation(pending_jobs_counts, job_vcpus, current_vcpu_min, current_vcpu_max, scaling_permission):
     total_jobs_count = sum(pending_jobs_counts.values())
     total_jobs_vcpu = total_jobs_count * job_vcpus
 
     new_vcpu_min = min(total_jobs_vcpu, current_vcpu_max)
 
-    if (new_vcpu_min != current_vcpu_min) and not dry_run:
-        changed = True
-        set_compute_environment_min_capacity(new_vcpu_min, compute_environment_name, region)
-    else:
-        changed = False
+    change = scaling_permission and (new_vcpu_min != current_vcpu_min)
 
     return {
-        'current_vcpu_max': current_vcpu_max,
-        'total_jobs_count': total_jobs_count,
-        'total_jobs_vcpu': total_jobs_vcpu,
-        'old_vcpu_min': current_vcpu_min,
-        'new_vcpu_min': new_vcpu_min,
-        'changed': changed
+        'change': change,
+        'new_vcpu_min': new_vcpu_min
     }
 
 
-def get_jobs_count(queue_name, region, job_status):
+def process_batch_configuration(batch_configuration):
+    job_vcpus, queue_name, region = (batch_configuration[i] for i in ('vcpus', 'queue_name', 'region'))
+    compute_environment_name = _find_compute_environment_name(queue_name, region)
+    current_configuration = get_compute_environment_configuration(compute_environment_name, region)
+    current_vcpu_min, current_vcpu_max, scaling_permission = (current_configuration[i] for i in ('minvCpus', 'maxvCpus', 'scaling_permission'))
+    pending_jobs_counts = _check_pending_jobs_counts(queue_name, region)
+
+    autoscaling_recommendation = calc_auto_scaling_recommendation(pending_jobs_counts, job_vcpus, current_vcpu_min, current_vcpu_max, scaling_permission)
+
+    if autoscaling_recommendation['change']:
+        _set_compute_environment_min_capacity(autoscaling_recommendation['new_vcpu_min'], compute_environment_name, region)
+
+    return {'current_configuration': current_configuration, 'pending_jobs_counts': pending_jobs_counts, 'autoscaling_recommendation': autoscaling_recommendation}
+
+
+def _get_jobs_count(queue_name, region, job_status):
     batch_client = boto3.client('batch', region_name=region)
     response = batch_client.list_jobs(jobQueue=queue_name,
                                       maxResults=10000,
@@ -65,7 +70,7 @@ def get_jobs_count(queue_name, region, job_status):
     return len(response['jobSummaryList'])
 
 
-def find_compute_environment_name(job_queues_name, region):
+def _find_compute_environment_name(job_queues_name, region):
     batch_client = boto3.client('batch', region_name=region)
     response = batch_client.describe_job_queues(jobQueues=[job_queues_name])
     job_queue_description = response['jobQueues'][0]

--- a/app/jobs/batch_autoscaling.py
+++ b/app/jobs/batch_autoscaling.py
@@ -1,4 +1,3 @@
-import sys
 import boto3
 
 def get_compute_environment_capacity(compute_environment_name, region):
@@ -26,7 +25,7 @@ def autoscale_compute_environments(batch_configurations, dry_run=False):
         except Exception as e:
             error_type = str(type(e))
             error_args = e.args
-            results.append({ 'batch_configuration': bc, "error_type": error_type, "error_args": error_args})
+            results.append({'batch_configuration': bc, "error_type": error_type, "error_args": error_args})
     return results
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ x-web-variables: &web-variables
   ? BASESPACE_CLIENT_ID
   ? BASESPACE_CLIENT_SECRET
   ? BASESPACE_OAUTH_REDIRECT_URI
+  ? ID_SEQ_ENVS_THAT_CAN_SCALE
 
 x-aws-variables: &aws-variables
   ? AWS_ACCESS_KEY_ID

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -12,6 +12,8 @@ IDSEQ_BENCH_MIN_FREQUENCY_HOURS = 1.0
 # by copying to the S3 location below.
 IDSEQ_BENCH_CONFIG = "s3://idseq-bench/config.json".freeze
 
+AWS_DEFAULT_REGION = ENV.fetch('AWS_DEFAULT_REGION') { "us-west-2" }
+
 class CheckPipelineRuns
   # Concurrency allowed
   MAX_SHARDS = 10
@@ -96,7 +98,19 @@ class CheckPipelineRuns
       'max_job_dispatch_lag_seconds' => PipelineRun::MAX_JOB_DISPATCH_LAG_SECONDS,
       'job_tag_prefix' => PipelineRun::JOB_TAG_PREFIX,
       'job_tag_keep_alive_seconds' => PipelineRun::JOB_TAG_KEEP_ALIVE_SECONDS,
-      'draining_tag' => PipelineRun::DRAINING_TAG
+      'draining_tag' => PipelineRun::DRAINING_TAG,
+      'batch_configurations' => [
+        {
+          'queue_name' => Sample::DEFAULT_QUEUE,
+          'vcpus' => Sample::DEFAULT_VCPUS,
+          'region_name' => AWS_DEFAULT_REGION
+        },
+        {
+          'queue_name' => Sample::DEFAULT_QUEUE_HIMEM,
+          'vcpus' => Sample::DEFAULT_VCPUS_HIMEM,
+          'region_name' => AWS_DEFAULT_REGION
+        }
+      ]
     }
     c_stdout, c_stderr, c_status = Open3.capture3("app/jobs/autoscaling.py '#{autoscaling_config.to_json}'")
     Rails.logger.info(c_stdout)

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -103,12 +103,12 @@ class CheckPipelineRuns
         {
           'queue_name' => Sample::DEFAULT_QUEUE,
           'vcpus' => Sample::DEFAULT_VCPUS,
-          'region_name' => AWS_DEFAULT_REGION
+          'region' => AWS_DEFAULT_REGION
         },
         {
           'queue_name' => Sample::DEFAULT_QUEUE_HIMEM,
           'vcpus' => Sample::DEFAULT_VCPUS_HIMEM,
-          'region_name' => AWS_DEFAULT_REGION
+          'region' => AWS_DEFAULT_REGION
         }
       ]
     }

--- a/test/jobs/__init__.py
+++ b/test/jobs/__init__.py
@@ -3,5 +3,5 @@ import sys
 
 # This is not a python package, so we need some hack to import class under test
 project_root_dir_name = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../")
-python_file_dir_name = project_root_dir_name + "/app/jobs" 
+python_file_dir_name = project_root_dir_name + "/app/jobs"
 sys.path.append(python_file_dir_name)

--- a/test/jobs/__init__.py
+++ b/test/jobs/__init__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# This is not a python package, so we need some hack to import class under test
+project_root_dir_name = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../")
+python_file_dir_name = project_root_dir_name + "/app/jobs" 
+sys.path.append(python_file_dir_name)

--- a/test/jobs/test_batch_autoscaling.py
+++ b/test/jobs/test_batch_autoscaling.py
@@ -1,36 +1,19 @@
 #!/usr/bin/env python
-import os
-import sys
-import json
-
 import unittest
 import botocore
 
-from mock import patch, call
+from mock import patch
 
 # Class under test
 import batch_autoscaling # pylint: disable=import-error
 
 
-FAKE_RESPONSE_METADATA = {
-    'RetryAttempts': 0,
-    'HTTPStatusCode': 200,
-    'RequestId': '12345678-abcd-def0-1234-567890abcdef',
-    'HTTPHeaders': {'content-type': 'application/json'}
-}
+FAKE_LIST_JOBS_RESPONSE = {'jobSummaryList': [
+    {'status': 'RUNNING', 'jobName': 'job-name-1', 'createdAt': 1561155711844, 'jobId': '11111111-abcd-ffff-1111-abcdabcd0001'},
+    {'status': 'RUNNING', 'jobName': 'job-name-2', 'createdAt': 1561155811844, 'jobId': '11111111-abcd-ffff-1111-abcdabcd0002'}
+]}
 
-FAKE_EMPTY_LIST_JOBS_RESPONSE = {
-    'jobSummaryList': [],
-    'ResponseMetadata': FAKE_RESPONSE_METADATA
-}
-
-FAKE_LIST_JOBS_RESPONSE = {
-    'jobSummaryList': [
-        {'status': 'RUNNABLE', 'jobName': 'job-name-1', 'createdAt': 1561155711844, 'jobId': '11111111-abcd-ffff-1111-abcdabcd0001'},
-        {'status': 'RUNNABLE', 'jobName': 'job-name-2', 'createdAt': 1561155811844, 'jobId': '11111111-abcd-ffff-1111-abcdabcd0002'}
-    ],
-    'ResponseMetadata': FAKE_RESPONSE_METADATA
-}
+FAKE_LIST_JOBS_RESPONSE_EMPTY = {'jobSummaryList': []}
 
 FAKE_QUEUE_NAME = 'fake-job-queue'
 FAKE_COMPUTE_ENVIRONMENT_NAME = 'fake-compute-environment'
@@ -40,150 +23,122 @@ FAKE_ACCOUNT = '123456789012'
 FAKE_COMPUT_ENVIRONMENT_ARN = "arn:aws:batch:{region}:{account}:compute-environment/{compute_env}".format(region=FAKE_REGION, account=FAKE_ACCOUNT, compute_env=FAKE_COMPUTE_ENVIRONMENT_NAME)
 
 FAKE_DESCRIBE_JOB_QUEUES_RESPONSE = {
-    "jobQueues": [
-        {
-            "status": "VALID",
-            "jobQueueArn": "arn:aws:batch:{region}:{account}:job-queue/{queue}".format(region=FAKE_REGION, account=FAKE_ACCOUNT, queue=FAKE_QUEUE_NAME),
-            "computeEnvironmentOrder": [
-                { "computeEnvironment": FAKE_COMPUT_ENVIRONMENT_ARN }
-            ],
-            "jobQueueName": FAKE_QUEUE_NAME
-        }
-    ],
-    "ResponseMetadata": FAKE_RESPONSE_METADATA
+    "jobQueues": [{
+        "status": "VALID",
+        "jobQueueArn": "arn:aws:batch:{region}:{account}:job-queue/{queue}".format(region=FAKE_REGION, account=FAKE_ACCOUNT, queue=FAKE_QUEUE_NAME),
+        "computeEnvironmentOrder": [
+            {"computeEnvironment": FAKE_COMPUT_ENVIRONMENT_ARN}
+        ],
+        "jobQueueName": FAKE_QUEUE_NAME
+    }]
 }
 
-FAKE_CANNOT_UPDATE_EXCEPTION = botocore.exceptions.ClientError(
-    {
-        'Error': {
-            'Code': 'ClientException',
-            'Message': 'Cannot update, compute environment ... is being modified.'
-        },
-        'ResponseMetadata': {
-            'HTTPHeaders': FAKE_RESPONSE_METADATA['HTTPHeaders']
-        }
-    }, 'UpdateComputeEnvironment'
-)
+FAKE_CANNOT_UPDATE_EXCEPTION = botocore.exceptions.ClientError({'Error': {'Code': 'ClientException', 'Message': 'Cannot update, compute environment ... is being modified.'}}, 'UpdateComputeEnvironment')
 
-FAKE_BATCH_CONFIGURATIONS = [
-    {
-        'queue_name': FAKE_QUEUE_NAME,
-        'vcpus': 12,
-        'region': FAKE_REGION
-    }
-]
+FAKE_BATCH_CONFIGURATIONS = [{'queue_name': FAKE_QUEUE_NAME, 'vcpus': 12, 'region': FAKE_REGION}]
 
-FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS = {
-    "ResponseMetadata": FAKE_RESPONSE_METADATA,
-    "computeEnvironments": [
-        {
-            "computeEnvironmentName": "davidcruz-compute-environment",
-            "computeResources": {
-                "desiredvCpus": 0,
-                "maxvCpus": 40,
-                "minvCpus": 0
-            }
+FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS_SCALING_TAG_SET = {
+    "computeEnvironments": [{
+        "computeEnvironmentName": FAKE_COMPUTE_ENVIRONMENT_NAME,
+        "computeResources": {
+            "desiredvCpus": 0, "maxvCpus": 40, "minvCpus": 0,
+            "tags": {"Name": FAKE_COMPUTE_ENVIRONMENT_NAME, "IDSeqEnvsThatCanScale": "1"}
         }
-    ]
+    }]
+}
+
+FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS_NO_SCALING_TAG = {
+    "computeEnvironments": [{
+        "computeEnvironmentName": FAKE_COMPUTE_ENVIRONMENT_NAME,
+        "computeResources": {
+            "desiredvCpus": 0, "maxvCpus": 40, "minvCpus": 0,
+            "tags": {"Name": FAKE_COMPUTE_ENVIRONMENT_NAME}
+        }
+    }]
 }
 
 class TestAutoscaling(unittest.TestCase):
     '''Tests for /app/jobs/autoscaling.py'''
 
-    @patch('batch_autoscaling.get_jobs_count', side_effect=[10, 5, 2])
-    def test_check_pending_jobs_counts(self, _mock_list_queue_jobs_count):
-        result = batch_autoscaling.check_pending_jobs_counts(FAKE_QUEUE_NAME, FAKE_REGION, job_status_list=('RUNNABLE', 'STARTING', 'RUNNING'))
+    def test_calc_auto_scaling_recommendation_1(self):
+        '''WHEN new capacity is same as current capacity THEN do not recommend a change'''
+        result = batch_autoscaling.calc_auto_scaling_recommendation(pending_jobs_counts={'RUNNABLE': 1, 'STARTING': 1, 'RUNNING': 1},
+                                                                    current_vcpu_min=36,
+                                                                    current_vcpu_max=40, job_vcpus=12, scaling_permission=True)
 
-        self.assertEqual(result, {'RUNNABLE': 10, 'STARTING': 5, 'RUNNING': 2})
+        self.assertEqual(result, {'change': False, 'new_vcpu_min': 36})
+
+
+    def test_calc_auto_scaling_recommendation_2(self):
+        '''WHEN new capacity is higher than current capacity THEN recommend a change to the higher capacity'''
+        result = batch_autoscaling.calc_auto_scaling_recommendation(pending_jobs_counts={'RUNNABLE': 2},
+                                                                    current_vcpu_min=10,
+                                                                    current_vcpu_max=40, job_vcpus=12, scaling_permission=True)
+
+        self.assertEqual(result, {'change': True, 'new_vcpu_min': 24})
+
+
+    def test_calc_auto_scaling_recommendation_3(self):
+        '''WHEN new capacity is lower than current capacity THEN recommend a change to the lower capacity'''
+        result = batch_autoscaling.calc_auto_scaling_recommendation(pending_jobs_counts={'RUNNABLE': 1},
+                                                                    current_vcpu_min=30,
+                                                                    current_vcpu_max=40, job_vcpus=12, scaling_permission=True)
+
+        self.assertEqual(result, {'change': True, 'new_vcpu_min': 12})
+
+
+    def test_calc_auto_scaling_recommendation_4(self):
+        '''WHEN total pending jobs exceed max capacity AND capacity is lower THEN recommend a change to capped to the maximum capacity'''
+        result = batch_autoscaling.calc_auto_scaling_recommendation(pending_jobs_counts={'RUNNABLE': 3, 'STARTING': 4, 'RUNNING': 12},
+                                                                    current_vcpu_min=12,
+                                                                    current_vcpu_max=40, job_vcpus=12, scaling_permission=True)
+
+        self.assertEqual(result, {'change': True, 'new_vcpu_min': 40})
+
+
+    def test_calc_auto_scaling_recommendation_5(self):
+        '''WHEN scaling permission is not set THEN do not recommend a change'''
+        result = batch_autoscaling.calc_auto_scaling_recommendation(pending_jobs_counts={'RUNNABLE': 3, 'STARTING': 4, 'RUNNING': 12},
+                                                                    current_vcpu_min=12,
+                                                                    current_vcpu_max=40, job_vcpus=12, scaling_permission=False)
+
+        self.assertEqual(result, {'change': False, 'new_vcpu_min': 40})
 
 
     @patch('batch_autoscaling.boto3.client')
-    def test_get_jobs_count(self, _mock_boto3):
-        _mock_boto3.return_value.list_jobs.return_value = FAKE_LIST_JOBS_RESPONSE
-
-        result = batch_autoscaling.get_jobs_count(FAKE_QUEUE_NAME, FAKE_REGION, 'RUNNABLE')
-
-        self.assertEqual(result, 2)
-
-
-    @patch('batch_autoscaling.boto3.client')
-    def test_set_compute_environment_min_capacity(self, _mock_boto3):
-        batch_autoscaling.set_compute_environment_min_capacity(20, FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
-
-        _mock_boto3.return_value.update_compute_environment.assert_called_once_with(
-            computeEnvironment=FAKE_COMPUTE_ENVIRONMENT_NAME, computeResources={'minvCpus': 20}
-        )
-
-
-    @patch('batch_autoscaling.boto3.client')
-    def test_get_compute_environment_capacity(self, _mock_boto3):
-        _mock_boto3.return_value.describe_compute_environments.return_value = FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS
-
-        result = batch_autoscaling.get_compute_environment_capacity(FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
-
-        self.assertEqual(result, {'minvCpus': 0, 'maxvCpus': 40})
-
-
-    @patch('batch_autoscaling.boto3.client')
-    def test_find_compute_environment_names(self, _mock_boto3):
+    def test_process_batch_configuration_1(self, _mock_boto3):
+        '''WHEN processing batch configuration THEN invoke dependencies and change the environment'''
+        _mock_boto3.return_value.list_jobs.side_effect = [FAKE_LIST_JOBS_RESPONSE, FAKE_LIST_JOBS_RESPONSE_EMPTY, FAKE_LIST_JOBS_RESPONSE_EMPTY]
         _mock_boto3.return_value.describe_job_queues.return_value = FAKE_DESCRIBE_JOB_QUEUES_RESPONSE
+        _mock_boto3.return_value.describe_compute_environments.return_value = FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS_SCALING_TAG_SET
 
-        result = batch_autoscaling.find_compute_environment_name(FAKE_QUEUE_NAME, FAKE_REGION)
-
-        self.assertEqual(result, FAKE_COMPUTE_ENVIRONMENT_NAME)
-
-
-    @patch('batch_autoscaling.find_compute_environment_name', return_value=FAKE_COMPUTE_ENVIRONMENT_NAME)
-    @patch('batch_autoscaling.get_compute_environment_capacity', return_value={'minvCpus': 36, 'maxvCpus': 40})
-    @patch('batch_autoscaling.check_pending_jobs_counts', return_value={'RUNNABLE': 1, 'STARTING': 1, 'RUNNING': 1})
-    @patch('batch_autoscaling.set_compute_environment_min_capacity', side_effect=Exception("shouldn't be invoked"))
-    def test_process_batch_configuration_1(self, *_):
-        '''new capacity is same as current'''
         result = batch_autoscaling.process_batch_configuration(FAKE_BATCH_CONFIGURATIONS[0])
 
-        self.assertEqual(result, {'current_vcpu_max': 40, 'new_vcpu_min': 36, 'old_vcpu_min': 36, 'total_jobs_count': 3, 'total_jobs_vcpu': 36, 'changed': False})
+        _mock_boto3.return_value.update_compute_environment.assert_called_once_with(computeEnvironment=FAKE_COMPUTE_ENVIRONMENT_NAME,
+                                                                                    computeResources={'minvCpus': 24})
+        self.assertEqual(result, {'autoscaling_recommendation': {'change': True, 'new_vcpu_min': 24},
+                                  'current_configuration': {'maxvCpus': 40, 'minvCpus': 0, 'scaling_permission': True},
+                                  'pending_jobs_counts': {'RUNNING': 2, 'STARTING': 0, 'RUNNABLE': 0}})
 
 
-    @patch('batch_autoscaling.find_compute_environment_name', return_value=FAKE_COMPUTE_ENVIRONMENT_NAME)
-    @patch('batch_autoscaling.get_compute_environment_capacity', return_value={'minvCpus': 10, 'maxvCpus': 40})
-    @patch('batch_autoscaling.check_pending_jobs_counts', return_value={'RUNNABLE': 2})
-    @patch('batch_autoscaling.set_compute_environment_min_capacity')
-    def test_process_batch_configuration_2(self, _mock_set_compute_environment_min_capacity, *_):
-        '''new capacity is higher'''
+    @patch('batch_autoscaling.boto3.client')
+    def test_process_batch_configuration_2(self, _mock_boto3):
+        '''WHEN processing batch configuration THEN invoke dependencies and change the environment'''
+        _mock_boto3.return_value.list_jobs.side_effect = [FAKE_LIST_JOBS_RESPONSE, FAKE_LIST_JOBS_RESPONSE_EMPTY, FAKE_LIST_JOBS_RESPONSE_EMPTY]
+        _mock_boto3.return_value.describe_job_queues.return_value = FAKE_DESCRIBE_JOB_QUEUES_RESPONSE
+        _mock_boto3.return_value.describe_compute_environments.return_value = FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS_NO_SCALING_TAG
+
         result = batch_autoscaling.process_batch_configuration(FAKE_BATCH_CONFIGURATIONS[0])
 
-        _mock_set_compute_environment_min_capacity.assert_called_once_with(24, FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
-        self.assertEqual(result, {'current_vcpu_max': 40, 'new_vcpu_min': 24, 'old_vcpu_min': 10, 'total_jobs_count': 2, 'total_jobs_vcpu': 24, 'changed': True})
-
-
-    @patch('batch_autoscaling.find_compute_environment_name', return_value=FAKE_COMPUTE_ENVIRONMENT_NAME)
-    @patch('batch_autoscaling.get_compute_environment_capacity', return_value={'minvCpus': 30, 'maxvCpus': 40})
-    @patch('batch_autoscaling.check_pending_jobs_counts', return_value={'RUNNABLE': 1})
-    @patch('batch_autoscaling.set_compute_environment_min_capacity')
-    def test_process_batch_configuration_3(self, _mock_set_compute_environment_min_capacity, *_):
-        '''new capacity is lower'''
-        result = batch_autoscaling.process_batch_configuration(FAKE_BATCH_CONFIGURATIONS[0])
-
-        _mock_set_compute_environment_min_capacity.assert_called_once_with(12, FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
-        self.assertEqual(result, {'current_vcpu_max': 40, 'new_vcpu_min': 12, 'old_vcpu_min': 30, 'total_jobs_count': 1, 'total_jobs_vcpu': 12, 'changed': True})
-
-
-
-    @patch('batch_autoscaling.find_compute_environment_name', return_value=FAKE_COMPUTE_ENVIRONMENT_NAME)
-    @patch('batch_autoscaling.get_compute_environment_capacity', return_value={'minvCpus': 12, 'maxvCpus': 40})
-    @patch('batch_autoscaling.check_pending_jobs_counts', return_value={'RUNNABLE': 3, 'STARTING': 4, 'RUNNING': 12})
-    @patch('batch_autoscaling.set_compute_environment_min_capacity')
-    def test_process_batch_configuration_5(self, _mock_set_compute_environment_min_capacity, *_):
-        '''new capacity capped to max'''
-        result = batch_autoscaling.process_batch_configuration(FAKE_BATCH_CONFIGURATIONS[0])
-
-        _mock_set_compute_environment_min_capacity.assert_called_once_with(40, FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
-        self.assertEqual(result, {'current_vcpu_max': 40, 'new_vcpu_min': 40, 'old_vcpu_min': 12, 'total_jobs_count': 19, 'total_jobs_vcpu': 228, 'changed': True})
+        _mock_boto3.return_value.update_compute_environment.assert_not_called()
+        self.assertEqual(result, {'autoscaling_recommendation': {'change': False, 'new_vcpu_min': 24},
+                                  'current_configuration': {'maxvCpus': 40, 'minvCpus': 0, 'scaling_permission': False},
+                                  'pending_jobs_counts': {'RUNNING': 2, 'STARTING': 0, 'RUNNABLE': 0}})
 
 
     @patch('batch_autoscaling.boto3.client', side_effect=FAKE_CANNOT_UPDATE_EXCEPTION)
-    def test_autoscale_compute_environments_1(self, _):
-        '''Error executing autoscale'''
+    def test_autoscale_compute_environments(self, _):
+        '''WHEN any error happens during autoscale for an specific environment THEN return the error message and don't break'''
         result = batch_autoscaling.autoscale_compute_environments(FAKE_BATCH_CONFIGURATIONS)
 
         self.assertEqual(result[0]['error_type'], "<class 'botocore.exceptions.ClientError'>")

--- a/test/jobs/test_batch_autoscaling.py
+++ b/test/jobs/test_batch_autoscaling.py
@@ -8,13 +8,9 @@ import botocore
 
 from mock import patch, call
 
-# This is not a python package, so we need some hack to import class under test
-project_root_dir_name = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../")
-python_file_dir_name = project_root_dir_name + "/app/jobs/" # batch_autoscaling.py
-sys.path.append(python_file_dir_name)
-
 # Class under test
-import batch_autoscaling # pylint: disable=wrong-import-position, import-error
+import batch_autoscaling # pylint: disable=import-error
+
 
 FAKE_RESPONSE_METADATA = {
     'RetryAttempts': 0,

--- a/test/jobs/test_batch_autoscaling.py
+++ b/test/jobs/test_batch_autoscaling.py
@@ -107,7 +107,7 @@ class TestAutoscaling(unittest.TestCase):
 
     @patch('batch_autoscaling.boto3.client')
     def test_process_batch_configuration_1(self, _mock_boto3):
-        '''WHEN processing batch configuration THEN invoke dependencies and change the environment'''
+        '''WHEN processing batch configuration with scaling tag set THEN invoke dependencies and change the environment'''
         _mock_boto3.return_value.list_jobs.side_effect = [FAKE_LIST_JOBS_RESPONSE, FAKE_LIST_JOBS_RESPONSE_EMPTY, FAKE_LIST_JOBS_RESPONSE_EMPTY]
         _mock_boto3.return_value.describe_job_queues.return_value = FAKE_DESCRIBE_JOB_QUEUES_RESPONSE
         _mock_boto3.return_value.describe_compute_environments.return_value = FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS_SCALING_TAG_SET
@@ -123,7 +123,7 @@ class TestAutoscaling(unittest.TestCase):
 
     @patch('batch_autoscaling.boto3.client')
     def test_process_batch_configuration_2(self, _mock_boto3):
-        '''WHEN processing batch configuration THEN invoke dependencies and change the environment'''
+        '''WHEN processing batch configuration with scaling tag not set THEN do not change the environment'''
         _mock_boto3.return_value.list_jobs.side_effect = [FAKE_LIST_JOBS_RESPONSE, FAKE_LIST_JOBS_RESPONSE_EMPTY, FAKE_LIST_JOBS_RESPONSE_EMPTY]
         _mock_boto3.return_value.describe_job_queues.return_value = FAKE_DESCRIBE_JOB_QUEUES_RESPONSE
         _mock_boto3.return_value.describe_compute_environments.return_value = FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS_NO_SCALING_TAG

--- a/test/jobs/test_batch_autoscaling.py
+++ b/test/jobs/test_batch_autoscaling.py
@@ -114,8 +114,8 @@ class TestAutoscaling(unittest.TestCase):
                                                              should_have_scaling_permission=True, should_change=True)
 
     def test_process_batch_configuration_2(self):
-        '''WHEN processing batch configuration with scaling tag not set AND scaling environment variable is present AND environment is the list THEN invoke dependencies and change the environment'''
-        with mock.patch.dict(os.environ, {'ID_SEQ_ENVS_THAT_CAN_SCALE': FAKE_COMPUTE_ENVIRONMENT_ARN + ',dummy_arn'}):
+        '''WHEN processing batch configuration with scaling tag not set AND scaling environment variable is present AND partial string of compute environment ARN is the list THEN invoke dependencies and change the environment'''
+        with mock.patch.dict(os.environ, {'ID_SEQ_ENVS_THAT_CAN_SCALE': FAKE_COMPUTE_ENVIRONMENT_NAME + ',dummy_arn_fragment'}):
             self._parameterized_test_process_batch_configuration(batch_describe_compute_environments_return_value=FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS_NO_SCALING_TAG,
                                                                  should_have_scaling_permission=True, should_change=True)
 
@@ -125,7 +125,7 @@ class TestAutoscaling(unittest.TestCase):
                                                              should_have_scaling_permission=False, should_change=False)
 
     def test_process_batch_configuration_4(self):
-        '''WHEN processing batch configuration with scaling tag not set AND scaling environment variable is present AND environment is not in the list THEN do not change the environment'''
+        '''WHEN processing batch configuration with scaling tag not set AND scaling environment variable is present AND compute environment is not in the list THEN do not change the environment'''
         with mock.patch.dict(os.environ, {'ID_SEQ_ENVS_THAT_CAN_SCALE': 'dummy_arn'}):
             self._parameterized_test_process_batch_configuration(batch_describe_compute_environments_return_value=FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS_NO_SCALING_TAG,
                                                                  should_have_scaling_permission=False, should_change=False)

--- a/test/jobs/test_batch_autoscaling.py
+++ b/test/jobs/test_batch_autoscaling.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+import os
+import sys
+import json
+
+import unittest
+import botocore
+
+from mock import patch, call
+
+# This is not a python package, so we need some hack to import class under test
+project_root_dir_name = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../")
+python_file_dir_name = project_root_dir_name + "/app/jobs/" # batch_autoscaling.py
+sys.path.append(python_file_dir_name)
+
+# Class under test
+import batch_autoscaling # pylint: disable=wrong-import-position, import-error
+
+FAKE_RESPONSE_METADATA = {
+    'RetryAttempts': 0,
+    'HTTPStatusCode': 200,
+    'RequestId': '12345678-abcd-def0-1234-567890abcdef',
+    'HTTPHeaders': {'content-type': 'application/json'}
+}
+
+FAKE_EMPTY_LIST_JOBS_RESPONSE = {
+    'jobSummaryList': [],
+    'ResponseMetadata': FAKE_RESPONSE_METADATA
+}
+
+FAKE_LIST_JOBS_RESPONSE = {
+    'jobSummaryList': [
+        {'status': 'RUNNABLE', 'jobName': 'job-name-1', 'createdAt': 1561155711844, 'jobId': '11111111-abcd-ffff-1111-abcdabcd0001'},
+        {'status': 'RUNNABLE', 'jobName': 'job-name-2', 'createdAt': 1561155811844, 'jobId': '11111111-abcd-ffff-1111-abcdabcd0002'}
+    ],
+    'ResponseMetadata': FAKE_RESPONSE_METADATA
+}
+
+FAKE_QUEUE_NAME = 'fake-job-queue'
+FAKE_COMPUTE_ENVIRONMENT_NAME = 'fake-compute-environment'
+FAKE_REGION = 'us-east-1'
+FAKE_ACCOUNT = '123456789012'
+
+FAKE_COMPUT_ENVIRONMENT_ARN = "arn:aws:batch:{region}:{account}:compute-environment/{compute_env}".format(region=FAKE_REGION, account=FAKE_ACCOUNT, compute_env=FAKE_COMPUTE_ENVIRONMENT_NAME)
+
+FAKE_DESCRIBE_JOB_QUEUES_RESPONSE = {
+    "jobQueues": [
+        {
+            "status": "VALID",
+            "jobQueueArn": "arn:aws:batch:{region}:{account}:job-queue/{queue}".format(region=FAKE_REGION, account=FAKE_ACCOUNT, queue=FAKE_QUEUE_NAME),
+            "computeEnvironmentOrder": [
+                { "computeEnvironment": FAKE_COMPUT_ENVIRONMENT_ARN }
+            ],
+            "jobQueueName": FAKE_QUEUE_NAME
+        }
+    ],
+    "ResponseMetadata": FAKE_RESPONSE_METADATA
+}
+
+FAKE_CANNOT_UPDATE_EXCEPTION = botocore.exceptions.ClientError(
+    {
+        'Error': {
+            'Code': 'ClientException',
+            'Message': 'Cannot update, compute environment ... is being modified.'
+        },
+        'ResponseMetadata': {
+            'HTTPHeaders': FAKE_RESPONSE_METADATA['HTTPHeaders']
+        }
+    }, 'UpdateComputeEnvironment'
+)
+
+FAKE_BATCH_CONFIGURATIONS = [
+    {
+        'queue_name': FAKE_QUEUE_NAME,
+        'vcpus': 12,
+        'region': FAKE_REGION
+    }
+]
+
+FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS = {
+    "ResponseMetadata": FAKE_RESPONSE_METADATA,
+    "computeEnvironments": [
+        {
+            "computeEnvironmentName": "davidcruz-compute-environment",
+            "computeResources": {
+                "desiredvCpus": 0,
+                "maxvCpus": 40,
+                "minvCpus": 0
+            }
+        }
+    ]
+}
+
+class TestAutoscaling(unittest.TestCase):
+    '''Tests for /app/jobs/autoscaling.py'''
+
+    @patch('batch_autoscaling.get_jobs_count', side_effect=[10, 5, 2])
+    def test_check_pending_jobs_counts(self, _mock_list_queue_jobs_count):
+        result = batch_autoscaling.check_pending_jobs_counts(FAKE_QUEUE_NAME, FAKE_REGION, job_status_list=('RUNNABLE', 'STARTING', 'RUNNING'))
+
+        self.assertEqual(result, {'RUNNABLE': 10, 'STARTING': 5, 'RUNNING': 2})
+
+
+    @patch('batch_autoscaling.boto3.client')
+    def test_get_jobs_count(self, _mock_boto3):
+        _mock_boto3.return_value.list_jobs.return_value = FAKE_LIST_JOBS_RESPONSE
+
+        result = batch_autoscaling.get_jobs_count(FAKE_QUEUE_NAME, FAKE_REGION, 'RUNNABLE')
+
+        self.assertEqual(result, 2)
+
+
+    @patch('batch_autoscaling.boto3.client')
+    def test_set_compute_environment_min_capacity(self, _mock_boto3):
+        batch_autoscaling.set_compute_environment_min_capacity(20, FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
+
+        _mock_boto3.return_value.update_compute_environment.assert_called_once_with(
+            computeEnvironment=FAKE_COMPUTE_ENVIRONMENT_NAME, computeResources={'minvCpus': 20}
+        )
+
+
+    @patch('batch_autoscaling.boto3.client')
+    def test_get_compute_environment_capacity(self, _mock_boto3):
+        _mock_boto3.return_value.describe_compute_environments.return_value = FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS
+
+        result = batch_autoscaling.get_compute_environment_capacity(FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
+
+        self.assertEqual(result, {'minvCpus': 0, 'maxvCpus': 40})
+
+
+    @patch('batch_autoscaling.boto3.client')
+    def test_find_compute_environment_names(self, _mock_boto3):
+        _mock_boto3.return_value.describe_job_queues.return_value = FAKE_DESCRIBE_JOB_QUEUES_RESPONSE
+
+        result = batch_autoscaling.find_compute_environment_name(FAKE_QUEUE_NAME, FAKE_REGION)
+
+        self.assertEqual(result, FAKE_COMPUTE_ENVIRONMENT_NAME)
+
+
+    @patch('batch_autoscaling.find_compute_environment_name', return_value=FAKE_COMPUTE_ENVIRONMENT_NAME)
+    @patch('batch_autoscaling.get_compute_environment_capacity', return_value={'minvCpus': 36, 'maxvCpus': 40})
+    @patch('batch_autoscaling.check_pending_jobs_counts', return_value={'RUNNABLE': 1, 'STARTING': 1, 'RUNNING': 1})
+    @patch('batch_autoscaling.set_compute_environment_min_capacity', side_effect=Exception("shouldn't be invoked"))
+    def test_process_batch_configuration_1(self, *_):
+        '''new capacity is same as current'''
+        result = batch_autoscaling.process_batch_configuration(FAKE_BATCH_CONFIGURATIONS[0])
+
+        self.assertEqual(result, {'current_vcpu_max': 40, 'new_vcpu_min': 36, 'old_vcpu_min': 36, 'total_jobs_count': 3, 'total_jobs_vcpu': 36, 'changed': False})
+
+
+    @patch('batch_autoscaling.find_compute_environment_name', return_value=FAKE_COMPUTE_ENVIRONMENT_NAME)
+    @patch('batch_autoscaling.get_compute_environment_capacity', return_value={'minvCpus': 10, 'maxvCpus': 40})
+    @patch('batch_autoscaling.check_pending_jobs_counts', return_value={'RUNNABLE': 2})
+    @patch('batch_autoscaling.set_compute_environment_min_capacity')
+    def test_process_batch_configuration_2(self, _mock_set_compute_environment_min_capacity, *_):
+        '''new capacity is higher'''
+        result = batch_autoscaling.process_batch_configuration(FAKE_BATCH_CONFIGURATIONS[0])
+
+        _mock_set_compute_environment_min_capacity.assert_called_once_with(24, FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
+        self.assertEqual(result, {'current_vcpu_max': 40, 'new_vcpu_min': 24, 'old_vcpu_min': 10, 'total_jobs_count': 2, 'total_jobs_vcpu': 24, 'changed': True})
+
+
+    @patch('batch_autoscaling.find_compute_environment_name', return_value=FAKE_COMPUTE_ENVIRONMENT_NAME)
+    @patch('batch_autoscaling.get_compute_environment_capacity', return_value={'minvCpus': 30, 'maxvCpus': 40})
+    @patch('batch_autoscaling.check_pending_jobs_counts', return_value={'RUNNABLE': 1})
+    @patch('batch_autoscaling.set_compute_environment_min_capacity')
+    def test_process_batch_configuration_3(self, _mock_set_compute_environment_min_capacity, *_):
+        '''new capacity is lower'''
+        result = batch_autoscaling.process_batch_configuration(FAKE_BATCH_CONFIGURATIONS[0])
+
+        _mock_set_compute_environment_min_capacity.assert_called_once_with(12, FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
+        self.assertEqual(result, {'current_vcpu_max': 40, 'new_vcpu_min': 12, 'old_vcpu_min': 30, 'total_jobs_count': 1, 'total_jobs_vcpu': 12, 'changed': True})
+
+
+
+    @patch('batch_autoscaling.find_compute_environment_name', return_value=FAKE_COMPUTE_ENVIRONMENT_NAME)
+    @patch('batch_autoscaling.get_compute_environment_capacity', return_value={'minvCpus': 12, 'maxvCpus': 40})
+    @patch('batch_autoscaling.check_pending_jobs_counts', return_value={'RUNNABLE': 3, 'STARTING': 4, 'RUNNING': 12})
+    @patch('batch_autoscaling.set_compute_environment_min_capacity')
+    def test_process_batch_configuration_5(self, _mock_set_compute_environment_min_capacity, *_):
+        '''new capacity capped to max'''
+        result = batch_autoscaling.process_batch_configuration(FAKE_BATCH_CONFIGURATIONS[0])
+
+        _mock_set_compute_environment_min_capacity.assert_called_once_with(40, FAKE_COMPUTE_ENVIRONMENT_NAME, FAKE_REGION)
+        self.assertEqual(result, {'current_vcpu_max': 40, 'new_vcpu_min': 40, 'old_vcpu_min': 12, 'total_jobs_count': 19, 'total_jobs_vcpu': 228, 'changed': True})
+
+
+    @patch('batch_autoscaling.boto3.client', side_effect=FAKE_CANNOT_UPDATE_EXCEPTION)
+    def test_autoscale_compute_environments_1(self, _):
+        '''Error executing autoscale'''
+        result = batch_autoscaling.autoscale_compute_environments(FAKE_BATCH_CONFIGURATIONS)
+
+        self.assertEqual(result[0]['error_type'], "<class 'botocore.exceptions.ClientError'>")
+        self.assertRegexpMatches(result[0]['error_args'][0], 'Cannot update')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

Batch is often slow or unwilling to scale up the idseq compute environment.   The gsnap and raspearch tiers may be up and idle, with many jobs waiting in the batch queues. (IDSEQ-237)


# Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*
* *See also [IDseq PR Guidelines](https://github.com/chanzuckerberg/idseq-web/blob/master/PR_GUIDELINES.md)*
