### PR TITLE
[Heatmap] Persist metadata selection and sorting options

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -393,6 +393,10 @@ class SamplesHeatmapView extends React.Component {
     this.metadataSortField = field;
     this.metadataSortAsc = dir;
     this.updateHistoryState();
+    logAnalyticsEvent("Heatmap_column-metadata-label_clicked", {
+      columnMetadataSortField: field,
+      sortDirection: dir ? "asc" : "desc",
+    });
   };
 
   handleSampleLabelClick = sampleId => {

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -74,6 +74,9 @@ class SamplesHeatmapView extends React.Component {
         readSpecificity: parseAndCheckInt(this.urlParams.readSpecificity, 1),
       },
       loading: false,
+      selectedMetadata: this.urlParams.selectedMetadata || [
+        "collection_location",
+      ],
       sampleIds: compact(
         map(parseAndCheckInt, this.urlParams.sampleIds || this.props.sampleIds)
       ),
@@ -161,14 +164,18 @@ class SamplesHeatmapView extends React.Component {
         JSON.parse(urlParams.thresholdFilters)
       );
     }
+    if (typeof urlParams.selectedMetadata === "string") {
+      urlParams.selectedMetadata.split(",");
+    }
     return urlParams;
   };
 
   getUrlParams = () => {
     return Object.assign(
       {
-        sampleIds: this.state.sampleIds,
+        selectedMetadata: this.state.selectedMetadata,
         removedTaxonIds: Array.from(this.removedTaxonIds),
+        sampleIds: this.state.sampleIds,
       },
       this.state.selectedOptions
     );
@@ -362,6 +369,15 @@ class SamplesHeatmapView extends React.Component {
     });
   };
 
+  handleMetadataChange = metadataFields => {
+    this.setState({
+      selectedMetadata: Array.from(metadataFields),
+    });
+    logAnalyticsEvent("SamplesHeatmapView_metadata_changed", {
+      selected: metadataFields,
+    });
+  };
+
   handleSampleLabelClick = sampleId => {
     if (!sampleId) {
       this.setState({
@@ -528,20 +544,22 @@ class SamplesHeatmapView extends React.Component {
     return (
       <ErrorBoundary>
         <SamplesHeatmapVis
+          data={this.state.data}
+          defaultMetadata={this.state.selectedMetadata}
+          metadataTypes={this.state.metadataTypes}
+          metric={this.state.selectedOptions.metric}
+          onMetadataChange={this.handleMetadataChange}
+          onRemoveTaxon={this.handleRemoveTaxon}
+          onSampleLabelClick={this.handleSampleLabelClick}
+          onTaxonLabelClick={this.handleTaxonLabelClick}
           ref={vis => {
             this.heatmapVis = vis;
           }}
           sampleIds={this.state.sampleIds}
           sampleDetails={this.state.sampleDetails}
+          scale={SCALE_OPTIONS[scaleIndex][1]}
           taxonIds={this.state.taxonIds}
           taxonDetails={this.state.taxonDetails}
-          data={this.state.data}
-          metadataTypes={this.state.metadataTypes}
-          metric={this.state.selectedOptions.metric}
-          scale={SCALE_OPTIONS[scaleIndex][1]}
-          onRemoveTaxon={this.handleRemoveTaxon}
-          onSampleLabelClick={this.handleSampleLabelClick}
-          onTaxonLabelClick={this.handleTaxonLabelClick}
           taxonFilterState={this.state.taxonFilterState}
         />
       </ErrorBoundary>

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -210,6 +210,8 @@ class SamplesHeatmapVis extends React.Component {
   };
 
   handleSelectedMetadataChange = selectedMetadata => {
+    const { onMetadataChange } = this.props;
+
     let intersection = new Set(
       [...this.state.selectedMetadata].filter(metadatum =>
         selectedMetadata.has(metadatum)
@@ -222,6 +224,7 @@ class SamplesHeatmapVis extends React.Component {
       },
       () => {
         this.heatmap.updateColumnMetadata(this.getSelectedMetadata());
+        onMetadataChange && onMetadataChange(selectedMetadata);
         logAnalyticsEvent("SamplesHeatmapVis_selected-metadata_changed", {
           selectedMetadata: current.length,
         });
@@ -342,7 +345,7 @@ class SamplesHeatmapVis extends React.Component {
 }
 
 SamplesHeatmapVis.defaultProps = {
-  defaultMetadata: ["collection_location"],
+  defaultMetadata: [],
 };
 
 SamplesHeatmapVis.propTypes = {
@@ -351,6 +354,7 @@ SamplesHeatmapVis.propTypes = {
   defaultMetadata: PropTypes.array,
   metadataTypes: PropTypes.array,
   metric: PropTypes.string,
+  onMetadataChange: PropTypes.func,
   onRemoveTaxon: PropTypes.func,
   onSampleLabelClick: PropTypes.func,
   onTaxonLabelClick: PropTypes.func,

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -42,6 +42,12 @@ class SamplesHeatmapVis extends React.Component {
   }
 
   componentDidMount() {
+    const {
+      onMetadataSortChange,
+      metadataSortField,
+      metadataSortAsc,
+    } = this.props;
+
     this.heatmap = new Heatmap(
       this.heatmapContainer,
       {
@@ -50,22 +56,25 @@ class SamplesHeatmapVis extends React.Component {
         values: this.props.data[this.props.metric],
       },
       {
+        customColorCallback: this.colorScale,
+        columnMetadata: this.getSelectedMetadata(),
+        initialColumnMetadataSortField: metadataSortField,
+        initialColumnMetadataSortAsc: metadataSortAsc,
+        onNodeHover: this.handleNodeHover,
+        onNodeHoverMove: this.handleMouseHoverMove,
+        onNodeHoverOut: this.handleNodeHoverOut,
+        onColumnMetadataSortChange: onMetadataSortChange,
+        onColumnMetadataLabelHover: this.handleColumnMetadataLabelHover,
+        onColumnMetadataLabelMove: this.handleMouseHoverMove,
+        onColumnMetadataLabelOut: this.handleColumnMetadataLabelOut,
+        onRemoveRow: this.props.onRemoveTaxon,
+        onCellClick: this.handleCellClick,
+        onColumnLabelClick: this.props.onSampleLabelClick,
+        onRowLabelClick: this.props.onTaxonLabelClick,
+        onAddColumnMetadataClick: this.handleAddColumnMetadataClick,
         scale: this.props.scale,
         // only display colors to positive values
         scaleMin: 0,
-        onNodeHover: this.handleNodeHover,
-        onNodeHoverOut: this.handleNodeHoverOut,
-        onNodeHoverMove: this.handleMouseHoverMove,
-        onColumnMetadataLabelHover: this.handleColumnMetadataLabelHover,
-        onColumnMetadataLabelOut: this.handleColumnMetadataLabelOut,
-        onColumnMetadataLabelMove: this.handleMouseHoverMove,
-        onRemoveRow: this.props.onRemoveTaxon,
-        onColumnLabelClick: this.props.onSampleLabelClick,
-        onRowLabelClick: this.props.onTaxonLabelClick,
-        onCellClick: this.handleCellClick,
-        onAddColumnMetadataClick: this.handleAddColumnMetadataClick,
-        columnMetadata: this.getSelectedMetadata(),
-        customColorCallback: this.colorScale,
       }
     );
     this.heatmap.start();
@@ -354,6 +363,9 @@ SamplesHeatmapVis.propTypes = {
   defaultMetadata: PropTypes.array,
   metadataTypes: PropTypes.array,
   metric: PropTypes.string,
+  metadataSortField: PropTypes.string,
+  metadataSortAsc: PropTypes.bool,
+  onMetadataSortChange: PropTypes.func,
   onMetadataChange: PropTypes.func,
   onRemoveTaxon: PropTypes.func,
   onSampleLabelClick: PropTypes.func,

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -8,8 +8,6 @@ import { interpolateYlOrRd } from "d3-scale-chromatic";
 import SvgSaver from "svgsaver";
 import cx from "classnames";
 
-import { logAnalyticsEvent } from "~/api/analytics";
-
 import symlog from "../../utils/d3/scales/symlog.js";
 import cs from "./heatmap.scss";
 import { CategoricalColormap } from "../../utils/colormaps/CategoricalColormap.js";
@@ -844,9 +842,6 @@ export default class Heatmap {
       this.options.onColumnMetadataLabelClick
         ? this.options.onColumnMetadataLabelClick(d.value, d3.event)
         : this.handleColumnMetadataLabelClick(d.value);
-      logAnalyticsEvent("Heatmap_column-metadata-label_clicked", {
-        columnMetadataSortField: d.value,
-      });
     };
 
     columnMetadataLabelEnter


### PR DESCRIPTION
### Description

* This change persists the selected metadata fields, the metadata field to sort by and the sorting direction.
* Side changes:
	* Move logging from visualization into the component. For general visualizations, we should avoid dependencies from other IDseq frameworks like logging. Better to add a callback and log from the components.
	* Fix a bug where long metadata field labels would be cut out when taxon names are short (e.g. when choosing genus)
	* Nit: Resorted some fields alphabetically

### Tests

* Create a heatmap from a samples DD view.
* Select a few metadata fields and sort by one of the fields.
* Verify that metadata state persists when a user:
	- changes filters that cause a new server query
	- clicks save and reopens the visualization from the visualizations tab
	- clicks share and opens the link copied to the clipboard.