### PR TITLE
[Maps] Adjust bubble sizes, location warning message, and dropdown sorting

### DIFF
--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -8,7 +8,8 @@ import GeoSearchInputBox from "../ui/controls/GeoSearchInputBox";
 
 import cs from "./metadata_input.scss";
 
-export const LOCATION_WARNING = "Set to county/district for privacy.";
+export const LOCATION_WARNING =
+  "Changed to county/district level for personal privacy.";
 
 class MetadataInput extends React.Component {
   constructor(props) {

--- a/app/assets/src/components/common/filters/LocationFilter.jsx
+++ b/app/assets/src/components/common/filters/LocationFilter.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { forEach, values } from "lodash/fp";
+import { forEach, values, sortBy } from "lodash/fp";
 import { BaseMultipleFilter } from "~/components/common/filters";
 
 class LocationFilter extends React.Component {
@@ -41,7 +41,7 @@ class LocationFilter extends React.Component {
     return (
       <BaseMultipleFilter
         {...otherProps}
-        options={this.expandParents(options)}
+        options={sortBy("text", this.expandParents(options))}
       />
     );
   }

--- a/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
@@ -9,8 +9,11 @@ class ShapeMarker extends React.Component {
   render() {
     let {
       active,
+      divisorConst,
       lat,
       lng,
+      maxSize,
+      minSize,
       onClick,
       onMouseEnter,
       onMouseLeave,
@@ -20,27 +23,21 @@ class ShapeMarker extends React.Component {
       sizeMultiple,
       title,
       zoom,
-      minSize,
-      maxSize,
     } = this.props;
 
-    // Scale based on the zoom and point count (zoomed-in = higher zoom)
-    // Log2 of the count scaled looked nice visually for not getting too large with many points.
-    const options = [1, 10, 100, 500, 1000, 3000];
-    pointCount = options[Math.floor(Math.random() * options.length)];
+    // Scale based on the zoom and point count (zoomed-in = higher zoom).
+    // Determined via eyeballing: scaling of a form x/(x+c) shows large differences at the lower
+    // end of the range and smaller differences as it approaches a horizontal asymptote.
+    // clamp(min, x/(x+c) * m * z, max)
     const computedSize =
       size ||
       Math.min(
         Math.max(
-          20 * pointCount / (200 + pointCount) * sizeMultiple * zoom,
+          pointCount / (pointCount + divisorConst) * sizeMultiple * zoom,
           minSize
         ),
         maxSize
       );
-
-    console.log("computed: ", computedSize);
-    console.log(title, pointCount);
-    console.log("9:35am");
 
     return (
       <Marker latitude={lat} longitude={lng}>
@@ -68,16 +65,19 @@ class ShapeMarker extends React.Component {
 
 // Defaults determined via eyeballing.
 ShapeMarker.defaultProps = {
-  minSize: 10,
-  sizeMultiple: 3,
-  zoom: 3,
+  divisorConst: 400,
   maxSize: 90,
+  minSize: 10,
+  sizeMultiple: 60,
+  zoom: 3,
 };
 
 ShapeMarker.propTypes = {
   active: PropTypes.bool,
+  divisorConst: PropTypes.number,
   lat: PropTypes.number,
   lng: PropTypes.number,
+  maxSize: PropTypes.number,
   minSize: PropTypes.number,
   onClick: PropTypes.func,
   onMouseEnter: PropTypes.func,

--- a/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { clamp } from "lodash/fp";
 import { Marker } from "react-map-gl";
 
 import CircleMarker from "~/components/views/discovery/mapping/CircleMarker";
@@ -28,15 +29,12 @@ class ShapeMarker extends React.Component {
     // Scale based on the zoom and point count (zoomed-in = higher zoom)
     // Determined via eyeballing: scaling of a form x/(x+c) shows larger differences at the lower
     // end of the range and smaller differences as it approaches a horizontal asymptote.
-    // clamp(min, x/(x+c) * m * z, max)
     const computedSize =
       size ||
-      Math.min(
-        Math.max(
-          pointCount / (pointCount + divisorConst) * sizeMultiple * zoom,
-          minSize
-        ),
-        maxSize
+      clamp(
+        minSize,
+        maxSize,
+        pointCount / (pointCount + divisorConst) * sizeMultiple * zoom
       );
 
     return (

--- a/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
@@ -7,11 +7,10 @@ import RectangleMarker from "~/components/views/discovery/mapping/RectangleMarke
 
 class ShapeMarker extends React.Component {
   render() {
-    const {
+    let {
       active,
       lat,
       lng,
-      minSize,
       onClick,
       onMouseEnter,
       onMouseLeave,
@@ -21,12 +20,19 @@ class ShapeMarker extends React.Component {
       sizeMultiple,
       title,
       zoom,
+      minSize,
     } = this.props;
 
     // Scale based on the zoom and point count (zoomed-in = higher zoom)
     // Log2 of the count scaled looked nice visually for not getting too large with many points.
+    const options = [1, 100, 1000, 3000];
+    pointCount = options[Math.floor(Math.random() * options.length)];
     const computedSize =
-      size || Math.max(Math.log2(pointCount) * sizeMultiple * zoom, minSize);
+      size ||
+      Math.max(
+        10 * pointCount / (100 + pointCount) * sizeMultiple * zoom,
+        minSize
+      );
 
     return (
       <Marker latitude={lat} longitude={lng}>
@@ -55,7 +61,7 @@ class ShapeMarker extends React.Component {
 // Defaults determined via eyeballing.
 ShapeMarker.defaultProps = {
   minSize: 14,
-  sizeMultiple: 2,
+  sizeMultiple: 10,
   zoom: 3,
 };
 

--- a/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
@@ -7,7 +7,7 @@ import RectangleMarker from "~/components/views/discovery/mapping/RectangleMarke
 
 class ShapeMarker extends React.Component {
   render() {
-    let {
+    const {
       active,
       divisorConst,
       lat,
@@ -25,8 +25,8 @@ class ShapeMarker extends React.Component {
       zoom,
     } = this.props;
 
-    // Scale based on the zoom and point count (zoomed-in = higher zoom).
-    // Determined via eyeballing: scaling of a form x/(x+c) shows large differences at the lower
+    // Scale based on the zoom and point count (zoomed-in = higher zoom)
+    // Determined via eyeballing: scaling of a form x/(x+c) shows larger differences at the lower
     // end of the range and smaller differences as it approaches a horizontal asymptote.
     // clamp(min, x/(x+c) * m * z, max)
     const computedSize =

--- a/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
+++ b/app/assets/src/components/views/discovery/mapping/ShapeMarker.jsx
@@ -21,18 +21,26 @@ class ShapeMarker extends React.Component {
       title,
       zoom,
       minSize,
+      maxSize,
     } = this.props;
 
     // Scale based on the zoom and point count (zoomed-in = higher zoom)
     // Log2 of the count scaled looked nice visually for not getting too large with many points.
-    const options = [1, 100, 1000, 3000];
+    const options = [1, 10, 100, 500, 1000, 3000];
     pointCount = options[Math.floor(Math.random() * options.length)];
     const computedSize =
       size ||
-      Math.max(
-        10 * pointCount / (100 + pointCount) * sizeMultiple * zoom,
-        minSize
+      Math.min(
+        Math.max(
+          20 * pointCount / (200 + pointCount) * sizeMultiple * zoom,
+          minSize
+        ),
+        maxSize
       );
+
+    console.log("computed: ", computedSize);
+    console.log(title, pointCount);
+    console.log("9:35am");
 
     return (
       <Marker latitude={lat} longitude={lng}>
@@ -60,9 +68,10 @@ class ShapeMarker extends React.Component {
 
 // Defaults determined via eyeballing.
 ShapeMarker.defaultProps = {
-  minSize: 14,
-  sizeMultiple: 10,
+  minSize: 10,
+  sizeMultiple: 3,
   zoom: 3,
+  maxSize: 90,
 };
 
 ShapeMarker.propTypes = {


### PR DESCRIPTION
### Description
- This PR bundles some small changes that we agreed to make at the map release meeting:
(1) Change the bubble sizing equation from log(x) to x/(x+c) to create more dramatic scaling differences at the lower end of the range of point values + tweak min/max sizes.
(2) Sort the left sidebar LocationV2 filter dropdown options alphabetically.
![Screen Shot 2019-07-30 at 10 12 37 AM](https://user-images.githubusercontent.com/5652739/62150592-45b6aa80-b2b3-11e9-8818-4cdb32409e70.png)
(3) Update the location warning message to clarify it is for personal privacy "of humans".

### Tests
(1) Go to the maps with a variety of bubble sizes and see differences in scaling
(2) Go to the left sidebar LocationV2 filter and see the list sorted alphabetically
(3) Go to a Human sample and type in a city name and see the location auto-restriction and warning message.