### PR TITLE
[Maps] Fix a bug when setting batch Locations with specificity restrictions

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -102,45 +102,34 @@ class Location < ApplicationRecord
 
   # Restrict Human location specificity to Subdivision, State, Country. Return new Location if
   # restriction added.
-  def self.check_and_restrict_specificity(location, host_genome_name)
+  def self.check_and_restrict_specificity(loc, host_genome_name)
     # We don't want Human locations with city
-    if host_genome_name == "Human" && location.city_name.present?
+    if host_genome_name == "Human" && loc[:city_name].present?
       # Return our existing entry if found
-      existing = Location.find_by(country_name: location.country_name, state_name: location.state_name, subdivision_name: location.subdivision_name, city_name: "")
-      return existing if existing
+      existing = Location.find_by(
+        country_name: loc[:country_name],
+        state_name: loc[:state_name],
+        subdivision_name: loc[:subdivision_name],
+        city_name: ""
+      )
+      return true, existing if existing
 
       # Redo the search for just the subdivision/state/country
-      success, resp = geosearch_by_levels(location.country_name, location.state_name, location.subdivision_name)
+      success, resp = geosearch_by_levels(
+        loc[:country_name],
+        loc[:state_name],
+        loc[:subdivision_name]
+      )
       unless success && !resp.empty?
-        raise "Couldn't find #{location.country_name}, #{location.state_name}, #{location.subdivision_name} (country, state, subdivision)"
+        raise "Couldn't find #{loc[:country_name]}, #{loc[:state_name]}, #{loc[:subdivision_name]} (country, state, subdivision)"
       end
 
       result = LocationHelper.adapt_location_iq_response(resp[0])
-      location = Location.find_by(locationiq_id: result[:locationiq_id]) || new_from_params(result)
-    end
-
-    location
-  end
-
-  def self.check_and_restrict_specificity_v2(location_data, host_genome_name)
-    # We don't want Human locations with city
-    if host_genome_name == "Human" && location_data[:city_name].present?
-      # Return our existing entry if found
-      existing = Location.find_by(country_name: location_data[:country_name], state_name: location_data[:state_name], subdivision_name: location_data[:subdivision_name], city_name: "")
-      return existing if existing
-
-      # Redo the search for just the subdivision/state/country
-      success, resp = geosearch_by_levels(location_data[:country_name], location_data[:state_name], location_data[:subdivision_name])
-      unless success && !resp.empty?
-        raise "Couldn't find #{location_data[:country_name]}, #{location_data[:state_name]}, #{location_data[:subdivision_name]} (country, state, subdivision)"
-      end
-
-      result = LocationHelper.adapt_location_iq_response(resp[0])
-      return Location.find_by(locationiq_id: result[:locationiq_id]) || new_from_params(result)
+      return true, Location.find_by(locationiq_id: result[:locationiq_id]) || new_from_params(result)
     end
 
     # Just return the input hash if no change
-    location_data
+    return false, loc
   end
 
   # Note: We are clustering at Country+State for now so Subdivision+City ids may be nil.

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -102,34 +102,34 @@ class Location < ApplicationRecord
 
   # Restrict Human location specificity to Subdivision, State, Country. Return new Location if
   # restriction added.
-  def self.check_and_restrict_specificity(loc, host_genome_name)
+  def self.check_and_restrict_specificity(location, host_genome_name)
     # We don't want Human locations with city
-    if host_genome_name == "Human" && loc[:city_name].present?
+    if host_genome_name == "Human" && location[:city_name].present?
       # Return our existing entry if found
       existing = Location.find_by(
-        country_name: loc[:country_name],
-        state_name: loc[:state_name],
-        subdivision_name: loc[:subdivision_name],
+        country_name: location[:country_name],
+        state_name: location[:state_name],
+        subdivision_name: location[:subdivision_name],
         city_name: ""
       )
-      return true, existing if existing
+      return existing if existing
 
       # Redo the search for just the subdivision/state/country
       success, resp = geosearch_by_levels(
-        loc[:country_name],
-        loc[:state_name],
-        loc[:subdivision_name]
+        location[:country_name],
+        location[:state_name],
+        location[:subdivision_name]
       )
       unless success && !resp.empty?
-        raise "Couldn't find #{loc[:country_name]}, #{loc[:state_name]}, #{loc[:subdivision_name]} (country, state, subdivision)"
+        raise "Couldn't find #{location[:country_name]}, #{location[:state_name]}, #{location[:subdivision_name]} (country, state, subdivision)"
       end
 
       result = LocationHelper.adapt_location_iq_response(resp[0])
-      return true, Location.find_by(locationiq_id: result[:locationiq_id]) || new_from_params(result)
+      return Location.find_by(locationiq_id: result[:locationiq_id]) || new_from_params(result)
     end
 
     # Just return the input hash if no change
-    return false, loc
+    return location
   end
 
   # Note: We are clustering at Country+State for now so Subdivision+City ids may be nil.

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -122,6 +122,10 @@ class Location < ApplicationRecord
     location
   end
 
+  def self.check_and_restrict_specificity_v2(location_data, host_genome_name)
+
+  end
+
   # Note: We are clustering at Country+State for now so Subdivision+City ids may be nil.
   def self.check_and_fetch_parents(location)
     present_parent_level_ids, missing_parent_levels = present_and_missing_parents(location)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -129,7 +129,7 @@ class Location < ApplicationRecord
     end
 
     # Just return the input hash if no change
-    return location
+    location
   end
 
   # Note: We are clustering at Country+State for now so Subdivision+City ids may be nil.

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -128,8 +128,8 @@ class Metadatum < ApplicationRecord
 
     # Set to existing Location or create a new one based on the external IDs. For the sake of not
     # trusting user input, we'll potentially re-fetch location details based on the API and OSM IDs.
-    resolved, location = Location.check_and_restrict_specificity(loc, sample.host_genome_name)
-    unless resolved
+    location = Location.check_and_restrict_specificity(loc, sample.host_genome_name)
+    unless location.is_a?(Location)
       location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
     end
     unless location.id

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -128,6 +128,7 @@ class Metadatum < ApplicationRecord
 
     # Set to existing Location or create a new one based on the external IDs. For the sake of not
     # trusting user input, we'll potentially re-fetch location details based on the API and OSM IDs.
+    puts "foobar 4:09pm, our loc commands: ", loc
     location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
     location = Location.check_and_restrict_specificity(location, sample.host_genome_name)
     unless location.id

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -128,10 +128,8 @@ class Metadatum < ApplicationRecord
 
     # Set to existing Location or create a new one based on the external IDs. For the sake of not
     # trusting user input, we'll potentially re-fetch location details based on the API and OSM IDs.
-    puts "foobar 4:12pm, our loc fields: ", loc
-    location = Location.check_and_restrict_specificity_v2(loc, sample.host_genome_name)
-
-    unless location.is_a?(Location)
+    resolved, location = Location.check_and_restrict_specificity(loc, sample.host_genome_name)
+    unless resolved
       location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
     end
     unless location.id

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -128,9 +128,12 @@ class Metadatum < ApplicationRecord
 
     # Set to existing Location or create a new one based on the external IDs. For the sake of not
     # trusting user input, we'll potentially re-fetch location details based on the API and OSM IDs.
-    puts "foobar 4:09pm, our loc commands: ", loc
-    location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
-    location = Location.check_and_restrict_specificity(location, sample.host_genome_name)
+    puts "foobar 4:12pm, our loc fields: ", loc
+    location = Location.check_and_restrict_specificity_v2(loc, sample.host_genome_name)
+
+    unless location.is_a?(Location)
+      location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
+    end
     unless location.id
       location = Location.check_and_fetch_parents(location)
       location.save!


### PR DESCRIPTION
### Description
- Description of the bug: When we get a Human location with a City name, we discard the City name and do a geosearch for the subdivision (county). The "bug" is that this means when you set a batch to, say, Redwood City, each entry will be changed to San Mateo County and then save San Mateo County. Then every sample in the list would redo this because it never stopped and saved "Redwood City" (so it's not found). Then you'll hit service provider rate limits of a few requests per second and the batch operation will fail.
- Solution: The gist is that we just move the check_and_restrict_specificity line before the call to find_or_new_by_api_ids. This means the specificity is restricted before we do extra geosearches. In the batch case, the first entry will still do a geosearch for the subdivision/county, but then subsequent lines will re-use that entry without re-fetching from the provider.

# Tests
- See tests