### PR TITLE
Show error if upload from S3 fails.

### DIFF
--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -314,6 +314,14 @@ class SampleView extends React.Component {
         issueType = "error";
         link = "mailto:help@idseq.net";
         break;
+      case "S3_UPLOAD_FAILED":
+        status = "SAMPLE FAILED";
+        message =
+          "Oh no! There was an issue uploading your sample file from S3.";
+        linkText = "Contact us for help.";
+        issueType = "error";
+        link = "mailto:help@idseq.net";
+        break;
       case "FAULTY_INPUT":
         status = "COMPLETE - ISSUE";
         message = `Sorry, something was wrong with your input file. ${

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -33,6 +33,7 @@ class Sample < ApplicationRecord
 
   # Constants for upload errors.
   UPLOAD_ERROR_BASESPACE_UPLOAD_FAILED = "BASESPACE_UPLOAD_FAILED".freeze
+  UPLOAD_ERROR_S3_UPLOAD_FAILED = "S3_UPLOAD_FAILED".freeze
 
   TOTAL_READS_JSON = "total_reads.json".freeze
   LOG_BASENAME = 'log.txt'.freeze
@@ -338,9 +339,12 @@ class Sample < ApplicationRecord
     raise stderr_array.join(" ") unless stderr_array.empty?
 
     self.status = STATUS_UPLOADED
-    save # this triggers pipeline command
+    save! # this triggers pipeline command
   rescue => e
-    LogUtil.log_err_and_airbrake("Failed to upload S3 sample '#{name}' (#{id}): #{e}")
+    LogUtil.log_err_and_airbrake("SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id}): #{e}")
+    self.status = STATUS_CHECKED
+    self.upload_error = Sample::UPLOAD_ERROR_S3_UPLOAD_FAILED
+    save!
   end
 
   # Uploads input files from basespace for this sample.


### PR DESCRIPTION
# Description

If the upload from S3 fails, show an error. Previously, it would spin on "Waiting" forever.

# Tests

* Verify that if the s3 upload is unsuccessful, the sample will be marked as failed in the sample list and the error will show. 

<img width="1364" alt="Screen Shot 2019-07-25 at 6 02 20 PM" src="https://user-images.githubusercontent.com/837004/61918588-c28a0300-af06-11e9-8c2f-c68c4d960133.png">

<img width="1406" alt="Screen Shot 2019-07-25 at 6 02 01 PM" src="https://user-images.githubusercontent.com/837004/61918590-c453c680-af06-11e9-8408-b014986dc158.png">
