### PR TITLE
IDSEQ-1069 - Fix issue with file upload triggering pipeline before uploads complete

### DIFF
--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -79,13 +79,16 @@ export const bulkUploadLocalWithMetadata = ({
 
           uploadFileToUrlWithRetries(file, url, {
             onUploadProgress: e => {
-              const percent = Math.round(e.loaded * 100 / e.total);
+              const percent = Math.floor(e.loaded * 100 / e.total);
               fileNamesToProgress[file.name] = percent;
               if (onUploadProgress) {
                 onUploadProgress(percent, file);
               }
             },
-            onSuccess: () => onFileUploadSuccess(sampleName, sample.id),
+            onSuccess: () => {
+              fileNamesToProgress[file.name] = 100;
+              onFileUploadSuccess(sampleName, sample.id);
+            },
             onError: error => onUploadError(file, error),
           });
         });


### PR DESCRIPTION
# Description

Fix issue with file upload triggering pipeline before uploads complete.

# Notes

`onUploadProgress` was using `Math.round` instead of `Math.floor`, which potentially could mark progress as being 100% in cases where more than 99.5% of the file had been uploaded. If that happened to one of the files, and the other one had already completed, `onFileUploadSuccess` would incorrectly assume both files as completed due during this check: `sampleFiles.every(f => fileNamesToProgress[f.name] === 100)`

# Tests

* Condition almost impossible to manually verify and mock libraries doesn't allow to mock uploadProgress.
