### PR TITLE
Fix CSS style on map_tooltip and table_renderers

### DIFF
--- a/app/assets/src/components/views/discovery/mapping/map_tooltip.scss
+++ b/app/assets/src/components/views/discovery/mapping/map_tooltip.scss
@@ -45,6 +45,7 @@ $tooltip-tip-size: 8px;
 
       .title {
         @include font-header-xs;
+        cursor: pointer;
 
         &.hoverable {
           &:hover {

--- a/app/assets/src/components/views/discovery/table_renderers.scss
+++ b/app/assets/src/components/views/discovery/table_renderers.scss
@@ -103,7 +103,7 @@
       margin-bottom: 1px;
 
       .sampleName {
-        @include font-body-s;
+        @include font-header-s;
 
         min-width: 0;
         text-align: left;


### PR DESCRIPTION
### Description
- Tiny PR to fix (1) pointer cursor on map tooltip, and (2) bolded sample names in the main data tables (they got unbolded by another style change).

### Tests
<img width="595" alt="Screen Shot 2019-08-02 at 1 58 48 PM" src="https://user-images.githubusercontent.com/5652739/62643914-dfa6d480-b8fd-11e9-80ff-560f6b3a12e9.png">
vs.

![Screen Shot 2019-08-07 at 10 26 18 AM](https://user-images.githubusercontent.com/5652739/62643982-fd743980-b8fd-11e9-9d32-5507514b6056.png)
