### PR TITLE
Add five new host genomes

### DIFF
--- a/db/migrate/20190725215533_add_rat_host.rb
+++ b/db/migrate/20190725215533_add_rat_host.rb
@@ -1,0 +1,22 @@
+class AddRatHost < ActiveRecord::Migration[5.1]
+  def up
+    return if HostGenome.find_by(name: "Rat")
+
+    hg = HostGenome.new
+    hg.name = "Rat"
+    hg.s3_star_index_path = "s3://idseq-database/host_filter/rat/2019-04-17/STAR_genome.tar"
+    hg.s3_bowtie2_index_path = "s3://idseq-database/host_filter/rat/2019-04-17/bowtie2_genome.tar"
+
+    human_host = HostGenome.find_by(name: "Human")
+    # For lack of a better default, use Human background.
+    # In the future, consider asking rat users to make a background model
+    # from their uninfected samples that we can substitute as the default.
+    hg.default_background_id = human_host.default_background_id if human_host
+    hg.save
+  end
+
+  def down
+    hg = HostGenome.find_by(name: "Rat")
+    hg.destroy if hg
+  end
+end

--- a/db/migrate/20190725222854_add_field_vole_host.rb
+++ b/db/migrate/20190725222854_add_field_vole_host.rb
@@ -1,0 +1,22 @@
+class AddFieldVoleHost < ActiveRecord::Migration[5.1]
+  def up
+    return if HostGenome.find_by(name: "Field Vole")
+
+    hg = HostGenome.new
+    hg.name = "Field Vole"
+    hg.s3_star_index_path = "s3://idseq-database/host_filter/field_vole/2019-04-17/STAR_genome.tar"
+    hg.s3_bowtie2_index_path = "s3://idseq-database/host_filter/field_vole/2019-04-17/bowtie2_genome.tar"
+
+    human_host = HostGenome.find_by(name: "Human")
+    # For lack of a better default, use Human background.
+    # In the future, consider asking field_vole users to make a background model
+    # from their uninfected samples that we can substitute as the default.
+    hg.default_background_id = human_host.default_background_id if human_host
+    hg.save
+  end
+
+  def down
+    hg = HostGenome.find_by(name: "Field Vole")
+    hg.destroy if hg
+  end
+end

--- a/db/migrate/20190725224942_add_bank_vole_host.rb
+++ b/db/migrate/20190725224942_add_bank_vole_host.rb
@@ -1,0 +1,22 @@
+class AddBankVoleHost < ActiveRecord::Migration[5.1]
+  def up
+    return if HostGenome.find_by(name: "Bank Vole")
+
+    hg = HostGenome.new
+    hg.name = "Bank Vole"
+    hg.s3_star_index_path = "s3://idseq-database/host_filter/bank_vole/2019-04-17/STAR_genome.tar"
+    hg.s3_bowtie2_index_path = "s3://idseq-database/host_filter/bank_vole/2019-04-17/bowtie2_genome.tar"
+
+    human_host = HostGenome.find_by(name: "Human")
+    # For lack of a better default, use Human background.
+    # In the future, consider asking bank_vole users to make a background model
+    # from their uninfected samples that we can substitute as the default.
+    hg.default_background_id = human_host.default_background_id if human_host
+    hg.save
+  end
+
+  def down
+    hg = HostGenome.find_by(name: "Bank Vole")
+    hg.destroy if hg
+  end
+end

--- a/db/migrate/20190725225000_add_spiny_mouse_host.rb
+++ b/db/migrate/20190725225000_add_spiny_mouse_host.rb
@@ -1,0 +1,22 @@
+class AddSpinyMouseHost < ActiveRecord::Migration[5.1]
+  def up
+    return if HostGenome.find_by(name: "Spiny Mouse")
+
+    hg = HostGenome.new
+    hg.name = "Spiny Mouse"
+    hg.s3_star_index_path = "s3://idseq-database/host_filter/spiny_mouse/2019-04-17/STAR_genome.tar"
+    hg.s3_bowtie2_index_path = "s3://idseq-database/host_filter/spiny_mouse/2019-04-17/bowtie2_genome.tar"
+
+    human_host = HostGenome.find_by(name: "Human")
+    # For lack of a better default, use Human background.
+    # In the future, consider asking spiny_mouse users to make a background model
+    # from their uninfected samples that we can substitute as the default.
+    hg.default_background_id = human_host.default_background_id if human_host
+    hg.save
+  end
+
+  def down
+    hg = HostGenome.find_by(name: "Spiny Mouse")
+    hg.destroy if hg
+  end
+end

--- a/db/migrate/20190725225016_add_rabbit_host.rb
+++ b/db/migrate/20190725225016_add_rabbit_host.rb
@@ -1,0 +1,22 @@
+class AddRabbitHost < ActiveRecord::Migration[5.1]
+  def up
+    return if HostGenome.find_by(name: "Rabbit")
+
+    hg = HostGenome.new
+    hg.name = "Rabbit"
+    hg.s3_star_index_path = "s3://idseq-database/host_filter/rabbit/2019-04-17/STAR_genome.tar"
+    hg.s3_bowtie2_index_path = "s3://idseq-database/host_filter/rabbit/2019-04-17/bowtie2_genome.tar"
+
+    human_host = HostGenome.find_by(name: "Human")
+    # For lack of a better default, use Human background.
+    # In the future, consider asking rabbit users to make a background model
+    # from their uninfected samples that we can substitute as the default.
+    hg.default_background_id = human_host.default_background_id if human_host
+    hg.save
+  end
+
+  def down
+    hg = HostGenome.find_by(name: "Rabbit")
+    hg.destroy if hg
+  end
+end


### PR DESCRIPTION
# Description

This adds five new host genomes requested by @eggerdesigns on behalf of Joe Chapell. 

# Notes

I'm not sure whether the human background is the best default for all of these or whether we should choose a more similar species such as a mouse. 

# Tests

* `rails db:migrate`, see no errors
* see host genomes in search filter dropdown choices
* run a sample with each new host in staging, see success