### PR TITLE
Fix Metadatum raw_value limit for location inputs

### DIFF
--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -23,7 +23,6 @@ class Metadatum < ApplicationRecord
   LOCATION_TYPE = 3
 
   # Validations
-  validates :raw_value, length: { maximum: 250 } # mysql varchar has a max limit of 255
   validates :string_validated_value, length: { maximum: 250 }
   validates :number_validated_value, numericality: true, allow_nil: true
   validate :set_validated_values

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -28,11 +28,4 @@ class MetadatumTest < ActiveSupport::TestCase
     loc.check_and_set_location_type
     assert_match MetadataValidationErrors::INVALID_LOCATION, loc.errors.full_messages[0]
   end
-
-  test "should raise validation error on long value" do
-    datum = metadata(:sample_human_sex)
-    datum.raw_value = "123" * 250
-    datum.save
-    assert_match "Raw value is too long (maximum is 250 characters)", datum.errors.full_messages[0]
-  end
 end


### PR DESCRIPTION
### Description
- I noticed a bug blocking location uploads because the location upload flows are using the `raw_value` field temporarily before setting it to nil before saving. However, in the validation chain something is causing the whole flow to fail before it gets save. I will investigate this further but this reverts the constraint to what it was before for now.
- This is revert of #2470 and I'll follow up more on it after this.

### Tests
Before:
![Aug-08-2019 21-10-21](https://user-images.githubusercontent.com/5652739/62753563-19bcc700-ba21-11e9-8453-65af46230d22.gif)

After:
![Aug-08-2019 21-11-01](https://user-images.githubusercontent.com/5652739/62753565-1b868a80-ba21-11e9-9aa0-8078cefb8fa9.gif)