### PR TITLE
Fix sidebar bug for errored samples

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -54,7 +54,7 @@ class PipelineTab extends React.Component {
 
   renderPipelineInfoField = field => {
     const { pipelineInfo } = this.props;
-    const { text, linkLabel, link } = pipelineInfo[field.key];
+    const { text, linkLabel, link } = pipelineInfo[field.key] || {};
 
     const metadataLink = linkLabel &&
       link && (
@@ -152,7 +152,7 @@ class PipelineTab extends React.Component {
 PipelineTab.propTypes = {
   pipelineInfo: PropTypes.objectOf(
     PropTypes.shape({
-      text: PropTypes.string.isRequired,
+      text: PropTypes.string,
       link: PropTypes.string,
       linkLabel: PropTypes.string,
     })


### PR DESCRIPTION
# Fix sidebar bug for errored samples
From https://github.com/chanzuckerberg/idseq-web/pull/2387

# Tests
Go to an errored sample's sampleView, click on "See sample details" and switch to "Pipeline" tab on sidebar (previously would error)
