### PR TITLE
[Pipeline Viz] Step descriptions

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
+++ b/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
@@ -8,7 +8,7 @@
 
 .stepName {
   @include font-header-l;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
   margin-right: 60px;
   word-break: break-all;
 }
@@ -26,12 +26,11 @@
 .description,
 .fileLink {
   @include font-body-s;
-  margin-bottom: 8px;
 }
 
 .fileLink {
   color: $primary-light;
-  cursor: pointer;
+  margin-bottom: 8px;
 }
 
 .fileGroup {

--- a/app/assets/src/components/views/PipelineViz/PipelineViz.jsx
+++ b/app/assets/src/components/views/PipelineViz/PipelineViz.jsx
@@ -144,15 +144,15 @@ class PipelineViz extends React.Component {
       })
       .flat();
 
-    const stepName = this.getStepDataAtIndices({
+    const stepInfo = this.getStepDataAtIndices({
       stageIndex: stageIndex,
       stepIndex: clickedNodeId,
-    }).name;
+    });
     this.setState({
       sidebarVisible: true,
       sidebarParams: {
-        stepName: stepName,
-        description: "",
+        stepName: stepInfo.name,
+        description: stepInfo.description,
         inputFiles: inputInfo,
         outputFiles: outputInfo,
       },

--- a/app/services/retrieve_pipeline_viz_graph_data_service.rb
+++ b/app/services/retrieve_pipeline_viz_graph_data_service.rb
@@ -1,6 +1,8 @@
 class RetrievePipelineVizGraphDataService
   include Callable
-  include PipelineRunsHelper # For step descriptions
+  # For step descriptions.
+  # TODO(ezhong): Move to server-fed descriptions.
+  include PipelineRunsHelper
 
   # Structures dag_json of each stage of the pipeline run into the following in @results for drawing
   # the pipeline visualization graphs on the React side:


### PR DESCRIPTION
# Description
Adds step descriptions to the sidebar. Descriptions are from `pipeline_runs_helper.rb` (originally used for `results_folder` view).


![image](https://user-images.githubusercontent.com/23442055/61503123-61ed4a00-a98b-11e9-8a35-3d94e4f56628.png)

# Notes
* Temporary — planning to include more dynamic step descriptions to ensure they are included for pipeline updates/changes 

# Tests
Go to `samples/[sample id]/pipeline_viz` and click on a node to see description on the sidebar (Not all nodes may have samples since descriptions are hardcoded / not necessarily updated with each pipeline change)
