### PR TITLE
Fix unload warning on downloading heatmap

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -204,7 +204,9 @@ class SamplesHeatmapView extends React.Component {
 
   handleDownloadCsv = () => {
     let url = new URL("/visualizations/download_heatmap", window.origin);
-    location.href = `${url.toString()}?${this.prepareParams()}`;
+    const href = `${url.toString()}?${this.prepareParams()}`;
+    // target="_blank" is needed to avoid unload handler
+    window.open(href, "_blank");
   };
 
   handleShareClick = async () => {


### PR DESCRIPTION
# Description

target="_blank" is needed to avoid unload handler

![image](https://user-images.githubusercontent.com/28797/62391304-4a7c9800-b519-11e9-9843-4a67ed3f5b16.png)

# Notes

* Not sure if any users complained about this. I noticed working on another heatmap issue. 

# Tests

* open a heatmap
* click download
* see no popup warning