### PR TITLE
Downgrade ruby image from Buster to Stretch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5-stretch
 
 # Install apt based dependencies required to run Rails as
 # well as RubyGems. As the Ruby image itself is based on a


### PR DESCRIPTION
# Description

The default docker 'ruby' image was upgraded to Buster.
Package `mysql-client` was removed from Debian Buster.
Apparently there is a scheduled transition to MariaDB.
To unblock our builds, we are temporarily moving back to stretch.

# Notes

* Stretch is gonna be maintained (w/ security updates) for at least another year
* We should fix this in such a way that we can upgrade to Buster. Options to analyze (https://jira.czi.team/browse/IDSEQ-1121):
	* Move to `mariadb-client`
	* Find another drop-in replacement

# Tests

Build works!