### PR TITLE
[Maps] Update more default fields to collection_location_v2

### DIFF
--- a/app/assets/src/components/views/amr_heatmap/AMRHeatmapVis.jsx
+++ b/app/assets/src/components/views/amr_heatmap/AMRHeatmapVis.jsx
@@ -18,7 +18,7 @@ const METRICS = [
   { text: "Depth", key: "depth" },
 ];
 
-const DEFAULT_SELECTED_METADATA = ["collection_location"];
+const DEFAULT_SELECTED_METADATA = ["collection_location_v2"];
 
 export default class AMRHeatmapVis extends React.Component {
   constructor(props) {

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -75,7 +75,7 @@ class SamplesHeatmapView extends React.Component {
       },
       loading: false,
       selectedMetadata: this.urlParams.selectedMetadata || [
-        "collection_location",
+        "collection_location_v2",
       ],
       sampleIds: compact(
         map(parseAndCheckInt, this.urlParams.sampleIds || this.props.sampleIds)

--- a/app/assets/src/components/views/phylo_tree/constants.js
+++ b/app/assets/src/components/views/phylo_tree/constants.js
@@ -16,7 +16,7 @@ export const SAMPLE_FIELDS = [
 ];
 
 export const SAMPLE_METADATA_FIELDS = [
-  "collection_location",
+  "collection_location_v2",
   "collection_date",
   "sample_type",
   "nucleotide_type",


### PR DESCRIPTION
### Description
- Unfortunate that I missed these before..
- This updates 3 more views (Taxon Heatmap, AMR Heatmap, and Phylo Tree tooltips) to use a default of `collection_location_v2` instead of `collection_location`.  Soon we can remove the old field entirely :).

### Notes
![Screen Shot 2019-08-01 at 5 52 46 PM](https://user-images.githubusercontent.com/5652739/62336459-3f782800-b485-11e9-98ca-94c5a5de0e46.png)
![Screen Shot 2019-08-01 at 5 45 56 PM](https://user-images.githubusercontent.com/5652739/62336461-430baf00-b485-11e9-9852-b9da56dc812d.png)
![Screen Shot 2019-08-01 at 5 48 46 PM](https://user-images.githubusercontent.com/5652739/62336463-456e0900-b485-11e9-9cb8-a5e85bfe4267.png)

### Tests
- Visit the three views above (Taxon Heatmap, AMR Heatmap, and Phylo Tree tooltips) and see "Collection Location" by default (no "Collection Location v1").