### PR TITLE
[RFC] Precompute top taxons for heatmap

### DIFF
--- a/db/migrate/20190809214512_create_top_taxon_count.rb
+++ b/db/migrate/20190809214512_create_top_taxon_count.rb
@@ -1,0 +1,30 @@
+class CreateTopTaxonCount < ActiveRecord::Migration[5.1]
+  def change
+    create_table :top_taxon_counts do |t|
+      # START OF COLUMNS COPIED FROM taxon_counts
+      t.references :pipeline_run, foreign_key: true
+      t.integer :tax_id
+      t.integer :tax_level
+      t.integer :count
+      t.string "name"
+      t.string "count_type"
+      t.float "percent_identity", limit: 24
+      t.float "alignment_length", limit: 24
+      t.float "e_value", limit: 24
+      t.integer "genus_taxid", default: -200, null: false
+      t.integer "superkingdom_taxid", default: -700, null: false
+      t.string "common_name"
+      t.integer "family_taxid", default: -300, null: false
+      t.integer "is_phage", limit: 1, default: 0, null: false
+      t.float "e_value", limit: 24, null: false
+      # END OF COLUMNS COPIED FROM taxon_counts
+
+      # START OF COLUMNS COMPUTED
+      t.float "rpm", limit: 24, null: false
+      t.integer "rpm_rank", null: false
+      # END OF COLUMNS COMPUTED
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
# Description

This a request for comment on a change that would help short and long-term performance and scalability.

The heatmap (and report) page is fundamentally slow because there are too many taxons per sample. Generating a heatmap for 50 samples typical results in 1M rows being fetched from `taxon_counts` that are filtered, sorted, then filtered again down to the top 30 per sample and per count type, 3000 rows total. 

The fully-indexed mysql query that does this typically executes in 5s, which seems pretty good for querying a 100M row table and processing 1M rows. However, 5+ secs is not a good experience when loading a heatmap for the first time, and we want the heatmap to be fast for more than 50 samples.

Given the above, the obvious optimization is to precompute the top N taxons per sample needed for a heatmap. Currently, the max N allowed in the UI is 100. So instead of `taxon_counts` we could query a table that is >100x smaller without any visible change. 

Thus, my design proposal is:

1. Add the new table included in this PR
2. In results monitor, after all rows are inserted into `taxon_counts`, insert into `top_taxon_counts`, using an adapted version of the query in `HeatmapHelper`
3. In `HeatmapHelper`, query `top_taxon_counts` if `rpm` is the selected metric else do the old query
4. Profit

# Notes

* We could get performance gains for `zscore` as well by either 
1) assuming that the top N taxons by zscore are in the top 100 taxons by rpm
2) precomputing zscores for the top backgrounds (similar to precaching)

* Question: why would someone want to rank by reads instead of rpm? 

* With our analytics, we could assess how good the current "30 to 100" taxons limit is on the heatmap page

* Partitioning taxon_counts is not a good solution because we are using an index already, not doing a full table scan

* The perf problem of taxon_counts will only get worse over time as the table grows, and as the taxon database grows

* The current TTI for the heatmap page as a whole is around 25s for 50 samples. I have another optimization planned separately that should take another 5s off that. 

* This table could also speed up the report page if we make the default view there show only the top 100 taxons. 

* Currently, after a heatmap loads once, it is cached in Redis so the slowness described above is mitigated

* If we don't care about loading NR info with NT (or vice versa), we could cut the data needed in half again. The only place I see in the heatmap where the NR counts appear is in the hover tooltips, which could be loaded by AJAX on hover

* We could add a foreign key constraint to `top_taxon_counts` on `taxon_counts` which would guarantee some consistency

* Starting 1M rows for a typical 50 sample heatmap: 
```
MySQL [idseq_prod]> select count(*) from taxon_counts where pipeline_run_id IN (14433, 14424, 14429, 14420, 14427, 14425, 14423, 14428, 14422, 14421, 14426, 14432, 14430, 14435, 14438, 14431, 14437, 14436, 14440, 14443, 14441, 14439, 14444, 14434, 14442, 14446, 14445, 14453, 14455, 14447, 14452, 14448, 14451, 14457, 14449, 14459, 14460, 14456, 14458, 14450, 14462, 14454, 14464, 14461, 14474, 14470, 14481, 14469, 14465, 14478, 14484, 14477, 14807)
    -> ;
+----------+
| count(*) |
+----------+
|   982917 |
+----------+
1 row in set (0.29 sec)
```

# Top taxons query

```
SELECT *
  FROM (
    SELECT
      @rank := IF(@current_id = pipeline_run_id, @rank + 1, 1) AS rank,
      @current_id := pipeline_run_id AS current_id,
      a.*
    FROM (

      SELECT
        pr.sample_id,
        pipeline_run_id,
        taxon_counts.tax_id,
        taxon_counts.count_type,
        taxon_counts.tax_level,
        genus_taxid,
        family_taxid,
        taxon_counts.name,
        superkingdom_taxid,
        is_phage,
        count               AS  r,
        stdev,
        mean,
        count / (
            (total_reads - total_ercc_reads) *
            COALESCE(fraction_subsampled, 1.0)
          ) * 1000 * 1000 AS rpm

        ,
        COALESCE(
          GREATEST(-99, LEAST(99,
            (count / (
            (total_reads - total_ercc_reads) *
            COALESCE(fraction_subsampled, 1.0)
          ) * 1000 * 1000 - mean) / stdev
          )),
          100) AS zscore
      FROM taxon_counts
      LEFT OUTER JOIN pipeline_runs pr ON pipeline_run_id = pr.id
      LEFT OUTER JOIN taxon_summaries ON
        26   = taxon_summaries.background_id   AND
        taxon_counts.count_type = taxon_summaries.count_type      AND
        taxon_counts.tax_level  = taxon_summaries.tax_level       AND
        taxon_counts.tax_id     = taxon_summaries.tax_id
      WHERE
        pipeline_run_id IN (14231, 14433, 14424, 14429, 14420, 14427, 14425, 14423, 14428, 14422, 14421, 14426, 14432, 14430, 14435, 14438, 14431, 14437, 14436, 14440, 14443, 14441, 14439, 14444, 14434, 14442, 14446, 14445, 14453, 14455, 14447, 14452, 14448, 14451, 14457, 14449, 14459, 14460, 14456, 14458, 14450, 14462, 14454, 14464, 14461, 14474, 14470, 14481, 14469, 14465, 14478, 14484, 14477, 14807)
        AND genus_taxid != -201
        AND count >= 5
        -- We need both types of counts for threshold filters
        AND taxon_counts.count_type IN ('NT', 'NR')

         AND taxon_counts.tax_id > 0




    ) a
    ORDER BY
      pipeline_run_id,
      count_type = 'NT' DESC,
      rpm ASC
  ) b
  -- Overfetch by a factor of 4 to allow for a) both count types, and
  -- b) any post-SQL filtering
  WHERE rank <= 121;
```

# EXPLAIN

```
+----+-------------+-----------------+--------+--------------------------------------------------------+---------------------------+---------+-----------------------------------------------------------------------------------------------------------+---------+------------------------------------+
| id | select_type | table           | type   | possible_keys                                          | key                       | key_len | ref                                                                                                       | rows    | Extra                              |
+----+-------------+-----------------+--------+--------------------------------------------------------+---------------------------+---------+-----------------------------------------------------------------------------------------------------------+---------+------------------------------------+
|  1 | PRIMARY     | <derived2>      | ALL    | NULL                                                   | NULL                      | NULL    | NULL                                                                                                      | 1763951 | Using where                        |
|  2 | DERIVED     | <derived3>      | ALL    | NULL                                                   | NULL                      | NULL    | NULL                                                                                                      | 1763951 | Using filesort                     |
|  3 | DERIVED     | taxon_counts    | range  | index_pr_tax_hit_level_tc,index_taxon_counts_on_tax_id | index_pr_tax_hit_level_tc | 14      | NULL                                                                                                      | 1763951 | Using index condition; Using where |
|  3 | DERIVED     | pr              | eq_ref | PRIMARY                                                | PRIMARY                   | 8       | idseq_prod.taxon_counts.pipeline_run_id                                                                   |       1 | NULL                               |
|  3 | DERIVED     | taxon_summaries | ref    | index_bg_tax_ct_level                                  | index_bg_tax_ct_level     | 787     | const,idseq_prod.taxon_counts.tax_id,idseq_prod.taxon_counts.count_type,idseq_prod.taxon_counts.tax_level |       1 | NULL                               |
+----+-------------+-----------------+--------+--------------------------------------------------------+---------------------------+---------+-----------------------------------------------------------------------------------------------------------+---------+------------------------------------+
```