### PR TITLE
[Metadata] Refresh project view after editing project-level metadata + Port over public sample notifications

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -957,9 +957,7 @@ class DiscoveryView extends React.Component {
 
   // Cloned from Samples.jsx (deprecated)
   checkPublicSamples = () => {
-    console.log("checkPublicSamples called");
     get("/samples/samples_going_public.json").then(res => {
-      console.log("res: ", res);
       if ((res || []).length) this.displayPublicSampleNotifications(res);
     });
   };

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -1,5 +1,3 @@
-import axios from "axios/index";
-import { partition } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import UrlQueryParser from "~/components/utils/UrlQueryParser";
@@ -20,6 +18,7 @@ import {
   mapKeys,
   mapValues,
   merge,
+  partition,
   pick,
   replace,
   sumBy,
@@ -956,12 +955,14 @@ class DiscoveryView extends React.Component {
     this.setState({ mapLocationData: clusteredData, mapLevel });
   };
 
+  // Cloned from Samples.jsx (deprecated)
   checkPublicSamples = () => {
     get("/samples/samples_going_public.json").then(res => {
       if ((res || []).length) this.displayPublicSampleNotifications(res);
     });
   };
 
+  // Cloned from Samples.jsx (deprecated)
   displayPublicSampleNotifications = samplesGoingPublic => {
     let previouslyDismissedSamples = new Set();
     try {

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -957,7 +957,9 @@ class DiscoveryView extends React.Component {
 
   // Cloned from Samples.jsx (deprecated)
   checkPublicSamples = () => {
+    console.log("checkPublicSamples called");
     get("/samples/samples_going_public.json").then(res => {
+      console.log("res: ", res);
       if ((res || []).length) this.displayPublicSampleNotifications(res);
     });
   };
@@ -973,13 +975,14 @@ class DiscoveryView extends React.Component {
       // catch and ignore possible old formats
     }
 
-    let [dismissedSamples, newSamples] = partition(samplesGoingPublic, sample =>
-      previouslyDismissedSamples.has(sample.id)
+    let [dismissedSamples, newSamples] = partition(
+      sample => previouslyDismissedSamples.has(sample.id),
+      samplesGoingPublic
     );
     if (newSamples.length > 0) {
       localStorage.setItem(
         "dismissedPublicSamples",
-        JSON.stringify(map(dismissedSamples, "id"))
+        JSON.stringify(map("id", dismissedSamples))
       );
       publicSampleNotificationsByProject(newSamples);
     }

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -955,14 +955,12 @@ class DiscoveryView extends React.Component {
     this.setState({ mapLocationData: clusteredData, mapLevel });
   };
 
-  // Cloned from Samples.jsx (deprecated)
   checkPublicSamples = () => {
     get("/samples/samples_going_public.json").then(res => {
       if ((res || []).length) this.displayPublicSampleNotifications(res);
     });
   };
 
-  // Cloned from Samples.jsx (deprecated)
   displayPublicSampleNotifications = samplesGoingPublic => {
     let previouslyDismissedSamples = new Set();
     try {
@@ -978,6 +976,8 @@ class DiscoveryView extends React.Component {
       samplesGoingPublic
     );
     if (newSamples.length > 0) {
+      // The purpose of setItem here is to keep the dismissed list from growing indefinitely. The
+      // value here will no longer include samples that went public in the past.
       localStorage.setItem(
         "dismissedPublicSamples",
         JSON.stringify(map("id", dismissedSamples))

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -667,8 +667,6 @@ class DiscoveryView extends React.Component {
     });
   };
 
-  handleProjectMetadataUpdated = () => {};
-
   getCurrentDimensions = () => {
     const { currentTab, projectDimensions, sampleDimensions } = this.state;
 

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -667,6 +667,8 @@ class DiscoveryView extends React.Component {
     });
   };
 
+  handleProjectMetadataUpdated = () => {};
+
   getCurrentDimensions = () => {
     const { currentTab, projectDimensions, sampleDimensions } = this.state;
 
@@ -1180,6 +1182,7 @@ class DiscoveryView extends React.Component {
               project={project || {}}
               fetchedSamples={samples}
               onProjectUpdated={this.handleProjectUpdated}
+              onMetadataUpdated={this.refreshDataFromProjectChange}
             />
           )}
           <DiscoveryHeader

--- a/app/assets/src/components/views/discovery/ProjectHeader.jsx
+++ b/app/assets/src/components/views/discovery/ProjectHeader.jsx
@@ -10,7 +10,12 @@ import ProjectUploadMenu from "~/components/views/samples/ProjectUploadMenu";
 import cs from "./project_header.scss";
 import cx from "classnames";
 
-const ProjectHeader = ({ project, fetchedSamples, onProjectUpdated }) => {
+const ProjectHeader = ({
+  project,
+  fetchedSamples,
+  onProjectUpdated,
+  onMetadataUpdated,
+}) => {
   const handleProjectUserAdded = (username, email) => {
     const userFound = find({ email }, project.users);
     if (!userFound) {
@@ -78,7 +83,10 @@ const ProjectHeader = ({ project, fetchedSamples, onProjectUpdated }) => {
 
       {project.editable && (
         <div className={cs.item}>
-          <ProjectUploadMenu project={project} />
+          <ProjectUploadMenu
+            project={project}
+            onMetadataUpdated={onMetadataUpdated}
+          />
         </div>
       )}
     </div>
@@ -87,8 +95,9 @@ const ProjectHeader = ({ project, fetchedSamples, onProjectUpdated }) => {
 
 ProjectHeader.propTypes = {
   fetchedSamples: PropTypes.array,
-  project: PropTypes.object.isRequired,
+  onMetadataUpdated: PropTypes.func,
   onProjectUpdated: PropTypes.func,
+  project: PropTypes.object.isRequired,
 };
 
 export default ProjectHeader;

--- a/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/MetadataUploadModal.jsx
@@ -42,7 +42,8 @@ class MetadataUploadModal extends React.Component {
   };
 
   handleComplete = async () => {
-    this.props.onClose();
+    const { onClose, onComplete } = this.props;
+    onClose();
 
     const response = await uploadMetadataForProject(
       this.props.project.id,
@@ -86,6 +87,8 @@ class MetadataUploadModal extends React.Component {
         projectSamples: this.state.projectSamples.length,
       });
     }
+
+    onComplete && onComplete();
   };
 
   getPages = () => {
@@ -139,6 +142,7 @@ class MetadataUploadModal extends React.Component {
 
 MetadataUploadModal.propTypes = {
   onClose: PropTypes.func,
+  onComplete: PropTypes.func,
   project: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,

--- a/app/assets/src/components/views/samples/ProjectUploadMenu.jsx
+++ b/app/assets/src/components/views/samples/ProjectUploadMenu.jsx
@@ -20,6 +20,9 @@ class ProjectUploadMenu extends React.Component {
   closeModal = () => this.setState({ modalOpen: false });
 
   render() {
+    const { onMetadataUpdated, project } = this.props;
+    const { modalOpen } = this.state;
+
     const trigger = (
       <div className={cs.trigger}>
         <i className="fa fa-plus-circle" />
@@ -33,7 +36,7 @@ class ProjectUploadMenu extends React.Component {
         key="1"
         onClick={() => {
           logAnalyticsEvent("ProjectUploadMenu_upload-sample-btn_clicked");
-          this.goToPage(`/samples/upload?projectId=${this.props.project.id}`);
+          this.goToPage(`/samples/upload?projectId=${project.id}`);
         }}
       />,
       <BareDropdown.Item
@@ -50,10 +53,11 @@ class ProjectUploadMenu extends React.Component {
           items={projectUploadItems}
           direction="left"
         />
-        {this.state.modalOpen && (
+        {modalOpen && (
           <MetadataUploadModal
             onClose={this.closeModal}
-            project={this.props.project}
+            onComplete={onMetadataUpdated}
+            project={project}
           />
         )}
       </div>
@@ -62,6 +66,7 @@ class ProjectUploadMenu extends React.Component {
 }
 
 ProjectUploadMenu.propTypes = {
+  onMetadataUpdated: PropTypes.func,
   project: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,

--- a/app/assets/src/components/views/samples/notifications.jsx
+++ b/app/assets/src/components/views/samples/notifications.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { union } from "lodash/fp";
 import PublicSampleNotification from "./PublicSampleNotification";
 import { showToast } from "~/components/utils/toast";
 
@@ -35,10 +36,10 @@ const publicSampleNotificationsByProject = samples => {
         localStorage.setItem(
           "dismissedPublicSamples",
           JSON.stringify(
-            new Set([
-              ...JSON.parse(localStorage.getItem("dismissedPublicSamples")),
-              ...projectSamples.map(sample => sample.id),
-            ])
+            union(
+              JSON.parse(localStorage.getItem("dismissedPublicSamples")),
+              projectSamples.map(sample => sample.id)
+            )
           )
         );
       }


### PR DESCRIPTION
### Description
Two changes bundled here:
- Refresh project data in the project view after editing in the batch metadata editor. Before the data actually wouldn't reload so the columns would be out of date. This was confusing on the maps because you would need to refresh before you see your newly inputted locations on the map.
- While making this change and looking at the project header, I noticed that the "public sample notifications" were never ported over to data discovery. I checked with Mark and just decided to copy them over to DiscoveryView.

### Notes
![Jul-10-2019 17-54-12](https://user-images.githubusercontent.com/5652739/61015131-3d67f100-a33f-11e9-88c5-0946fb151e48.gif)
![Screen Shot 2019-07-10 at 6 04 57 PM](https://user-images.githubusercontent.com/5652739/61015135-41940e80-a33f-11e9-806b-f75ec45e8704.png)

# Tests
- Go to a project, go to Upload Metadata in the upper-right, change the metadata and save, and see the data reload to have current column values.
- Load data discovery and watch the public samples notifications appear. You could force it by modifying checkPublicSamples.