### PR TITLE
IDSEQ-1120 - Fix issue with local upload when uploading zero byte files

### DIFF
--- a/app/assets/src/components/ui/controls/FilePicker.jsx
+++ b/app/assets/src/components/ui/controls/FilePicker.jsx
@@ -63,6 +63,7 @@ class FilePicker extends React.Component {
       <Dropzone
         acceptClassName={cs.accepted}
         maxSize={5e9}
+        minSize={1}
         onDrop={onChange || this.onChange}
         onDropRejected={onRejected || this.onRejected}
         className={cx(cs.filePicker, className, file && cs.active)}

--- a/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
@@ -8,8 +8,6 @@ import _fp, {
   sortBy,
   slice,
   sumBy,
-  compose,
-  join,
 } from "lodash/fp";
 import cx from "classnames";
 

--- a/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
@@ -8,6 +8,8 @@ import _fp, {
   sortBy,
   slice,
   sumBy,
+  compose,
+  join,
 } from "lodash/fp";
 import cx from "classnames";
 
@@ -57,14 +59,15 @@ class LocalSampleFileUpload extends React.Component {
   onRejected = rejectedFiles => {
     const emptyFiles = rejectedFiles.filter(f => f.size === 0);
     const bigFiles = rejectedFiles.filter(f => f.size !== 0);
+    const mapNames = _fp.compose(_fp.join(", "), _fp.map("name"));
     let msg = "Some of your files cannot be uploaded.\n";
     if (emptyFiles.length > 0) {
-      const fileNames = _.map(emptyFiles, "name").join(", ");
-      msg += `- Empty files: ${fileNames}\n`;
+      msg += `- Empty files: ${mapNames(emptyFiles)}\n`;
     }
     if (bigFiles.length > 0) {
-      const fileNames = _.map(bigFiles, "name").join(", ");
-      msg += `- Too large: ${fileNames}\nSize must be under 5GB for local uploads. For larger files, please try our CLI.`;
+      msg += `- Too large: ${mapNames(
+        bigFiles
+      )}\nSize must be under 5GB for local uploads. For larger files, please try our CLI.`;
     }
     window.alert(msg);
   };

--- a/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
@@ -54,14 +54,20 @@ class LocalSampleFileUpload extends React.Component {
     this.props.onChange(localSamples, sampleNamesToFiles);
   };
 
-  onRejected = rejectedFiles =>
-    window.alert(
-      `${rejectedFiles
-        .map(f => f.name)
-        .join(
-          ", "
-        )} cannot be uploaded. Size must be under 5GB for local uploads. For larger files, please try our CLI.`
-    );
+  onRejected = rejectedFiles => {
+    const emptyFiles = rejectedFiles.filter(f => f.size === 0);
+    const bigFiles = rejectedFiles.filter(f => f.size !== 0);
+    let msg = "Some of your files cannot be uploaded.\n";
+    if (emptyFiles.length > 0) {
+      const fileNames = _.map(emptyFiles, "name").join(", ");
+      msg += `- Empty files: ${fileNames}\n`;
+    }
+    if (bigFiles.length > 0) {
+      const fileNames = _.map(bigFiles, "name").join(", ");
+      msg += `- Too large: ${fileNames}\nSize must be under 5GB for local uploads. For larger files, please try our CLI.`;
+    }
+    window.alert(msg);
+  };
 
   toggleInfo = () => {
     this.setState(


### PR DESCRIPTION
# Description

Fix an issue when users try to upload a local file with zero bytes.

# Notes

Interface should display an error whenever a user drops a zero byte file to file drop area.
Currently, it silently accepts the file and leave the sample in a WAITING state, without notifying any erros.

# Tests

- Manual test:
![image](https://user-images.githubusercontent.com/8084076/61096252-b46abb80-a40b-11e9-8406-d2818537e004.png)

