### PR TITLE
[MetadataInput] Add a warning when city-level info is stripped from sensitive locations

### DIFF
--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { get, isArray, size } from "lodash/fp";
+import { compact, get, isArray } from "lodash/fp";
 
 import Input from "~/components/ui/controls/Input";
 import Dropdown from "~/components/ui/controls/dropdowns/Dropdown";
@@ -28,8 +28,11 @@ class MetadataInput extends React.Component {
 
     let warning = "";
     if (isHuman && get("geo_level", result) === "city") {
-      const match = result.name.match(/,\s(.*)/);
-      if (size(match) >= 2) result.name = match[1];
+      result.name = compact([
+        result.subdivision_name,
+        result.state_name,
+        result.country_name,
+      ]).join(", ");
       warning = LOCATION_WARNING;
     }
     this.setState({ locationWarning: warning });

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -20,7 +20,9 @@ class MetadataInput extends React.Component {
   }
 
   // For human samples, drop the city part of the name and show a warning.
-  // TODO(jsheu): Consider moving the warnings to the backend.
+  // Note that the backend will redo the geosearch for confirmation, so don't
+  // modify geo_level here.
+  // TODO(jsheu): Consider moving the warnings to the backend and generalizing.
   processLocationSelection = result => {
     const { isHuman } = this.props;
 

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -8,7 +8,7 @@ import GeoSearchInputBox from "../ui/controls/GeoSearchInputBox";
 
 import cs from "./metadata_input.scss";
 
-export const GEO_PRIVACY_WARNING = "Set to county/district for privacy.";
+export const LOCATION_WARNING = "Set to county/district for privacy.";
 
 class MetadataInput extends React.Component {
   constructor(props) {
@@ -28,7 +28,7 @@ class MetadataInput extends React.Component {
     if (isHuman && get("geo_level", result) === "city") {
       const match = result.name.match(/,\s(.*)/);
       if (size(match) >= 2) result.name = match[1];
-      warning = GEO_PRIVACY_WARNING;
+      warning = LOCATION_WARNING;
     }
     this.setState({ locationWarning: warning });
     return result;

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -1,10 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { isArray } from "lodash";
+import { get, isArray } from "lodash/fp";
 
 import Input from "~/components/ui/controls/Input";
 import Dropdown from "~/components/ui/controls/dropdowns/Dropdown";
 import GeoSearchInputBox from "../ui/controls/GeoSearchInputBox";
+
+import cs from "./metadata_input.scss";
+
+export const GEO_PRIVACY_WARNING = "Set to county/district for privacy.";
 
 class MetadataInput extends React.Component {
   constructor(props) {
@@ -15,21 +19,16 @@ class MetadataInput extends React.Component {
     };
   }
 
-  handleLocationSelect = result => {
-    if (result.geo_level && result.geo_level === "city") {
-      console.log(result);
-      console.log("This will be saved at the county level");
+  processLocationSelection = result => {
+    let warning;
+    if (get("geo_level", result) === "city") {
       const match = result.name.match(/,\s(.*)/);
       if (match && match.length >= 2) result.name = match[1];
-
-      result.name = result.name
-        .split(", ")
-        .shift()
-        .join(", ");
-      this.setState({
-        locationWarning: "Changed to county/district for privacy",
-      });
+      warning = GEO_PRIVACY_WARNING;
+    } else {
+      warning = "";
     }
+    this.setState({ locationWarning: warning });
     return result;
   };
 
@@ -79,12 +78,14 @@ class MetadataInput extends React.Component {
             className={className}
             // Calls save on selection
             onResultSelect={({ result }) => {
-              result = this.handleLocationSelect(result);
+              result = this.processLocationSelection(result);
               onChange(metadataType.key, result, true);
             }}
             value={value}
           />
-          {locationWarning}
+          {locationWarning && (
+            <span className={cs.warning}>{locationWarning}</span>
+          )}
         </React.Fragment>
       );
     } else {

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -7,6 +7,32 @@ import Dropdown from "~/components/ui/controls/dropdowns/Dropdown";
 import GeoSearchInputBox from "../ui/controls/GeoSearchInputBox";
 
 class MetadataInput extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      locationWarning: "",
+    };
+  }
+
+  handleLocationSelect = result => {
+    if (result.geo_level && result.geo_level === "city") {
+      console.log(result);
+      console.log("This will be saved at the county level");
+      const match = result.name.match(/,\s(.*)/);
+      if (match && match.length >= 2) result.name = match[1];
+
+      result.name = result.name
+        .split(", ")
+        .shift()
+        .join(", ");
+      this.setState({
+        locationWarning: "Changed to county/district for privacy",
+      });
+    }
+    return result;
+  };
+
   render() {
     const {
       value,
@@ -16,6 +42,7 @@ class MetadataInput extends React.Component {
       className,
       isHuman,
     } = this.props;
+    const { locationWarning } = this.state;
 
     if (isArray(metadataType.options)) {
       const options = metadataType.options.map(option => ({
@@ -47,14 +74,18 @@ class MetadataInput extends React.Component {
       );
     } else if (metadataType.dataType === "location") {
       return (
-        <GeoSearchInputBox
-          className={className}
-          // Calls save on selection
-          onResultSelect={({ result }) =>
-            onChange(metadataType.key, result, true)
-          }
-          value={value}
-        />
+        <React.Fragment>
+          <GeoSearchInputBox
+            className={className}
+            // Calls save on selection
+            onResultSelect={({ result }) => {
+              result = this.handleLocationSelect(result);
+              onChange(metadataType.key, result, true);
+            }}
+            value={value}
+          />
+          {locationWarning}
+        </React.Fragment>
       );
     } else {
       return (

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { get, isArray } from "lodash/fp";
+import { get, isArray, size } from "lodash/fp";
 
 import Input from "~/components/ui/controls/Input";
 import Dropdown from "~/components/ui/controls/dropdowns/Dropdown";
@@ -19,14 +19,16 @@ class MetadataInput extends React.Component {
     };
   }
 
+  // For human samples, drop the city part of the name and show a warning.
+  // TODO(jsheu): Consider moving the warnings to the backend.
   processLocationSelection = result => {
-    let warning;
-    if (get("geo_level", result) === "city") {
+    const { isHuman } = this.props;
+
+    let warning = "";
+    if (isHuman && get("geo_level", result) === "city") {
       const match = result.name.match(/,\s(.*)/);
-      if (match && match.length >= 2) result.name = match[1];
+      if (size(match) >= 2) result.name = match[1];
       warning = GEO_PRIVACY_WARNING;
-    } else {
-      warning = "";
     }
     this.setState({ locationWarning: warning });
     return result;

--- a/app/assets/src/components/common/metadata_input.scss
+++ b/app/assets/src/components/common/metadata_input.scss
@@ -1,0 +1,5 @@
+@import "~styles/themes/typography";
+
+.warning {
+  @include font-body-xxxs;
+}


### PR DESCRIPTION
### Description
- This adds a warning message when city-level info is going to be stripped from human sample locations.
- This is a little hacky since ideally the backend would generate the warnings (and is doing the real resolution), but we don't have warnings in the single-sample case (only errors). Ideally we'll add generalized warnings to support all the metadata fields.
- One benefit to having this on the frontend as well is that the specific city name doesn't have to hit our servers (although we generated the geosearch results of course).

![Jul-10-2019 14-58-44](https://user-images.githubusercontent.com/5652739/61008851-96c32680-a325-11e9-8f1d-3e6571de21f7.gif)
![Jul-10-2019 15-01-55](https://user-images.githubusercontent.com/5652739/61008852-99258080-a325-11e9-955b-6f705aa86e29.gif)

### Tests
- Go to a sample, open the sidebar, try adding a collection_location_v2 at the city level on a human sample, see the error message. Try the same thing for the project-level metadata editor.