### PR TITLE
Bump LongRunningSampleEvent threshold to 10 hours

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -901,7 +901,7 @@ class PipelineRun < ApplicationRecord
     MetricUtil.put_metric_now("samples.running.run_time", run_time, tags, "gauge")
 
     if alert_sent.zero?
-      threshold = 8.hours
+      threshold = 10.hours
       if run_time > threshold
         msg = "LongRunningSampleEvent: Sample #{sample.id} by #{sample.user.role_name} has been running #{duration_hrs} hours. #{job_status_display} " \
           "See: #{status_url}"

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -901,7 +901,8 @@ class PipelineRun < ApplicationRecord
     MetricUtil.put_metric_now("samples.running.run_time", run_time, tags, "gauge")
 
     if alert_sent.zero?
-      threshold = 10.hours
+      # NOTE (2019-08-02): Based on the last 3000 successful samples, only 0.17% took longer than 12 hours.
+      threshold = 12.hours
       if run_time > threshold
         msg = "LongRunningSampleEvent: Sample #{sample.id} by #{sample.user.role_name} has been running #{duration_hrs} hours. #{job_status_display} " \
           "See: #{status_url}"


### PR DESCRIPTION
### Description
- Raise the LongRunningSampleEvent threshold from 8 hours to 10 hours to fit better with the distribution of normally running samples.