### PR TITLE
Filter out test data from analytics

### DIFF
--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -151,9 +151,9 @@ class MetricUtil
       end
     end
 
-    def a_test?
-      Rails.env == "test" ||
-        (request && request.user_agent == "Rails Testing")
+    def a_test?(request = nil)
+      Rails.env.test? ||
+        (!request.nil? && request.user_agent == "Rails Testing")
     end
   end
 end

--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -40,7 +40,7 @@ class MetricUtil
   # segment says the server lib batches automatically. See
   # https://segment.com/docs/sources/server/http/#batch.
   def self.log_analytics_event(event, user, properties = {}, request = nil)
-    if SEGMENT_ANALYTICS
+    if SEGMENT_ANALYTICS && !a_test?(request)
       # current_user should be passed from a controller
       user_id = user ? user.id : 0
 
@@ -149,6 +149,11 @@ class MetricUtil
           Rails.logger.warn("Unable to send data: #{response.message}")
         end
       end
+    end
+
+    def a_test?
+      Rails.env == "test" ||
+        (request && request.user_agent == "Rails Testing")
     end
   end
 end

--- a/app/lib/metric_util_test.rb
+++ b/app/lib/metric_util_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class HeatmapHelperTest < ActiveSupport::TestCase
-  test "test data filter works" do
-    assert_equal MetricUtil.send(:a_test?), true
-  end
-end

--- a/app/lib/metric_util_test.rb
+++ b/app/lib/metric_util_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class HeatmapHelperTest < ActiveSupport::TestCase
+  test "test data filter works" do
+    assert_equal MetricUtil.send(:a_test?), true
+  end
+end

--- a/spec/lib/metric_util_spec.rb
+++ b/spec/lib/metric_util_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe MetricUtil do
+  describe "#a_test?" do
+    it "returns true when running in RSpec" do
+      expect(MetricUtil.send(:a_test?)).to eq(true)
+    end
+
+    it "returns false when env is overridden" do
+      temp = Rails.env
+      begin
+        Rails.env = "asdf"
+        expect(MetricUtil.send(:a_test?)).to eq(false)
+      rescue => err
+        raise err
+      ensure
+        Rails.env = temp
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

It looks like robot data was inserted into our active users by one of our tests because the user names were "Admin User" and the traffic only came from ruby. This protects against that happening in future while preserving the ability to test analytics manually in dev environment. 

# Tests

* rails t