### PR TITLE
Fix has many through in Background

### DIFF
--- a/app/controllers/backgrounds_controller.rb
+++ b/app/controllers/backgrounds_controller.rb
@@ -115,6 +115,6 @@ class BackgroundsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def background_params
-    params.require(:background).permit(:name, pipeline_run_ids: [])
+    params.require(:background).permit(:name, pipeline_run_ids: [], sample_ids: [])
   end
 end

--- a/app/models/background.rb
+++ b/app/models/background.rb
@@ -1,6 +1,6 @@
 class Background < ApplicationRecord
-  has_and_belongs_to_many :samples, through: :pipeline_runs
   has_and_belongs_to_many :pipeline_runs
+  has_many :samples, through: :pipeline_runs
   has_many :taxon_summaries, dependent: :destroy
   belongs_to :project, optional: true
   validate :validate_size

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -67,7 +67,7 @@ class Sample < ApplicationRecord
   belongs_to :user, optional: true, counter_cache: true # use .size for cache, use .count to force COUNT query
   belongs_to :host_genome, optional: true
   has_many :pipeline_runs, -> { order(created_at: :desc) }, dependent: :destroy
-  has_and_belongs_to_many :backgrounds, through: :pipeline_runs
+  has_many :backgrounds, through: :pipeline_runs
   has_many :input_files, dependent: :destroy
   accepts_nested_attributes_for :input_files
   has_many :metadata, dependent: :destroy

--- a/test/controllers/backgrounds_controller_test.rb
+++ b/test/controllers/backgrounds_controller_test.rb
@@ -24,13 +24,7 @@ class BackgroundsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update background" do
-    skip "This passes locally but fails in Travis because of s3 call. See archive_background_to_s3."
-    patch background_url(@background), params: {
-      background: {
-        name: @background.name,
-        pipeline_run_ids: @background.pipeline_runs.map(&:id),
-      },
-    }
+    patch background_url(@background), params: { background: { name: @background.name, pipeline_run_ids: @background.pipeline_runs.map(&:id), sample_ids: @background.samples.pluck(:id) } }
     assert_redirected_to background_url(@background)
   end
 

--- a/test/controllers/backgrounds_controller_test.rb
+++ b/test/controllers/backgrounds_controller_test.rb
@@ -24,7 +24,13 @@ class BackgroundsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update background" do
-    patch background_url(@background), params: { background: { name: @background.name, pipeline_run_ids: @background.pipeline_runs.map(&:id) } }
+    skip "This passes locally but fails in Travis because of s3 call. See archive_background_to_s3."
+    patch background_url(@background), params: {
+      background: {
+        name: @background.name,
+        pipeline_run_ids: @background.pipeline_runs.map(&:id),
+      },
+    }
     assert_redirected_to background_url(@background)
   end
 


### PR DESCRIPTION
# Description

Investigation shows that `Background.last.samples` gets this SQL:

```
[2019-08-01T20:48:19] DEBUG ActiveRecord::Base :   Background Load (0.4ms)  SELECT  `backgrounds`.* FROM `backgrounds` ORDER BY `backgrounds`.`id` DESC LIMIT 1
[2019-08-01T20:48:19] DEBUG ActiveRecord::Base :   Sample Load (0.9ms)  SELECT  `samples`.* FROM `samples` INNER JOIN `backgrounds_samples` ON `samples`.`id` = `backgrounds_samples`.`sample_id` WHERE `backgrounds_samples`.`background_id` = 111 LIMIT 11
```

and `backgrounds_samples` table is empty in prod. 

It looks like the assoc was misconfigured. 

Rails docs do not mention `through` option at all: https://apidock.com/rails/ActiveRecord/Associations/ClassMethods/has_and_belongs_to_many

# Notes

There was only one callsite of background.samples or sample.backgrounds that I could find. It's in `assign_attributes_and_has_changed` which itself is only called once:

```
  # PATCH/PUT /backgrounds/1
  # PATCH/PUT /backgrounds/1.json
  def update
    current_data = @background.to_json(include: [{ pipeline_runs: { only: [:id, :sample_id] } }])
    current_data_full_string = @background.to_json(include: [{ pipeline_runs: { only: [:id, :sample_id] } },
                                                             :taxon_summaries,])
    background_changed = assign_attributes_and_has_changed?(background_params)
```

Tracing the code, it looks like the bug of always zero `background.samples` would only have caused the background to always be updated, but please double check.

I also checked for other instances of `has_and_belongs_to_many` + `through` and I didn't see any.

# Tests

* In the rails console, run`Background.last.samples`.
* See no records before, see records after