### PR TITLE
Log current desiredvCpus value

### DIFF
--- a/app/jobs/batch_autoscaling.py
+++ b/app/jobs/batch_autoscaling.py
@@ -11,7 +11,7 @@ def get_compute_environment_configuration(compute_environment_name, region):
     ecs_cluster_arn = compute_environment_data['ecsClusterArn']
     compute_resources = compute_environment_data['computeResources']
     scaling_permission = _get_scaling_permission(ecs_cluster_arn, region)
-    return {'minvCpus': compute_resources['minvCpus'], 'maxvCpus': compute_resources['maxvCpus'], 'scaling_permission': scaling_permission}
+    return {'minvCpus': compute_resources['minvCpus'], 'maxvCpus': compute_resources['maxvCpus'], 'desiredvCpus': compute_resources['desiredvCpus'], 'scaling_permission': scaling_permission}
 
 def _get_scaling_permission(ecs_cluster_arn, region):
     ecs_client = boto3.client('ecs', region_name=region)

--- a/test/jobs/test_batch_autoscaling.py
+++ b/test/jobs/test_batch_autoscaling.py
@@ -36,7 +36,7 @@ FAKE_BATCH_CONFIGURATIONS = [{'queue_name': FAKE_QUEUE_NAME, 'vcpus': 12, 'regio
 FAKE_DESCRIBE_COMPUTE_ENVIRONMENTS = {"computeEnvironments": [{"computeEnvironmentName": FAKE_COMPUTE_ENVIRONMENT_NAME,
                                                                "computeEnvironmentArn": FAKE_COMPUTE_ENVIRONMENT_ARN,
                                                                "ecsClusterArn": FAKE_ECS_CLUSTER_ARN,
-                                                               "computeResources": {"desiredvCpus": 0, "maxvCpus": 40, "minvCpus": 0,
+                                                               "computeResources": {"desiredvCpus": 4, "maxvCpus": 40, "minvCpus": 0,
                                                                                     "tags": {}}}]}
 
 FAKE_DESCRIBE_CLUSTERS_SCALING_TAG_SET = {"clusters": [{"status": "ACTIVE",
@@ -110,7 +110,7 @@ class TestAutoscaling(unittest.TestCase):
             else:
                 _mock_boto3.return_value.update_compute_environment.assert_not_called()
             self.assertEqual(result, {'autoscaling_recommendation': {'change': should_change, 'new_vcpu_min': 24},
-                                      'current_configuration': {'maxvCpus': 40, 'minvCpus': 0, 'desiredvCpus': 0, 'scaling_permission': should_have_scaling_permission},
+                                      'current_configuration': {'maxvCpus': 40, 'minvCpus': 0, 'desiredvCpus': 4, 'scaling_permission': should_have_scaling_permission},
                                       'compute_environment_name': FAKE_COMPUTE_ENVIRONMENT_NAME,
                                       'pending_jobs_counts': {'RUNNING': 2, 'STARTING': 0, 'RUNNABLE': 0}})
 

--- a/test/jobs/test_batch_autoscaling.py
+++ b/test/jobs/test_batch_autoscaling.py
@@ -110,7 +110,7 @@ class TestAutoscaling(unittest.TestCase):
             else:
                 _mock_boto3.return_value.update_compute_environment.assert_not_called()
             self.assertEqual(result, {'autoscaling_recommendation': {'change': should_change, 'new_vcpu_min': 24},
-                                      'current_configuration': {'maxvCpus': 40, 'minvCpus': 0, 'scaling_permission': should_have_scaling_permission},
+                                      'current_configuration': {'maxvCpus': 40, 'minvCpus': 0, 'desiredvCpus': 0, 'scaling_permission': should_have_scaling_permission},
                                       'compute_environment_name': FAKE_COMPUTE_ENVIRONMENT_NAME,
                                       'pending_jobs_counts': {'RUNNING': 2, 'STARTING': 0, 'RUNNABLE': 0}})
 


### PR DESCRIPTION
# Description

Log current `desiredvCpus` for compute environments on batch autoscaler.

# Notes

This value was missing from logs and I wanted to created some stats.

# Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*
* *See also [IDseq PR Guidelines](https://github.com/chanzuckerberg/idseq-web/blob/master/PR_GUIDELINES.md)*
