### PR TITLE
[Taxon Search] Search text on any part of the word and avoid SQL injection.

### DIFF
--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -22,7 +22,7 @@ module ElasticsearchHelper
     query = sanitize(query)
 
     # sanitize tax_levels
-    tax_levels = tax_levels.select {|l| TaxonCount::NAME_2_LEVEL[l] }
+    tax_levels = tax_levels.select { |l| TaxonCount::NAME_2_LEVEL[l] }
 
     matching_taxa = []
     taxon_ids = []

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -17,9 +17,12 @@ module ElasticsearchHelper
     results
   end
 
-  def taxon_search(prefix, tax_levels = TaxonCount::NAME_2_LEVEL.keys, filters = {})
+  def taxon_search(query, tax_levels = TaxonCount::NAME_2_LEVEL.keys, filters = {})
     return {} if Rails.env == "test"
-    prefix = sanitize(prefix)
+    query = sanitize(query)
+
+    # sanitize tax_levels
+    tax_levels = tax_levels.select {|l| TaxonCount::NAME_2_LEVEL[l] }
 
     matching_taxa = []
     taxon_ids = []
@@ -28,7 +31,7 @@ module ElasticsearchHelper
         size: ElasticsearchHelper::MAX_SEARCH_RESULTS,
         query: {
           query_string: {
-            query: "#{prefix}*",
+            query: "*#{query}*",
             fields: ["#{level}_name"]
           }
         },
@@ -84,9 +87,9 @@ module ElasticsearchHelper
     return filter_by_samples(taxon_ids, Sample.joins(:project).where(project: Project.where(id: project_id)))
   end
 
-  def sanitize(prefix)
+  def sanitize(text)
     # Add \\ to escape special characters. Four \ to escape the backslashes.
     # Escape anything that isn't in "a-zA-Z0-9 ._|'/"
-    prefix.gsub(%r{([^a-zA-Z0-9 ._|'\/])}, '\\\\\1') if prefix
+    text.gsub(%r{([^a-zA-Z0-9 ._|'\/])}, '\\\\\1') if text
   end
 end


### PR DESCRIPTION

# Description

* Search any part of the word (as opposed to prefix search for any word)
* Sanitize `tax_levels` to avoid SQL injection.

# Notes

* Naturally, this change makes the ElasticSearch query slower. 
* Below are a few raw results: with the code run to extract them. However, true impact depends on several factors, namely, number of results return, popularity of search due to ES cache, etc. Despite the below results I saw some instances where search could be ~10x slower than prefix search.

```
foo = ActionView::Base.new
foo.extend ElasticsearchHelper
foo.taxon_search("ruptri", ["species", "genus"])
foo.taxon_search("enteri", ["species", "genus"])
foo.taxon_search("salmo", ["species", "genus"])

Results for ElasticSearch queries only (species query + genus query)

Prefix search:
(middle of the word)   ruptri: 0.028 + 0.122 = 0.150
(start of second word) enteri: 0.019 + 0.052 = 0.071
(start of first word)  salmo:  0.028 + 0.091 = 0.119 

Free search: 
(middle of the word)   ruptri: 0.126 + 0.212 = 0.328 (2.2x slower)
(start of second word) enteri: 0.123 + 0.253 = 0.376 (5.3x slower)
(start of first word)  salmo:  0.138 + 0.229 = 0.367 (3.1x slower)
```

* Since our current bottleneck for most use cases is not ElasticSearch but the filter by samples and projects that happens afterwords, I propose deploying this change and evaluate the performance impact on 3/4 weeks.
