### PR TITLE
[Pipeline Viz] Node Hovering

### DIFF
--- a/app/assets/src/components/ui/icons/PipelineStageArrowheadIcon.jsx
+++ b/app/assets/src/components/ui/icons/PipelineStageArrowheadIcon.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const PipelineStageArrowheadIcon = props => {
+  return (
+    <svg
+      className={props.className}
+      viewBox="0 0 97 60"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+    >
+      <g id="Styleguide-and-Components" stroke="none" strokeWidth="1">
+        <g
+          id="1.1-Styleguide-Copy"
+          transform="translate(-865.000000, -1980.000000)"
+        >
+          <polygon
+            id="Path-5-Copy"
+            points="865 1980 874.880859 2009.53369 865 2039.06738 961.522461 2009.53369"
+          />
+        </g>
+      </g>
+    </svg>
+  );
+};
+
+PipelineStageArrowheadIcon.propTypes = {
+  className: PropTypes.string,
+};
+
+export default PipelineStageArrowheadIcon;

--- a/app/assets/src/components/views/PipelineViz.jsx
+++ b/app/assets/src/components/views/PipelineViz.jsx
@@ -4,7 +4,9 @@ import PropTypes from "prop-types";
 import ReactPanZoom from "@ajainarayanan/react-pan-zoom";
 
 import RemoveIcon from "~/components/ui/icons/RemoveIcon";
-import NetworkGraph from "~/components/visualizations/NetworkGraph.js";
+import NetworkGraph from "~/components/visualizations/NetworkGraph";
+import PipelineStageArrowheadIcon from "~/components/ui/icons/PipelineStageArrowheadIcon";
+
 import cs from "./pipeline_viz.scss";
 
 const START_NODE_ID = -1;
@@ -256,8 +258,8 @@ class PipelineViz extends React.Component {
       },
       groups: {
         startEndNodes: {
-          widthConstraint: 8,
-          heightConstraint: 0,
+          shape: "dot",
+          size: 1,
           color: backgroundColor,
           fixed: {
             x: true,
@@ -311,7 +313,7 @@ class PipelineViz extends React.Component {
   }
 
   render() {
-    const stageContainers = this.stageNames.map((stageName, i) => {
+    let stageContainers = this.stageNames.map((stageName, i) => {
       const isOpened = this.state.stagesOpened[i];
 
       return (
@@ -326,10 +328,7 @@ class PipelineViz extends React.Component {
           <div className={isOpened ? cs.openedStage : cs.hidden}>
             <div className={cs.graphLabel}>
               {stageName}
-              <RemoveIcon
-                className={cs.closeButton}
-                onClick={() => this.toggleStage(i)}
-              />
+              <RemoveIcon onClick={() => this.toggleStage(i)} />
             </div>
             <div
               className={cs.graph}
@@ -341,6 +340,19 @@ class PipelineViz extends React.Component {
         </div>
       );
     });
+
+    stageContainers = stageContainers.reduce((containers, stage, i) => {
+      if (i > 0) {
+        containers.push(
+          <div className={cs.stageArrow} key={`stageArrow-${i}`}>
+            <div className={cs.stageArrowBody} />
+            <PipelineStageArrowheadIcon className={cs.stageArrowHead} />
+          </div>
+        );
+      }
+      containers.push(stage);
+      return containers;
+    }, []);
 
     return (
       <div onWheel={this.handleMouseWheelZoom}>

--- a/app/assets/src/components/views/PipelineViz.jsx
+++ b/app/assets/src/components/views/PipelineViz.jsx
@@ -245,8 +245,6 @@ class PipelineViz extends React.Component {
     const { highlightColor } = this.props;
     const graph = this.graphs[stageIndex];
     const stepInfo = this.getStepDataAtIndices(stageIndex, info.node);
-    const inputEdges = graph.getConnectedEdges(info.node, "to");
-    const outputEdges = graph.getConnectedEdges(info.node, "from");
 
     const inputColorOptions = {
       color: {
@@ -256,18 +254,16 @@ class PipelineViz extends React.Component {
       },
       width: 2,
     };
-    const outputColorOptions = {
-      color: {
-        color: highlightColor,
-        hover: highlightColor,
-        inherit: false,
-      },
-      width: 2,
-    };
+
+    const inputEdges = graph.getConnectedEdges(info.node, "to");
+    graph.updateEdges(inputEdges, inputColorOptions);
 
     const updatedInterStageArrows = [...this.state.interStageArrows];
     stepInfo.inputInfo.forEach(inputFile => {
-      if (inputFile.fromStageIndex && inputFile.fromStageIndex != stageIndex) {
+      if (
+        inputFile.fromStageIndex != null &&
+        inputFile.fromStageIndex != stageIndex
+      ) {
         const prevGraph = this.graphs[inputFile.fromStageIndex];
         const edgeId = prevGraph.getEdgeBetweenNodes(
           inputFile.fromStepIndex,
@@ -277,6 +273,18 @@ class PipelineViz extends React.Component {
         updatedInterStageArrows[inputFile.fromStageIndex] = "from";
       }
     });
+
+    const outputColorOptions = {
+      color: {
+        color: highlightColor,
+        hover: highlightColor,
+        inherit: false,
+      },
+      width: 2,
+    };
+
+    const outputEdges = graph.getConnectedEdges(info.node, "from");
+    graph.updateEdges(outputEdges, outputColorOptions);
 
     stepInfo.outputInfo.forEach(outputFile => {
       outputFile.to.forEach(outputNode => {
@@ -292,8 +300,6 @@ class PipelineViz extends React.Component {
       });
     });
 
-    graph.updateEdges(inputEdges, inputColorOptions);
-    graph.updateEdges(outputEdges, outputColorOptions);
     this.setState({
       interStageArrows: updatedInterStageArrows,
     });
@@ -422,9 +428,9 @@ class PipelineViz extends React.Component {
     } else {
       // Create edges to output node if its output files appear in next stage's inputs.
       const nextStageData = this.stagesData[index + 1];
+      const connectedNodes = new Set();
       const interEdgeData = nextStageData.steps
         .map(step => {
-          const connectedNodes = new Set();
           return step.inputInfo.reduce((edges, inputFileInfo) => {
             if (
               inputFileInfo.fromStageIndex == index &&
@@ -691,7 +697,7 @@ PipelineViz.defaultProps = {
   backgroundColor: "#f8f8f8",
   nodeColor: "#eaeaea",
   edgeColor: "#999999",
-  highlightColor: "#3768FA",
+  highlightColor: "#3867fa",
   zoomMin: 0.5,
   zoomMax: 3,
 };

--- a/app/assets/src/components/views/PipelineViz.jsx
+++ b/app/assets/src/components/views/PipelineViz.jsx
@@ -300,6 +300,8 @@ class PipelineViz extends React.Component {
       });
     });
 
+    this.graphs.forEach(graph => this.centerEndNodeVertically(graph));
+
     this.setState({
       interStageArrows: updatedInterStageArrows,
     });
@@ -328,6 +330,8 @@ class PipelineViz extends React.Component {
         });
       }
     });
+
+    this.graphs.forEach(graph => this.centerEndNodeVertically(graph));
 
     this.setState({
       interStageArrows: ["", "", ""],

--- a/app/assets/src/components/views/pipeline_viz.scss
+++ b/app/assets/src/components/views/pipeline_viz.scss
@@ -49,7 +49,7 @@
     }
 
     &.toColoring {
-      background-color: $primary-medium;
+      background-color: $primary-light;
       padding: 1px 0;
     }
   }

--- a/app/assets/src/components/views/pipeline_viz.scss
+++ b/app/assets/src/components/views/pipeline_viz.scss
@@ -42,6 +42,16 @@
     width: calc(100% - 12px);
     padding: 0.5px 0;
     background-color: $medium-grey;
+
+    &.fromColoring {
+      background-color: $black;
+      padding: 1px 0;
+    }
+
+    &.toColoring {
+      background-color: $primary-medium;
+      padding: 1px 0;
+    }
   }
 
   .stageArrowHead {
@@ -49,6 +59,14 @@
     right: 0;
     height: 100%;
     fill: $medium-grey;
+
+    &.fromColoring {
+      fill: $black;
+    }
+
+    &.toColoring {
+      fill: $primary-medium;
+    }
   }
 }
 

--- a/app/assets/src/components/views/pipeline_viz.scss
+++ b/app/assets/src/components/views/pipeline_viz.scss
@@ -25,6 +25,7 @@
   text-align: center;
   font-weight: $font-weight-bold;
   cursor: pointer;
+  word-break: break-word;
 }
 
 .stageArrow {

--- a/app/assets/src/components/views/pipeline_viz.scss
+++ b/app/assets/src/components/views/pipeline_viz.scss
@@ -4,23 +4,48 @@
 .pipelineViz {
   display: flex;
   justify-content: center;
+  align-items: center;
 }
 
 .stage {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 24px;
+  margin: 24px 0;
 }
 
 .stageButton {
   background-color: $light-grey;
   border-radius: 8px;
   padding: 12px;
-  width: 120px;
+  width: 250px;
   text-align: center;
   font-weight: $font-weight-bold;
   cursor: pointer;
+}
+
+.stageArrow {
+  width: 50px;
+  height: 10px;
+  display: flex;
+  align-items: center;
+  overflow: visible;
+  position: relative;
+  flex-shrink: 0;
+
+  .stageArrowBody {
+    position: relative;
+    width: calc(100% - 12px);
+    padding: 0.5px 0;
+    background-color: $medium-grey;
+  }
+
+  .stageArrowHead {
+    position: absolute;
+    right: 0;
+    height: 100%;
+    fill: $medium-grey;
+  }
 }
 
 .graph {
@@ -28,14 +53,13 @@
 }
 
 .graphLabel {
-  display: "flex";
-  justify-content: "space-between";
-  flex-wrap: "wrap";
-}
-
-.closeButton {
-  padding: 3px 12px;
-  cursor: pointer;
+  padding: 24px;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  width: 100%;
+  position: absolute;
+  top: 0;
 }
 
 .hidden {
@@ -46,6 +70,11 @@
   background-color: $off-white;
   border-radius: 6px;
   height: 50vh;
-  padding: 16px;
+  padding: 16px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   font-weight: $font-weight-bold;
+  position: relative;
 }

--- a/app/assets/src/components/visualizations/NetworkGraph.js
+++ b/app/assets/src/components/visualizations/NetworkGraph.js
@@ -28,8 +28,8 @@ export default class NetworkGraph {
     let maxCanvasX = Number.MIN_VALUE;
     this.data.nodes.getIds().forEach(nodeId => {
       const boundingBox = this.graph.getBoundingBox(nodeId);
-      minCanvasX = Math.min(minCanvasX, boundingBox.right);
-      maxCanvasX = Math.max(maxCanvasX, boundingBox.left);
+      minCanvasX = Math.min(minCanvasX, boundingBox.left);
+      maxCanvasX = Math.max(maxCanvasX, boundingBox.right);
     });
     const minDOMX = this.graph.canvasToDOM({ x: minCanvasX }).x;
     const maxDOMX = this.graph.canvasToDOM({ x: maxCanvasX }).x;

--- a/app/assets/src/components/visualizations/NetworkGraph.js
+++ b/app/assets/src/components/visualizations/NetworkGraph.js
@@ -50,10 +50,11 @@ export default class NetworkGraph {
 
   updateEdges(edgeIds, options) {
     const edges = this.data.edges.get(edgeIds);
-    const updateInfo = edges.map(edge => {
-      return Object.assign({ id: edge.id }, options);
+    edges.forEach(edge => {
+      const newEdge = Object.assign({ to: edge.to, from: edge.from }, options);
+      this.data.edges.add(newEdge);
+      this.data.edges.remove(edge.id);
     });
-    this.data.edges.update(updateInfo);
   }
 
   minimizeWidthGivenScale(scale) {

--- a/app/assets/src/components/visualizations/NetworkGraph.js
+++ b/app/assets/src/components/visualizations/NetworkGraph.js
@@ -37,12 +37,15 @@ export default class NetworkGraph {
         filterFunc = edge => edge.to == nodeId || edge.from == nodeId;
     }
 
-    return this.data.edges
-      .get({
-        fields: ["id"],
-        filter: filterFunc,
-      })
-      .map(edge => edge.id);
+    return this.data.edges.getIds({
+      filter: filterFunc,
+    });
+  }
+
+  getEdgeBetweenNodes(fromNodeId, toNodeId) {
+    return this.data.edges.getIds({
+      filter: edge => edge.from == fromNodeId && edge.to == toNodeId,
+    })[0];
   }
 
   updateEdges(edgeIds, options) {


### PR DESCRIPTION

# Node Hovering
* Highlights corresponding input and output edges when hovering over a node

![ezgif-2-382bdcf4356e](https://user-images.githubusercontent.com/23442055/60537650-d94d8900-9cbd-11e9-9179-4ecaacbe7002.gif)

# Notes
* Current z-index "fix" on updateEdge removes, the adds an edge so it will be drawn ontop. Considering a more efficient solution where each edge has three versions (black, blue, grey), where black and blue edges are placed on the very top, and hovering toggles which ones are visible.

# Tests
Go to `samples/[SAMPLE_ID]/stage_results` with pipeline viz enabled account


