### PR TITLE
Improve basespace uploading logic.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -325,7 +325,7 @@ class ProjectsController < ApplicationController
   end
 
   def project_reports_csv_status
-    stdout = Syscall.pipe(["aws", "s3", "ls", @project.report_tar_s3(current_user.id)], ["wc", "-l"])
+    stdout = Syscall.pipe_with_output(["aws", "s3", "ls", @project.report_tar_s3(current_user.id)], ["wc", "-l"])
     return if stdout.blank?
     final_complete = stdout.to_i == 1
     if final_complete
@@ -351,7 +351,7 @@ class ProjectsController < ApplicationController
   end
 
   def host_gene_counts_status
-    stdout = Syscall.pipe(["aws", "s3", "ls", @project.host_gene_counts_tar_s3(current_user.id)], ["wc", "-l"])
+    stdout = Syscall.pipe_with_output(["aws", "s3", "ls", @project.host_gene_counts_tar_s3(current_user.id)], ["wc", "-l"])
     return if stdout.blank?
     final_complete = stdout.to_i == 1
     if final_complete

--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -111,7 +111,7 @@ module PipelineRunsHelper
 
   def upload_dag_json_and_return_job_command(dag_json, dag_s3, dag_name, key_s3_params = nil, copy_done_file = "")
     # Upload dag json
-    Syscall.pipe(["echo", dag_json], ["aws", "s3", "cp", "-", dag_s3])
+    Syscall.pipe_with_output(["echo", dag_json], ["aws", "s3", "cp", "-", dag_s3])
 
     # Generate job command
     dag_path_on_worker = "/mnt/#{dag_name}.json"

--- a/app/models/input_file.rb
+++ b/app/models/input_file.rb
@@ -23,7 +23,7 @@ class InputFile < ApplicationRecord
       elsif !sample.user.can_upload(source.to_s)
         errors.add(:input_files, "forbidden s3 bucket")
       elsif !sample.bulk_mode # skip the check for bulk mode
-        fhead = Syscall.pipe(["aws", "s3", "cp", source.to_s, "-"], ["head", "-c", "100"])
+        fhead = Syscall.pipe_with_output(["aws", "s3", "cp", source.to_s, "-"], ["head", "-c", "100"])
         errors.add(:input_files, "forbidden file object") if fhead.empty?
       end
     end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -401,7 +401,7 @@ class PipelineRun < ApplicationRecord
     ercc_s3_path = "#{host_filter_output_s3_path}/#{ERCC_OUTPUT_NAME}"
     _stdout, _stderr, status = Open3.capture3("aws", "s3", "ls", ercc_s3_path)
     return unless status.exitstatus.zero?
-    ercc_lines = Syscall.pipe(["aws", "s3", "cp", ercc_s3_path, "-"], ["grep", "ERCC"], ["cut", "-f1,2"])
+    ercc_lines = Syscall.pipe_with_output(["aws", "s3", "cp", ercc_s3_path, "-"], ["grep", "ERCC"], ["cut", "-f1,2"])
     ercc_counts_array = []
     ercc_lines.split(/\r?\n/).each do |line|
       fields = line.split("\t")

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -642,7 +642,7 @@ class Sample < ApplicationRecord
   end
 
   def self.pipeline_commit(branch)
-    o = Syscall.pipe(["git", "ls-remote", "https://github.com/chanzuckerberg/idseq-dag.git"], ["grep", "refs/heads/#{branch}"])
+    o = Syscall.pipe_with_output(["git", "ls-remote", "https://github.com/chanzuckerberg/idseq-dag.git"], ["grep", "refs/heads/#{branch}"])
     return false if o.blank?
     o.split[0]
   end


### PR DESCRIPTION
# Description

Different approach that uses curl and streaming to remove the need for storing the file in disk on the resque worker.

# Notes

Also added a new function in Syscall that wraps around the shell commands to make testing easier. Renamed the existing `pipe` method in `Syscall` to `pipe_with_output` to distinguish it from the new pipe.

# Tests
* Verify that Basespace uploading still works.
* Verify that tests pass.
* On staging, will verify that the samples still run through the entire pipeline correctly (and all results are loaded).