### PR TITLE
[Locations] Delete the Metadatum object when they set the field to empty string

### DIFF
--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -126,7 +126,7 @@ class Metadatum < ApplicationRecord
         self.location_id = nil
       else
         puts "foobar 4:16pm"
-        self.delete
+        delete
       end
       return
     end

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -121,11 +121,11 @@ class Metadatum < ApplicationRecord
 
     unless loc[:locationiq_id]
       # Unresolved plain text selection (wrapped 'name')
-      # Delete if they cleared out the field
       if loc[:name].present?
         self.string_validated_value = loc[:name]
         self.location_id = nil
       else
+        # Delete if they cleared out the field
         delete
       end
       return

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -121,11 +121,11 @@ class Metadatum < ApplicationRecord
 
     unless loc[:locationiq_id]
       # Unresolved plain text selection (wrapped 'name')
+      # Delete if they cleared out the field
       if loc[:name].present?
         self.string_validated_value = loc[:name]
         self.location_id = nil
       else
-        puts "foobar 4:16pm"
         delete
       end
       return

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -121,8 +121,13 @@ class Metadatum < ApplicationRecord
 
     unless loc[:locationiq_id]
       # Unresolved plain text selection (wrapped 'name')
-      self.string_validated_value = loc[:name]
-      self.location_id = nil
+      if loc[:name].present?
+        self.string_validated_value = loc[:name]
+        self.location_id = nil
+      else
+        puts "foobar 4:16pm"
+        self.delete
+      end
       return
     end
 

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -17,6 +17,11 @@ class MetadatumTest < ActiveSupport::TestCase
     mock_create.verify
   end
 
+  test "should delete cleared out Location values" do
+    loc = Metadatum.new(raw_value: "{}")
+    assert_nil loc.check_and_set_location_type
+  end
+
   test "should raise Location validation/setting errors" do
     loc = metadata(:sample_collection_location_v2)
     loc.raw_value = "{\"locationiq_id\":\"123\"}"


### PR DESCRIPTION
### Description
- This fixes a bug with empty string locations. Before you would get {name:""} and an empty location Metadatum.

### Tests
- Tested in local console by setting a location on a sample, then clearing it out and saving "" instead and checking that it disappeared, ex: `Sample.find(1500).metadata.last`