### PR TITLE
Upgraded travis ruby version to 2.5 to match that of the dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 env:
   CI: yes
 rvm:
-- 2.4
+- 2.5
 services:
   - docker
 before_install:


### PR DESCRIPTION
# Description
Upgrading the travisCI ruby version to match that in the [Dockerfile](https://github.com/chanzuckerberg/idseq-web/blob/master/Dockerfile#L1). Try to get our tests to parity with prod.

# Notes

# Tests
unittests
