### PR TITLE
Add upload heartbeat to bulk upload

### DIFF
--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -84,6 +84,9 @@ export const bulkUploadLocalWithMetadata = ({
         const sampleName = sample.name;
         const files = sampleNamesToFiles[sampleName];
 
+        // Start pinging server to monitor uploads server-side
+        startUploadHeartbeat(sample.id);
+
         sample.input_files.map(inputFileAttributes => {
           const file = files[inputFileAttributes.name];
           const url = inputFileAttributes.presigned_url;
@@ -194,11 +197,13 @@ export const bulkUploadLocal = ({
 // Local uploads go directly from the browser to S3, so we don't know if an upload was interrupted.
 // Ping the heartbeat endpoint periodically to say the browser is actively uploading this sample.
 export const startUploadHeartbeat = async sampleId => {
-  const interval = 60000; // 60 sec
-  setInterval(() => {
+  const sendHeartbeat = () => {
     putWithCSRF(`/samples/${sampleId}/upload_heartbeat.json`).catch(() =>
       // eslint-disable-next-line no-console
       console.error("Can't connect to IDseq server.")
     );
-  }, interval);
+  };
+  sendHeartbeat(); // Send first heartbeat immediately so we know it is working
+  const interval = 60000; // 60 sec
+  setInterval(sendHeartbeat, interval);
 };

--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -85,7 +85,7 @@ export const bulkUploadLocalWithMetadata = ({
         const files = sampleNamesToFiles[sampleName];
 
         // Start pinging server to monitor uploads server-side
-        startUploadHeartbeat(sample.id);
+        const interval = startUploadHeartbeat(sample.id);
 
         sample.input_files.map(inputFileAttributes => {
           const file = files[inputFileAttributes.name];
@@ -102,6 +102,7 @@ export const bulkUploadLocalWithMetadata = ({
             onSuccess: () => {
               fileNamesToProgress[file.name] = 100;
               onFileUploadSuccess(sampleName, sample.id);
+              clearInterval(interval);
             },
             onError: error => onUploadError(file, error),
           });
@@ -205,5 +206,5 @@ export const startUploadHeartbeat = async sampleId => {
   };
   sendHeartbeat(); // Send first heartbeat immediately so we know it is working
   const interval = 60000; // 60 sec
-  setInterval(sendHeartbeat, interval);
+  return setInterval(sendHeartbeat, interval);
 };


### PR DESCRIPTION
# Description

This adds the existing heartbeat feature to the new bulk upload code path. See https://jira.czi.team/browse/IDSEQ-1237 . 

# Notes

* I also changed the heartbeat function to send a first heartbeat immediately for instant feedback. 

# Tests

* Open http://localhost:3000/samples/upload 
* Upload some files
* See heartbeat request in debug console