### PR TITLE
Fix sidebar tab pipeline versions

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/SampleDetailsMode.jsx
@@ -55,7 +55,7 @@ class SampleDetailsMode extends React.Component {
   }
 
   fetchMetadata = async () => {
-    const { sampleId, showPipelineVizLink } = this.props;
+    const { sampleId, showPipelineVizLink, pipelineVersion } = this.props;
     this.setState({
       metadata: null,
       additionalInfo: null,
@@ -67,7 +67,7 @@ class SampleDetailsMode extends React.Component {
     }
 
     const [metadata, metadataTypes] = await Promise.all([
-      getSampleMetadata(sampleId),
+      getSampleMetadata(sampleId, pipelineVersion),
       getSampleMetadataFields(sampleId),
     ]);
 

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/utils.js
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/utils.js
@@ -35,7 +35,9 @@ export const processPipelineInfo = (additionalInfo, showPipelineVizLink) => {
       ...(showPipelineVizLink
         ? {
             linkLabel: "View Pipeline Visualization",
-            link: `/samples/${pipelineRun.sample_id}/stage_results`,
+            link: `/samples/${pipelineRun.sample_id}/pipeline_viz/${
+              pipelineRun.version.pipeline
+            }`,
           }
         : {}),
     };

--- a/app/assets/src/components/views/report/utils/download.js
+++ b/app/assets/src/components/views/report/utils/download.js
@@ -65,7 +65,7 @@ const getDownloadLinkInfoMap = (sampleId, pipelineRun) => ({
     newPage: true,
   },
   [PIPELINE_VIZ_LABEL]: {
-    path: `/samples/${sampleId}/stage_results`,
+    path: `/samples/${sampleId}/pipeline_viz/${pipelineRun.pipeline_version}`,
     newPage: true,
   },
 });


### PR DESCRIPTION
# Description
* Fixes bug introduced [here](https://github.com/chanzuckerberg/idseq-web/pull/2387/files#diff-338aeb4a6898a3a53f709ea5a868f828L69) where sample details sidebar doesn't update when switching between pipeline versions
* Updates links to pipeline viz to new route + with selected pipeline version (due to changes in https://github.com/chanzuckerberg/idseq-web/pull/2404)

# Tests
Go to a sample page, open "Sample Details" sidebar => Pipeline tab, toggle pipeline versions and see changes reflected