### PR TITLE
Add back-end for basespace integration.

### DIFF
--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -4,17 +4,12 @@ import {
   markSampleUploaded,
   uploadFileToUrlWithRetries,
 } from "~/api";
-import { map } from "lodash/fp";
 
 import { bulkUploadWithMetadata } from "~/api/metadata";
 import { putWithCSRF } from "./core";
 
-// TODO(mark): Implement back-end for basespace sample uploading.
-export const bulkUploadBasespace = async ({ samples, metadata }) => {
-  return {
-    sample_ids: map("id", samples),
-  };
-};
+export const bulkUploadBasespace = async ({ samples, metadata }) =>
+  bulkUploadWithMetadata(samples, metadata);
 
 export const bulkUploadRemote = ({ samples, metadata }) =>
   metadata

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -33,7 +33,6 @@ const BASESPACE_SAMPLE_FIELDS = [
   "name",
   "project_id",
   "host_genome_id",
-  "basespace_project_id",
   "basespace_access_token",
   "basespace_dataset_id",
 ];

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -237,10 +237,11 @@ class SampleView extends React.Component {
   };
 
   pipelineInProgress = () => {
-    if (
-      this.props.pipelineRun &&
-      this.props.pipelineRun.results_finalized > 0
-    ) {
+    const { sample, pipelineRun } = this.props;
+    if (sample.upload_error) {
+      return false;
+    }
+    if (pipelineRun && pipelineRun.results_finalized > 0) {
       return false;
     }
     return true;
@@ -260,12 +261,15 @@ class SampleView extends React.Component {
   };
 
   renderPipelineWarnings = () => {
+    const { pipelineRun } = this.props;
+    if (!pipelineRun) return null;
+
     const warnings = [];
 
     if (
       !this.pipelineInProgress() &&
-      pipelineVersionHasAssembly(this.props.pipelineRun.pipeline_version) &&
-      this.props.pipelineRun.assembled !== 1
+      pipelineVersionHasAssembly(pipelineRun.pipeline_version) &&
+      pipelineRun.assembled !== 1
     ) {
       warnings.push("The reads did not assemble for this run.");
     }
@@ -299,7 +303,17 @@ class SampleView extends React.Component {
   renderSampleReportError = () => {
     const { pipelineRun, sample } = this.props;
     let status, message, linkText, issueType, link;
-    switch (pipelineRun.known_user_error) {
+    switch (
+      sample.upload_error || (pipelineRun && pipelineRun.known_user_error)
+    ) {
+      case "BASESPACE_UPLOAD_FAILED":
+        status = "SAMPLE FAILED";
+        message =
+          "Oh no! There was an issue uploading your sample file from Basespace.";
+        linkText = "Contact us for help.";
+        issueType = "error";
+        link = "mailto:help@idseq.net";
+        break;
       case "FAULTY_INPUT":
         status = "COMPLETE - ISSUE";
         message = `Sorry, something was wrong with your input file. ${

--- a/app/controllers/basespace_controller.rb
+++ b/app/controllers/basespace_controller.rb
@@ -1,13 +1,8 @@
-BASESPACE_OAUTH_URL = ["https://api.basespace.illumina.com/v1pre3/oauthv2/token",
-                       BASESPACE_CURRENT_PROJECTS_URL = "https://api.basespace.illumina.com/v1pre3/users/current/projects".freeze].freeze
-BASESPACE_PROJECT_DATASETS_URL = "https://api.basespace.illumina.com/v2/projects/%s/datasets".freeze
-# The maximum number of items to fetch from a Basespace API endpoint at one time.
-# If we don't set this, it defaults to 10.
-# TODO(mark): Implement a way to automatically fetch additional pages if necessary.
-BASESPACE_PAGE_SIZE = 1024
+BASESPACE_OAUTH_URL = "https://api.basespace.illumina.com/v1pre3/oauthv2/token".freeze
 
 class BasespaceController < ApplicationController
   include HttpHelper
+  include BasespaceHelper
 
   before_action :admin_required
 
@@ -44,32 +39,20 @@ class BasespaceController < ApplicationController
       return
     end
 
-    # 1024 is the maximum limit allowed by Basespace.
-    # If users reach this limit, we will need to implement multiple requests to fetch all the projects.
-    response = HttpHelper.get_json(
-      BASESPACE_CURRENT_PROJECTS_URL,
-      { limit: BASESPACE_PAGE_SIZE },
-      "Authorization" => "Bearer #{access_token}"
-    )
+    bs_projects = basespace_projects(access_token)
 
-    if response.nil? || response["Response"].nil? || response["Response"]["Items"].nil?
+    if bs_projects.nil?
       render json: {
         error: "unable to fetch data from basespace"
       }
       return
     end
 
-    # Just return selected fields.
-    formatted_projects = response["Response"]["Items"].map do |dataset|
-      {
-        id: dataset["Id"],
-        name: dataset["Name"]
-      }
-    end
-
-    render json: formatted_projects
+    render json: bs_projects
   end
 
+  # Actually fetches basespace DATASETS, which are collections of related fastq files (such as paired-end files)
+  # This roughly corresponds to "samples" in IDseq.
   def samples_for_project
     access_token = params[:access_token]
     basespace_project_id = params[:basespace_project_id]
@@ -88,51 +71,15 @@ class BasespaceController < ApplicationController
       return
     end
 
-    # 1024 is the maximum limit allowed by Basespace.
-    # If users reach this limit, we will need to implement multiple requests to fetch all the samples.
-    response = HttpHelper.get_json(
-      BASESPACE_PROJECT_DATASETS_URL % basespace_project_id,
-      { limit: BASESPACE_PAGE_SIZE },
-      "Authorization" => "Bearer #{access_token}"
-    )
+    bs_samples = samples_for_basespace_project(basespace_project_id, access_token)
 
-    if response.nil? || response["Items"].nil?
+    if bs_samples.nil?
       render json: {
         error: "unable to fetch data from basespace"
       }
       return
     end
 
-    # Just return selected fields.
-    formatted_samples = response["Items"].map do |dataset|
-      {
-        basespace_dataset_id: dataset["Id"],
-        name: dataset["Name"],
-        file_size: dataset["TotalSize"],
-        file_type: get_dataset_file_type(dataset),
-        basespace_project_id: basespace_project_id,
-        basespace_project_name: dataset["Project"]["Name"]
-      }
-    end
-
-    # Remove all non-FASTQ files.
-    # We will add other file types as we encounter them.
-    formatted_samples = formatted_samples.select { |dataset| dataset[:file_type].present? }
-
-    render json: formatted_samples
-  end
-
-  private
-
-  def get_dataset_file_type(dataset)
-    if dataset["DatasetType"].present? && dataset["DatasetType"]["Name"].downcase.include?("fastq")
-      if dataset["Attributes"].present? && dataset["Attributes"]["common_fastq"].present? && dataset["Attributes"]["common_fastq"]["IsPairedEnd"] == true
-        return "Paired-end FASTQ"
-      else
-        return "Single-end FASTQ"
-      end
-    end
-
-    return nil
+    render json: bs_samples
   end
 end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -536,7 +536,7 @@ class SamplesController < ApplicationController
       errors << SampleUploadErrors.invalid_project_id(sample)
     end
 
-    upload_errors, samples = upload_samples_with_metadata(samples_to_upload, metadata).values_at("errors", "samples")
+    upload_errors, samples = upload_samples_with_metadata(samples_to_upload, metadata, current_user).values_at("errors", "samples")
 
     errors.concat(upload_errors)
 
@@ -1240,7 +1240,7 @@ class SamplesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def samples_params
-    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name,
+    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name, :basespace_dataset_id, :basespace_access_token,
                                          input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts]])
     new_params[:samples] if new_params
   end
@@ -1251,6 +1251,7 @@ class SamplesController < ApplicationController
                         :host_genome_id, :host_genome_name, :sample_location, :sample_date, :sample_tissue,
                         :sample_template, :sample_library, :sample_sequencer,
                         :sample_notes, :search, :subsample, :max_input_fragments,
+                        :basespace_dataset_id, :basespace_access_token,
                         :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection, :client,
                         input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts]]
     permitted_params.concat([:pipeline_branch, :dag_vars, :s3_preload_result_path, :alignment_config_name, :subsample]) if current_user.admin?

--- a/app/helpers/basespace_helper.rb
+++ b/app/helpers/basespace_helper.rb
@@ -1,0 +1,126 @@
+require 'open-uri'
+
+# TODO(mark): Investigate if there is a way to fetch the user's current projects with v2 API. No obvious way from the docs.
+BASESPACE_CURRENT_PROJECTS_URL = "https://api.basespace.illumina.com/v1pre3/users/current/projects".freeze
+BASESPACE_PROJECT_DATASETS_URL = "https://api.basespace.illumina.com/v2/projects/%s/datasets".freeze
+BASESPACE_DATASET_FILES_URL = "https://api.basespace.illumina.com/v2/datasets/%s/files?filehrefcontentresolution=true".freeze
+# 1024 is the maximum limit allowed by Basespace.
+# If users reach this limit, we will need to implement multiple requests to fetch all the samples.
+BASESPACE_PAGE_SIZE = 1024
+
+module BasespaceHelper
+  def fetch_from_basespace(url, access_token, params = {})
+    HttpHelper.get_json(
+      url,
+      params.merge(limit: BASESPACE_PAGE_SIZE),
+      "Authorization" => "Bearer #{access_token}"
+    )
+  end
+
+  def basespace_projects(access_token)
+    response = fetch_from_basespace(BASESPACE_CURRENT_PROJECTS_URL, access_token)
+
+    if response.nil? || response.dig("Response", "Items").nil?
+      if response.present? && response.dig("ResponseStatus", "Message").present?
+        LogUtil.log_err_and_airbrake("basespace_projects failed with error: #{response['ResponseStatus']['Message']}")
+      end
+      return nil
+    end
+
+    # Just return selected fields.
+    response["Response"]["Items"].map do |dataset|
+      {
+        id: dataset["Id"],
+        name: dataset["Name"]
+      }
+    end
+  end
+
+  def samples_for_basespace_project(project_id, access_token)
+    response = fetch_from_basespace(BASESPACE_PROJECT_DATASETS_URL % project_id, access_token)
+
+    if response.nil? || response["Items"].nil?
+      if response.present? && response["ErrorMessage"].present?
+        LogUtil.log_err_and_airbrake("samples_for_basespace_project failed with error: #{response['ErrorMessage']}")
+      end
+      return nil
+    end
+
+    # Just return selected fields.
+    formatted_samples = response["Items"].map do |dataset|
+      {
+        basespace_dataset_id: dataset["Id"],
+        name: dataset["Name"],
+        file_size: dataset["TotalSize"],
+        file_type: get_dataset_file_type(dataset),
+        basespace_project_id: project_id,
+        basespace_project_name: dataset["Project"]["Name"]
+      }
+    end
+
+    # Remove all non-FASTQ files.
+    # We will add other file types as we encounter them.
+    formatted_samples.select { |dataset| dataset[:file_type].present? }
+  end
+
+  def files_for_basespace_dataset(dataset_id, access_token)
+    response = fetch_from_basespace(BASESPACE_DATASET_FILES_URL % dataset_id, access_token, filehrefcontentresolution: "true")
+
+    if response.nil? || response["Items"].nil?
+      if response.present? && response["ErrorMessage"].present?
+        LogUtil.log_err_and_airbrake("files_for_basespace_dataset failed with error: #{response['ErrorMessage']}")
+      end
+      return nil
+    end
+
+    return response["Items"].map do |file|
+      {
+        name: file["Name"],
+        # Path to download the file. Includes all auth information to download the file.
+        download_path: file["HrefContent"],
+        # Store the file id for debugging purposes.
+        # Without a valid access token, the file cannot be accessed using the file id.
+        source_path: file["Href"]
+      }
+    end
+  end
+
+  def upload_from_basespace_to_s3(basespace_path, s3_path, file_name)
+    temp_file = Tempfile.new
+    success = false
+
+    begin
+      # Download the basespace file into a temp file.
+      download = open(basespace_path)
+      IO.copy_stream(download, temp_file.path.to_s)
+
+      # Upload the temp file to S3.
+      upload_success = Syscall.s3_cp(temp_file.path.to_s, "#{s3_path}/#{file_name}")
+      # Raise an error if the copy failed.
+      raise StandardError, "failed to copy to S3 #{stderr}" unless upload_success
+
+      success = true
+    rescue => exception
+      LogUtil.log_err_and_airbrake("Failed to transfer file from basespace to #{s3_path} for #{file_name}")
+      Rails.logger.error(exception)
+    ensure
+      temp_file.unlink
+    end
+
+    return success
+  end
+
+  private
+
+  def get_dataset_file_type(dataset)
+    if dataset.present? && dataset["DatasetType"].present? && dataset["DatasetType"]["Name"].downcase.include?("fastq")
+      if dataset.dig("Attributes", "common_fastq", "IsPairedEnd") == true
+        return "Paired-end FASTQ"
+      else
+        return "Single-end FASTQ"
+      end
+    end
+
+    return nil
+  end
+end

--- a/app/helpers/error_helper.rb
+++ b/app/helpers/error_helper.rb
@@ -29,6 +29,22 @@ module ErrorHelper
     def self.missing_required_metadata(sample, missing_metadata_fields)
       "Could not save sample '#{sample['name']}'. Missing required metadata: #{missing_metadata_fields.join(', ')}"
     end
+
+    def self.missing_input_files_or_basespace_params(sample_name)
+      "Could not save sample '#{sample_name}'. Either input_files_attributes or basespace_access_token/basespace_dataset_id is required in sample."
+    end
+
+    def self.error_fetching_basespace_files_for_dataset(basespace_dataset_id, sample_name, sample_id)
+      "Error fetching Basespace files for dataset #{basespace_dataset_id} for sample '#{sample_name}' (#{sample_id})"
+    end
+
+    def self.no_files_in_basespace_dataset(basespace_dataset_id, sample_name, sample_id)
+      "No files were found when trying to upload from basespace dataset #{basespace_dataset_id} for sample '#{sample_name}' (#{sample_id})"
+    end
+
+    def self.upload_from_basespace_failed(sample_name, sample_id, file_name, basespace_dataset_id, max_tries)
+      "Upload of sample '#{sample_name}' (#{sample_id}) file '#{file_name}', basespace dataset #{basespace_dataset_id} failed after #{max_tries} retries"
+    end
   end
 
   LOCATION_INVALID_ERROR = "Please input a location.".freeze

--- a/app/helpers/http_helper.rb
+++ b/app/helpers/http_helper.rb
@@ -3,9 +3,11 @@ require "net/http"
 module HttpHelper
   def self.post_json(url, body)
     uri = URI.parse(url)
-    request = Net::HTTP::Post.new(uri)
+
+    request = Net::HTTP::Post.new(uri.request_uri)
     request.content_type = "application/json"
     request.body = JSON.dump(body)
+
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == "https"
 
@@ -27,17 +29,17 @@ module HttpHelper
 
   def self.get_json(url, params, headers)
     uri = URI.parse(url)
-    request = Net::HTTP::Get.new(url)
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = uri.scheme == "https"
+    # Add params to url
+    uri.query = params.to_query
 
+    request = Net::HTTP::Get.new(uri.request_uri)
     # Add headers
     headers.each do |key, value|
       request[key] = value
     end
 
-    # Add params to url
-    uri.query = URI.encode_www_form(params)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == "https"
 
     response = http.request(request)
 

--- a/app/jobs/transfer_basespace_files.rb
+++ b/app/jobs/transfer_basespace_files.rb
@@ -1,0 +1,16 @@
+# Job to upload input files from basespace file to s3 for a particular sample.
+class TransferBasespaceFiles
+  @queue = :transfer_basespace_files
+
+  # sample_id is the id of the sample we are uploading files to.
+  # basespace_dataset_id is the id of dataset from basespace we are uploading samples from.
+  #   A dataset is a basespace concept meaning a collection of one or more related files (such as paired fastq files)
+  # basespace_access_token is the access token that authorizes us to download these files
+  def self.perform(sample_id, basespace_dataset_id, basespace_access_token)
+    Rails.logger.info("Start TransferBasespaceFiles for sample id #{sample_id}")
+    sample = Sample.find(sample_id)
+    sample.transfer_basespace_files(basespace_dataset_id, basespace_access_token)
+  rescue => e
+    Rails.logger.error(e)
+  end
+end

--- a/app/models/input_file.rb
+++ b/app/models/input_file.rb
@@ -4,6 +4,7 @@ class InputFile < ApplicationRecord
   belongs_to :sample
   SOURCE_TYPE_LOCAL = 'local'.freeze
   SOURCE_TYPE_S3 = 's3'.freeze
+  SOURCE_TYPE_BASESPACE = 'basespace'.freeze
 
   FILE_REGEX = %r{\A[^\s\/]+\.(fastq|fq|fastq.gz|fq.gz|fasta|fa|fasta.gz|fa.gz)\z}
   BULK_FILE_PAIRED_REGEX = /([^ ]*)_R(\d)(_001)?.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
@@ -11,7 +12,7 @@ class InputFile < ApplicationRecord
   S3_CP_PIPE_ERROR = '[Errno 32] Broken pipe'.freeze
 
   validates :name, presence: true, format: { with: FILE_REGEX, message: "file must match format '#{FILE_REGEX}'" }
-  validates :source_type, presence: true, inclusion: { in: %w[local s3] }
+  validates :source_type, presence: true, inclusion: { in: %w[local s3 basespace] }
   validate :s3_source_check, on: :create
 
   def s3_source_check

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -22,12 +22,17 @@ class Sample < ApplicationRecord
   include TestHelper
   include MetadataHelper
   include PipelineRunsHelper
+  include BasespaceHelper
+  include ErrorHelper
 
   STATUS_CREATED = 'created'.freeze
   STATUS_UPLOADED = 'uploaded'.freeze
   STATUS_RERUN    = 'need_rerun'.freeze
   STATUS_RETRY_PR = 'retry_pr'.freeze # retry existing pipeline run
   STATUS_CHECKED = 'checked'.freeze # status regarding pipeline kickoff is checked
+
+  # Constants for upload errors.
+  UPLOAD_ERROR_BASESPACE_UPLOAD_FAILED = "BASESPACE_UPLOAD_FAILED".freeze
 
   TOTAL_READS_JSON = "total_reads.json".freeze
   LOG_BASENAME = 'log.txt'.freeze
@@ -51,7 +56,8 @@ class Sample < ApplicationRecord
                      :sample_template, # this refers to nucleotide type (RNA or DNA)
                      :sample_library, :sample_sequencer, :sample_notes, :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection].freeze
 
-  attr_accessor :bulk_mode
+  # These are temporary variables that are not saved to the database. They only persist for the lifetime of the Sample object.
+  attr_accessor :bulk_mode, :basespace_dataset_id, :basespace_access_token
 
   belongs_to :project
   # This is the user who uploaded the sample, possibly distinct from the user(s) owning the sample's project
@@ -113,7 +119,7 @@ class Sample < ApplicationRecord
 
   def input_files_checks
     # validate that we have the correct number of input files
-    errors.add(:input_files, "invalid number") unless input_files.size.between?(1, 2)
+    errors.add(:input_files, "invalid number") unless input_files.size.between?(1, 2) || uploaded_from_basespace?
     # validate that both input files have the same source_type and file_type
     if input_files.length == 2
       errors.add(:input_files, "have different source types") unless input_files[0].source_type == input_files[1].source_type
@@ -246,8 +252,17 @@ class Sample < ApplicationRecord
   end
 
   def initiate_input_file_upload
-    return unless input_files.first.source_type == InputFile::SOURCE_TYPE_S3
-    Resque.enqueue(InitiateS3Cp, id)
+    # The reason why we don't check input_files.first.source_type == InputFile::SOURCE_TYPE_BASESPACE here is:
+    # We don't yet have the input files at this point.
+    # The basespace API doesn't let us query for all input files for a project.
+    # We can only query all the datasets (and get the dataset IDs).
+    # We then need to query each dataset individually (with a separate API call) to get the input files.
+    # We do this query inside the TransferBasespaceFiles resque task.
+    if uploaded_from_basespace?
+      Resque.enqueue(TransferBasespaceFiles, id, basespace_dataset_id, basespace_access_token)
+    elsif !input_files.empty? && input_files.first.source_type == InputFile::SOURCE_TYPE_S3
+      Resque.enqueue(InitiateS3Cp, id)
+    end
   end
 
   def initiate_s3_cp
@@ -326,6 +341,72 @@ class Sample < ApplicationRecord
     save # this triggers pipeline command
   rescue => e
     LogUtil.log_err_and_airbrake("Failed to upload S3 sample '#{name}' (#{id}): #{e}")
+  end
+
+  # Uploads input files from basespace for this sample.
+  # basespace_dataset_id is the id of the dataset from basespace we are uploading samples from.
+  #   A dataset is a basespace concept meaning a collection of one or more related files (such as paired fastq files)
+  # basespace_access_token is the access token that authorizes us to download these files.
+  def transfer_basespace_files(basespace_dataset_id, basespace_access_token)
+    # Only continue if the sample status is CREATED and not yet UPLOADED.
+    return unless status == STATUS_CREATED
+
+    files = files_for_basespace_dataset(basespace_dataset_id, basespace_access_token)
+
+    # Raise error if fetching the files failed, or we fetched zero files (since we can't proceed with zero files)
+    raise SampleUploadErrors.error_fetching_basespace_files_for_dataset(basespace_dataset_id, name, id) if files.nil?
+    raise SampleUploadErrors.no_files_in_basespace_dataset(basespace_dataset_id, name, id) if files.empty?
+
+    # Retry uploading three times, in case of transient network failures.
+    files.each do |file|
+      max_tries = 3
+      try = 0
+      # Use exponential backoff in case the issue is overload on Illumina servers.
+      time_between_tries = [60, 300]
+
+      Rails.logger.info("Starting upload of sample '#{name}' (#{id}) file '#{file[:name]}' from Basespace")
+      while try < max_tries
+        success = upload_from_basespace_to_s3(file[:download_path], sample_input_s3_path, file[:name])
+
+        if success
+          break
+        else
+          Rails.logger.error("Try ##{try}: Upload of sample '#{name}' (#{id}) file '#{file[:name]}' from Basespace failed")
+          try += 1
+          if try < max_tries
+            Kernel.sleep(time_between_tries[try - 1])
+          else
+            raise SampleUploadErrors.upload_from_basespace_failed(name, id, file[:name], basespace_dataset_id, max_tries)
+          end
+        end
+      end
+
+      input_file = InputFile.new(
+        name: file[:name],
+        source_type: InputFile::SOURCE_TYPE_BASESPACE,
+        source: file[:source_path]
+      )
+
+      input_files << input_file
+    end
+
+    self.status = STATUS_UPLOADED
+    save!
+  rescue => e
+    Rails.logger.info(e)
+    LogUtil.log_err_and_airbrake("SampleUploadFailedEvent: #{e}")
+
+    self.status = STATUS_CHECKED
+    self.upload_error = Sample::UPLOAD_ERROR_BASESPACE_UPLOAD_FAILED
+
+    # It's possible the error is caused by failed validation on the input files.
+    # Clear the input files before trying to save again.
+    self.input_files = []
+    save!
+  end
+
+  def uploaded_from_basespace?
+    uploaded_from_basespace == 1
   end
 
   def sample_input_s3_path

--- a/db/migrate/20190717221024_add_basespace_upload_fields_to_sample.rb
+++ b/db/migrate/20190717221024_add_basespace_upload_fields_to_sample.rb
@@ -1,0 +1,6 @@
+class AddBasespaceUploadFieldsToSample < ActiveRecord::Migration[5.1]
+  def change
+    add_column :samples, :uploaded_from_basespace, :integer, limit: 1, default: 0
+    add_column :samples, :upload_error, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_612_205_949) do
+ActiveRecord::Schema.define(version: 20_190_717_221_024) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -367,6 +367,8 @@ ActiveRecord::Schema.define(version: 20_190_612_205_949) do
     t.text "dag_vars"
     t.integer "max_input_fragments"
     t.datetime "client_updated_at"
+    t.integer "uploaded_from_basespace", limit: 1, default: 0
+    t.string "upload_error"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
     t.index ["user_id"], name: "index_samples_on_user_id"
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
       <<: *web-variables
       <<: *aws-variables
       <<: *travis-variables
-    command: bundle exec "QUEUE=q03_pipeline_run,precache_report_info,* COUNT=5 rake resque:workers"
+    command: bundle exec "QUEUE=q03_pipeline_run,precache_report_info,transfer_basespace_files,* COUNT=5 rake resque:workers"
   resque_result_monitor:
     image: chanzuckerberg/idseq-web:compose
     volumes:

--- a/spec/controllers/basespace_controller_spec.rb
+++ b/spec/controllers/basespace_controller_spec.rb
@@ -130,13 +130,16 @@ RSpec.describe BasespaceController, type: :controller do
         end
       end
 
-      context "when response is nil" do
+      context "when basespace API call fails" do
         before do
           allow(HttpHelper).to receive(:get_json)
-            .and_return(nil)
+            .and_return("ResponseStatus" => {
+                          "Message" => "Failed to list projects"
+                        })
         end
 
         it "returns an error" do
+          expect(LogUtil).to receive(:log_err_and_airbrake).with("basespace_projects failed with error: Failed to list projects").exactly(1).times
           get :projects, params: { access_token: "123" }
 
           json_response = JSON.parse(response.body)
@@ -228,13 +231,14 @@ RSpec.describe BasespaceController, type: :controller do
         end
       end
 
-      context "when response is nil" do
+      context "when basespace API call fails" do
         before do
           allow(HttpHelper).to receive(:get_json)
-            .and_return(nil)
+            .and_return("ErrorMessage" => "Failed to get samples for project")
         end
 
         it "returns an error" do
+          expect(LogUtil).to receive(:log_err_and_airbrake).with("samples_for_basespace_project failed with error: Failed to get samples for project").exactly(1).times
           get :samples_for_project, params: { access_token: "123", basespace_project_id: 77 }
 
           json_response = JSON.parse(response.body)

--- a/spec/helpers/basespace_helper_spec.rb
+++ b/spec/helpers/basespace_helper_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+require "webmock/rspec"
+
+RSpec.describe BasespaceHelper, type: :helper do
+  describe "#files_for_basespace_dataset" do
+    let(:file_one_name) { "sample_one.fastq.gz" }
+    let(:file_one_href_content) { "https://basespace.amazonaws.com/abc123/sample_one.fastq.gz" }
+    let(:file_one_href) { "https://api.basespace.illumina.com/v2/files/1" }
+
+    let(:file_two_name) { "sample_two.fastq.gz" }
+    let(:file_two_href_content) { "https://basespace.amazonaws.com/abc123/sample_two.fastq.gz" }
+    let(:file_two_href) { "https://api.basespace.illumina.com/v2/files/2" }
+
+    let(:fake_dataset_id) { "abc123real" }
+    let(:fake_access_token) { "token" }
+
+    context "basespace API call returns successfully" do
+      before do
+        allow(HttpHelper).to receive(:get_json)
+          .and_return(
+            "Items" => [
+              {
+                "Name" => file_one_name,
+                "HrefContent" => file_one_href_content,
+                "Href" => file_one_href,
+                "Id" => "1"
+              },
+              {
+                "Name" => file_two_name,
+                "HrefContent" => file_two_href_content,
+                "Href" => file_two_href,
+                "Id" => "2"
+              }
+            ]
+          )
+      end
+
+      it "returns selected fields of files" do
+        files = helper.files_for_basespace_dataset(fake_dataset_id, fake_access_token)
+
+        expect(files).to eq(
+          [
+            {
+              name: file_one_name,
+              download_path: file_one_href_content,
+              source_path: file_one_href
+            },
+            {
+              name: file_two_name,
+              download_path: file_two_href_content,
+              source_path: file_two_href
+            }
+          ]
+        )
+      end
+    end
+
+    context "basespace API returns zero samples" do
+      before do
+        allow(HttpHelper).to receive(:get_json)
+          .and_return("Items" => [])
+      end
+
+      it "returns zero samples" do
+        files = helper.files_for_basespace_dataset(fake_dataset_id, fake_access_token)
+
+        expect(files).to eq([])
+      end
+    end
+
+    context "basespace API call fails" do
+      before do
+        allow(HttpHelper).to receive(:get_json)
+          .and_return("ErrorMessage" => "Failed to get files")
+      end
+
+      it "returns nil" do
+        expect(LogUtil).to receive(:log_err_and_airbrake).with("files_for_basespace_dataset failed with error: Failed to get files").exactly(1).times
+        files = helper.files_for_basespace_dataset(fake_dataset_id, fake_access_token)
+
+        expect(files).to eq(nil)
+      end
+    end
+  end
+
+  describe "#upload_from_basespace_to_s3" do
+    let(:fake_basespace_path) { "fake_basespace_path" }
+    let(:fake_s3_path) { "fake_s3_path" }
+    let(:fake_file_name) { "fake_file_name" }
+
+    context "upload happens successfully" do
+      before do
+        expect(helper).to receive(:open).with(fake_basespace_path).exactly(1).times
+        expect(IO).to receive(:copy_stream).exactly(1).times
+        expect(Syscall).to receive(:s3_cp).with(anything, "#{fake_s3_path}/#{fake_file_name}").exactly(1).times.and_return(true)
+      end
+
+      it "returns true" do
+        response = helper.upload_from_basespace_to_s3(fake_basespace_path, fake_s3_path, fake_file_name)
+        expect(response).to be true
+      end
+    end
+  end
+end

--- a/spec/helpers/http_helper_spec.rb
+++ b/spec/helpers/http_helper_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe HttpHelper, type: :helper do
     context "#a successful HTTP request" do
       before do
         stub_request(:get, "https://www.example.com")
+          .with(query: { "param_one" => ["a", "b"] })
           .to_return(body: { "foo" => "bar" }.to_json)
       end
 
       def make_get_request
         HttpHelper.get_json("https://www.example.com", {
-                              "param_one" => "a"
+                              "param_one" => ["a", "b"]
                             }, "Authorization" => "Bearer abc")
       end
 
@@ -21,16 +22,14 @@ RSpec.describe HttpHelper, type: :helper do
         expect(response).to include_json("foo" => "bar")
       end
 
-      it "sends an HTTP get request with the correct headers" do
+      it "sends an HTTP get request with the correct headers and params" do
         make_get_request()
 
         expect(
           a_request(:get, "https://www.example.com")
-            .with(headers: { "Authorization" => "Bearer abc" })
+            .with(headers: { "Authorization" => "Bearer abc" }, query: { "param_one" => ["a", "b"] })
         ).to have_been_made
       end
-      # TODO(mark): Test that get request sends the correct query params.
-      # Couldn"t figure out how to do it properly with Webmock, as it doesn't seem to recognize encode_www_form query params.
     end
 
     context "#a failed HTTP request" do

--- a/spec/helpers/samples_helper_spec.rb
+++ b/spec/helpers/samples_helper_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+require "webmock/rspec"
+
+RSpec.describe SamplesHelper, type: :helper do
+  describe "#upload_samples_with_metadata" do
+    context "with basespace samples" do
+      let(:fake_access_token) { "fake_access_token" }
+      let(:fake_dataset_id) { "fake_dataset_id" }
+      let(:fake_sample_name) { "fake_sample_name" }
+
+      before do
+        @project = create(:public_project)
+        @joe = create(:joe)
+        @host_genome = create(:host_genome)
+      end
+
+      let(:basespace_sample_attributes) do
+        [
+          {
+            basespace_access_token: fake_access_token,
+            basespace_dataset_id: fake_dataset_id,
+            host_genome_id: @host_genome.id,
+            name: fake_sample_name,
+            project_id: @project.id
+          }
+        ]
+      end
+
+      let(:metadata_attributes) do
+        {
+          fake_sample_name.to_s => {
+            "Sample Type" => "CSF",
+            "Nucleotide Type" => "DNA",
+            "Collection Location" => "CA, USA",
+            "Collection Date" => "2010-01"
+          }
+        }
+      end
+
+      it "saved successfully" do
+        # Set up mocks
+        expect(Resque).to receive(:enqueue).with(
+          TransferBasespaceFiles, anything, fake_dataset_id, fake_access_token
+        ).exactly(1).times
+
+        response = helper.upload_samples_with_metadata(
+          basespace_sample_attributes,
+          metadata_attributes,
+          @joe
+        )
+
+        expect(response["samples"].length).to be 1
+        expect(response["errors"].length).to be 0
+
+        created_sample = response["samples"][0]
+
+        expect(created_sample.name).to eq(fake_sample_name)
+        expect(created_sample.host_genome.id).to be @host_genome.id
+        expect(created_sample.project.id).to be @project.id
+        expect(created_sample.bulk_mode).to be nil
+        expect(created_sample.uploaded_from_basespace).to be 1
+        expect(created_sample.user).to eq(@joe)
+
+        expect(Metadatum.where(sample_id: created_sample.id).length).to be 4
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Sample Type").length).to be 1
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Sample Type")[0].raw_value).to eq("CSF")
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Nucleotide Type").length).to be 1
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Nucleotide Type")[0].raw_value).to eq("DNA")
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Collection Location").length).to be 1
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Collection Location")[0].raw_value).to eq("CA, USA")
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Collection Date").length).to be 1
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Collection Date")[0].raw_value).to eq("2010-01")
+      end
+
+      it "fails if basespace_access_token is not provided" do
+        response = helper.upload_samples_with_metadata(
+          basespace_sample_attributes.map { |sample| sample.reject { |key, _| key == :basespace_access_token } },
+          metadata_attributes,
+          @joe
+        )
+
+        expect(response["samples"].length).to be 0
+        expect(response["errors"]).to eq([
+                                           ErrorHelper::SampleUploadErrors.missing_input_files_or_basespace_params(fake_sample_name)
+                                         ])
+      end
+
+      it "fails if basespace_dataset_id is not provided" do
+        response = helper.upload_samples_with_metadata(
+          basespace_sample_attributes.map { |sample| sample.reject { |key, _| key == :basespace_dataset_id } },
+          metadata_attributes,
+          @joe
+        )
+
+        expect(response["samples"].length).to be 0
+        expect(response["errors"]).to eq([
+                                           ErrorHelper::SampleUploadErrors.missing_input_files_or_basespace_params(fake_sample_name)
+                                         ])
+      end
+    end
+  end
+end

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -1,0 +1,185 @@
+require 'rails_helper'
+
+describe Sample, type: :model do
+  let(:file_one_name) { "sample_one.fastq.gz" }
+  let(:file_one_href_content) { "https://basespace.amazonaws.com/abc123/sample_one.fastq.gz" }
+  let(:file_one_href) { "https://api.basespace.illumina.com/v2/files/1" }
+
+  let(:file_two_name) { "sample_two.fastq.gz" }
+  let(:file_two_href_content) { "https://basespace.amazonaws.com/abc123/sample_two.fastq.gz" }
+  let(:file_two_href) { "https://api.basespace.illumina.com/v2/files/2" }
+
+  let(:fake_dataset_id) { "fake_dataset_id" }
+  let(:fake_access_token) { "fake_access_token" }
+
+  let(:fake_files_for_basespace_dataset_response) do
+    [
+      {
+        name: file_one_name,
+        download_path: file_one_href_content,
+        source_path: file_one_href
+      },
+      {
+        name: file_two_name,
+        download_path: file_two_href_content,
+        source_path: file_two_href
+      }
+    ]
+  end
+
+  context "#transfer_basespace_files" do
+    before do
+      project = create(:public_project)
+      create(:alignment_config, name: AlignmentConfig::DEFAULT_NAME)
+      @sample = create(:sample, project: project, status: Sample::STATUS_CREATED, input_files: [], uploaded_from_basespace: 1)
+    end
+
+    context "fetches file metadata and downloads files successfully" do
+      it "updates the sample as expected and kicks off the pipeline" do
+        # Set up mocks.
+        expect(@sample).to receive(:files_for_basespace_dataset).exactly(1).times.and_return(fake_files_for_basespace_dataset_response)
+        expect(@sample).to receive(:upload_from_basespace_to_s3).exactly(2).times.and_return(true)
+        expect(@sample).to receive(:kickoff_pipeline).exactly(1).times
+
+        @sample.transfer_basespace_files(fake_dataset_id, fake_access_token)
+
+        expect(@sample.status).to eq(Sample::STATUS_CHECKED)
+        expect(@sample.upload_error).to eq(nil)
+        expect(@sample.input_files.length).to be 2
+
+        expect(@sample.input_files[0].name).to eq(file_one_name)
+        expect(@sample.input_files[0].source_type).to eq(InputFile::SOURCE_TYPE_BASESPACE)
+        expect(@sample.input_files[0].source).to eq(file_one_href)
+        expect(@sample.input_files[1].name).to eq(file_two_name)
+        expect(@sample.input_files[1].source_type).to eq(InputFile::SOURCE_TYPE_BASESPACE)
+        expect(@sample.input_files[1].source).to eq(file_two_href)
+      end
+
+      it "updates the sample as expected and kicks off the pipeline with only one input file" do
+        # Set up mocks.
+        expect(@sample).to receive(:files_for_basespace_dataset).exactly(1).times.and_return([
+                                                                                               {
+                                                                                                 name: file_one_name,
+                                                                                                 download_path: file_one_href_content,
+                                                                                                 source_path: file_one_href
+                                                                                               }
+                                                                                             ])
+        expect(@sample).to receive(:upload_from_basespace_to_s3).exactly(1).times.and_return(true)
+        expect(@sample).to receive(:kickoff_pipeline).exactly(1).times
+
+        @sample.transfer_basespace_files(fake_dataset_id, fake_access_token)
+
+        expect(@sample.status).to eq(Sample::STATUS_CHECKED)
+        expect(@sample.upload_error).to eq(nil)
+        expect(@sample.input_files.length).to be 1
+
+        expect(@sample.input_files[0].name).to eq(file_one_name)
+        expect(@sample.input_files[0].source_type).to eq(InputFile::SOURCE_TYPE_BASESPACE)
+        expect(@sample.input_files[0].source).to eq(file_one_href)
+      end
+
+      it "does nothing if sample.status != STATUS_CREATED" do
+        # Set up mocks.
+        expect(@sample).to receive(:files_for_basespace_dataset).exactly(0).times
+        expect(@sample).to receive(:upload_from_basespace_to_s3).exactly(0).times
+        expect(@sample).to receive(:kickoff_pipeline).exactly(0).times
+
+        @sample.status = Sample::STATUS_UPLOADED
+
+        @sample.transfer_basespace_files(fake_dataset_id, fake_access_token)
+
+        expect(@sample.status).to eq(Sample::STATUS_UPLOADED)
+        expect(@sample.upload_error).to eq(nil)
+        expect(@sample.input_files.length).to be 0
+      end
+
+      it "runs the input file checks and fails if the two basespace files have the same source" do
+        expect(@sample).to receive(:files_for_basespace_dataset).exactly(1).times.and_return([
+                                                                                               {
+                                                                                                 name: file_one_name,
+                                                                                                 download_path: file_one_href_content,
+                                                                                                 source_path: file_one_href
+                                                                                               },
+                                                                                               {
+                                                                                                 name: file_two_name,
+                                                                                                 download_path: file_two_href_content,
+                                                                                                 source_path: file_one_href # This is the same as the previous
+                                                                                               }
+                                                                                             ])
+
+        expect(@sample).to receive(:upload_from_basespace_to_s3).exactly(2).times.and_return(2)
+        expect(@sample).to receive(:kickoff_pipeline).exactly(0).times
+        # Check that the proper error message is logged.
+        expect(LogUtil).to receive(:log_err_and_airbrake).with(
+          "SampleUploadFailedEvent: Validation failed: Input files have identical read 1 source and read 2 source"
+        ).exactly(1).times
+
+        @sample.transfer_basespace_files(fake_dataset_id, fake_access_token)
+
+        expect(@sample.status).to eq(Sample::STATUS_CHECKED)
+        expect(@sample.upload_error).to eq(Sample::UPLOAD_ERROR_BASESPACE_UPLOAD_FAILED)
+        expect(@sample.input_files.length).to be 0
+      end
+    end
+
+    context "cannot fetch file metadata for basespace dataset" do
+      it "fails gracefully and adds a failed pipeline run" do
+        # Set up mocks.
+        expect(@sample).to receive(:files_for_basespace_dataset).exactly(1).times.and_return(nil)
+        expect(@sample).to receive(:upload_from_basespace_to_s3).exactly(0).times
+        expect(@sample).to receive(:kickoff_pipeline).exactly(0).times
+        # Check that the proper error message is logged.
+        expect(LogUtil).to receive(:log_err_and_airbrake).with(
+          "SampleUploadFailedEvent: #{ErrorHelper::SampleUploadErrors.error_fetching_basespace_files_for_dataset(fake_dataset_id, @sample.name, @sample.id)}"
+        ).exactly(1).times
+
+        @sample.transfer_basespace_files(fake_dataset_id, fake_access_token)
+
+        expect(@sample.status).to eq(Sample::STATUS_CHECKED)
+        expect(@sample.upload_error).to eq(Sample::UPLOAD_ERROR_BASESPACE_UPLOAD_FAILED)
+        expect(@sample.input_files.length).to be 0
+      end
+    end
+
+    context "fetched zero files for basespace dataset" do
+      it "fails gracefully and adds a failed pipeline run" do
+        # Set up mocks.
+        expect(@sample).to receive(:files_for_basespace_dataset).exactly(1).times.and_return([])
+        expect(@sample).to receive(:upload_from_basespace_to_s3).exactly(0).times
+        expect(@sample).to receive(:kickoff_pipeline).exactly(0).times
+        # Check that the proper error message is logged.
+        expect(LogUtil).to receive(:log_err_and_airbrake).with(
+          "SampleUploadFailedEvent: #{ErrorHelper::SampleUploadErrors.no_files_in_basespace_dataset(fake_dataset_id, @sample.name, @sample.id)}"
+        ).exactly(1).times
+
+        @sample.transfer_basespace_files(fake_dataset_id, fake_access_token)
+
+        expect(@sample.status).to eq(Sample::STATUS_CHECKED)
+        expect(@sample.upload_error).to eq(Sample::UPLOAD_ERROR_BASESPACE_UPLOAD_FAILED)
+        expect(@sample.input_files.length).to be 0
+      end
+    end
+
+    context "cannot download basespace files" do
+      it "fails gracefully and adds a failed pipeline run" do
+        # Set up mocks.
+        expect(@sample).to receive(:files_for_basespace_dataset).exactly(1).times.and_return(fake_files_for_basespace_dataset_response)
+        expect(@sample).to receive(:upload_from_basespace_to_s3).exactly(3).times.and_return(false)
+        expect(@sample).to receive(:kickoff_pipeline).exactly(0).times
+        # Expect to sleep 60 after first failure, then sleep 300 on second failure.
+        expect(Kernel).to receive(:sleep).with(60).ordered
+        expect(Kernel).to receive(:sleep).with(300).ordered
+        # Check that the proper error message is logged.
+        expect(LogUtil).to receive(:log_err_and_airbrake).with(
+          "SampleUploadFailedEvent: #{ErrorHelper::SampleUploadErrors.upload_from_basespace_failed(@sample.name, @sample.id, file_one_name, fake_dataset_id, 3)}"
+        ).exactly(1).times
+
+        @sample.transfer_basespace_files(fake_dataset_id, fake_access_token)
+
+        expect(@sample.status).to eq(Sample::STATUS_CHECKED)
+        expect(@sample.upload_error).to eq(Sample::UPLOAD_ERROR_BASESPACE_UPLOAD_FAILED)
+        expect(@sample.input_files.length).to be 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add code to detect basespace files from dataset ids and download the files to
the correct folder in S3.

Ensure that sample fails gracefully if download is unsuccessful.


# Tests

* Verified that back-end tests pass.
* Verified that Basespace upload succeeds locally. (the sample files end up in S3 and host filtering begins)
