### PR TITLE
[Visualizations Tab] Fix phylo tree icon

### DIFF
--- a/app/assets/src/components/views/visualizations/VisualizationsView.jsx
+++ b/app/assets/src/components/views/visualizations/VisualizationsView.jsx
@@ -72,7 +72,7 @@ class VisualizationsView extends React.Component {
         <HeatmapPrivate className={cs.icon} />
       );
     } else if (visualizationType == "phylo_tree") {
-      publicAccess ? (
+      return publicAccess ? (
         <PhyloTreePublic className={cs.icon} />
       ) : (
         <PhyloTreePrivate className={cs.icon} />


### PR DESCRIPTION
# Description

- Minor bug where the icon wasn't being returned.

# Notes

Works now:
![Screen Shot 2019-07-01 at 12 25 40 PM](https://user-images.githubusercontent.com/5652739/60461470-7b586d00-9bfb-11e9-897a-17f75c4dcd88.png)

# Tests
- Make sure you have a phylo tree saved (go to a phylo tree and click save) and then go to the Visualizations tab and see the icon there.