### PR TITLE
Fix loading amr counts for empty result values

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -553,8 +553,13 @@ class PipelineRun < ApplicationRecord
 
   def db_load_amr_counts
     amr_results = PipelineRun.download_file(s3_file_for("amr_counts"), local_amr_full_results_path)
-    unless File.zero?(amr_results)
-      amr_counts_array = []
+    if amr_results.nil?
+      Rails.logger.error("No AMR results file found for PipelineRun ##{id}. Is the pipeline okay?")
+      return
+    end
+    amr_counts_array = []
+    # results can be as small as ~80 bytes, so play it safe; empty results are 1 byte files
+    unless File.size?(amr_results) < 10
       amr_results_table = CSV.read(amr_results, headers: true)
       amr_results_table.each do |row|
         amr_counts_array << {
@@ -570,8 +575,8 @@ class PipelineRun < ApplicationRecord
           dpm: row["dpm"],
         }
       end
-      update(amr_counts_attributes: amr_counts_array)
     end
+    update(amr_counts_attributes: amr_counts_array)
   end
 
   def taxon_counts_json_name


### PR DESCRIPTION
# Description

Prod currently errors on loading empty results for amr counts, which are ~1 byte CSV files. This fixes it by only trying to read the CSV if the file is of a reasonable size for non empty results.

# Notes

Part of my change for updated results

# Tests

* Should write an automated Rspec test for this
![Screen Shot 2019-08-13 at 10 31 41 AM](https://user-images.githubusercontent.com/24234461/62963299-8e8f5880-bdb5-11e9-9b50-d92a306be335.png)
