### PR TITLE
backfill deuterostome flag and add updated host template

### DIFF
--- a/app/lib/add_host_genome_migration_example.rb
+++ b/app/lib/add_host_genome_migration_example.rb
@@ -1,4 +1,7 @@
 class AddCarpHost < ActiveRecord::Migration[5.1]
+  # TEMPLATE for a migration adding a host genome.
+  # The example chosen here is "Carp" host.
+  # Replace occurrences of "Carp" as well as other column values as appropriate.
   def up
     return if HostGenome.find_by(name: "Carp")
 

--- a/app/lib/add_host_genome_migration_example.rb
+++ b/app/lib/add_host_genome_migration_example.rb
@@ -1,0 +1,23 @@
+class AddCarpHost < ActiveRecord::Migration[5.1]
+  def up
+    return if HostGenome.find_by(name: "Carp")
+
+    hg = HostGenome.new
+    hg.name = "Carp"
+    hg.s3_star_index_path = "s3://idseq-database/host_filter/carp/2019-04-17/STAR_genome.tar"
+    hg.s3_bowtie2_index_path = "s3://idseq-database/host_filter/carp/2019-04-17/bowtie2_genome.tar"
+    hg.skip_deutero_filter = nil # set this to 1 if host is NOT a deuterostome
+
+    human_host = HostGenome.find_by(name: "Human")
+    # For lack of a better default, use Human background.
+    # In the future, consider asking carp users to make a background model
+    # from their uninfected samples that we can substitute as the default.
+    hg.default_background_id = human_host.default_background_id if human_host
+    hg.save
+  end
+
+  def down
+    hg = HostGenome.find_by(name: "Carp")
+    hg.destroy if hg
+  end
+end

--- a/db/migrate/20190809014153_set_deutero_flag.rb
+++ b/db/migrate/20190809014153_set_deutero_flag.rb
@@ -1,0 +1,5 @@
+class SetDeuteroFlag < ActiveRecord::Migration[5.1]
+  def change
+    HostGenome.where(name: ["Tick", "ERCC only", "C.elegans", "Bee", "Salpingoeca rosetta"]).update_all(skip_deutero_filter: 1) # rubocop:disable Rails/SkipsModelValidations
+  end
+end


### PR DESCRIPTION
# Description
Corrects the `skip_deutero_filter` flag on existing host genomes that are not, in fact, deuterostomes.
Updates the migration template for adding new host genomes with a line that sets the `skip_deutero_filter` flag.

TODO: Once this goes in, update the link to the migration template on this wiki: https://github.com/chanzuckerberg/idseq-web/wiki/%5BDev%5D-How-to-update-host-genomes