### PR TITLE
Fix performance issue with samples/index when loading private_until date.

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -157,7 +157,7 @@ class SamplesController < ApplicationController
     samples = samples.order(Hash[order_by => order_dir])
     limited_samples = samples.offset(offset).limit(limit)
 
-    limited_samples_json = limited_samples.as_json(
+    limited_samples_json = limited_samples.includes(:project).as_json(
       only: [:id, :name, :host_genome_id, :project_id, :created_at, :public],
       methods: [:private_until]
     )


### PR DESCRIPTION
# Description

* Fix an issue on json encoding that was triggering `n+1` queries to load the private_until date.

# Tests

* Nothing changes from a logical point of view.
* Verify that samples still load correctly.