### PR TITLE
[Locations] Fix bug with filtering by Unknown locations

### DIFF
--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -106,8 +106,8 @@ module LocationHelper
                              .group_by { |(_, geo_level)| geo_level }
                              .map { |field, values| [field, values.map { |id| id[0] }] }
                              .to_h
-    samples = samples_with_metadata.includes(metadata: :location)
 
+    samples = samples_with_metadata.includes(metadata: :location)
     # Plain text locations in string_validated_value + multi-geo-level location search
     if locations_by_geo_level.present?
       samples.where(

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -106,8 +106,8 @@ module LocationHelper
                              .group_by { |(_, geo_level)| geo_level }
                              .map { |field, values| [field, values.map { |id| id[0] }] }
                              .to_h
-
     samples = samples_with_metadata.includes(metadata: :location)
+
     # Plain text locations in string_validated_value + multi-geo-level location search
     if locations_by_geo_level.present?
       samples.where(

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -109,11 +109,15 @@ module LocationHelper
 
     samples = samples_with_metadata.includes(metadata: :location)
     # Plain text locations in string_validated_value + multi-geo-level location search
-    samples.where(
-      "`metadata`.`string_validated_value` IN (?)"\
-        " OR #{locations_by_geo_level.keys.map { |k| "`locations`.`#{k}_id` IN (?)" }.join(' OR ')}",
-      query,
-      *locations_by_geo_level.values
-    )
+    if locations_by_geo_level.present?
+      samples.where(
+        "`metadata`.`string_validated_value` IN (?)"\
+      " OR #{locations_by_geo_level.keys.map { |k| "`locations`.`#{k}_id` IN (?)" }.join(' OR ')}",
+        query,
+        *locations_by_geo_level.values
+      )
+    else
+      samples.where("`metadata`.`string_validated_value` IN (?)", query)
+    end
   end
 end

--- a/spec/helpers/location_helper_spec.rb
+++ b/spec/helpers/location_helper_spec.rb
@@ -80,7 +80,31 @@ RSpec.describe LocationHelper, type: :helper do
   end
 
   describe "#filter_by_name" do
-    pending "add test for filtering by location names (with Factories)"
+    it "filters samples by a location name query with location results" do
+      query_text = "Washington"
+      expected = [Sample.new]
+      samples = double()
+
+      expect(Location).to receive_message_chain(:where, :pluck, :group_by, :map, :to_h).and_return(country: [147], state: [153], city: [188])
+      expect(samples).to receive(:includes).with(metadata: :location).and_return(samples)
+      expect(samples).to receive(:where).with("`metadata`.`string_validated_value` IN (?) OR `locations`.`country_id` IN (?) OR `locations`.`state_id` IN (?) OR `locations`.`city_id` IN (?)", query_text, [147], [153], [188]).and_return(expected)
+
+      result = LocationHelper.filter_by_name(samples, query_text)
+      expect(result).to eq(expected)
+    end
+
+    it "filters samples by a location name query with NO location results" do
+      query_text = "Washington"
+      expected = [Sample.new]
+      samples = double()
+
+      expect(Location).to receive(:where).and_return([])
+      expect(samples).to receive(:includes).with(metadata: :location).and_return(samples)
+      expect(samples).to receive(:where).with("`metadata`.`string_validated_value` IN (?)", query_text).and_return(expected)
+
+      result = LocationHelper.filter_by_name(samples, query_text)
+      expect(result).to eq(expected)
+    end
   end
 
   describe "#adapt_location_iq_response" do


### PR DESCRIPTION
### Description
- There was a bug where filtering by Unknown / "Not set" locations wouldn't work. The side effect was that the filter would still get stored in their URL state, so a refresh wouldn't work either and it would break the interface for the user unless they manually removed the filter from the URL.

### Notes
- The bug was in LocationHelper#filter_by_name where the SQL statement just had a dangling "OR" at the end if there were no locations. The statement would look like
```sql
SELECT `samples`.`id` FROM `samples` LEFT OUTER JOIN `metadata` ON `metadata`.`sample_id` = `samples`.`id` LEFT OUTER JOIN `metadata_fields` ON `metadata_fields`.`id` = `metadata`.`metadata_field_id` LEFT OUTER JOIN `locations` ON `locations`.`id` = `metadata`.`location_id` WHERE (project_id in (25,50,63)) AND `metadata`.`metadata_field_id` = 363 AND (`metadata`.`string_validated_value` IN ('not_set') OR )
```

### Tests
- Go to `http://localhost:3000/projects/dimensions.json?domain=my_data&locationV2[]=not_set` and see results (before would crash).