### PR TITLE
Change ID cols to bigint

### DIFF
--- a/db/migrate/20190719221024_change_foreign_keys_to_bigint.rb
+++ b/db/migrate/20190719221024_change_foreign_keys_to_bigint.rb
@@ -1,0 +1,17 @@
+class ChangeForeignKeysToBigint < ActiveRecord::Migration[5.1]
+  def up
+    change_column :metadata, :sample_id, :bigint
+    change_column :metadata, :location_id, :bigint
+
+    change_column :favorite_projects, :project_id, :bigint
+    change_column :favorite_projects, :user_id, :bigint
+  end
+
+  def down
+    change_column :metadata, :sample_id, :integer
+    change_column :metadata, :location_id, :integer
+
+    change_column :favorite_projects, :project_id, :integer
+    change_column :favorite_projects, :user_id, :integer
+  end
+end


### PR DESCRIPTION
# Description

For https://github.com/chanzuckerberg/idseq-web/pull/2419 to work, foreign keys types need to match the key col they reference. 

# Tests

* Run `db:migrate`, see no errors