### PR TITLE
[IDSEQ-1230] Send email on account request

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -86,7 +86,11 @@ class HomeController < ApplicationController
       return
     end
 
-    UserMailer.account_request_reply(home_params[:email])
+    begin
+      UserMailer.account_request_reply(home_params[:email]).deliver_now
+    rescue
+      LogUtil.log_err_and_airbrake("account_request_reply(#{home_params[:email]} failed")
+    end
 
     body = ""
     home_params.each do |k, v|

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -88,8 +88,9 @@ class HomeController < ApplicationController
 
     begin
       UserMailer.account_request_reply(home_params[:email]).deliver_now
-    rescue
+    rescue => err
       LogUtil.log_err_and_airbrake("account_request_reply(#{home_params[:email]} failed")
+      LogUtil.log_backtrace(err)
     end
 
     body = ""

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -86,6 +86,8 @@ class HomeController < ApplicationController
       return
     end
 
+    UserMailer.account_request_reply(home_params[:email])
+
     body = ""
     home_params.each do |k, v|
       body += "#{k}: #{v}\n"

--- a/app/lib/url_util.rb
+++ b/app/lib/url_util.rb
@@ -4,7 +4,9 @@ class UrlUtil
   # absolute URLs to be the same in emails and in other places.
   def self.absolute_base_url
     options = Rails.application.config.action_mailer.default_url_options
-    host, port, protocol = options[:host], options[:port], options[:protocol] # rubocop:disable Style/ParallelAssignment
+    host = options[:host]
+    port = options[:port]
+    protocol = options[:protocol]
     if protocol.nil?
       protocol = Rails.application.config.force_ssl ? "https" : "http"
     end

--- a/app/lib/url_util.rb
+++ b/app/lib/url_util.rb
@@ -4,7 +4,7 @@ class UrlUtil
   # absolute URLs to be the same in emails and in other places.
   def self.absolute_base_url
     options = Rails.application.config.action_mailer.default_url_options
-    host, port, protocol = options[:host], options[:port], options[:protocol] # rubocop:disable Performance/ParallelAssignment
+    host, port, protocol = options[:host], options[:port], options[:protocol] # rubocop:disable Style/ParallelAssignment
     if protocol.nil?
       protocol = Rails.application.config.force_ssl ? "https" : "http"
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -13,4 +13,11 @@ class UserMailer < ApplicationMailer
     account_email = "accounts@idseq.net"
     mail(to: account_email, subject: "New sign up from landing page", body: body)
   end
+
+  def account_request_reply(request_email)
+    mail(
+      to: request_email,
+      subject: "Thank you for contacting the IDseq Team"
+    )
+  end
 end

--- a/app/views/user_mailer/account_request_reply.html.erb
+++ b/app/views/user_mailer/account_request_reply.html.erb
@@ -1,0 +1,8 @@
+<p>Hello,</p>
+<p>
+  Thank you for contacting IDseq! <br/>
+  We will be in touch soon to learn more about your work and how IDSeq can help you.
+</p>
+<p>
+  Cheers,<br/> The IDseq Team
+</p>

--- a/app/views/user_mailer/account_request_reply.html.erb
+++ b/app/views/user_mailer/account_request_reply.html.erb
@@ -1,7 +1,8 @@
 <p>Hello,</p>
 <p>
-  Thank you for contacting IDseq! <br/>
-  We will be in touch soon to learn more about your work and how IDSeq can help you.
+  Thank you for your interest in IDseq! <br/>
+  We will be in touch soon to learn more about your work and how IDSeq can help you.<br/>
+  If your team is already on IDseq, ask a collaborator to add you to a project to get immediate access.
 </p>
 <p>
   Cheers,<br/> The IDseq Team

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -23,4 +23,8 @@ class UserMailerPreview < ActionMailer::Preview
   def reset_password_instructions
     CustomDeviseMailer.reset_password_instructions(User.first, "fake_token", {})
   end
+
+  def account_request_reply
+    UserMailer.account_request_reply(User.first.email)
+  end
 end


### PR DESCRIPTION
# Description

* Send email on account request to confirm contact and inform that the team will be in touch soon.

# Tests

Request a new account on IDseq's landing page:
* Action mailer reports email sent in logs.
* Will confirm in staging that the email is correctly sent.
