### PR TITLE
Change rspec db setup to be same as rails test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - docker-compose run --rm webtest "rubocop -R --config .rubocop_todo.yml"
   - docker-compose run --rm webtest "rake db:drop db:create db:migrate db:seed"
   - docker-compose run --rm webtest "rails test"
-  - docker-compose run --rm webtest "rake db:drop db:create db:migrate db:reset"
+  - docker-compose run --rm webtest "rake db:drop db:create db:migrate db:seed"
   - docker-compose run --rm webtest "rspec"
   - docker-compose run --rm webtest "npm test"
   - docker-compose run --rm webtest "pip install mock; python -m unittest discover -v -s /app/test/ -p 'test_*.py'"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -442,6 +442,7 @@ ActiveRecord::Schema.define(version: 20_190_717_221_024) do
     t.integer "family_taxid", default: -300, null: false
     t.integer "is_phage", limit: 1, default: 0, null: false
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
+    t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
   end
 
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/spec/factories/host_genomes.rb
+++ b/spec/factories/host_genomes.rb
@@ -1,5 +1,20 @@
 FactoryBot.define do
   factory :host_genome, class: HostGenome do
+    transient do
+      metadata_fields { [] }
+    end
     sequence(:name) { |n| "Host #{n}" }
+
+    after :create do |host_genome, options|
+      options.metadata_fields.each do |metadata_field_name|
+        metadata_field = MetadataField.find_by(name: metadata_field_name)
+        unless metadata_field
+          metadata_field = create(:metadata_field, name: metadata_field_name)
+        end
+
+        # Add the metadata field to the host genome if it doesn't already exist.
+        host_genome.metadata_fields << metadata_field unless host_genome.metadata_field_ids.include?(metadata_field.id)
+      end
+    end
   end
 end

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -25,11 +25,14 @@ FactoryBot.define do
     # ensure the metadata field is added to the host genome
     before(:create) do |sample, options|
       options.metadata_fields.each_key do |metadata_field_name|
-        unless MetadataField.exists?(name: metadata_field_name)
-          metadata_field = create(:metadata_field, name: metadata_field_name, default_for_new_host_genome: 1)
-          # This is needed to make metadata pass validation below
-          sample.host_genome.metadata_fields << metadata_field
+        metadata_field = MetadataField.find_by(name: metadata_field_name)
+        unless metadata_field
+          metadata_field = create(:metadata_field, name: metadata_field_name)
         end
+        # This is needed to make metadata pass validation below
+        metadata_field.default_for_new_host_genome = 1
+        metadata_field.save!
+        sample.host_genome.metadata_fields << metadata_field
       end
     end
 

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -23,13 +23,11 @@ FactoryBot.define do
 
     # metadata fields
     # ensure the metadata field is added to the host genome
-    # TODO(tiago): will not work if the host genome was created before.
-    # COuld find out why the host genome metadata fields could not be updated.
-    before(:create) do |_sample, options|
+    before(:create) do |sample, options|
       options.metadata_fields.each_key do |metadata_field_name|
-        unless MetadataField.exists?(name: metadata_field_name)
-          create(:metadata_field, name: metadata_field_name, default_for_new_host_genome: 1)
-        end
+        metadata_field = create(:metadata_field, name: metadata_field_name, default_for_new_host_genome: 1)
+        # This is needed to make metadata pass validation below
+        sample.host_genome.metadata_fields << metadata_field
       end
     end
 

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -25,9 +25,11 @@ FactoryBot.define do
     # ensure the metadata field is added to the host genome
     before(:create) do |sample, options|
       options.metadata_fields.each_key do |metadata_field_name|
-        metadata_field = create(:metadata_field, name: metadata_field_name, default_for_new_host_genome: 1)
-        # This is needed to make metadata pass validation below
-        sample.host_genome.metadata_fields << metadata_field
+        unless MetadataField.exists?(name: metadata_field_name)
+          metadata_field = create(:metadata_field, name: metadata_field_name, default_for_new_host_genome: 1)
+          # This is needed to make metadata pass validation below
+          sample.host_genome.metadata_fields << metadata_field
+        end
       end
     end
 

--- a/spec/helpers/samples_helper_spec.rb
+++ b/spec/helpers/samples_helper_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe SamplesHelper, type: :helper do
       before do
         @project = create(:public_project)
         @joe = create(:joe)
-        @host_genome = create(:host_genome)
+        # Add the metadata fields to the host genome so that the metadata will pass validation.
+        @host_genome = create(:host_genome, metadata_fields: [
+                                "Fake Metadata Field One", "Fake Metadata Field Two"
+                              ])
       end
 
       let(:basespace_sample_attributes) do
@@ -29,10 +32,8 @@ RSpec.describe SamplesHelper, type: :helper do
       let(:metadata_attributes) do
         {
           fake_sample_name.to_s => {
-            "Sample Type" => "CSF",
-            "Nucleotide Type" => "DNA",
-            "Collection Location" => "CA, USA",
-            "Collection Date" => "2010-01"
+            "Fake Metadata Field One" => "CSF",
+            "Fake Metadata Field Two" => "DNA"
           }
         }
       end
@@ -61,15 +62,11 @@ RSpec.describe SamplesHelper, type: :helper do
         expect(created_sample.uploaded_from_basespace).to be 1
         expect(created_sample.user).to eq(@joe)
 
-        expect(Metadatum.where(sample_id: created_sample.id).length).to be 4
-        expect(Metadatum.where(sample_id: created_sample.id, key: "Sample Type").length).to be 1
-        expect(Metadatum.where(sample_id: created_sample.id, key: "Sample Type")[0].raw_value).to eq("CSF")
-        expect(Metadatum.where(sample_id: created_sample.id, key: "Nucleotide Type").length).to be 1
-        expect(Metadatum.where(sample_id: created_sample.id, key: "Nucleotide Type")[0].raw_value).to eq("DNA")
-        expect(Metadatum.where(sample_id: created_sample.id, key: "Collection Location").length).to be 1
-        expect(Metadatum.where(sample_id: created_sample.id, key: "Collection Location")[0].raw_value).to eq("CA, USA")
-        expect(Metadatum.where(sample_id: created_sample.id, key: "Collection Date").length).to be 1
-        expect(Metadatum.where(sample_id: created_sample.id, key: "Collection Date")[0].raw_value).to eq("2010-01")
+        expect(Metadatum.where(sample_id: created_sample.id).length).to be 2
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Fake Metadata Field One").length).to be 1
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Fake Metadata Field One")[0].raw_value).to eq("CSF")
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Fake Metadata Field Two").length).to be 1
+        expect(Metadatum.where(sample_id: created_sample.id, key: "Fake Metadata Field Two")[0].raw_value).to eq("DNA")
       end
 
       it "fails if basespace_access_token is not provided" do


### PR DESCRIPTION
# Description

In working on https://github.com/chanzuckerberg/idseq-web/pull/2419, I found that rspec was running off of `schema.rb` version of our db.  Following https://github.com/chanzuckerberg/idseq-web/pull/2419 , `schema.rb` will no longer execute because the foreign key constraints require creating the tables in a specific order.  `schema.rb` is alphabetical.

In any case, we should not use `schema.rb` for more than documentation because we use the migrated db in local, staging and prod. 

# Tests

* Run `RAILS_ENV=test rake db:drop db:create db:migrate db:seed`
* Run rspec, see no errors