### PR TITLE
[Maps] Consolidate Table vs. Map mode checkboxes to allow for persistent selections

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -113,18 +113,18 @@ class DiscoveryView extends React.Component {
         mapSidebarProjectDimensions: [],
         mapSidebarSampleDimensions: [],
         mapSidebarSampleStats: {},
-        selectedSampleIds: new Set(),
         mapSidebarTab: "summary",
-        rawMapLocationData: {},
         project: null,
         projectDimensions: [],
         projectId: projectId,
         projects: [],
+        rawMapLocationData: {},
         sampleDimensions: [],
         sampleIds: [],
         samples: [],
         samplesAllLoaded: false,
         search: null,
+        selectedSampleIds: new Set(),
         showFilters: true,
         showStats: true,
         visualizations: [],
@@ -1016,7 +1016,6 @@ class DiscoveryView extends React.Component {
                 mapLocationData={mapLocationData}
                 mapPreviewedLocationId={mapPreviewedLocationId}
                 mapPreviewedSamples={mapPreviewedSamples}
-                selectedSampleIds={selectedSampleIds}
                 mapTilerKey={mapTilerKey}
                 onClearFilters={this.handleClearFilters}
                 onDisplaySwitch={this.handleDisplaySwitch}
@@ -1026,11 +1025,12 @@ class DiscoveryView extends React.Component {
                 onMapMarkerClick={this.handleMapMarkerClick}
                 onMapTooltipTitleClick={this.handleMapTooltipTitleClick}
                 onSampleSelected={this.handleSampleSelected}
+                onSelectedSamplesUpdate={this.handleSelectedSamplesUpdate}
                 projectId={projectId}
                 ref={samplesView => (this.samplesView = samplesView)}
                 samples={samples}
                 selectableIds={sampleIds}
-                onSelectedSamplesUpdate={this.handleSelectedSamplesUpdate}
+                selectedSampleIds={selectedSampleIds}
               />
             </div>
             {!samples.length &&
@@ -1103,7 +1103,6 @@ class DiscoveryView extends React.Component {
               allowedFeatures={allowedFeatures}
               currentTab={mapSidebarTab}
               discoveryCurrentTab={currentTab}
-              selectedSampleIds={selectedSampleIds}
               loading={loading}
               onFilterClick={this.handleMetadataFilterClick}
               onProjectSelected={this.handleProjectSelected}
@@ -1138,6 +1137,7 @@ class DiscoveryView extends React.Component {
                   : mapSidebarSampleStats
               }
               selectableIds={mapPreviewedSampleIds}
+              selectedSampleIds={selectedSampleIds}
             />
           ) : (
             <DiscoverySidebar

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -113,7 +113,7 @@ class DiscoveryView extends React.Component {
         mapSidebarProjectDimensions: [],
         mapSidebarSampleDimensions: [],
         mapSidebarSampleStats: {},
-        mapSidebarSelectedSampleIds: new Set(),
+        selectedSampleIds: new Set(),
         mapSidebarTab: "summary",
         rawMapLocationData: {},
         project: null,
@@ -880,8 +880,8 @@ class DiscoveryView extends React.Component {
     });
   };
 
-  handleMapSidebarSelectUpdate = mapSidebarSelectedSampleIds => {
-    this.setState({ mapSidebarSelectedSampleIds });
+  handleSelectedSamplesUpdate = selectedSampleIds => {
+    this.setState({ selectedSampleIds });
   };
 
   handleMapSidebarTabChange = mapSidebarTab => {
@@ -962,7 +962,7 @@ class DiscoveryView extends React.Component {
       mapLocationData,
       mapPreviewedLocationId,
       mapPreviewedSamples,
-      mapSidebarSelectedSampleIds,
+      selectedSampleIds,
       projectId,
       projects,
       sampleIds,
@@ -1016,7 +1016,7 @@ class DiscoveryView extends React.Component {
                 mapLocationData={mapLocationData}
                 mapPreviewedLocationId={mapPreviewedLocationId}
                 mapPreviewedSamples={mapPreviewedSamples}
-                mapSidebarSelectedSampleIds={mapSidebarSelectedSampleIds}
+                selectedSampleIds={selectedSampleIds}
                 mapTilerKey={mapTilerKey}
                 onClearFilters={this.handleClearFilters}
                 onDisplaySwitch={this.handleDisplaySwitch}
@@ -1030,6 +1030,7 @@ class DiscoveryView extends React.Component {
                 ref={samplesView => (this.samplesView = samplesView)}
                 samples={samples}
                 selectableIds={sampleIds}
+                onSelectedSamplesUpdate={this.handleSelectedSamplesUpdate}
               />
             </div>
             {!samples.length &&
@@ -1076,7 +1077,7 @@ class DiscoveryView extends React.Component {
       mapSidebarProjectDimensions,
       mapSidebarSampleDimensions,
       mapSidebarSampleStats,
-      mapSidebarSelectedSampleIds,
+      selectedSampleIds,
       mapSidebarTab,
       projectDimensions,
       projects,
@@ -1102,12 +1103,12 @@ class DiscoveryView extends React.Component {
               allowedFeatures={allowedFeatures}
               currentTab={mapSidebarTab}
               discoveryCurrentTab={currentTab}
-              initialSelectedSampleIds={mapSidebarSelectedSampleIds}
+              selectedSampleIds={selectedSampleIds}
               loading={loading}
               onFilterClick={this.handleMetadataFilterClick}
               onProjectSelected={this.handleProjectSelected}
               onSampleClicked={this.handleSampleSelected}
-              onSelectionUpdate={this.handleMapSidebarSelectUpdate}
+              onSelectionUpdate={this.handleSelectedSamplesUpdate}
               onTabChange={this.handleMapSidebarTabChange}
               projectDimensions={
                 isEmpty(mapSidebarProjectDimensions)

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -190,7 +190,7 @@ export default class MapPreviewSidebar extends React.Component {
 
   handleSelectRow = (value, checked) => {
     const { selectedSampleIds, onSelectionUpdate } = this.props;
-    let newSelected = selectedSampleIds;
+    let newSelected = new Set(selectedSampleIds);
     if (checked) {
       newSelected.add(value);
     } else {

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -190,7 +190,6 @@ export default class MapPreviewSidebar extends React.Component {
 
   handleSelectRow = (value, checked) => {
     const { selectedSampleIds, onSelectionUpdate } = this.props;
-
     let newSelected = selectedSampleIds;
     if (checked) {
       newSelected.add(value);
@@ -198,7 +197,6 @@ export default class MapPreviewSidebar extends React.Component {
       newSelected.delete(value);
     }
     onSelectionUpdate(newSelected);
-
     logAnalyticsEvent("MapPreviewSidebar_row_selected", {
       selectedSampleIds: newSelected.size,
     });
@@ -414,7 +412,6 @@ MapPreviewSidebar.propTypes = {
   className: PropTypes.string,
   currentTab: PropTypes.string,
   discoveryCurrentTab: PropTypes.string,
-  selectedSampleIds: PropTypes.instanceOf(Set),
   loading: PropTypes.bool,
   onFilterClick: PropTypes.func,
   onProjectSelected: PropTypes.func,
@@ -422,10 +419,11 @@ MapPreviewSidebar.propTypes = {
   onSelectionUpdate: PropTypes.func.isRequired,
   onTabChange: PropTypes.func,
   projectDimensions: PropTypes.array,
-  projectStats: PropTypes.object,
   projects: PropTypes.array,
+  projectStats: PropTypes.object,
   sampleDimensions: PropTypes.array,
   samples: PropTypes.array,
   sampleStats: PropTypes.object,
   selectableIds: PropTypes.array.isRequired,
+  selectedSampleIds: PropTypes.instanceOf(Set),
 };

--- a/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
+++ b/app/assets/src/components/views/discovery/mapping/MapPreviewSidebar.jsx
@@ -26,12 +26,6 @@ export default class MapPreviewSidebar extends React.Component {
   constructor(props) {
     super(props);
 
-    const { initialSelectedSampleIds } = this.props;
-
-    this.state = {
-      selectedSampleIds: initialSelectedSampleIds || new Set(),
-    };
-
     this.sampleColumns = [
       {
         dataKey: "sample",
@@ -195,7 +189,7 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   handleSelectRow = (value, checked) => {
-    const { selectedSampleIds } = this.state;
+    const { selectedSampleIds, onSelectionUpdate } = this.props;
 
     let newSelected = selectedSampleIds;
     if (checked) {
@@ -203,10 +197,10 @@ export default class MapPreviewSidebar extends React.Component {
     } else {
       newSelected.delete(value);
     }
-    this.setSelectedSampleIds(newSelected);
+    onSelectionUpdate(newSelected);
 
     logAnalyticsEvent("MapPreviewSidebar_row_selected", {
-      selectedSampleIds: newSelected.length,
+      selectedSampleIds: newSelected.size,
     });
   };
 
@@ -231,8 +225,7 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   isSelectAllChecked = () => {
-    const { selectableIds } = this.props;
-    const { selectedSampleIds } = this.state;
+    const { selectableIds, selectedSampleIds } = this.props;
     return (
       !isEmpty(selectableIds) &&
       isEmpty(difference(selectableIds, Array.from(selectedSampleIds)))
@@ -240,14 +233,13 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   handleSelectAllRows = (value, checked) => {
-    const { selectableIds } = this.props;
-    const { selectedSampleIds } = this.state;
+    const { selectableIds, selectedSampleIds, onSelectionUpdate } = this.props;
     let newSelected = new Set(
       checked
         ? union(Array.from(selectedSampleIds), selectableIds)
         : difference(Array.from(selectedSampleIds), selectableIds)
     );
-    this.setSelectedSampleIds(newSelected);
+    onSelectionUpdate(newSelected);
 
     logAnalyticsEvent("MapPreviewSidebar_select-all-rows_clicked");
   };
@@ -256,12 +248,6 @@ export default class MapPreviewSidebar extends React.Component {
     const { onTabChange } = this.props;
     onTabChange && onTabChange(tab);
     logAnalyticsEvent("MapPreviewSidebar_tab_clicked", { tab });
-  };
-
-  setSelectedSampleIds = selectedSampleIds => {
-    const { onSelectionUpdate } = this.props;
-    this.setState({ selectedSampleIds });
-    onSelectionUpdate && onSelectionUpdate(selectedSampleIds);
   };
 
   computeTabs = () => {
@@ -289,7 +275,7 @@ export default class MapPreviewSidebar extends React.Component {
   };
 
   renderTable = () => {
-    const { selectedSampleIds } = this.state;
+    const { selectedSampleIds } = this.props;
 
     const rowHeight = 60;
     const batchSize = 1e4;
@@ -428,12 +414,12 @@ MapPreviewSidebar.propTypes = {
   className: PropTypes.string,
   currentTab: PropTypes.string,
   discoveryCurrentTab: PropTypes.string,
-  initialSelectedSampleIds: PropTypes.instanceOf(Set),
+  selectedSampleIds: PropTypes.instanceOf(Set),
   loading: PropTypes.bool,
   onFilterClick: PropTypes.func,
   onProjectSelected: PropTypes.func,
   onSampleClicked: PropTypes.func,
-  onSelectionUpdate: PropTypes.func,
+  onSelectionUpdate: PropTypes.func.isRequired,
   onTabChange: PropTypes.func,
   projectDimensions: PropTypes.array,
   projectStats: PropTypes.object,

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -31,7 +31,6 @@ class SamplesView extends React.Component {
 
     this.state = {
       phyloTreeCreationModalOpen: false,
-      selectedSampleIds: new Set(),
     };
 
     this.columns = [
@@ -146,34 +145,35 @@ class SamplesView extends React.Component {
   }
 
   handleSelectRow = (value, checked) => {
-    const { selectedSampleIds } = this.state;
-    let newSelected = new Set(selectedSampleIds);
+    const { selectedSampleIds, onSelectedSamplesUpdate } = this.props;
+    let newSelected = selectedSampleIds; // copy this?
     if (checked) {
       newSelected.add(value);
     } else {
       newSelected.delete(value);
     }
-    this.setState({ selectedSampleIds: newSelected });
+    onSelectedSamplesUpdate(newSelected);
     logAnalyticsEvent("SamplesView_row_selected", {
-      selectedSampleIds: newSelected.length,
+      selectedSampleIds: newSelected.size,
     });
   };
 
   handleSelectAllRows = (value, checked) => {
-    const { selectableIds } = this.props;
-    const { selectedSampleIds } = this.state;
+    const {
+      selectableIds,
+      selectedSampleIds,
+      onSelectedSamplesUpdate,
+    } = this.props;
     let newSelected = new Set(
       checked
         ? union(Array.from(selectedSampleIds), selectableIds)
         : difference(Array.from(selectedSampleIds), selectableIds)
     );
-    this.setState({ selectedSampleIds: newSelected });
+    onSelectedSamplesUpdate(newSelected);
   };
 
   isSelectAllChecked = () => {
-    const { selectedSampleIds } = this.state;
-    const { selectableIds } = this.props;
-
+    const { selectableIds, selectedSampleIds } = this.props;
     return (
       !isEmpty(selectableIds) &&
       isEmpty(difference(selectableIds, Array.from(selectedSampleIds)))
@@ -186,13 +186,8 @@ class SamplesView extends React.Component {
   };
 
   renderHeatmapTrigger = () => {
-    const { mapSidebarSelectedSampleIds, currentDisplay } = this.props;
-    const { selectedSampleIds } = this.state;
-
-    const targetSampleIds =
-      currentDisplay === "map"
-        ? mapSidebarSelectedSampleIds
-        : selectedSampleIds;
+    const { selectedSampleIds } = this.props;
+    const targetSampleIds = selectedSampleIds;
 
     if (this.props.admin) {
       const heatmapOptions = [
@@ -247,17 +242,9 @@ class SamplesView extends React.Component {
   };
 
   renderDownloadTrigger = () => {
-    const {
-      projectId,
-      currentDisplay,
-      mapSidebarSelectedSampleIds,
-    } = this.props;
-    const { selectedSampleIds } = this.state;
+    const { projectId, selectedSampleIds } = this.props;
 
-    const targetSampleIds =
-      currentDisplay === "map"
-        ? mapSidebarSelectedSampleIds
-        : selectedSampleIds;
+    const targetSampleIds = selectedSampleIds;
 
     const downloadOptions = [{ text: "Sample Table", value: "samples_table" }];
     if (projectId) {
@@ -296,19 +283,15 @@ class SamplesView extends React.Component {
     const {
       currentDisplay,
       mapPreviewedSamples,
-      mapSidebarSelectedSampleIds,
+      selectedSampleIds,
       samples,
     } = this.props;
-    const { selectedSampleIds } = this.state;
 
     // NOTE(jsheu): For mapSidebar sample names to appear in CollectionModal,
     // they need to be presently loaded/fetched. Otherwise the ids work but says "and more..." for un-fetched samples.
     const targetSamples =
       currentDisplay === "map" ? mapPreviewedSamples : samples;
-    const targetSampleIds =
-      currentDisplay === "map"
-        ? mapSidebarSelectedSampleIds
-        : selectedSampleIds;
+    const targetSampleIds = selectedSampleIds;
 
     return targetSampleIds.size < 2 ? (
       <SaveIcon
@@ -332,17 +315,9 @@ class SamplesView extends React.Component {
   };
 
   renderToolbar = () => {
-    const {
-      allowedFeatures,
-      currentDisplay,
-      mapSidebarSelectedSampleIds,
-    } = this.props;
-    const { selectedSampleIds } = this.state;
+    const { allowedFeatures, selectedSampleIds } = this.props;
 
-    const targetSampleIds =
-      currentDisplay === "map"
-        ? mapSidebarSelectedSampleIds
-        : selectedSampleIds;
+    const targetSampleIds = selectedSampleIds;
 
     return (
       <div className={cs.samplesToolbar}>
@@ -382,8 +357,12 @@ class SamplesView extends React.Component {
   };
 
   renderTable = () => {
-    const { activeColumns, onLoadRows, protectedColumns } = this.props;
-    const { selectedSampleIds } = this.state;
+    const {
+      activeColumns,
+      onLoadRows,
+      protectedColumns,
+      selectedSampleIds,
+    } = this.props;
 
     // TODO(tiago): replace by automated cell height computing
     const rowHeight = 66;
@@ -539,6 +518,8 @@ SamplesView.propTypes = {
   protectedColumns: PropTypes.array,
   samples: PropTypes.array,
   selectableIds: PropTypes.array.isRequired,
+  selectedSampleIds: PropTypes.instanceOf(Set),
+  onSelectedSamplesUpdate: PropTypes.func,
 };
 
 export default SamplesView;

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -146,7 +146,7 @@ class SamplesView extends React.Component {
 
   handleSelectRow = (value, checked) => {
     const { selectedSampleIds, onSelectedSamplesUpdate } = this.props;
-    let newSelected = selectedSampleIds;
+    let newSelected = new Set(selectedSampleIds);
     if (checked) {
       newSelected.add(value);
     } else {

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -146,7 +146,7 @@ class SamplesView extends React.Component {
 
   handleSelectRow = (value, checked) => {
     const { selectedSampleIds, onSelectedSamplesUpdate } = this.props;
-    let newSelected = selectedSampleIds; // copy this?
+    let newSelected = selectedSampleIds;
     if (checked) {
       newSelected.add(value);
     } else {
@@ -187,7 +187,6 @@ class SamplesView extends React.Component {
 
   renderHeatmapTrigger = () => {
     const { selectedSampleIds } = this.props;
-    const targetSampleIds = selectedSampleIds;
 
     if (this.props.admin) {
       const heatmapOptions = [
@@ -195,7 +194,7 @@ class SamplesView extends React.Component {
         { text: "AMR Heatmap", value: "/amr_heatmap" },
       ];
 
-      return targetSampleIds.size < 2 ? (
+      return selectedSampleIds.size < 2 ? (
         <HeatmapIcon className={cx(cs.icon, cs.disabled, cs.heatmap)} />
       ) : (
         <BareDropdown
@@ -203,12 +202,12 @@ class SamplesView extends React.Component {
           className={cx(cs.icon, cs.heatmapDropdown)}
           items={heatmapOptions.map(option => {
             const params = getURLParamString({
-              sampleIds: Array.from(targetSampleIds),
+              sampleIds: Array.from(selectedSampleIds),
             });
             const log = () =>
               logAnalyticsEvent("SamplesView_heatmap-option_clicked", {
                 option,
-                selectedSampleIds: targetSampleIds.length,
+                selectedSampleIds: selectedSampleIds.size,
               });
             return (
               <BareDropdown.Item
@@ -224,15 +223,15 @@ class SamplesView extends React.Component {
     } else {
       const log = () =>
         logAnalyticsEvent("SamplesView_heatmap-icon_clicked", {
-          selectedSampleIds: targetSampleIds.length,
+          selectedSampleIds: selectedSampleIds.size,
         });
-      return targetSampleIds.size < 2 ? (
+      return selectedSampleIds.size < 2 ? (
         <HeatmapIcon className={cx(cs.icon, cs.disabled, cs.heatmap)} />
       ) : (
         <a
           onClick={log}
           href={`/visualizations/heatmap?sampleIds=${Array.from(
-            targetSampleIds
+            selectedSampleIds
           )}`}
         >
           <HeatmapIcon className={cx(cs.icon, cs.heatmap)} />
@@ -243,8 +242,6 @@ class SamplesView extends React.Component {
 
   renderDownloadTrigger = () => {
     const { projectId, selectedSampleIds } = this.props;
-
-    const targetSampleIds = selectedSampleIds;
 
     const downloadOptions = [{ text: "Sample Table", value: "samples_table" }];
     if (projectId) {
@@ -267,11 +264,11 @@ class SamplesView extends React.Component {
           new ReportsDownloader({
             projectId,
             downloadOption,
-            selectedSampleIds: targetSampleIds,
+            selectedSampleIds,
           });
           logAnalyticsEvent("SamplesView_download-dropdown-option_clicked", {
             projectId,
-            selectedSamplesCount: targetSampleIds.length,
+            selectedSamplesCount: selectedSampleIds.size,
             downloadOption,
           });
         }}
@@ -291,9 +288,7 @@ class SamplesView extends React.Component {
     // they need to be presently loaded/fetched. Otherwise the ids work but says "and more..." for un-fetched samples.
     const targetSamples =
       currentDisplay === "map" ? mapPreviewedSamples : samples;
-    const targetSampleIds = selectedSampleIds;
-
-    return targetSampleIds.size < 2 ? (
+    return selectedSampleIds.size < 2 ? (
       <SaveIcon
         className={cx(cs.icon, cs.disabled, cs.save)}
         popupText={"Save a Collection"}
@@ -306,9 +301,9 @@ class SamplesView extends React.Component {
             popupText={"Save a Collection"}
           />
         }
-        selectedSampleIds={targetSampleIds}
+        selectedSampleIds={selectedSampleIds}
         fetchedSamples={targetSamples.filter(sample =>
-          targetSampleIds.has(sample.id)
+          selectedSampleIds.has(sample.id)
         )}
       />
     );
@@ -316,9 +311,6 @@ class SamplesView extends React.Component {
 
   renderToolbar = () => {
     const { allowedFeatures, selectedSampleIds } = this.props;
-
-    const targetSampleIds = selectedSampleIds;
-
     return (
       <div className={cs.samplesToolbar}>
         {allowedFeatures &&
@@ -333,7 +325,7 @@ class SamplesView extends React.Component {
             onClick={() =>
               logAnalyticsEvent(`SamplesView_sample-counter_clicked`)
             }
-            text={`${targetSampleIds.size}`}
+            text={`${selectedSampleIds.size}`}
           />
           <span className={cs.label}>Selected</span>
         </div>
@@ -504,7 +496,6 @@ SamplesView.propTypes = {
   mapLocationData: PropTypes.objectOf(PropTypes.Location),
   mapPreviewedLocationId: PropTypes.number,
   mapPreviewedSamples: PropTypes.array,
-  mapSidebarSelectedSampleIds: PropTypes.instanceOf(Set),
   mapTilerKey: PropTypes.string,
   onClearFilters: PropTypes.func,
   onDisplaySwitch: PropTypes.func,
@@ -514,12 +505,12 @@ SamplesView.propTypes = {
   onMapMarkerClick: PropTypes.func,
   onMapTooltipTitleClick: PropTypes.func,
   onSampleSelected: PropTypes.func,
+  onSelectedSamplesUpdate: PropTypes.func,
   projectId: PropTypes.number,
   protectedColumns: PropTypes.array,
   samples: PropTypes.array,
   selectableIds: PropTypes.array.isRequired,
   selectedSampleIds: PropTypes.instanceOf(Set),
-  onSelectedSamplesUpdate: PropTypes.func,
 };
 
 export default SamplesView;


### PR DESCRIPTION
### Description
- This PR consolidates the "checkboxes in table mode" with the "checkboxes in map preview mode" so that the user can naturally select across the different modes and take action on the samples.
- Code is actually cleaner now which is nice.
- All the ids.length need to be changed to ids.size since .length is undefined on Sets.

### Notes
![Jul-11-2019 17-14-25](https://user-images.githubusercontent.com/5652739/61093490-9f882b00-a3ff-11e9-886e-d2de0feac0df.gif)
![Jul-11-2019 17-13-46](https://user-images.githubusercontent.com/5652739/61093493-a0b95800-a3ff-11e9-902d-4238016ede69.gif)

### Tests
- Go to data discovery, play around with the checkboxes in table mode and map preview mode. See the workflows above.