### PR TITLE
Fix phylo tree tooltip for collection locations

### DIFF
--- a/app/assets/src/components/ui/containers/DataTooltip.jsx
+++ b/app/assets/src/components/ui/containers/DataTooltip.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { isObject } from "lodash/fp";
 import cs from "./data_tooltip.scss";
 
 const DataTooltip = ({ data, subtitle, title, singleColumn }) => {
@@ -23,7 +24,12 @@ const DataTooltip = ({ data, subtitle, title, singleColumn }) => {
               ) : (
                 <React.Fragment>
                   <div className={cs.dataTooltipLabel}>{keyValuePair[0]}</div>
-                  <div className={cs.dataTooltipValue}>{keyValuePair[1]}</div>
+                  <div className={cs.dataTooltipValue}>
+                    {/*Use .name if value is an object (e.g. location object)*/}
+                    {isObject(keyValuePair[1])
+                      ? keyValuePair[1].name
+                      : keyValuePair[1]}
+                  </div>
                 </React.Fragment>
               )}
             </div>


### PR DESCRIPTION
### Description
- There was a bug `Objects are not valid as a React child` when displaying a location object in the phylo tree tooltip.

### Tests
- Go to a phylo tree, hover over an "IDseq sample" node with a resolved location (e.g. not just a plain text location), and see the name rendered.

<img width="575" alt="Screen Shot 2019-08-10 at 10 18 06 AM" src="https://user-images.githubusercontent.com/5652739/62824905-740c7380-bb58-11e9-9b29-9d8cc91d5630.png">
