### PR TITLE
Improve db queries, reduce Brakeman warnings, and add Brakeman [High] as blocking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,8 @@ script:
   - docker-compose run --rm webtest "rspec"
   - docker-compose run --rm webtest "npm test"
   - docker-compose run --rm webtest "pip install mock; python -m unittest discover -v -s /app/test/ -p 'test_*.py'"
-  # Run brakeman once to get a full report.
-  - brakeman --no-pager || true
-  # Run again on High so exit code will fail the build. Hide output to avoid confusion.
-  - brakeman --no-pager -w3 >/dev/null 2>&1
+  # Block on High Confidence warnings
+  - brakeman --no-pager -w3
 env:
   global:
   - secure: l6JImOInd+PoLwf9hbAl6QmjXE4mShlG7SEkasSKk6XzT4npNTUqqYVVpNewr1f58U97SdHShv6WgxKIiUpX+adIBp9b59CsI7SCKxt1aSp9egyZE6F1ZIoqjmfH6o9U4dUkE32TJdG4Tn/QMd0fj3nCqathFIWFhato6ovqXmJpklJHH9BGbK330bEYG1LoUU3u/hIhBc8bAuNIO15eih1vMltYiSw5ScQxBMjcCskAjEeb8EA7i82pEpyD9iBWcIomw5Mrro0IInjJbudIQ5RukNZtI3zZXiSbR8m8VWzK8A8ixihHKRbBoLXn3X719s13FIJKL2Pn1utxMx4zrLLUx4iMafey2e8iG9C3JYyHu6UoR/E5hcSCdhHDmwiCiIQF8cHt2sZNVE33rEGdEkhsPgwlH16O6kBJmVOqaaihPN/yjzIyjxDoyknPfswpkiRiuqaa9XDXh5dgU0xHDfKic6ioAJvRMn0Ngbo7Ogi90rTaxksFFo7UAL9mChQaB+qtJk+tU0I7PFTR52ie62KcIAfqU3PFOo1jchmw7uEu/k8yNpZM4gar2gnl8gqe5dIVqkTDfNWBTlYX17dTqeHB7ZqCRKZzYcEZK8SVmw9fs/JTouwQK2nXgwEnp7dJdofvZgXhLZ4/ZhNniLn0ObDQauzYKPKgk819CtIb968=

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - docker-compose run --rm webtest "pip install mock; python -m unittest discover -v -s /app/test/ -p 'test_*.py'"
   # Run brakeman once to get a full report.
   - brakeman --no-pager || true
-  # Run again on High so High confidence warnings will fail the build. Hide output to avoid confusion.
+  # Run again on High so exit code will fail the build. Hide output to avoid confusion.
   - brakeman --no-pager -w3 >/dev/null 2>&1
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ script:
   - brakeman --no-pager || true
   # Run again on High so exit code will fail the build. Hide output to avoid confusion.
   - brakeman --no-pager -w3 >/dev/null 2>&1
-
 env:
   global:
   - secure: l6JImOInd+PoLwf9hbAl6QmjXE4mShlG7SEkasSKk6XzT4npNTUqqYVVpNewr1f58U97SdHShv6WgxKIiUpX+adIBp9b59CsI7SCKxt1aSp9egyZE6F1ZIoqjmfH6o9U4dUkE32TJdG4Tn/QMd0fj3nCqathFIWFhato6ovqXmJpklJHH9BGbK330bEYG1LoUU3u/hIhBc8bAuNIO15eih1vMltYiSw5ScQxBMjcCskAjEeb8EA7i82pEpyD9iBWcIomw5Mrro0IInjJbudIQ5RukNZtI3zZXiSbR8m8VWzK8A8ixihHKRbBoLXn3X719s13FIJKL2Pn1utxMx4zrLLUx4iMafey2e8iG9C3JYyHu6UoR/E5hcSCdhHDmwiCiIQF8cHt2sZNVE33rEGdEkhsPgwlH16O6kBJmVOqaaihPN/yjzIyjxDoyknPfswpkiRiuqaa9XDXh5dgU0xHDfKic6ioAJvRMn0Ngbo7Ogi90rTaxksFFo7UAL9mChQaB+qtJk+tU0I7PFTR52ie62KcIAfqU3PFOo1jchmw7uEu/k8yNpZM4gar2gnl8gqe5dIVqkTDfNWBTlYX17dTqeHB7ZqCRKZzYcEZK8SVmw9fs/JTouwQK2nXgwEnp7dJdofvZgXhLZ4/ZhNniLn0ObDQauzYKPKgk819CtIb968=

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ script:
   - docker-compose run --rm webtest "rspec"
   - docker-compose run --rm webtest "npm test"
   - docker-compose run --rm webtest "pip install mock; python -m unittest discover -v -s /app/test/ -p 'test_*.py'"
-  - brakeman --no-pager || true
+  # Run once to get full report. Run again on High so High warnings will fail the build.
+  - brakeman --no-pager || brakeman --no-pager -w3
 env:
   global:
   - secure: l6JImOInd+PoLwf9hbAl6QmjXE4mShlG7SEkasSKk6XzT4npNTUqqYVVpNewr1f58U97SdHShv6WgxKIiUpX+adIBp9b59CsI7SCKxt1aSp9egyZE6F1ZIoqjmfH6o9U4dUkE32TJdG4Tn/QMd0fj3nCqathFIWFhato6ovqXmJpklJHH9BGbK330bEYG1LoUU3u/hIhBc8bAuNIO15eih1vMltYiSw5ScQxBMjcCskAjEeb8EA7i82pEpyD9iBWcIomw5Mrro0IInjJbudIQ5RukNZtI3zZXiSbR8m8VWzK8A8ixihHKRbBoLXn3X719s13FIJKL2Pn1utxMx4zrLLUx4iMafey2e8iG9C3JYyHu6UoR/E5hcSCdhHDmwiCiIQF8cHt2sZNVE33rEGdEkhsPgwlH16O6kBJmVOqaaihPN/yjzIyjxDoyknPfswpkiRiuqaa9XDXh5dgU0xHDfKic6ioAJvRMn0Ngbo7Ogi90rTaxksFFo7UAL9mChQaB+qtJk+tU0I7PFTR52ie62KcIAfqU3PFOo1jchmw7uEu/k8yNpZM4gar2gnl8gqe5dIVqkTDfNWBTlYX17dTqeHB7ZqCRKZzYcEZK8SVmw9fs/JTouwQK2nXgwEnp7dJdofvZgXhLZ4/ZhNniLn0ObDQauzYKPKgk819CtIb968=

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,10 @@ script:
   - docker-compose run --rm webtest "rspec"
   - docker-compose run --rm webtest "npm test"
   - docker-compose run --rm webtest "pip install mock; python -m unittest discover -v -s /app/test/ -p 'test_*.py'"
-  # Run once to get full report. Run again on High so High warnings will fail the build.
-  - brakeman --no-pager || brakeman --no-pager -w3
+  # Run brakeman on High so High confidence warnings will fail the build.
+  - brakeman --no-pager -w3
+  # Run again to generate full report.
+  - brakeman --no-pager
 env:
   global:
   - secure: l6JImOInd+PoLwf9hbAl6QmjXE4mShlG7SEkasSKk6XzT4npNTUqqYVVpNewr1f58U97SdHShv6WgxKIiUpX+adIBp9b59CsI7SCKxt1aSp9egyZE6F1ZIoqjmfH6o9U4dUkE32TJdG4Tn/QMd0fj3nCqathFIWFhato6ovqXmJpklJHH9BGbK330bEYG1LoUU3u/hIhBc8bAuNIO15eih1vMltYiSw5ScQxBMjcCskAjEeb8EA7i82pEpyD9iBWcIomw5Mrro0IInjJbudIQ5RukNZtI3zZXiSbR8m8VWzK8A8ixihHKRbBoLXn3X719s13FIJKL2Pn1utxMx4zrLLUx4iMafey2e8iG9C3JYyHu6UoR/E5hcSCdhHDmwiCiIQF8cHt2sZNVE33rEGdEkhsPgwlH16O6kBJmVOqaaihPN/yjzIyjxDoyknPfswpkiRiuqaa9XDXh5dgU0xHDfKic6ioAJvRMn0Ngbo7Ogi90rTaxksFFo7UAL9mChQaB+qtJk+tU0I7PFTR52ie62KcIAfqU3PFOo1jchmw7uEu/k8yNpZM4gar2gnl8gqe5dIVqkTDfNWBTlYX17dTqeHB7ZqCRKZzYcEZK8SVmw9fs/JTouwQK2nXgwEnp7dJdofvZgXhLZ4/ZhNniLn0ObDQauzYKPKgk819CtIb968=

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,11 @@ script:
   - docker-compose run --rm webtest "rspec"
   - docker-compose run --rm webtest "npm test"
   - docker-compose run --rm webtest "pip install mock; python -m unittest discover -v -s /app/test/ -p 'test_*.py'"
-  # Run brakeman on High so High confidence warnings will fail the build.
-  - brakeman --no-pager -w3
-  # Run again to generate full report.
-  - brakeman --no-pager
+  # Run brakeman once to get a full report.
+  - brakeman --no-pager || true
+  # Run again on High so High confidence warnings will fail the build. Hide output to avoid confusion.
+  - brakeman --no-pager -w3 >/dev/null 2>&1
+
 env:
   global:
   - secure: l6JImOInd+PoLwf9hbAl6QmjXE4mShlG7SEkasSKk6XzT4npNTUqqYVVpNewr1f58U97SdHShv6WgxKIiUpX+adIBp9b59CsI7SCKxt1aSp9egyZE6F1ZIoqjmfH6o9U4dUkE32TJdG4Tn/QMd0fj3nCqathFIWFhato6ovqXmJpklJHH9BGbK330bEYG1LoUU3u/hIhBc8bAuNIO15eih1vMltYiSw5ScQxBMjcCskAjEeb8EA7i82pEpyD9iBWcIomw5Mrro0IInjJbudIQ5RukNZtI3zZXiSbR8m8VWzK8A8ixihHKRbBoLXn3X719s13FIJKL2Pn1utxMx4zrLLUx4iMafey2e8iG9C3JYyHu6UoR/E5hcSCdhHDmwiCiIQF8cHt2sZNVE33rEGdEkhsPgwlH16O6kBJmVOqaaihPN/yjzIyjxDoyknPfswpkiRiuqaa9XDXh5dgU0xHDfKic6ioAJvRMn0Ngbo7Ogi90rTaxksFFo7UAL9mChQaB+qtJk+tU0I7PFTR52ie62KcIAfqU3PFOo1jchmw7uEu/k8yNpZM4gar2gnl8gqe5dIVqkTDfNWBTlYX17dTqeHB7ZqCRKZzYcEZK8SVmw9fs/JTouwQK2nXgwEnp7dJdofvZgXhLZ4/ZhNniLn0ObDQauzYKPKgk819CtIb968=

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1124,7 +1124,7 @@ class SamplesController < ApplicationController
   # PUT /samples/:id/resync_prod_data_to_staging
   def resync_prod_data_to_staging
     if Rails.env == 'staging'
-      pr_ids = @sample.pipeline_run_ids.join(",")
+      pr_ids = ActiveRecord::Base.connection.quote(@sample.pipeline_run_ids.join(","))
       unless pr_ids.empty?
         ['taxon_counts', 'taxon_byteranges', 'contigs'].each do |table_name|
           ActiveRecord::Base.connection.execute("REPLACE INTO idseq_staging.#{table_name} SELECT * FROM idseq_prod.#{table_name} WHERE pipeline_run_id IN (#{pr_ids})")

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1124,10 +1124,10 @@ class SamplesController < ApplicationController
   # PUT /samples/:id/resync_prod_data_to_staging
   def resync_prod_data_to_staging
     if Rails.env == 'staging'
-      pr_ids = ActiveRecord::Base.connection.quote(@sample.pipeline_run_ids.join(","))
+      pr_ids = @sample.pipeline_run_ids
       unless pr_ids.empty?
         ['taxon_counts', 'taxon_byteranges', 'contigs'].each do |table_name|
-          ActiveRecord::Base.connection.execute("REPLACE INTO idseq_staging.#{table_name} SELECT * FROM idseq_prod.#{table_name} WHERE pipeline_run_id IN (#{pr_ids})")
+          ActiveRecord::Base.connection.execute(ActiveRecord::Base.send(:sanitize_sql, ["REPLACE INTO idseq_staging.#{table_name} SELECT * FROM idseq_prod.#{table_name} WHERE pipeline_run_id IN (?)", pr_ids]))
         end
       end
       Resque.enqueue(InitiateS3ProdSyncToStaging, @sample.id)

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -195,7 +195,7 @@ class PhyloTree < ApplicationRecord
     # If the tree is for genus level or higher, get the top species underneath (these species will have genbank records pulled in idseq-dag)
     if tax_level > TaxonCount::TAX_LEVEL_SPECIES
       level_str = (TaxonCount::LEVEL_2_NAME[tax_level]).to_s
-      taxid_column = "#{level_str}_taxid"
+      taxid_column = ActiveRecord::Base.connection.quote_column_name("#{level_str}_taxid")
       species_counts = TaxonCount.where(pipeline_run_id: pipeline_run_ids).where("#{taxid_column} = ?", taxid).where(tax_level: TaxonCount::TAX_LEVEL_SPECIES)
       species_counts = species_counts.order('pipeline_run_id, count DESC')
       top_taxid_by_run_id = {}

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -32,7 +32,7 @@ class PhyloTree < ApplicationRecord
       all
     else
       # user can see tree iff user can see all pipeline_runs
-      viewable_pipeline_run_ids = sanitize_sql(PipelineRun.viewable(user).pluck(:id).join(','))
+      viewable_pipeline_run_ids = PipelineRun.viewable(user).pluck(:id).join(',')
       where("id not in (select phylo_tree_id
                         from phylo_trees_pipeline_runs
                         where pipeline_run_id not in (?))", viewable_pipeline_run_ids)

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -32,7 +32,7 @@ class PhyloTree < ApplicationRecord
       all
     else
       # user can see tree iff user can see all pipeline_runs
-      viewable_pipeline_run_ids = PipelineRun.viewable(user).pluck(:id).join(',')
+      viewable_pipeline_run_ids = PipelineRun.viewable(user).pluck(:id)
       where("id not in (select phylo_tree_id
                         from phylo_trees_pipeline_runs
                         where pipeline_run_id not in (?))", viewable_pipeline_run_ids)

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -32,10 +32,10 @@ class PhyloTree < ApplicationRecord
       all
     else
       # user can see tree iff user can see all pipeline_runs
-      viewable_pipeline_run_ids = PipelineRun.viewable(user).pluck(:id)
+      viewable_pipeline_run_ids = sanitize_sql(PipelineRun.viewable(user).pluck(:id).join(','))
       where("id not in (select phylo_tree_id
                         from phylo_trees_pipeline_runs
-                        where pipeline_run_id not in (#{viewable_pipeline_run_ids.join(',')}))")
+                        where pipeline_run_id not in (?))", viewable_pipeline_run_ids)
     end
   end
 

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -645,7 +645,7 @@ class PipelineRun < ApplicationRecord
     update_is_phage
 
     # rm the json
-    _stdout, _stderr, _status = Open3.capture3("rm -f #{downloaded_json_path}")
+    _stdout, _stderr, _status = Open3.capture3("rm", "-f", downloaded_json_path)
   end
 
   def db_load_taxon_counts

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -830,7 +830,7 @@ class PipelineRun < ApplicationRecord
     stats_array = stats_array.select { |entry| entry.key?("task") }
     job_stats.destroy_all
     update(job_stats_attributes: stats_array)
-    _stdout, _stderr, _status = Open3.capture3("rm -f #{downloaded_stats_path}")
+    _stdout = Syscall.run("rm", "-f", downloaded_stats_path)
   end
 
   def update_job_status

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1120,7 +1120,7 @@ class PipelineRun < ApplicationRecord
     # available;  this code merges them into taxon_counts.name.
     lineage_version = alignment_config.lineage_version
     %w[species genus family].each do |level|
-      level_id = TaxonCount::NAME_2_LEVEL[level]
+      level_id = ActiveRecord::Base.connection.quote(TaxonCount::NAME_2_LEVEL[level])
       TaxonCount.connection.execute("
         UPDATE taxon_counts, taxon_lineages
         SET taxon_counts.name = taxon_lineages.#{level}_name,


### PR DESCRIPTION
### Description
- None of these changes were exploitable (as far as I know) so this is not sensitive.
- This PR address all the Brakeman High confidence warnings. I made minimal changes and verified the parameters already had whitelisted inputs or controlled params, but we can add even more parameterization and sanitization. We should also dive into the Medium confidence warnings later.
- As discussed, this PR sets up Travis such that Brakeman High confidence warnings will return a non-zero exit code and fail the build. Devs should run brakeman locally if they want to view a full report.
- I plan to write up more notes on preferred mitigations in general.

### Notes
#### Before
![Screen Shot 2019-07-17 at 3 12 15 PM](https://user-images.githubusercontent.com/5652739/61418218-b1aa1380-a8ae-11e9-9832-e2367bc5bb5a.png)
[and more]

#### After
![Screen Shot 2019-07-17 at 3 12 59 PM](https://user-images.githubusercontent.com/5652739/61418220-b373d700-a8ae-11e9-954a-db67536f768a.png)
[and more]

### Tests
- Ran commands manually in local console to verify results.

phylo_tree#viewable:
- Ran `PhyloTree.viewable(User.find_by(role: 0))` (or other user with trees).
- SQL statement and output were correct.

phylo_tree#job_command:
- Ran `PhyloTree.find(114).send(:job_command)`
- SQL statement and output were correct.

pipeline_run#load_taxons and load_job_stats:
- Ran Open3.capture3 manually. Output was correct.

pipeline_run#update_names:
- Ran `PipelineRun.last.update_names`
- SQL statement and output were correct.

samples#resync_prod_data_to_staging:
- Ran with filler values (ex: sample 2000). SQL statement and output were correct.
- Note: there will be another task to remove this functionality.