### PR TITLE
Force index in heatmap query

### DIFF
--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -217,6 +217,8 @@ module HeatmapHelper
       #{rpm_sql} AS rpm,
       #{zscore_sql} AS zscore
     FROM taxon_counts
+    -- Needed to avoid a full table scan
+    FORCE INDEX (index_pr_tax_hit_level_tc)
     LEFT OUTER JOIN pipeline_runs pr ON pipeline_run_id = pr.id
     LEFT OUTER JOIN taxon_summaries ON
       #{background_id.to_i}   = taxon_summaries.background_id   AND
@@ -350,6 +352,8 @@ module HeatmapHelper
         )                                AS  neglogevalue,
         taxon_counts.percent_concordant  AS  percentconcordant
       FROM taxon_counts
+      -- Needed to avoid a full table scan
+      FORCE INDEX (index_pr_tax_hit_level_tc)
       LEFT OUTER JOIN taxon_summaries ON
         #{background_id.to_i}   = taxon_summaries.background_id   AND
         taxon_counts.count_type = taxon_summaries.count_type      AND


### PR DESCRIPTION
# Description

Heatmaps are still slow, taking 0.5s * n samples on initial render. A 50 sample heatmap takes 25s. The most expensive part is getting all the taxons for the samples, about 50% of the total time. `taxon_counts` is now more than 114M rows. 

After more investigation with @davidrissato, I discovered that we can get a 2x speed-up on a 50 sample query by forcing mysql to use an existing index. We don't know why mysql was not using the index automatically. There does not seem to ever be any disadvantage. 

# Tests

* Run modified query in mysql console, see 2x speedup
* Run heatmap locally, see same results
