### PR TITLE
[Maps] Update feature flag to hide location_v1 fields

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -185,16 +185,12 @@ class MetadataTab extends React.Component {
           <RequestContext.Consumer>
             {({ allowedFeatures } = {}) => {
               return validKeys.map(key => {
-                // Don't show collection_location_v2 unless you have maps in requestContext
-                // allowedFeatures.
                 // TODO(jsheu): Migrate all to location_v2 after release
-                if (
-                  key === "collection_location_v2" &&
-                  !(allowedFeatures && allowedFeatures.includes("maps"))
-                ) {
-                  return null;
+                if (allowedFeatures && allowedFeatures.includes("maps")) {
+                  if (key === "collection_location") return;
+                } else {
+                  if (key === "collection_location_v2") return;
                 }
-
                 return (
                   <div className={cs.field} key={metadataTypes[key].key}>
                     <div className={cs.label}>{metadataTypes[key].name}</div>

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -185,6 +185,7 @@ class MetadataTab extends React.Component {
           <RequestContext.Consumer>
             {({ allowedFeatures } = {}) => {
               return validKeys.map(key => {
+                // Hide the implicit v1 if you have 'maps'. Else hide v2.
                 // TODO(jsheu): Migrate all to location_v2 after release
                 if (allowedFeatures && allowedFeatures.includes("maps")) {
                   if (key === "collection_location") return;

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -71,7 +71,7 @@ class GeoSearchInputBox extends React.Component {
     const { onResultSelect } = this.props;
 
     // Wrap plain text submission
-    if (isString(result)) result = { name: result };
+    if (isString(result) && result !== "") result = { name: result };
 
     this.setState({ value: result });
 

--- a/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
@@ -167,16 +167,7 @@ class DiscoveryFilters extends React.Component {
           />
           {this.renderTags("taxon")}
         </div>
-        <div className={cs.filterContainer}>
-          <BaseMultipleFilter
-            onChange={this.handleChange.bind(this, "locationSelected")}
-            selected={location && location.length ? locationSelected : null}
-            options={location}
-            label="Location"
-          />
-          {this.renderTags("location")}
-        </div>
-        {allowedFeatures.includes("maps") && (
+        {allowedFeatures.includes("maps") ? (
           <div className={cs.filterContainer}>
             <LocationFilter
               onChange={this.handleChange.bind(this, "locationV2Selected")}
@@ -184,9 +175,19 @@ class DiscoveryFilters extends React.Component {
                 locationV2 && locationV2.length ? locationV2Selected : null
               }
               options={locationV2}
-              label="Location v2"
+              label="Location"
             />
             {this.renderTags("locationV2")}
+          </div>
+        ) : (
+          <div className={cs.filterContainer}>
+            <BaseMultipleFilter
+              onChange={this.handleChange.bind(this, "locationSelected")}
+              selected={location && location.length ? locationSelected : null}
+              options={location}
+              label="Location"
+            />
+            {this.renderTags("location")}
           </div>
         )}
         <div className={cs.filterContainer}>

--- a/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
@@ -22,7 +22,7 @@ class DiscoveryHeader extends React.Component {
     // category "Tissue": key: "tissue", value: id, text: title
     // TODO(jsheu): Replace location "v1"
     let category = result.category;
-    if (category !== "locationV2") category = gicategory.toLowerCase();
+    if (category !== "locationV2") category = category.toLowerCase();
     let value = result.id;
     switch (category) {
       case "taxon": {

--- a/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
@@ -20,7 +20,9 @@ class DiscoveryHeader extends React.Component {
     // category "Location": key: "location", value: id, text: title
     // category "Host": key: "host", value: id, text: title
     // category "Tissue": key: "tissue", value: id, text: title
-    const category = result.category.toLowerCase();
+    // TODO(jsheu): Replace location "v1"
+    let category = result.category;
+    if (category !== "locationV2") category = gicategory.toLowerCase();
     let value = result.id;
     switch (category) {
       case "taxon": {

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -350,15 +350,12 @@ export default class DiscoverySidebar extends React.Component {
             </div>
             <div className={cs.hasBackground}>
               <span className={cs.rowLabel}>Location</span>
-              {this.buildMetadataRows("location")}
-            </div>
-            {allowedFeatures &&
-              allowedFeatures.includes("maps") && (
-                <div className={cs.hasBackground}>
-                  <span className={cs.rowLabel}>Location v2</span>
-                  {this.buildMetadataRows("locationV2")}
-                </div>
+              {this.buildMetadataRows(
+                allowedFeatures && allowedFeatures.includes("maps")
+                  ? "locationV2"
+                  : "location"
               )}
+            </div>
           </Accordion>
         </div>
       </div>

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -824,7 +824,8 @@ class DiscoveryView extends React.Component {
       return;
     }
 
-    const sampleIds = mapLocationData[mapPreviewedLocationId].sample_ids;
+    const filters = this.preparedFilters();
+    filters["locationV2"] = mapLocationData[mapPreviewedLocationId].name;
 
     // Fetch previewed samples
     // TODO(jsheu): Consider paginating fetching for thousands of samples at a location
@@ -832,7 +833,8 @@ class DiscoveryView extends React.Component {
       samples: fetchedSamples,
       sampleIds: fetchedSampleIds,
     } = await getDiscoverySamples({
-      sampleIds,
+      // TODO(jsheu): Consider using location ID instead (need multi-level search).
+      filters,
       limit: 1e4, // Server needs a max, 1e4 at one location is a good cutoff.
       listAllIds: true,
     });
@@ -848,10 +850,6 @@ class DiscoveryView extends React.Component {
 
     // Fetch stats and dimensions for the map sidebar. Special request with the current filters
     // and the previewed location.
-    const locationName = mapLocationData[mapPreviewedLocationId].name;
-    const filters = this.preparedFilters();
-    filters["locationV2"] = locationName;
-
     const params = {
       domain,
       projectId,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -838,6 +838,8 @@ class DiscoveryView extends React.Component {
       filters,
       limit: 1e4, // Server needs a max, 1e4 at one location is a good cutoff.
       listAllIds: true,
+      projectId,
+      search,
     });
     this.setState(
       {

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -834,6 +834,7 @@ class DiscoveryView extends React.Component {
       sampleIds: fetchedSampleIds,
     } = await getDiscoverySamples({
       // TODO(jsheu): Consider using location ID instead (need multi-level search).
+      domain,
       filters,
       limit: 1e4, // Server needs a max, 1e4 at one location is a good cutoff.
       listAllIds: true,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -681,30 +681,37 @@ class DiscoveryView extends React.Component {
   };
 
   getClientSideSuggestions = async query => {
+    const { allowedFeatures } = this.props;
     const { projects } = this.state;
     const dimensions = this.getCurrentDimensions();
 
     let suggestions = {};
     const re = new RegExp(escapeRegExp(query), "i");
-    ["host", "tissue", "location"].forEach(category => {
-      let dimension = find({ dimension: category }, dimensions);
-      if (dimension) {
-        const results = dimension.values
-          .filter(entry => re.test(entry.text))
-          .map(entry => ({
-            category,
-            id: entry.value,
-            title: entry.text,
-          }));
+    const allowedMaps = allowedFeatures && allowedFeatures.includes("maps");
+    ["host", "tissue", allowedMaps ? "locationV2" : "location"].forEach(
+      category => {
+        let dimension = find({ dimension: category }, dimensions);
+        if (dimension) {
+          const results = dimension.values
+            .filter(entry => re.test(entry.text))
+            .map(entry => ({
+              category,
+              id: entry.value,
+              title: entry.text,
+            }));
 
-        if (results.length) {
-          suggestions[category] = {
-            name: capitalize(category),
-            results,
-          };
+          if (results.length) {
+            suggestions[category] = {
+              name:
+                allowedMaps && category === "locationV2"
+                  ? "location"
+                  : capitalize(category),
+              results,
+            };
+          }
         }
       }
-    });
+    );
 
     const filteredProjects = projects.filter(project => re.test(project.name));
     if (filteredProjects.length) {

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -54,7 +54,10 @@ class SamplesView extends React.Component {
         className: cs.basicCell,
       },
       {
-        dataKey: "collectionLocation",
+        dataKey:
+          allowedFeatures && allowedFeatures.includes("maps")
+            ? "collectionLocationV2"
+            : "collectionLocation",
         label: "Location",
         flexGrow: 1,
         className: cs.basicCell,
@@ -132,16 +135,6 @@ class SamplesView extends React.Component {
           TableRenderers.formatDuration(rowData[dataKey]),
       },
     ];
-
-    // TODO(jsheu): Upon release, replace Location 'v1'
-    if (allowedFeatures.includes("maps")) {
-      this.columns.push({
-        dataKey: "collectionLocationV2",
-        label: "Location v2",
-        flexGrow: 1,
-        className: cs.basicCell,
-      });
-    }
   }
 
   handleSelectRow = (value, checked) => {
@@ -351,10 +344,17 @@ class SamplesView extends React.Component {
   renderTable = () => {
     const {
       activeColumns,
+      allowedFeatures,
       onLoadRows,
       protectedColumns,
       selectedSampleIds,
     } = this.props;
+
+    let updatedActiveColumns = Object.assign([], activeColumns);
+    if (allowedFeatures && allowedFeatures.includes("maps")) {
+      const index = updatedActiveColumns.indexOf("collectionLocation");
+      if (index !== -1) updatedActiveColumns[index] += "V2";
+    }
 
     // TODO(tiago): replace by automated cell height computing
     const rowHeight = 66;
@@ -365,7 +365,7 @@ class SamplesView extends React.Component {
           ref={infiniteTable => (this.infiniteTable = infiniteTable)}
           columns={this.columns}
           defaultRowHeight={rowHeight}
-          initialActiveColumns={activeColumns}
+          initialActiveColumns={updatedActiveColumns}
           loadingClassName={csTableRenderer.loading}
           onLoadRows={onLoadRows}
           onSelectAllRows={withAnalytics(

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -350,10 +350,11 @@ class SamplesView extends React.Component {
       selectedSampleIds,
     } = this.props;
 
-    let updatedActiveColumns = Object.assign([], activeColumns);
+    // TODO(jsheu): Remove after full release of maps.
+    const updatedActiveColumns = Object.assign([], activeColumns);
     if (allowedFeatures && allowedFeatures.includes("maps")) {
-      const index = updatedActiveColumns.indexOf("collectionLocation");
-      if (index !== -1) updatedActiveColumns[index] += "V2";
+      const i = updatedActiveColumns.indexOf("collectionLocation");
+      if (i !== -1) updatedActiveColumns[i] += "V2";
     }
 
     // TODO(tiago): replace by automated cell height computing

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -498,10 +498,15 @@ class ProjectsController < ApplicationController
                              .includes(metadata_fields: [:host_genomes])
                              .map(&:metadata_fields).flatten.uniq.map(&:field_info)
               end
+
     # TODO(jsheu): Migrate all to location_v2 after release
-    unless current_user.allowed_feature?("maps")
-      results = results.reject { |f| f[:key] == "collection_location_v2" }
-    end
+    # Hide location_v2 unless you have 'maps'. Otherwise hide the implicit v1.
+    location_field = if current_user.allowed_feature?("maps")
+                       "collection_location"
+                     else
+                       "collection_location_v2"
+                     end
+    results = results.reject { |f| f[:key] == location_field }
 
     render json: results
   end

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -33,7 +33,7 @@ module LocationHelper
       lng: body["lon"] ? body["lon"].to_f.round(2) : nil,
       country_code: address["country_code"] || "",
       osm_id: body["osm_id"].to_i,
-      osm_type: body["osm_type"],
+      osm_type: body["osm_type"] || "",
       locationiq_id: body["place_id"].to_i
     }
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -100,7 +100,6 @@ class Location < ApplicationRecord
     else
       # If osm_id and osm_type are missing, just use the original params.
       # 'New' without saving so make sure caller saves.
-      loc[:osm_type] = ""
       new_from_params(loc)
     end
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -90,7 +90,7 @@ class Location < ApplicationRecord
     existing = Location.find_by(locationiq_id: loc[:locationiq_id])
     if existing
       existing
-    elsif loc[:osm_id] > 0 && loc[:osm_type]
+    elsif loc[:osm_id].to_i > 0 && loc[:osm_type]
       success, resp = geosearch_by_osm_id(loc[:osm_id], loc[:osm_type])
       raise "Couldn't fetch OSM ID #{loc[:osm_id]} (#{loc[:osm_type]})" unless success
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -86,17 +86,22 @@ class Location < ApplicationRecord
   # If we already have the location (via LocationIQ ID), return that. Otherwise fetch details via
   # OSM ID/type. OSM IDs can change often but LocationIQ IDs should be stable. We can't geosearch
   # by LocationIQ ID, so we need to use both.
-  def self.find_or_new_by_api_ids(locationiq_id, osm_id, osm_type)
-    existing = Location.find_by(locationiq_id: locationiq_id)
+  def self.find_or_new_by_api_ids(loc)
+    existing = Location.find_by(locationiq_id: loc[:locationiq_id])
     if existing
       existing
-    else
-      success, resp = geosearch_by_osm_id(osm_id, osm_type)
-      raise "Couldn't fetch OSM ID #{osm_id} (#{osm_type})" unless success
+    elsif loc[:osm_id] > 0 && loc[:osm_type]
+      success, resp = geosearch_by_osm_id(loc[:osm_id], loc[:osm_type])
+      raise "Couldn't fetch OSM ID #{loc[:osm_id]} (#{loc[:osm_type]})" unless success
 
       resp = LocationHelper.adapt_location_iq_response(resp)
       # 'New' without saving so make sure caller saves.
       new_from_params(resp)
+    else
+      # If osm_id and osm_type are missing, just use the original params.
+      # 'New' without saving so make sure caller saves.
+      loc[:osm_type] = ""
+      new_from_params(loc)
     end
   end
 

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -124,9 +124,6 @@ class Metadatum < ApplicationRecord
       if loc[:name].present?
         self.string_validated_value = loc[:name]
         self.location_id = nil
-      else
-        # Delete if they cleared out the field
-        destroy unless destroyed?
       end
       return
     end

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -126,10 +126,7 @@ class Metadatum < ApplicationRecord
         self.location_id = nil
       else
         # Delete if they cleared out the field
-        unless destroyed?
-          Rails.logger.error("foobar 2:51pm going to delete")
-          destroy
-        end
+        destroy unless destroyed?
       end
       return
     end
@@ -149,8 +146,6 @@ class Metadatum < ApplicationRecord
     self.raw_value = nil
     self.string_validated_value = nil
     self.location_id = location.id
-  rescue FrozenError => err
-    Rails.logger.error("#{err.message} hello world")
   rescue => err
     LogUtil.log_err_and_airbrake("Failed to save location metadatum: #{err.message}")
     LogUtil.log_backtrace(err)

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -126,7 +126,10 @@ class Metadatum < ApplicationRecord
         self.location_id = nil
       else
         # Delete if they cleared out the field
-        delete
+        unless destroyed?
+          Rails.logger.error("foobar 2:51pm going to delete")
+          destroy
+        end
       end
       return
     end
@@ -146,6 +149,8 @@ class Metadatum < ApplicationRecord
     self.raw_value = nil
     self.string_validated_value = nil
     self.location_id = location.id
+  rescue FrozenError => err
+    Rails.logger.error("#{err.message} hello world")
   rescue => err
     LogUtil.log_err_and_airbrake("Failed to save location metadatum: #{err.message}")
     LogUtil.log_backtrace(err)

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -135,7 +135,7 @@ class Metadatum < ApplicationRecord
     # trusting user input, we'll potentially re-fetch location details based on the API and OSM IDs.
     location = Location.check_and_restrict_specificity(loc, sample.host_genome_name)
     unless location.is_a?(Location)
-      location = Location.find_or_new_by_api_ids(loc[:locationiq_id], loc[:osm_id], loc[:osm_type])
+      location = Location.find_or_new_by_api_ids(loc)
     end
     unless location.id
       location = Location.check_and_fetch_parents(location)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -771,13 +771,6 @@ class Sample < ApplicationRecord
         status: "ok"
       }
     end
-  rescue FrozenError => e
-    Rails.logger.error("foobar 2:41pm")
-    Rails.logger.error(e.message)
-    return {
-      status: "error",
-      error: "There was an error saving your metadata."
-    }
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error(e)
     # Don't send the detailed error message to the user.

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -771,6 +771,13 @@ class Sample < ApplicationRecord
         status: "ok"
       }
     end
+  rescue FrozenError => e
+    Rails.logger.error("foobar 2:41pm")
+    Rails.logger.error(e.message)
+    return {
+      status: "error",
+      error: "There was an error saving your metadata."
+    }
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error(e)
     # Don't send the detailed error message to the user.

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -727,6 +727,10 @@ class Sample < ApplicationRecord
       }
     else
       # If the value didn't change or isn't present, don't re-save the metadata field.
+      if m.id && val.blank?
+        # If the object existed and the user cleared out the new value, delete it.
+        m.delete
+      end
       return {
         metadatum: nil,
         status: "ok"

--- a/db/migrate/20190725182344_fix_location_iq_id.rb
+++ b/db/migrate/20190725182344_fix_location_iq_id.rb
@@ -1,0 +1,10 @@
+class FixLocationIqId < ActiveRecord::Migration[5.1]
+  def up
+    # Limit 5 here gives us max 9,223,372,036,854,775,807 (https://gist.github.com/icyleaf/9089250).
+    change_column :locations, :locationiq_id, :integer, limit: 5
+  end
+
+  def down
+    change_column :locations, :locationiq_id, :integer, limit: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_719_233_448) do
+ActiveRecord::Schema.define(version: 20_190_725_182_344) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -151,7 +151,7 @@ ActiveRecord::Schema.define(version: 20_190_719_233_448) do
     t.string "subdivision_name", limit: 100, default: "", null: false, comment: "Second-level administrative division (e.g. county/district/division/province/etc.) of this location if available"
     t.string "city_name", limit: 100, default: "", null: false, comment: "City (or equivalent) of this location if available"
     t.bigint "osm_id", comment: "OpenStreetMap ID for traceability. May change at any time."
-    t.integer "locationiq_id", comment: "Data provider API ID for traceability."
+    t.bigint "locationiq_id", comment: "Data provider API ID for traceability."
     t.decimal "lat", precision: 10, scale: 6, comment: "The latitude of this location if available"
     t.decimal "lng", precision: 10, scale: 6, comment: "The longitude of this location if available"
     t.datetime "created_at", null: false

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -90,7 +90,7 @@ class LocationTest < ActiveSupport::TestCase
     mock = MiniTest::Mock.new
     mock.expect(:call, new_location, [{ locationiq_id: "123" }])
     Location.stub :find_by, mock do
-      res = Location.find_or_new_by_api_ids("123", nil, nil)
+      res = Location.find_or_new_by_api_ids(locationiq_id: "123")
       assert_equal new_location, res
     end
   end
@@ -106,7 +106,7 @@ class LocationTest < ActiveSupport::TestCase
     Location.stub :find_by, nil do
       Location.stub :geosearch_by_osm_id, mock_geosearch do
         Location.stub :new_from_params, new_location do
-          res = Location.find_or_new_by_api_ids("123", osm_id, osm_type)
+          res = Location.find_or_new_by_api_ids(locationiq_id: "123", osm_id: osm_id, osm_type: osm_type)
           assert_equal new_location, res
         end
       end

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -8,7 +8,7 @@ class MetadatumTest < ActiveSupport::TestCase
     mock_create = MiniTest::Mock.new
     loc = metadata(:sample_collection_location_v2)
     fields = JSON.parse(loc.raw_value, symbolize_names: true)
-    mock_create.expect(:call, locations(:ucsf), [fields[:locationiq_id], fields[:osm_id], fields[:osm_type]])
+    mock_create.expect(:call, locations(:ucsf), [fields])
 
     Location.stub :find_or_new_by_api_ids, mock_create do
       res = loc.check_and_set_location_type


### PR DESCRIPTION
### Description
- This updates the 'maps' feature flag to hide Location V1 fields instead of showing V1 and V2 fields side-by-side. Now you will only see one field or the others.
- This is according to the new Maps feature release plan (will add the feature flag to everyone): https://czi.quip.com/gzWdAafIX8Yb/LocationMapping-Sprint-Plan

### Notes
With the feature enabled:
![Screen Shot 2019-07-22 at 4 31 23 PM](https://user-images.githubusercontent.com/5652739/61672273-df70cd00-ac9f-11e9-8332-3626aa7aa95e.png)
![Screen Shot 2019-07-22 at 4 31 48 PM](https://user-images.githubusercontent.com/5652739/61672286-e8fa3500-ac9f-11e9-80bd-5e8044d3d2b0.png)
![Screen Shot 2019-07-22 at 4 32 05 PM](https://user-images.githubusercontent.com/5652739/61672290-f3b4ca00-ac9f-11e9-98cb-ab9161c96330.png)

With `allowed_features: nil`:
![Screen Shot 2019-07-22 at 4 33 30 PM](https://user-images.githubusercontent.com/5652739/61672279-e26bbd80-ac9f-11e9-9212-15b2adb6fd97.png)
![Screen Shot 2019-07-22 at 4 33 04 PM](https://user-images.githubusercontent.com/5652739/61672288-f0b9d980-ac9f-11e9-8ede-3495bbe056cc.png)
![Screen Shot 2019-07-22 at 4 32 46 PM](https://user-images.githubusercontent.com/5652739/61672303-fa434180-ac9f-11e9-8524-ba562fb9ef60.png)

### Tests
- Go to data discovery and play around with all the fields at the sections in the demo screenshots.