### PR TITLE
[Pipeline Viz] Add download links for files

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/PipelineStepDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/PipelineStepDetailsMode.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import { openUrl } from "~utils/links";
 import cs from "./pipeline_step_details_mode.scss";
 
 class PipelineStepDetailsMode extends React.Component {
@@ -44,12 +45,12 @@ class PipelineStepDetailsMode extends React.Component {
     return fileList.map((file, i) => {
       const cssClass = file.url ? cs.fileLink : cs.disabledFileLink;
       const content = file.url ? (
-        <a href={file.url} target="_blank">
-          {file.fileName}
-        </a>
+        // Use onClick instead of href to remove url appearance when hovering.
+        <a onClick={() => openUrl(file.url)}>{file.fileName}</a>
       ) : (
         file.fileName
       );
+
       return (
         <div className={cssClass} key={`${file.fileName}-${i}`}>
           {content}

--- a/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/PipelineStepDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/PipelineStepDetailsMode.jsx
@@ -11,22 +11,12 @@ class PipelineStepDetailsMode extends React.Component {
     }
 
     const fileGroupList = inputFiles.map((inputFileGroup, i) => {
-      const fileList = inputFileGroup.files.map((file, i) => {
-        return (
-          <div className={cs.fileLink} key={`${file.fileName}-${i}`}>
-            {file.fileName}
-          </div>
-        );
-      });
-
-      // TODO(ezhong): Figure out what to put as fileGroupHeader if input is
-      // provided by a user (instead of step output)
       return (
         <div className={cs.fileGroup} key={`inputFileGroup.fromStepName-${i}`}>
           <div
             className={cs.fileGroupHeader}
           >{`From ${inputFileGroup.fromStepName || "Sample"}:`}</div>
-          {fileList}
+          {this.renderFileList(inputFileGroup.files)}
         </div>
       );
     });
@@ -41,20 +31,31 @@ class PipelineStepDetailsMode extends React.Component {
   renderOutputFiles() {
     const { outputFiles } = this.props;
     if (outputFiles && outputFiles.length) {
-      const fileList = outputFiles.map((file, i) => {
-        return (
-          <div className={cs.fileLink} key={`${file.fileName}-${i}`}>
-            {file.fileName}
-          </div>
-        );
-      });
       return (
         <div className={cs.stepFilesListBox}>
           <div className={cs.stepFilesListBoxHeader}>Output Files</div>
-          {fileList}
+          {this.renderFileList(outputFiles)}
         </div>
       );
     }
+  }
+
+  renderFileList(fileList) {
+    return fileList.map((file, i) => {
+      const cssClass = file.url ? cs.fileLink : cs.disabledFileLink;
+      const content = file.url ? (
+        <a href={file.url} target="_blank">
+          {file.fileName}
+        </a>
+      ) : (
+        file.fileName
+      );
+      return (
+        <div className={cssClass} key={`${file.fileName}-${i}`}>
+          {content}
+        </div>
+      );
+    });
   }
 
   render() {
@@ -77,13 +78,17 @@ PipelineStepDetailsMode.propTypes = {
     PropTypes.shape({
       fromStepName: PropTypes.string,
       files: PropTypes.arrayOf(
-        PropTypes.shape({ fileName: PropTypes.string.isRequired })
+        PropTypes.shape({
+          fileName: PropTypes.string.isRequired,
+          url: PropTypes.string,
+        })
       ).isRequired,
     }).isRequired
   ).isRequired,
   outputFiles: PropTypes.arrayOf(
     PropTypes.shape({
       fileName: PropTypes.string.isRequired,
+      url: PropTypes.string,
     }).isRequired
   ).isRequired,
 };

--- a/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
+++ b/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
@@ -24,7 +24,8 @@
 }
 
 .description,
-.fileLink {
+.fileLink,
+.disabledFileLink {
   @include font-body-s;
   margin-bottom: 8px;
 }
@@ -32,6 +33,11 @@
 .fileLink {
   color: $primary-light;
   cursor: pointer;
+}
+
+.disabledFileLink {
+  color: $medium-grey;
+  cursor: default;
 }
 
 .fileGroup {

--- a/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
+++ b/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
@@ -43,7 +43,8 @@
 .fileGroup {
   margin-bottom: 8px;
 
-  .fileLink {
+  .fileLink,
+  .disabledFileLink {
     margin-left: 25px;
   }
 

--- a/app/assets/src/components/views/PipelineViz/PipelineViz.jsx
+++ b/app/assets/src/components/views/PipelineViz/PipelineViz.jsx
@@ -117,9 +117,8 @@ class PipelineViz extends React.Component {
         : "";
       return {
         fromStepName: fromStepName,
-        // TODO(ezhong): Include file url for downloading
         files: edgeInfo.files.map(file => {
-          return { fileName: file };
+          return { fileName: file.displayName, url: file.url };
         }),
       };
     });
@@ -134,10 +133,10 @@ class PipelineViz extends React.Component {
       .map(edgeInfo => {
         // Remove duplicate output file listings
         return edgeInfo.files.reduce((files, fileInfo) => {
-          if (!seenFiles.has(fileInfo)) {
-            seenFiles.add(fileInfo);
-            // TODO(ezhong): Include file url for downloading
-            files.push({ fileName: fileInfo });
+          let fileInfoAsString = JSON.stringify(fileInfo);
+          if (!seenFiles.has(fileInfoAsString)) {
+            seenFiles.add(fileInfoAsString);
+            files.push({ fileName: fileInfo.displayName, url: fileInfo.url });
           }
           return files;
         }, []);

--- a/app/controllers/pipeline_viz_controller.rb
+++ b/app/controllers/pipeline_viz_controller.rb
@@ -13,7 +13,7 @@ class PipelineVizController < ApplicationController
       )
 
       if pipeline_run
-        @results = RetrievePipelineVizGraphDataService.call(pipeline_run.id, current_user.admin?)
+        @results = RetrievePipelineVizGraphDataService.call(pipeline_run.id, current_user.admin?, current_user.id != sample.user_id)
         respond_to do |format|
           format.html
           format.json { render json: @results }

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -223,8 +223,8 @@ class Sample < ApplicationRecord
     end
   end
 
-  def results_folder_files
-    pr = first_pipeline_run
+  def results_folder_files(pipeline_version = nil)
+    pr = pipeline_version ? pipeline_run_by_version(pipeline_version) : first_pipeline_run
     return list_outputs(sample_output_s3_path) unless pr
     file_list = []
     if pipeline_version_at_least_2(pr.pipeline_version)

--- a/app/services/retrieve_pipeline_viz_graph_data_service.rb
+++ b/app/services/retrieve_pipeline_viz_graph_data_service.rb
@@ -92,8 +92,8 @@ class RetrievePipelineVizGraphDataService
       edge_info = JSON.parse(input_output_json, symbolize_names: true)
       edges.push(from: edge_info[:from],
                  to: edge_info[:to],
-                 files: file_paths.map { |file_path| file_path_to_info[file_path] || { display_name: file_path.split("/").last } },
-                 isIntraStage: edge_info[:to] && edge_info[:from] && edge_info[:to][:stageIndex] == edge_info[:from][:stageIndex])
+                 files: file_paths.map { |file_path| file_path_to_info[file_path] || { displayName: file_path.split("/").last } },
+                 isIntraStage: (edge_info[:to] && edge_info[:from] && edge_info[:to][:stageIndex] == edge_info[:from][:stageIndex])) || false
     end
     return edges
   end

--- a/app/services/retrieve_pipeline_viz_graph_data_service.rb
+++ b/app/services/retrieve_pipeline_viz_graph_data_service.rb
@@ -111,9 +111,10 @@ class RetrievePipelineVizGraphDataService
     input_output_to_file_paths.each do |input_output_json, file_paths|
       edge_info = JSON.parse(input_output_json, symbolize_names: true)
       files = file_paths.map do |file_path|
+        file_path = file_path.split('/', 4).last # Remove s3://idseq-.../ to match key
         file_info = file_path_to_info[file_path]
-        display_name = file_info ? file_info.display_name : file_path.split("/").last
-        url = file_info ? file_info.url : nil
+        display_name = file_info ? file_info[:display_name] : file_path.split("/").last
+        url = file_info ? file_info[:url] : nil
         { displayName: display_name, url: url }
       end
 
@@ -148,7 +149,7 @@ class RetrievePipelineVizGraphDataService
 
   def remove_host_filtering_urls(edges)
     edges.each do |edge|
-      if (edge[:from] && edge[:from][:stageIndex].zero?) || (edge[:to] && edge[:to][:stageIndex].zero?)
+      if (edge[:to] && edge[:to][:stageIndex].zero?) || edge[:from].nil?
         edge[:files].each { |file| file[:url] = nil }
       end
     end

--- a/app/services/retrieve_pipeline_viz_graph_data_service.rb
+++ b/app/services/retrieve_pipeline_viz_graph_data_service.rb
@@ -15,7 +15,6 @@ class RetrievePipelineVizGraphDataService
     stages = create_stage_nodes_scaffolding
     edges = create_edges
     populate_nodes_with_edges(stages, edges)
-    add_final_outputs_edges(stages, edges)
 
     return { stages: stages, edges: edges }
   end
@@ -41,11 +40,62 @@ class RetrievePipelineVizGraphDataService
   end
 
   def create_edges
-    edges = []
-    @all_dag_jsons.each_with_index do |dag_json, stage_index|
-      edges.concat(intra_stage_edges(dag_json, stage_index))
+    file_path_to_info = {}
+    @pipeline_run.sample.results_folder_files(@pipeline_run.pipeline_version).each do |file_entry|
+      file_path_to_info[file_entry[:key]] = file_entry
     end
-    edges.concat(inter_stage_edges)
+
+    file_path_to_outputting_step = {}
+    file_path_to_inputting_steps = {}
+    all_file_paths = Set.new
+    @all_dag_jsons.each_with_index do |stage_dag_json, stage_index|
+      stage_dag_json["steps"].each_with_index do |step, step_index|
+        stage_dag_json["targets"][step["out"]].each do |file_name|
+          file_path = "#{stage_dag_json['output_dir_s3']}/#{@pipeline_run.pipeline_version}/#{file_name}"
+          file_path_to_outputting_step[file_path] = { stageIndex: stage_index, stepIndex: step_index }
+          all_file_paths.add file_path
+        end
+
+        step["in"].each do |in_target|
+          stage_dag_json["targets"][in_target].each do |file_name|
+            file_path = if stage_dag_json["given_targets"].key? in_target
+                          "#{stage_dag_json['given_targets'][in_target]['s3_dir']}/#{file_name}"
+                        else
+                          "#{stage_dag_json['output_dir_s3']}/#{@pipeline_run.pipeline_version}/#{file_name}"
+                        end
+
+            unless file_path_to_inputting_steps.key? file_path
+              file_path_to_inputting_steps[file_path] = []
+            end
+            file_path_to_inputting_steps[file_path].push(stageIndex: stage_index, stepIndex: step_index)
+            all_file_paths.add file_path
+          end
+        end
+      end
+    end
+
+    input_output_to_file_paths = {}
+    all_file_paths.to_a.each do |file_path|
+      output_info = file_path_to_outputting_step[file_path]
+      (file_path_to_inputting_steps[file_path] ? file_path_to_inputting_steps[file_path] : [nil]).each do |input_info|
+        from_to_json = { from: output_info, to: input_info }.to_json
+
+        unless input_output_to_file_paths.key? from_to_json
+          input_output_to_file_paths[from_to_json] = []
+        end
+        input_output_to_file_paths[from_to_json].push(file_path)
+      end
+    end
+
+    edges = []
+    input_output_to_file_paths.each do |input_output_json, file_paths|
+      edge_info = JSON.parse(input_output_json, symbolize_names: true)
+      edges.push(from: edge_info[:from],
+                 to: edge_info[:to],
+                 files: file_paths.map { |file_path| file_path_to_info[file_path] || { display_name: file_path.split("/").last } },
+                 isIntraStage: edge_info[:to] && edge_info[:from] && edge_info[:to][:stageIndex] == edge_info[:from][:stageIndex])
+    end
+    return edges
   end
 
   def populate_nodes_with_edges(stages_with_nodes, edges)
@@ -59,94 +109,6 @@ class RetrievePipelineVizGraphDataService
         to_stage_index = edge[:to][:stageIndex]
         to_step_index = edge[:to][:stepIndex]
         stages_with_nodes[to_stage_index][:steps][to_step_index][:inputEdges].push(edge_index)
-      end
-    end
-  end
-
-  def intra_stage_edges(stage_dag_json, stage_index)
-    target_to_outputting_step = {}
-    stage_dag_json["steps"].each_with_index do |step, step_index|
-      target_to_outputting_step[step["out"]] = step_index
-    end
-
-    edges = []
-    stage_dag_json["steps"].each_with_index do |step, to_step_index|
-      step["in"].each do |in_target|
-        from_step_index = target_to_outputting_step[in_target]
-        unless from_step_index.nil?
-          # TODO(ezhong): Include file download links for files.
-          files = stage_dag_json["targets"][in_target]
-          edges.push(from: {
-                       stageIndex: stage_index,
-                       stepIndex: from_step_index
-                     }, to: {
-                       stageIndex: stage_index,
-                       stepIndex: to_step_index
-                     },
-                     files: files,
-                     isIntraStage: true)
-        end
-      end
-    end
-    return edges
-  end
-
-  def inter_stage_edges
-    file_path_to_outputting_step = {}
-    @all_dag_jsons.each_with_index do |stage_dag_json, stage_index|
-      stage_dag_json["steps"].each_with_index do |step, step_index|
-        stage_dag_json["targets"][step["out"]].each do |file_name|
-          file_path = "#{stage_dag_json['output_dir_s3']}/#{@pipeline_run.pipeline_version}/#{file_name}"
-          file_path_to_outputting_step[file_path] = { stageIndex: stage_index, stepIndex: step_index }
-        end
-      end
-    end
-
-    edges = []
-    @all_dag_jsons.each_with_index do |stage_dag_json, to_stage_index|
-      stage_dag_json["steps"].each_with_index do |step, to_step_index|
-        # Group files with the same outputting step, as they lie on the same edge.
-        outputting_step_to_files = {}
-
-        step["in"].each do |in_target|
-          if stage_dag_json["given_targets"].key? in_target
-            dir_path = stage_dag_json["given_targets"][in_target]["s3_dir"]
-            stage_dag_json["targets"][in_target].each do |file_name|
-              file_path = "#{dir_path}/#{file_name}"
-              outputting_step_info = file_path_to_outputting_step[file_path]
-              unless outputting_step_to_files.key?(outputting_step_info)
-                outputting_step_to_files[outputting_step_info] = []
-              end
-              outputting_step_to_files[outputting_step_info].push(file_name)
-            end
-          end
-        end
-
-        outputting_step_to_files.each do |outputting_step_info, files|
-          edges.push(from: outputting_step_info,
-                     to: {
-                       stageIndex: to_stage_index,
-                       stepIndex: to_step_index
-                     },
-                     # TODO(ezhong): Include file download links for files.
-                     files: files,
-                     isIntraStage: false)
-        end
-      end
-    end
-    return edges
-  end
-
-  def add_final_outputs_edges(stage_step_data, edge_data)
-    stage_step_data.each_with_index do |stage, stage_index|
-      stage[:steps].each_with_index do |step, step_index|
-        if step[:outputEdges].empty?
-          dag_json = @all_dag_jsons[stage_index]
-          out_target = dag_json["steps"][step_index]["out"]
-          edge_data.push(from: { stageIndex: stage_index, stepIndex: step_index },
-                         files: dag_json["targets"][out_target])
-          step[:outputEdges].push(edge_data.length - 1)
-        end
       end
     end
   end

--- a/app/services/retrieve_pipeline_viz_graph_data_service.rb
+++ b/app/services/retrieve_pipeline_viz_graph_data_service.rb
@@ -4,7 +4,7 @@ class RetrievePipelineVizGraphDataService
   def initialize(pipeline_run_id, is_admin)
     @pipeline_run = PipelineRun.find(pipeline_run_id)
     @all_dag_jsons = []
-    @pipeline_run.pipeline_run_stages.map do |stage|
+    @pipeline_run.pipeline_run_stages.each do |stage|
       if stage.name != "Experimental" || is_admin
         @all_dag_jsons.push(JSON.parse(stage.dag_json || "{}"))
       end

--- a/spec/controllers/pipeline_viz_controller_spec.rb
+++ b/spec/controllers/pipeline_viz_controller_spec.rb
@@ -79,26 +79,26 @@ RSpec.describe PipelineVizController, type: :controller do
       {
         "from" => { "stageIndex" => 0, "stepIndex" => 0 },
         "to" => { "stageIndex" => 0, "stepIndex" => 1 },
-        "files" => ["file2"],
+        "files" => [{ "displayName" => "file2" }],
         "isIntraStage" => true
       },
       # Edges from inter_stage_edges
       {
         "from" => nil,
         "to" => { "stageIndex" => 0, "stepIndex" => 0 },
-        "files" => ["file1"],
+        "files" => [{ "displayName" => "file1" }],
         "isIntraStage" => false
       },
       {
         "from" => { "stageIndex" => 0, "stepIndex" => 1 },
         "to" => { "stageIndex" => 1, "stepIndex" => 0 },
-        "files" => ["file3"],
+        "files" => [{ "displayName" => "file3" }],
         "isIntraStage" => false
       },
       # Edges from add_final_output_edges
       {
         "from" => { "stageIndex" => 1, "stepIndex" => 0 },
-        "files" => ["file4"]
+        "files" => [{ "displayName" => "file4" }]
       }
     ]
   }
@@ -168,7 +168,7 @@ RSpec.describe PipelineVizController, type: :controller do
         expected_stage_results_no_experimental["edges"].pop(2) # Remove edges in and to experimental stage data
         # Push new outputting edge for first (and now only) stage
         expected_stage_results_no_experimental["edges"].push("from" => { "stageIndex" => 0, "stepIndex" => 1 },
-                                                             "files" => ["file3"])
+                                                             "files" => [{ "displayName" => "file3" }])
 
         get :show, params: { format: "json", sample_id: sample.id }
 
@@ -188,7 +188,7 @@ RSpec.describe PipelineVizController, type: :controller do
         expected_stage_results_no_experimental["edges"].pop(2) # Remove edges in and to experimental stage data
         # Push new outputting edge for first (and now only) stage
         expected_stage_results_no_experimental["edges"].push("from" => { "stageIndex" => 0, "stepIndex" => 1 },
-                                                             "files" => ["file3"])
+                                                             "files" => [{ "displayName" => "file3" }])
 
         get :show, params: { format: "json", sample_id: sample.id }
 

--- a/spec/services/retrieve_pipeline_viz_graph_data_service_spec.rb
+++ b/spec/services/retrieve_pipeline_viz_graph_data_service_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe RetrievePipelineVizGraphDataService do
       },
       {
         from: { stageIndex: 1, stepIndex: 0 },
-        files: [{ displayName: "bowtie2_1.fa", url: "test" }]
+        files: [{ displayName: "bowtie2_1.fa", url: "test url" }]
       }
     ]
   }

--- a/spec/services/retrieve_pipeline_viz_graph_data_service_spec.rb
+++ b/spec/services/retrieve_pipeline_viz_graph_data_service_spec.rb
@@ -1,0 +1,183 @@
+require 'rails_helper'
+require 'json'
+
+RSpec.describe RetrievePipelineVizGraphDataService do
+  given_targets_dir = "s3://idseq.../samples/theProjectId/theSampleId/results/1.0"
+  output_dir = "s3://idseq.../samples/theProjectId/theSampleId/results"
+
+  pr_stages_data = [{
+    name: "Host Filtering",
+    dag_json: {
+      output_dir_s3: output_dir,
+      targets: {
+        one: ["unmapped1.fq"],
+        two: ["trimmomatic1.fq"],
+        three: ["priceseq1.fa"]
+      },
+      steps: [
+        {
+          in: ["one"],
+          out: "two",
+          class: "step_one"
+        }, {
+          in: ["two"],
+          out: "three",
+          class: "step_two"
+        }
+      ],
+      given_targets: {
+        one: {
+          s3_dir: given_targets_dir
+        }
+      }
+    }.to_json
+  }, {
+    name: "Experimental",
+    dag_json: {
+      output_dir_s3: output_dir,
+      targets: {
+        three: ["priceseq1.fa"],
+        four: ["bowtie2_1.fa"]
+      },
+      steps: [
+        {
+          in: ["three"],
+          out: "four",
+          class: "step_three"
+        }
+      ],
+      given_targets: {
+        three: {
+          s3_dir: given_targets_dir
+        }
+      }
+    }.to_json
+  }]
+
+  expected_stage_results = {
+    stages: [
+      {
+        steps: [
+          {
+            name: "step_one",
+            inputEdges: [1],
+            outputEdges: [0]
+          },
+          {
+            name: "step_two",
+            inputEdges: [0],
+            outputEdges: [2]
+          }
+        ]
+      }, {
+        steps: [{
+          name: "step_three",
+          inputEdges: [2],
+          outputEdges: [3]
+        }]
+      }
+    ],
+    edges: [
+      {
+        from: { stageIndex: 0, stepIndex: 0 },
+        to: { stageIndex: 0, stepIndex: 1 },
+        files: [{ displayName: "trimmomatic1.fq", url: "test url" }],
+        isIntraStage: true
+      },
+      {
+        from: nil,
+        to: { stageIndex: 0, stepIndex: 0 },
+        files: [{ displayName: "unmapped1.fq", url: "test url" }],
+        isIntraStage: false
+      },
+      {
+        from: { stageIndex: 0, stepIndex: 1 },
+        to: { stageIndex: 1, stepIndex: 0 },
+        files: [{ displayName: "priceseq1.fa", url: "test url" }],
+        isIntraStage: false
+      },
+      {
+        from: { stageIndex: 1, stepIndex: 0 },
+        files: [{ displayName: "bowtie2_1.fa", url: "test" }]
+      }
+    ]
+  }
+
+  describe "Retrieving graph" do
+    before do
+      # Project and sample required to create pipeline run.
+      project = create(:public_project)
+      sample = create(:sample, project: project)
+
+      @pr = create(:pipeline_run, sample: sample, pipeline_run_stages_data: pr_stages_data)
+    end
+
+    it "should be structured correctly" do
+      results = RetrievePipelineVizGraphDataService.call(@pr.id, true, false)
+      expect(results).to include_json(expected_stage_results)
+      expect(results.keys).to contain_exactly(*expected_stage_results.keys)
+    end
+
+    context "as admin" do
+      it "sees all stage results" do
+        is_admin = true
+        results = RetrievePipelineVizGraphDataService.call(@pr.id, is_admin, false)
+
+        # Host filtering and experimental; other stages omitted for brevity.
+        expect(results[:stages].length).to be(2)
+      end
+    end
+
+    context "as nonadmin" do
+      it "sees all stage results except experimental" do
+        is_admin = false
+        results = RetrievePipelineVizGraphDataService.call(@pr.id, is_admin, false)
+
+        # Only host filtering (other stages omitted for brevity)
+        expect(results[:stages].length).to be(1)
+      end
+    end
+
+    context "without host filtering urls" do
+      it "does not include host filtering urls" do
+        remove_host_filtering = true
+        results = RetrievePipelineVizGraphDataService.call(@pr.id, false, remove_host_filtering)
+
+        # Get files in each edge in Host Filtering stage (except final output) and check for no url
+        edges = results[:edges]
+        host_filtering = results[:stages][0]
+        host_filtering[:steps].each do |step|
+          step[:inputEdges].each do |edge_index|
+            edge = edges[edge_index]
+            if edge[:to][:stageIndex] == 0
+              edge[:files].each do |file|
+                expect(file[:url]).to be_nil
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "with host filtering urls" do
+      it "includes host filtering urls" do
+        remove_host_filtering = false
+        results = RetrievePipelineVizGraphDataService.call(@pr.id, false, remove_host_filtering)
+
+        # Get files in each edge in Host Filtering stage (except final output) and check for url
+        edges = results[:edges]
+        host_filtering = results[:stages][0]
+        host_filtering[:steps].each do |step|
+          step[:inputEdges].each do |edge_index|
+            edge = edges[edge_index]
+            if edge[:to][:stageIndex] == 0
+              edge[:files].each do |file|
+                expect(file[:url]).to be_truthy
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description
Adds download links for files on sidebar

# Notes
* Only admin will be able to see experimental results
* Host filtering results only visible by sample owner
* Refactor of how edges are constructed in pipeline viz graph service

# Tests

* **Backend**:  New `retrieve_pipeline_viz_graph_data_service_spec.rb` tests!
* **Frontend**: Go to `samples/[sample id]/pipeline_viz`, click on a node, then click on file on sidebar to download.
