### PR TITLE
Improve error message if user forgets to select project.

### DIFF
--- a/app/assets/src/components/common/ProjectSelect.jsx
+++ b/app/assets/src/components/common/ProjectSelect.jsx
@@ -16,6 +16,7 @@ class ProjectSelect extends React.Component {
   };
 
   render() {
+    const { disabled, erred } = this.props;
     return (
       <Dropdown
         fluid
@@ -24,7 +25,8 @@ class ProjectSelect extends React.Component {
         value={this.props.value}
         placeholder="Select project"
         search
-        disabled={this.props.disabled}
+        disabled={disabled}
+        erred={erred}
       />
     );
   }
@@ -35,6 +37,7 @@ ProjectSelect.propTypes = {
   value: PropTypes.number, // the project id
   onChange: PropTypes.func.isRequired, // the entire project object is returned
   disabled: PropTypes.bool,
+  erred: PropTypes.bool,
 };
 
 export default ProjectSelect;

--- a/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
@@ -47,18 +47,12 @@ class Dropdown extends React.Component {
 
   renderTrigger = () => {
     const text =
-      this.state.value !== undefined && this.state.value !== null ? (
-        <span>{this.state.labels[this.state.value.toString()]}</span>
-      ) : (
-        <span className={cs.placeholder}>{this.props.placeholder}</span>
-      );
+      this.state.value !== undefined && this.state.value !== null
+        ? this.state.labels[this.state.value.toString()]
+        : null;
 
-    const hasText =
-      this.state.value !== undefined &&
-      this.state.value !== null &&
-      this.state.labels[this.state.value.toString()];
     const labelText =
-      this.props.label && hasText ? this.props.label + ":" : this.props.label;
+      this.props.label && text ? this.props.label + ":" : this.props.label;
 
     return (
       <DropdownTrigger
@@ -66,6 +60,8 @@ class Dropdown extends React.Component {
         value={text}
         rounded={this.props.rounded}
         className={cs.dropdownTrigger}
+        placeholder={this.props.placeholder}
+        erred={this.props.erred}
       />
     );
   };
@@ -97,6 +93,7 @@ Dropdown.propTypes = {
   className: PropTypes.string,
   placeholder: PropTypes.string,
   disabled: PropTypes.bool,
+  erred: PropTypes.bool,
   fluid: PropTypes.bool,
   rounded: PropTypes.bool,
   label: PropTypes.string,

--- a/app/assets/src/components/ui/controls/dropdowns/common/DropdownTrigger.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/common/DropdownTrigger.jsx
@@ -11,9 +11,12 @@ class DropdownTrigger extends React.Component {
       rounded,
       active,
       disabled,
+      erred,
       className,
       onClick,
+      placeholder,
     } = this.props;
+
     return (
       <div
         className={cx(
@@ -21,13 +24,16 @@ class DropdownTrigger extends React.Component {
           cs.dropdownTrigger,
           rounded && cs.rounded,
           active && cs.active,
-          disabled && cs.disabled
+          disabled && cs.disabled,
+          erred && cs.erred
         )}
         onClick={onClick}
       >
         <div className={cs.labelContainer}>
           {label && <span className={cs.label}>{label}</span>}
-          {value}
+          <span className={cx(value === null && cs.placeholder)}>
+            {value || placeholder}
+          </span>
         </div>
       </div>
     );
@@ -38,9 +44,11 @@ DropdownTrigger.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string,
   value: PropTypes.node,
+  placeholder: PropTypes.string,
   rounded: PropTypes.bool,
   active: PropTypes.bool,
   disabled: PropTypes.bool,
+  erred: PropTypes.bool,
   onClick: PropTypes.func,
 };
 

--- a/app/assets/src/components/ui/controls/dropdowns/common/dropdown_trigger.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/common/dropdown_trigger.scss
@@ -36,4 +36,16 @@
     font-weight: 600;
     margin-right: 5px;
   }
+
+  .placeholder {
+    color: $light-grey;
+  }
+
+  &.erred {
+    border: 1px solid $error;
+
+    .placeholder {
+      color: $error;
+    }
+  }
 }

--- a/app/assets/src/components/ui/controls/dropdowns/dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/dropdown.scss
@@ -7,9 +7,3 @@
     }
   }
 }
-
-.dropdown {
-  .placeholder {
-    color: $light-grey;
-  }
-}

--- a/app/assets/src/components/views/SampleUploadFlow/BasespaceSampleImport.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/BasespaceSampleImport.jsx
@@ -13,6 +13,7 @@ import {
 import { withAnalytics } from "~/api/analytics";
 
 import { openBasespaceOAuthPopup } from "./utils";
+import { NO_TARGET_PROJECT_ERROR } from "./constants";
 import cs from "./basespace_sample_import.scss";
 
 export default class BasespaceSampleImport extends React.Component {
@@ -29,6 +30,17 @@ export default class BasespaceSampleImport extends React.Component {
     window.addEventListener("message", this.handleMessageEvent);
     if (accessToken) {
       this.fetchBasespaceProjects(accessToken);
+    }
+  }
+
+  componentDidUpdate() {
+    if (
+      this.state.error === NO_TARGET_PROJECT_ERROR &&
+      this.props.project !== null
+    ) {
+      this.setState({
+        error: "",
+      });
     }
   }
 
@@ -87,13 +99,14 @@ export default class BasespaceSampleImport extends React.Component {
 
   fetchSamplesForBasespaceProject = async () => {
     const { selectedProjectId, basespaceProjects } = this.state;
-    const { onChange, accessToken, project } = this.props;
+    const { onChange, accessToken, project, onNoProject } = this.props;
 
     if (!this.props.project) {
       this.setState({
-        error: "Please select a project.",
+        error: NO_TARGET_PROJECT_ERROR,
         errorType: "error",
       });
+      onNoProject();
       return;
     } else {
       this.setState({
@@ -218,4 +231,5 @@ BasespaceSampleImport.propTypes = {
   project: PropTypes.Project,
   basespaceClientId: PropTypes.string.isRequired,
   basespaceOauthRedirectUri: PropTypes.string.isRequired,
+  onNoProject: PropTypes.func.isRequired,
 };

--- a/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
@@ -6,7 +6,9 @@ import PrimaryButton from "~ui/controls/buttons/PrimaryButton";
 import PropTypes from "~/components/utils/propTypes";
 import { bulkImportRemoteSamples } from "~/api";
 import { logAnalyticsEvent } from "~/api/analytics";
+import Notification from "~ui/notifications/Notification";
 
+import { NO_TARGET_PROJECT_ERROR } from "./constants";
 import cs from "./sample_upload_flow.scss";
 
 class RemoteSampleFileUpload extends React.Component {
@@ -15,6 +17,17 @@ class RemoteSampleFileUpload extends React.Component {
     remoteS3Path: "",
     lastPathChecked: "",
   };
+
+  componentDidUpdate() {
+    if (
+      this.state.error === NO_TARGET_PROJECT_ERROR &&
+      this.props.project !== null
+    ) {
+      this.setState({
+        error: "",
+      });
+    }
+  }
 
   toggleInfo = () => {
     this.setState(
@@ -38,8 +51,9 @@ class RemoteSampleFileUpload extends React.Component {
   handleConnect = async () => {
     if (!this.props.project) {
       this.setState({
-        error: "Please select a project.",
+        error: NO_TARGET_PROJECT_ERROR,
       });
+      this.props.onNoProject();
       return;
     }
 
@@ -141,7 +155,16 @@ class RemoteSampleFileUpload extends React.Component {
             onClick={this.handleConnect}
           />
         </div>
-        {this.state.error && <div className={cs.error}>{this.state.error}</div>}
+
+        {this.state.error && (
+          <Notification
+            type="error"
+            displayStyle="flat"
+            className={cs.notification}
+          >
+            {this.state.error}
+          </Notification>
+        )}
       </div>
     );
   }
@@ -150,6 +173,8 @@ class RemoteSampleFileUpload extends React.Component {
 RemoteSampleFileUpload.propTypes = {
   project: PropTypes.Project,
   onChange: PropTypes.func.isRequired,
+  onNoProject: PropTypes.func.isRequired,
+  showNoProjectError: PropTypes.bool,
 };
 
 export default RemoteSampleFileUpload;

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -65,6 +65,7 @@ class UploadSampleStep extends React.Component {
     removedLocalFiles: [], // Invalid local files that were removed.
     sampleNamesToFiles: {}, // Needed for local samples.
     validatingSamples: false, // Disable the "Continue" button while validating samples.
+    showNoProjectError: false, // Whether we should show an error if no project is currently selected.
   };
 
   async componentDidMount() {
@@ -201,6 +202,7 @@ class UploadSampleStep extends React.Component {
     this.props.onDirty();
     this.setState({
       validatingSamples: true,
+      showNoProjectError: false,
     });
 
     const [
@@ -344,6 +346,7 @@ class UploadSampleStep extends React.Component {
     this.props.onDirty();
     this.setState({
       validatingSamples: true,
+      showNoProjectError: false,
     });
 
     const [
@@ -571,6 +574,12 @@ class UploadSampleStep extends React.Component {
     });
   };
 
+  handleNoProject = () => {
+    this.setState({
+      showNoProjectError: true,
+    });
+  };
+
   getSampleNamesToFiles = () => {
     return flow(
       keyBy("name"),
@@ -599,6 +608,7 @@ class UploadSampleStep extends React.Component {
           <RemoteSampleFileUpload
             project={selectedProject}
             onChange={samples => this.handleSampleChange(samples, "remote")}
+            onNoProject={this.handleNoProject}
           />
         );
       case BASESPACE_UPLOAD_TAB:
@@ -610,6 +620,7 @@ class UploadSampleStep extends React.Component {
             onAccessTokenChange={this.handleBasespaceAccessTokenChange}
             basespaceClientId={this.props.basespaceClientId}
             basespaceOauthRedirectUri={this.props.basespaceOauthRedirectUri}
+            onNoProject={this.handleNoProject}
           />
         );
       default:
@@ -646,6 +657,10 @@ class UploadSampleStep extends React.Component {
               value={get("id", this.state.selectedProject)}
               onChange={this.handleProjectChange}
               disabled={this.state.createProjectOpen}
+              erred={
+                this.state.showNoProjectError &&
+                this.state.selectedProject === null
+              }
             />
             {this.state.createProjectOpen ? (
               <div className={cs.projectCreationContainer}>

--- a/app/assets/src/components/views/SampleUploadFlow/constants.js
+++ b/app/assets/src/components/views/SampleUploadFlow/constants.js
@@ -1,0 +1,2 @@
+export const NO_TARGET_PROJECT_ERROR =
+  "Please select an IDseq project to upload your samples to.";

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -26,8 +26,6 @@
   }
 
   .controls {
-    margin: 30px 0 60px;
-
     .helpText {
       @include font-body-xxs;
       margin-bottom: 10px;
@@ -211,9 +209,8 @@
     }
   }
 
-  .error {
-    margin-top: 5px;
-    color: $error;
+  .notification {
+    margin-top: 10px;
   }
 }
 


### PR DESCRIPTION
# Description

Before, the error message is ambiguous, especially for Basespace upload (since the user also has to pick a Basespace project)

<img width="1298" alt="Screen Shot 2019-07-25 at 7 41 57 PM" src="https://user-images.githubusercontent.com/837004/61922154-5adab480-af14-11e9-8163-f2ac9509c5e5.png">

<img width="1257" alt="Screen Shot 2019-07-25 at 7 42 08 PM" src="https://user-images.githubusercontent.com/837004/61922161-5e6e3b80-af14-11e9-8b90-bb738e7f507b.png">

With this change, the error message is more detailed, and the erred Dropdown is also highlighted in red.

<img width="1293" alt="Screen Shot 2019-07-25 at 7 29 56 PM" src="https://user-images.githubusercontent.com/837004/61922175-6ded8480-af14-11e9-87c8-21e145b8a4e8.png">

Also changed the error messages in S3 upload tab to use <Notification> to make it more consistent.

<img width="1244" alt="Screen Shot 2019-07-25 at 7 26 50 PM" src="https://user-images.githubusercontent.com/837004/61922184-747bfc00-af14-11e9-9c3f-75d4aa1e1015.png">

<img width="1228" alt="Screen Shot 2019-07-25 at 7 27 02 PM" src="https://user-images.githubusercontent.com/837004/61922224-878ecc00-af14-11e9-8ee2-14f93f67f76a.png">

# Notes

Also moved the placeholder prop from Dropdown to DropdownTrigger, so that it's easier to style them both at once during the erred state.

# Tests

* Verified that all error states behave as expected (see screenshots)
* Verified that dropdowns on other pages, such as the Sample Upload page, are unaffected. (since we made a change to Dropdown)