### PR TITLE
[Maps] Fix geosearch box and Location V2 switch in development environments

### DIFF
--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -53,6 +53,7 @@ class GeoSearchInputBox extends React.Component {
       console.log(e);
       logAnalyticsEvent("GeoSearchInputBox_request_erred", {
         query,
+        message: e.message,
       });
     }
 

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -48,6 +48,7 @@ class GeoSearchInputBox extends React.Component {
         };
       }
     } catch (e) {
+      // In the case of an error (e.g. no API key in dev), just catch and show the plain text option.
       // eslint-disable-next-line no-console
       console.log(e);
     }

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -51,6 +51,9 @@ class GeoSearchInputBox extends React.Component {
       // In the case of an error (e.g. no API key in dev), just catch and show the plain text option.
       // eslint-disable-next-line no-console
       console.log(e);
+      logAnalyticsEvent("GeoSearchInputBox_request_erred", {
+        query,
+      });
     }
 
     // Let users select an unresolved plain text option

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -28,8 +28,8 @@ class GeoSearchInputBox extends React.Component {
 
   // Fetch geosearch results and format into categories for LiveSearchBox
   handleSearchTriggered = async query => {
-    let categories = {};
     let serverSideSuggestions = [];
+    let categories = {};
     try {
       serverSideSuggestions = await getGeoSearchSuggestions(query);
       // Semantic UI Search expects results as: `{ category: { name: '', results: [{ title: '', description: '' }] }`
@@ -58,6 +58,7 @@ class GeoSearchInputBox extends React.Component {
       name: noMatchName,
       results: [{ title: query, name: query }],
     };
+
     logAnalyticsEvent("GeoSearchInputBox_location_queried", {
       query: query,
       numResults: serverSideSuggestions.length,

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -28,10 +28,9 @@ class GeoSearchInputBox extends React.Component {
 
   // Fetch geosearch results and format into categories for LiveSearchBox
   handleSearchTriggered = async query => {
-    let serverSideSuggestions = [];
     let categories = {};
     try {
-      serverSideSuggestions = await getGeoSearchSuggestions(query);
+      const serverSideSuggestions = await getGeoSearchSuggestions(query);
       // Semantic UI Search expects results as: `{ category: { name: '', results: [{ title: '', description: '' }] }`
       if (serverSideSuggestions.length > 0) {
         const locationsCategory = "Location Results";
@@ -47,6 +46,10 @@ class GeoSearchInputBox extends React.Component {
           }),
         };
       }
+      logAnalyticsEvent("GeoSearchInputBox_location_queried", {
+        query: query,
+        numResults: serverSideSuggestions.length,
+      });
     } catch (e) {
       // In the case of an error (e.g. no API key in dev), just catch and show the plain text option.
       // eslint-disable-next-line no-console
@@ -63,11 +66,6 @@ class GeoSearchInputBox extends React.Component {
       name: noMatchName,
       results: [{ title: query, name: query }],
     };
-
-    logAnalyticsEvent("GeoSearchInputBox_location_queried", {
-      query: query,
-      numResults: serverSideSuggestions.length,
-    });
     return categories;
   };
 

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -28,30 +28,36 @@ class GeoSearchInputBox extends React.Component {
 
   // Fetch geosearch results and format into categories for LiveSearchBox
   handleSearchTriggered = async query => {
-    const serverSideSuggestions = await getGeoSearchSuggestions(query);
-    // Semantic UI Search expects results as: `{ category: { name: '', results: [{ title: '', description: '' }] }`
     let categories = {};
-    if (serverSideSuggestions.length > 0) {
-      const locationsCategory = "Location Results";
-      categories[locationsCategory] = {
-        name: locationsCategory,
-        // Format title/description for the text box.
-        results: serverSideSuggestions.map(r => {
-          const nameParts = r.name.split(", ");
-          r.title = nameParts[0];
-          r.description = nameParts.slice(1).join(", ");
-          r.key = `loc-${r.locationiq_id}`;
-          return r;
-        }),
-      };
+    let serverSideSuggestions = [];
+    try {
+      serverSideSuggestions = await getGeoSearchSuggestions(query);
+      // Semantic UI Search expects results as: `{ category: { name: '', results: [{ title: '', description: '' }] }`
+      if (serverSideSuggestions.length > 0) {
+        const locationsCategory = "Location Results";
+        categories[locationsCategory] = {
+          name: locationsCategory,
+          // Format title/description for the text box.
+          results: serverSideSuggestions.map(r => {
+            const nameParts = r.name.split(", ");
+            r.title = nameParts[0];
+            r.description = nameParts.slice(1).join(", ");
+            r.key = `loc-${r.locationiq_id}`;
+            return r;
+          }),
+        };
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log(e);
     }
+
     // Let users select an unresolved plain text option
     let noMatchName = "Plain Text (No Location Match)";
     categories[noMatchName] = {
       name: noMatchName,
       results: [{ title: query, name: query }],
     };
-
     logAnalyticsEvent("GeoSearchInputBox_location_queried", {
       query: query,
       numResults: serverSideSuggestions.length,

--- a/db/migrate/20190729235747_switch_location_to_v2.rb
+++ b/db/migrate/20190729235747_switch_location_to_v2.rb
@@ -1,0 +1,25 @@
+class SwitchLocationToV2 < ActiveRecord::Migration[5.1]
+  def up
+    mf = MetadataField.find_by(name: "collection_location")
+    if mf
+      mf.update(is_core: 0, is_default: 0, is_required: 0, display_name: "Collection Location v1")
+    end
+
+    mf = MetadataField.where(name: "collection_location_v2")
+    if mf
+      mf.update(is_core: 1, is_default: 1, is_required: 1, display_name: "Collection Location")
+    end
+  end
+
+  def down
+    mf = MetadataField.find_by(name: "collection_location", display_name: "Collection Location")
+    if mf
+      mf.update(is_core: 1, is_default: 1, is_required: 1)
+    end
+
+    mf = MetadataField.where(name: "collection_location_v2")
+    if mf
+      mf.update(is_core: 0, is_default: 0, is_required: 0, display_name: "Collection Location v2")
+    end
+  end
+end

--- a/db/migrate/20190729235747_switch_location_to_v2.rb
+++ b/db/migrate/20190729235747_switch_location_to_v2.rb
@@ -2,24 +2,24 @@ class SwitchLocationToV2 < ActiveRecord::Migration[5.1]
   def up
     mf = MetadataField.find_by(name: "collection_location")
     if mf
-      mf.update(is_core: 0, is_default: 0, is_required: 0, display_name: "Collection Location v1")
+      mf.update(is_core: 0, is_default: 0, is_required: 0, display_name: "Collection Location v1", default_for_new_host_genome: 0)
     end
 
     mf = MetadataField.where(name: "collection_location_v2")
     if mf
-      mf.update(is_core: 1, is_default: 1, is_required: 1, display_name: "Collection Location")
+      mf.update(is_core: 1, is_default: 1, is_required: 1, display_name: "Collection Location", default_for_new_host_genome: 1)
     end
   end
 
   def down
     mf = MetadataField.find_by(name: "collection_location", display_name: "Collection Location")
     if mf
-      mf.update(is_core: 1, is_default: 1, is_required: 1)
+      mf.update(is_core: 1, is_default: 1, is_required: 1, default_for_new_host_genome: 1)
     end
 
     mf = MetadataField.where(name: "collection_location_v2")
     if mf
-      mf.update(is_core: 0, is_default: 0, is_required: 0, display_name: "Collection Location v2")
+      mf.update(is_core: 0, is_default: 0, is_required: 0, display_name: "Collection Location v2", default_for_new_host_genome: 0)
     end
   end
 end

--- a/db/migrate/20190729235747_switch_location_to_v2.rb
+++ b/db/migrate/20190729235747_switch_location_to_v2.rb
@@ -2,24 +2,24 @@ class SwitchLocationToV2 < ActiveRecord::Migration[5.1]
   def up
     mf = MetadataField.find_by(name: "collection_location")
     if mf
-      mf.update(is_core: 0, is_default: 0, is_required: 0, display_name: "Collection Location v1", default_for_new_host_genome: 0)
+      mf.update(is_core: 0, is_default: 0, is_required: 0, default_for_new_host_genome: 0, display_name: "Collection Location v1")
     end
 
     mf = MetadataField.where(name: "collection_location_v2")
     if mf
-      mf.update(is_core: 1, is_default: 1, is_required: 1, display_name: "Collection Location", default_for_new_host_genome: 1)
+      mf.update(is_core: 1, is_default: 1, is_required: 1, default_for_new_host_genome: 1, display_name: "Collection Location")
     end
   end
 
   def down
-    mf = MetadataField.find_by(name: "collection_location", display_name: "Collection Location")
+    mf = MetadataField.find_by(name: "collection_location")
     if mf
-      mf.update(is_core: 1, is_default: 1, is_required: 1, default_for_new_host_genome: 1)
+      mf.update(is_core: 1, is_default: 1, is_required: 1, default_for_new_host_genome: 1, display_name: "Collection Location")
     end
 
     mf = MetadataField.where(name: "collection_location_v2")
     if mf
-      mf.update(is_core: 0, is_default: 0, is_required: 0, display_name: "Collection Location v2", default_for_new_host_genome: 0)
+      mf.update(is_core: 0, is_default: 0, is_required: 0, default_for_new_host_genome: 0, display_name: "Collection Location v2")
     end
   end
 end


### PR DESCRIPTION
### Description
(1) Fixes the geosearch box in development environments without the location provider API keys. Before it would fail and appear to spin forever:
![Jul-29-2019 17-06-20](https://user-images.githubusercontent.com/5652739/62090910-751dd680-b223-11e9-863f-56ef6082aff9.gif)

(2) Swaps collection_location => collection_location_v2 in the migration and makes the field required. For devs b/c I already toggled these flags in the deployed environments.

### Tests
See pic + verified database state locally.