### PR TITLE
[Pipeline Viz] Style sidebar

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/PipelineStepDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/PipelineStepDetailsMode.jsx
@@ -1,10 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
+import cx from "classnames";
 
 import { openUrl } from "~utils/links";
+import { Accordion } from "~/components/layout";
 import cs from "./pipeline_step_details_mode.scss";
 
 class PipelineStepDetailsMode extends React.Component {
+  renderStepInfo() {
+    const { description } = this.props;
+    if (description) {
+      const header = <div className={cs.title}>Step Info</div>;
+      return (
+        <Accordion header={header} className={cs.accordion}>
+          <div className={cx(cs.description, cs.accordionContent)}>
+            {description}
+          </div>
+        </Accordion>
+      );
+    }
+  }
+
   renderInputFiles() {
     const { inputFiles } = this.props;
     if (!inputFiles || !inputFiles.length) {
@@ -16,27 +32,31 @@ class PipelineStepDetailsMode extends React.Component {
         <div className={cs.fileGroup} key={`inputFileGroup.fromStepName-${i}`}>
           <div
             className={cs.fileGroupHeader}
-          >{`From ${inputFileGroup.fromStepName || "Sample"}:`}</div>
+          >{`From ${inputFileGroup.fromStepName || "Sample"} Step:`}</div>
           {this.renderFileList(inputFileGroup.files)}
         </div>
       );
     });
+
+    const fileGroupHeader = <div className={cs.title}>Input Files</div>;
     return (
-      <div className={cs.stepFilesListBox}>
-        <div className={cs.stepFilesListBoxHeader}>Input Files</div>
-        {fileGroupList}
-      </div>
+      <Accordion className={cs.accordion} header={fileGroupHeader}>
+        <div className={cs.accordionContent}>{fileGroupList}</div>
+      </Accordion>
     );
   }
 
   renderOutputFiles() {
-    const { outputFiles } = this.props;
+    const { stepName, outputFiles } = this.props;
     if (outputFiles && outputFiles.length) {
+      const outputFilesHeader = <div className={cs.title}>Output Files</div>;
       return (
-        <div className={cs.stepFilesListBox}>
-          <div className={cs.stepFilesListBoxHeader}>Output Files</div>
-          {this.renderFileList(outputFiles)}
-        </div>
+        <Accordion className={cs.accordion} header={outputFilesHeader}>
+          <div className={cx(cs.accordionContent, cs.fileGroup)}>
+            <div className={cs.fileGroupHeader}>{`From ${stepName} Step:`}</div>
+            {this.renderFileList(outputFiles)}
+          </div>
+        </Accordion>
       );
     }
   }
@@ -60,11 +80,11 @@ class PipelineStepDetailsMode extends React.Component {
   }
 
   render() {
-    const { stepName, description } = this.props;
+    const { stepName } = this.props;
     return (
       <div className={cs.content}>
         <div className={cs.stepName}>{stepName}</div>
-        <div className={cs.description}>{description}</div>
+        {this.renderStepInfo()}
         {this.renderInputFiles()}
         {this.renderOutputFiles()}
       </div>

--- a/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
+++ b/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
@@ -3,7 +3,16 @@
 @import "~styles/themes/colors";
 
 .content {
+  @include font-body-xxs;
   padding: 30px;
+}
+
+.accordion {
+  border-bottom: 1px solid $light-grey;
+}
+
+.accordionContent {
+  margin-bottom: 20px;
 }
 
 .stepName {
@@ -13,20 +22,9 @@
   word-break: break-all;
 }
 
-.stepFilesListBoxHeader {
-  @include font-header-s;
-  margin-top: 25px;
-  margin-bottom: 10px;
-}
-
-.stepFilesListBox {
-  margin-bottom: 25px;
-}
-
-.description,
-.fileLink,
-.disabledFileLink {
-  @include font-body-s;
+.title {
+  @include font-header-accordion;
+  height: 40px;
 }
 
 .fileLink {
@@ -40,7 +38,7 @@
 }
 
 .fileGroup {
-  margin-bottom: 8px;
+  margin-bottom: 18px;
 
   .fileLink,
   .disabledFileLink {
@@ -48,6 +46,7 @@
   }
 
   .fileGroupHeader {
+    @include font-header-xs;
     margin-bottom: 8px;
   }
 }

--- a/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
+++ b/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
@@ -17,7 +17,7 @@
 
 .stepName {
   @include font-header-l;
-  margin-bottom: 12px;
+  margin-bottom: 16px;
   margin-right: 60px;
   word-break: break-all;
 }


### PR DESCRIPTION
# Description

Styles sidebar to match mocks (adding accordion, fixing font styling, etc)

![image](https://user-images.githubusercontent.com/23442055/62104128-8252b980-b253-11e9-9118-64cb238580ae.png)

# Notes

Currently, the step info accordion doesn't show up if there is no description (by intention)

# Tests

Go to `samples/[sample id]/pipeline_viz` on an pipeline viz enabled account and click on a node to see the sidebar appear.
