### PR TITLE
[Pipeline Viz] Add pipeline_viz_experimental flag

### DIFF
--- a/app/assets/src/components/views/PipelineViz/PipelineViz.jsx
+++ b/app/assets/src/components/views/PipelineViz/PipelineViz.jsx
@@ -24,7 +24,7 @@ class PipelineViz extends React.Component {
       "Host Filtering",
       "Alignment",
       "Post Processing",
-      ...(props.admin ? ["Experimental"] : []),
+      ...(props.showExperimental ? ["Experimental"] : []),
     ];
 
     this.graphs = [];
@@ -832,7 +832,7 @@ const nodeColors = PropTypes.shape({
 });
 
 PipelineViz.propTypes = {
-  admin: PropTypes.bool,
+  showExperimental: PropTypes.bool,
   graphData: PropTypes.object,
   pipelineRun: PropTypes.PipelineRun,
   sample: PropTypes.Sample,
@@ -853,7 +853,7 @@ PipelineViz.propTypes = {
 };
 
 PipelineViz.defaultProps = {
-  admin: false,
+  showExperimental: false,
   backgroundColor: cs.offWhite,
   notStartedNodeColor: {
     default: cs.notStartedBg,

--- a/app/controllers/pipeline_viz_controller.rb
+++ b/app/controllers/pipeline_viz_controller.rb
@@ -7,6 +7,7 @@ class PipelineVizController < ApplicationController
   # GET /sample/:sample_id/pipeline_viz/:pipeline_version.json
   def show
     feature_allowed = current_user.allowed_feature_list.include?("pipeline_viz")
+    @show_experimental = current_user.allowed_feature_list.include?("pipeline_viz_experimental") || current_user.admin?
     if feature_allowed
       @sample = current_power.samples.find_by(id: params[:sample_id])
       pipeline_version = params[:pipeline_version]
@@ -15,7 +16,7 @@ class PipelineVizController < ApplicationController
       )
 
       if pipeline_run
-        @results = RetrievePipelineVizGraphDataService.call(pipeline_run.id, current_user.admin?, current_user.id != @sample.user_id)
+        @results = RetrievePipelineVizGraphDataService.call(pipeline_run.id, @show_experimental, current_user.id != @sample.user_id)
         @pipeline_versions = @sample.pipeline_versions
         @last_processed_at = pipeline_run.created_at
         @pipeline_run_display = curate_pipeline_run_display(pipeline_run)

--- a/app/services/retrieve_pipeline_viz_graph_data_service.rb
+++ b/app/services/retrieve_pipeline_viz_graph_data_service.rb
@@ -27,12 +27,12 @@ class RetrievePipelineVizGraphDataService
   #           - displayName: A string to display the file as
   #           - url: An optional string to download the file
 
-  def initialize(pipeline_run_id, is_admin, remove_host_filtering_urls)
+  def initialize(pipeline_run_id, see_experimental, remove_host_filtering_urls)
     @pipeline_run = PipelineRun.find(pipeline_run_id)
     @all_dag_jsons = []
     @stage_names = []
     @pipeline_run.pipeline_run_stages.each do |stage|
-      if stage.dag_json && (stage.name != "Experimental" || is_admin)
+      if stage.dag_json && (stage.name != "Experimental" || see_experimental)
         @all_dag_jsons.push(JSON.parse(stage.dag_json || "{}"))
         @stage_names.push(stage.name)
       end

--- a/app/views/pipeline_viz/show.html.erb
+++ b/app/views/pipeline_viz/show.html.erb
@@ -1,7 +1,7 @@
 <div id="PipelineStageResults">
   <%= javascript_tag do %>
     react_component('PipelineViz', {
-        admin: <%= current_user.admin %>,
+        showExperimental: <%= @show_experimental %>,
         graphData: JSON.parse('<%= raw escape_json(@results) %>'),
         pipelineRun: <%= raw escape_json(@pipeline_run_display) %>,
         sample: <%= raw escape_json(@sample) %>,

--- a/spec/controllers/pipeline_viz_controller_spec.rb
+++ b/spec/controllers/pipeline_viz_controller_spec.rb
@@ -233,5 +233,21 @@ RSpec.describe PipelineVizController, type: :controller do
         expect(response).to have_http_status 401
       end
     end
+
+    describe "Get pipeline stage results with pipeline viz experimental flag enabled" do
+      it "can see all stage results, including experimental" do
+        @joe.add_allowed_feature("pipeline_viz_experimental")
+
+        project = create(:public_project)
+        sample = create(:sample, project: project,
+                                 pipeline_runs_data: [{ pipeline_run_stages_data: pipeline_run_stages_data }])
+
+        get :show, params: { format: "json", sample_id: sample.id }
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to include_json(expected_stage_results)
+        expect(json_response.keys).to contain_exactly(*expected_stage_results.keys)
+      end
+    end
   end
 end

--- a/spec/services/retrieve_pipeline_viz_graph_data_service_spec.rb
+++ b/spec/services/retrieve_pipeline_viz_graph_data_service_spec.rb
@@ -148,20 +148,20 @@ RSpec.describe RetrievePipelineVizGraphDataService do
       end
     end
 
-    context "as admin" do
+    context "with see_experimental flag" do
       it "sees all stage results" do
-        is_admin = true
-        results = RetrievePipelineVizGraphDataService.call(@pr.id, is_admin, false)
+        see_experimental = true
+        results = RetrievePipelineVizGraphDataService.call(@pr.id, see_experimental, false)
 
         # Host filtering and experimental; other stages omitted for brevity.
         expect(results[:stages].length).to be(2)
       end
     end
 
-    context "as nonadmin" do
+    context "without see_experimental flag" do
       it "sees all stage results except experimental" do
-        is_admin = false
-        results = RetrievePipelineVizGraphDataService.call(@pr.id, is_admin, false)
+        see_experimental = false
+        results = RetrievePipelineVizGraphDataService.call(@pr.id, see_experimental, false)
 
         # Only host filtering (other stages omitted for brevity)
         expect(results[:stages].length).to be(1)


### PR DESCRIPTION
# Description

Adds a `pipeline_viz_experimental` flag so that users who are not admins but contribute to the development of the pipeline (ie scientists @ Biohub) can view results from the experimental stage.

# Tests

* Updated corresponding rspec tests
* View pipeline_viz from an admin user without the flag, along with nonadmin user with and without the flag to make sure that nothing breaks.
