### PR TITLE
[Maps] Fix assorted bugs (duplicate locations and UI)

### DIFF
--- a/app/assets/src/components/common/filters/LocationFilter.jsx
+++ b/app/assets/src/components/common/filters/LocationFilter.jsx
@@ -32,12 +32,12 @@ class LocationFilter extends React.Component {
         mergedOptions[val].count += option.count;
       }
     }, options);
-
     return values(mergedOptions);
   };
 
   render() {
     const { options, ...otherProps } = this.props;
+
     return (
       <BaseMultipleFilter
         {...otherProps}

--- a/app/assets/src/components/common/filters/LocationFilter.jsx
+++ b/app/assets/src/components/common/filters/LocationFilter.jsx
@@ -1,30 +1,43 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { concat, forEach, values } from "lodash/fp";
+import { forEach, values } from "lodash/fp";
 import { BaseMultipleFilter } from "~/components/common/filters";
 
 class LocationFilter extends React.Component {
   expandParents = options => {
-    let parentOptions = {};
+    let mergedOptions = {};
     forEach(option => {
+      // Tally parents
       forEach(parent => {
-        if (!parentOptions[parent]) {
-          parentOptions[parent] = {
+        if (!mergedOptions[parent]) {
+          mergedOptions[parent] = {
             text: parent,
             value: parent,
             count: option.count,
           };
         } else {
-          parentOptions[parent].count += option.count;
+          mergedOptions[parent].count += option.count;
         }
       }, option.parents || []);
+
+      // Tally current option
+      const val = option.value;
+      if (!mergedOptions[val]) {
+        mergedOptions[val] = {
+          text: option.text,
+          value: val,
+          count: option.count,
+        };
+      } else {
+        mergedOptions[val].count += option.count;
+      }
     }, options);
-    return concat(options, values(parentOptions));
+
+    return values(mergedOptions);
   };
 
   render() {
     const { options, ...otherProps } = this.props;
-
     return (
       <BaseMultipleFilter
         {...otherProps}

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -1198,14 +1198,15 @@ class DiscoveryView extends React.Component {
               )}
           </div>
           <div className={cs.centerPane}>
-            {currentDisplay === "table" ? (
-              <NarrowContainer className={cs.viewContainer}>
-                {this.renderCenterPaneContent()}
-              </NarrowContainer>
-            ) : (
+            {currentDisplay === "map" &&
+            ["samples", "projects"].includes(currentTab) ? (
               <div className={cs.viewContainer}>
                 {this.renderCenterPaneContent()}
               </div>
+            ) : (
+              <NarrowContainer className={cs.viewContainer}>
+                {this.renderCenterPaneContent()}
+              </NarrowContainer>
             )}
           </div>
           {this.renderRightPane()}

--- a/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
+++ b/app/assets/src/components/views/discovery/mapping/DiscoveryMap.jsx
@@ -1,4 +1,4 @@
-import { get, throttle, upperFirst, sumBy, size, values } from "lodash/fp";
+import { get, throttle, upperFirst, size, map, uniq, flatten } from "lodash/fp";
 import React from "react";
 
 import { logAnalyticsEvent } from "~/api/analytics";
@@ -156,7 +156,8 @@ class DiscoveryMap extends React.Component {
   renderBanner = () => {
     const { currentTab, mapLocationData, onClearFilters } = this.props;
     const idsField = currentTab === "samples" ? "sample_ids" : "project_ids";
-    const itemCount = sumBy(p => size(p[idsField]), values(mapLocationData));
+    // De-dup ids so you don't double-count
+    const itemCount = size(uniq(flatten(map(idsField, mapLocationData))));
     return (
       <MapBanner
         item={currentTab}

--- a/app/assets/src/components/views/discovery/mapping/MapBanner.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapBanner.jsx
@@ -14,7 +14,7 @@ class MapBanner extends React.Component {
       return (
         <div className={cs.bannerContainer}>
           <div className={cs.banner}>
-            {`No ${item} found. Try adjusting search or filters. `}
+            {`No ${item} with locations found. Try adjusting search or filters. `}
             <span
               className={cs.clearAll}
               onClick={withAnalytics(

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -242,6 +242,7 @@ export default class MapPreviewSidebar extends React.Component {
   handleSelectAllRows = (value, checked) => {
     const { selectableIds } = this.props;
     const { selectedSampleIds } = this.state;
+    console.log("selected: ", selectedSampleIds);
     let newSelected = new Set(
       checked
         ? union(selectedSampleIds, selectableIds)

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -242,11 +242,10 @@ export default class MapPreviewSidebar extends React.Component {
   handleSelectAllRows = (value, checked) => {
     const { selectableIds } = this.props;
     const { selectedSampleIds } = this.state;
-    console.log("selected: ", selectedSampleIds);
     let newSelected = new Set(
       checked
-        ? union(selectedSampleIds, selectableIds)
-        : difference(selectedSampleIds, selectableIds)
+        ? union(Array.from(selectedSampleIds), selectableIds)
+        : difference(Array.from(selectedSampleIds), selectableIds)
     );
     this.setSelectedSampleIds(newSelected);
 

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -164,8 +164,8 @@ class SamplesView extends React.Component {
     const { selectedSampleIds } = this.state;
     let newSelected = new Set(
       checked
-        ? union(selectedSampleIds, selectableIds)
-        : difference(selectedSampleIds, selectableIds)
+        ? union(Array.from(selectedSampleIds), selectableIds)
+        : difference(Array.from(selectedSampleIds), selectableIds)
     );
     this.setState({ selectedSampleIds: newSelected });
   };

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -81,7 +81,6 @@
         flex: 0 0 auto;
         height: 21px;
         width: 21px;
-        vertical-align: middle;
 
         &:not(.disabled) {
           cursor: pointer;

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -20,7 +20,7 @@ class LocationsController < ApplicationController
       if success
         results = resp.map { |r| LocationHelper.adapt_location_iq_response(r) }
         # Just keep the first if you get duplicate locations
-        results = results.uniq { |r| [r[:name], r[:geo_level], r[:lat], r[:lng]] }
+        results = results.uniq { |r| [r[:name], r[:geo_level], r[:osm_type]] }
       end
     end
     event = MetricUtil::ANALYTICS_EVENT_NAMES[:location_geosearched]

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -20,7 +20,7 @@ class LocationsController < ApplicationController
       if success
         results = resp.map { |r| LocationHelper.adapt_location_iq_response(r) }
         # Just keep the first if you get duplicate locations
-        results = results.uniq { |r| [r[:name], r[:geo_level], r[:osm_type]] }
+        results = results.uniq { |r| [r[:name], r[:geo_level]] }
       end
     end
     event = MetricUtil::ANALYTICS_EVENT_NAMES[:location_geosearched]

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -19,6 +19,8 @@ class LocationsController < ApplicationController
       success, resp = Location.geosearch(query)
       if success
         results = resp.map { |r| LocationHelper.adapt_location_iq_response(r) }
+        # Just keep the first if you get duplicate locations
+        results = results.uniq { |r| [r[:name], r[:geo_level], r[:lat], r[:lng]] }
       end
     end
     event = MetricUtil::ANALYTICS_EVENT_NAMES[:location_geosearched]


### PR DESCRIPTION
# Description
- LocationFilter: This change fixes duplicate lines appearing. Before you'd get duplicates with the parents by concatenating arrays.
![Screen Shot 2019-07-01 at 3 29 27 PM](https://user-images.githubusercontent.com/5652739/60474909-8924e700-9c29-11e9-8ad2-d8e4f68aba1e.png)
- DiscoveryView: This adds back NarrowContainer to the visualization tab so it doesn't get super wide if you click over from when you were on the map view.
- DiscoveryMap: This fixes a bug where sample_ids/project_ids were getting double-counted at their parents and main nodes.
- MapPreviewSidebar/SamplesView: Array.from is necessary because `selectedSampleIds` is actually `set` and union/difference requires two arrays. This fixes the persistence of samples when you click "select all" on different locations (before it would discard previously selected values).
![Screen Shot 2019-07-01 at 12 40 31 PM](https://user-images.githubusercontent.com/5652739/60474926-a35ec500-9c29-11e9-9c23-7318619c6f1f.png)
- samples_view.scss: The vertical-align made the heatmap icon jump when it got activated.
- LocationsController: This de-dups location results if they have the same name/geo_level/osm_type. Keeping the first one is good enough. This fixes duplicate keys in the geosearch results.
![Screen Shot 2019-07-01 at 5 23 55 PM](https://user-images.githubusercontent.com/5652739/60474898-80341580-9c29-11e9-8012-f711ae76bbea.png)

# Test
- LocationFilter: Go to the location sidebar, try some locations, make sure you don't see duplicates.
- DiscoveryView: Go to maps view, click over to Visualization tab, stretch out your screen, make sure it still has a NarrowContainer.
- DiscoveryMap: Go to the samples maps view, zoom around different geolevels, make sure the sample count in the top map banner doesn't change.
- MapPreviewSidebar/SamplesView: Go to the maps, go to a location, click a few samples, go to a different location, click select all checkbox, make sure your old count of samples were still collected.
- LocationsController: Go to http://localhost:3000/locations/external_search?query=Redwood%20City and don't see duplicate locations.