### PR TITLE
update repository benchmark config to match deployed version

### DIFF
--- a/config/idseq-bench-config.json
+++ b/config/idseq-bench-config.json
@@ -24,8 +24,7 @@
     "********************************************************************************"
   ],
   "defaults": {
-    "how_to_use_these_defaults":
-      "These properties may be overridden in each entry of active_benchmarks below.",
+    "how_to_use_these_defaults": "These properties may be overridden in each entry of active_benchmarks below.",
     "project_name": "IDSeq Bench",
     "user_email": "bdimitrov@chanzuckerberg.com",
     "frequency_hours": 24,
@@ -33,23 +32,32 @@
     "trigger_on_pipeline_change": true,
     "pipeline_branch": "master",
     "host": "Human",
-    "comment":
-      "No comment provided for this benchmark in s3://idseq-bench/config.json."
+    "comment": "No comment provided for this benchmark in s3://idseq-bench/config.json."
   },
   "active_benchmarks": {
-    "s3://idseq-bench/4": {
-      "comment":
-        "Comprehensive general benchmark built with idseq-bench.  Deployed 2018-10-11.",
-      "environments": ["prod", "staging"]
+    "s3://idseq-bench/5": {
+      "comment": "Comprehensive general benchmark built with idseq-bench, contains additional microbes (beyond bench/4) commonly found in IDseq samples. Deployed 2019-04-30.",
+      "environments": [
+        "prod",
+        "staging"
+      ]
     }
   },
   "retired_benchmarks": {
+    "s3://idseq-bench/4": {
+      "comment": "Comprehensive general benchmark built with idseq-bench.  Deployed 2018-10-11.  Retired 2019-04-30 (presumably).",
+      "environments": [
+        "prod",
+        "staging"
+      ]
+    },
     "s3://idseq-bench/3": {
-      "comment":
-        "A tiny pseudo-benchmark meant for exercising the job control logic.  Deployed 2018-10-11",
-      "environments": ["development"],
+      "comment": "A tiny pseudo-benchmark meant for exercising the job control logic.  Deployed 2018-10-11",
+      "environments": [
+        "development"
+      ],
       "project_name": "IDSeq Bench Development",
-      "frequency_hours": 1.0
+      "frequency_hours": 1
     }
   }
 }


### PR DESCRIPTION
Changes were made to the active (deployed) config without checking in the corresponding changes here under version control.   Remedying this.

Also, including the retired benchmark in the config.

Test plan:   There were whitespace formatting changes that made it difficult to compare directly.   However, the "jq" utility was handy for checking json syntax and reformatting to where the comparison is quite easy.   Here were the commands:

aws --profile biohub-idseq s3 cp s3://idseq-bench/config.json - | jq > b.txt

cat idseq-bench-config.json | jq > b.txt

diff a.txt b.txt

