### PR TITLE
Fix DCR display (remove percentage).

### DIFF
--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -88,7 +88,7 @@ class SamplesView extends React.Component {
         flexGrow: 1,
         className: cs.basicCell,
         cellDataGetter: ({ dataKey, rowData }) =>
-          TableRenderers.formatPercentage(rowData[dataKey]),
+          TableRenderers.formatNumber(rowData[dataKey]),
       },
       {
         dataKey: "erccReads",


### PR DESCRIPTION
# Description

Fixes a bug where a percentage symbol was mistakenly added to DCR value.

# Tests

* Load samples table and verify that DCR is not shown as percentage (also verify corresponds to ratio between reads before and after cd-hitdup step).
