### PR TITLE
Ensure idseq-cli gets `upgrade_required` status

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -54,6 +54,7 @@ class SamplesController < ApplicationController
   PAGE_SIZE = 30
   MAX_PAGE_SIZE_V2 = 100
   MAX_BINS = 34
+  MIN_CLI_VERSION = '0.6.0'.freeze
 
   # GET /samples
   # GET /samples.json
@@ -517,7 +518,7 @@ class SamplesController < ApplicationController
     # Check if the client is up-to-date. "web" is always valid whereas the
     # CLI client should provide a version string to-be-checked against the
     # minimum version here. Bulk upload from CLI goes to this method.
-    min_version = Gem::Version.new('0.5.0')
+    min_version = Gem::Version.new(MIN_CLI_VERSION)
     unless client && (client == "web" || Gem::Version.new(client) >= min_version)
       render json: {
         message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.",
@@ -1019,7 +1020,7 @@ class SamplesController < ApplicationController
     # CLI client should provide a version string to-be-checked against the
     # minimum version here. Bulk upload from CLI goes to this method.
     client = params.delete(:client)
-    min_version = Gem::Version.new('0.5.0')
+    min_version = Gem::Version.new(MIN_CLI_VERSION)
     unless client && (client == "web" || Gem::Version.new(client) >= min_version)
       render json: {
         message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.",

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -54,7 +54,7 @@ class SamplesController < ApplicationController
   PAGE_SIZE = 30
   MAX_PAGE_SIZE_V2 = 100
   MAX_BINS = 34
-  MIN_CLI_VERSION = '0.5.0'.freeze
+  MIN_CLI_VERSION = '0.7.3'.freeze
 
   # GET /samples
   # GET /samples.json

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1025,7 +1025,7 @@ class SamplesController < ApplicationController
       render json: {
         message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.",
         status: :upgrade_required,
-      }
+      }, status: :upgrade_required
       return
     end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -54,7 +54,7 @@ class SamplesController < ApplicationController
   PAGE_SIZE = 30
   MAX_PAGE_SIZE_V2 = 100
   MAX_BINS = 34
-  MIN_CLI_VERSION = '0.6.0'.freeze
+  MIN_CLI_VERSION = '0.5.0'.freeze
 
   # GET /samples
   # GET /samples.json

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -523,7 +523,7 @@ class SamplesController < ApplicationController
       render json: {
         message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.",
         status: :upgrade_required,
-      }
+      }, status: :upgrade_required
       return
     end
 

--- a/test/controllers/samples_bulk_upload_test.rb
+++ b/test/controllers/samples_bulk_upload_test.rb
@@ -251,7 +251,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     post user_session_path, params: @user_params
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.5.0",
+      client: "0.8.0",
       metadata: {
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
@@ -295,7 +295,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     post user_session_path, params: @user_params
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.5.0",
+      client: "0.8.0",
       metadata: {
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
@@ -396,7 +396,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert !@metadata_validation_project.metadata_fields.include?(@core_field)
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.5.0",
+      client: "0.8.0",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -447,7 +447,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert @host_genome_human.metadata_fields.pluck(:name).include?("Custom Field 2")
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.5.0",
+      client: "0.8.0",
       metadata: {
         "RR004_water_2_S23B" => {
           'sample_type' => 'blood',
@@ -500,7 +500,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert_equal 0, MetadataField.where(name: "Custom Field").length
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.5.0",
+      client: "0.8.0",
       metadata: {
         "Human Sample" => {
           'sample_type' => 'blood',
@@ -578,7 +578,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     post user_session_path, params: @user_nonadmin_params
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.5.0",
+      client: "0.8.0",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -622,7 +622,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     post user_session_path, params: @user_nonadmin_params
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.5.0",
+      client: "0.8.0",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -666,7 +666,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     post user_session_path, params: @user_nonadmin_params
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.5.0",
+      client: "0.8.0",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',

--- a/test/controllers/samples_bulk_upload_test.rb
+++ b/test/controllers/samples_bulk_upload_test.rb
@@ -243,7 +243,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
       ],
     }, as: :json
 
-    assert_response :success
+    assert_response :upgrade_required
     assert_equal "upgrade_required", @response.parsed_body["status"]
   end
 


### PR DESCRIPTION
### Description
- This ensures that the Python `requests` library gets a `426 Upgrade Required` status code on the returned request. Otherwise the deprecation warning may not display properly (on previous versions of idseq-cli).
- Originally I was going to raise the min version to 0.6.0 (a few months ago) but I noticed this bug.

### Tests
- Try to upload with a package version below 0.5.0, see messages:

<img width="933" alt="Screen Shot 2019-08-12 at 6 15 40 PM" src="https://user-images.githubusercontent.com/5652739/62984069-8dc2ea80-bde6-11e9-8955-9a5cbc1777af.png">