### PR TITLE
Set Metadatum raw_value length max to same as string_validated_value

### DIFF
--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -24,6 +24,7 @@ class Metadatum < ApplicationRecord
 
   # Validations
   validates :string_validated_value, length: { maximum: 250 }
+  validates :raw_value, length: { maximum: 250 } # mysql varchar has a max limit of 255
   validates :number_validated_value, numericality: true, allow_nil: true
   validate :set_validated_values
 

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -23,8 +23,8 @@ class Metadatum < ApplicationRecord
   LOCATION_TYPE = 3
 
   # Validations
-  validates :string_validated_value, length: { maximum: 250 }
   validates :raw_value, length: { maximum: 250 } # mysql varchar has a max limit of 255
+  validates :string_validated_value, length: { maximum: 250 }
   validates :number_validated_value, numericality: true, allow_nil: true
   validate :set_validated_values
 

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -28,4 +28,11 @@ class MetadatumTest < ActiveSupport::TestCase
     loc.check_and_set_location_type
     assert_match MetadataValidationErrors::INVALID_LOCATION, loc.errors.full_messages[0]
   end
+
+  test "should raise validation error on long value" do
+    datum = metadata(:sample_human_sex)
+    datum.raw_value = "123" * 250
+    datum.save
+    assert_match "Raw value is too long (maximum is 250 characters)", datum.errors.full_messages[0]
+  end
 end


### PR DESCRIPTION
# Description

See https://jira.czi.team/browse/IDSEQ-1186.

This makes Rails validate `raw_value`. It looks like in rare cases `string_validated_value` could have passed while `raw_value` was longer than 255 chars, the mysql limit. 

# Notes

* Another solution would be to change the col type to `text` for unlimited size. 

# Tests

rails t test/models/metadatum_test.rb