### PR TITLE
IDSEQ-985 Add better styling for grayed-out heatmap cells.

### DIFF
--- a/app/assets/src/components/ui/containers/DataTooltip.jsx
+++ b/app/assets/src/components/ui/containers/DataTooltip.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { isObject } from "lodash/fp";
+import cx from "classnames";
+
 import cs from "./data_tooltip.scss";
 
 const DataTooltip = ({ data, subtitle, title, singleColumn }) => {
@@ -9,9 +11,12 @@ const DataTooltip = ({ data, subtitle, title, singleColumn }) => {
   // - subtitle
   // - an array of object(section_name, data: array([label, value], [..]))
 
-  const renderSection = (sectionName, dataValues) => {
+  const renderSection = (sectionName, dataValues, isDisabled) => {
     return (
-      <div className={cs.dataTooltipSection} key={`section-${sectionName}`}>
+      <div
+        className={cx(cs.dataTooltipSection, isDisabled && cs.disabled)}
+        key={`section-${sectionName}`}
+      >
         <div className={cs.dataTooltipSectionName}>{sectionName}</div>
         {dataValues.map(keyValuePair => {
           return (
@@ -40,7 +45,9 @@ const DataTooltip = ({ data, subtitle, title, singleColumn }) => {
   };
 
   const renderSections = data => {
-    return data.map(section => renderSection(section.name, section.data));
+    return data.map(section =>
+      renderSection(section.name, section.data, section.disabled)
+    );
   };
 
   return (
@@ -53,7 +60,15 @@ const DataTooltip = ({ data, subtitle, title, singleColumn }) => {
 };
 
 DataTooltip.propTypes = {
-  data: PropTypes.array,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      // Array of key-value pairs.
+      data: PropTypes.arrayOf(PropTypes.array),
+      // Grey out the section if disabled.
+      disabled: PropTypes.bool,
+    })
+  ),
   subtitle: PropTypes.string,
   title: PropTypes.string,
   singleColumn: PropTypes.bool,

--- a/app/assets/src/components/ui/containers/data_tooltip.scss
+++ b/app/assets/src/components/ui/containers/data_tooltip.scss
@@ -1,11 +1,12 @@
 @import "~styles/themes/colors";
+@import "~styles/themes/typography";
 
 .dataTooltip {
+  @include font-body-xxs;
   background-color: $white;
   border: 1px solid $light-grey;
   border-radius: 5px;
   box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
-  font-size: 8pt;
   height: auto;
   min-width: 200px;
   max-width: 400px;
@@ -13,26 +14,35 @@
   pointer-events: none;
 
   &Title {
+    @include font-label-xs;
     border-bottom: 1px solid $lightest-grey;
     color: $medium-grey;
     margin-bottom: 10px;
-    text-transform: uppercase;
   }
 
   &Subtitle {
-    font-weight: 700;
+    @include font-body-xxs;
+    margin-bottom: 15px;
   }
 
   &SectionName {
+    @include font-label-xs;
     border-bottom: 1px solid $lightest-grey;
     color: $medium-grey;
     margin-bottom: 10px;
-    text-transform: uppercase;
   }
 
   &Section {
     &:not(:first-child) {
       margin-top: 20px;
+    }
+
+    &.disabled {
+      color: $light-grey;
+
+      .dataTooltipSectionName {
+        color: $light-grey;
+      }
     }
   }
 
@@ -41,7 +51,7 @@
   }
 
   &Label {
-    font-weight: 700;
+    @include font-header-xxs;
     margin-right: 10px;
     width: 160px;
     flex-shrink: 0;

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -587,6 +587,7 @@ class SamplesHeatmapView extends React.Component {
           taxonIds={this.state.taxonIds}
           taxonDetails={this.state.taxonDetails}
           taxonFilterState={this.state.taxonFilterState}
+          thresholdFilters={this.state.selectedOptions.thresholdFilters}
         />
       </ErrorBoundary>
     );

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import { keyBy } from "lodash/fp";
+import { size, map, keyBy } from "lodash/fp";
 
 import { logAnalyticsEvent } from "~/api/analytics";
 import { DataTooltip } from "~ui/containers";
@@ -10,8 +10,12 @@ import Heatmap from "~/components/visualizations/heatmap/Heatmap";
 import { getTooltipStyle } from "~/components/utils/tooltip";
 import MetadataLegend from "~/components/common/Heatmap/MetadataLegend";
 import MetadataSelector from "~/components/common/Heatmap/MetadataSelector";
+import { splitIntoMultipleLines } from "~/helpers/strings";
+import AlertIcon from "~ui/icons/AlertIcon";
 
 import cs from "./samples_heatmap_vis.scss";
+
+const CAPTION_LINE_WIDTH = 180;
 
 class SamplesHeatmapVis extends React.Component {
   constructor(props) {
@@ -76,6 +80,7 @@ class SamplesHeatmapVis extends React.Component {
         scale: this.props.scale,
         // only display colors to positive values
         scaleMin: 0,
+        printCaption: this.generateHeatmapCaptions(),
       }
     );
     this.heatmap.start();
@@ -90,6 +95,9 @@ class SamplesHeatmapVis extends React.Component {
       this.heatmap.updateData({
         columnLabels: this.extractSampleLabels(), // Also includes column metadata.
       });
+    }
+    if (this.props.thresholdFilters !== prevProps.thresholdFilters) {
+      this.heatmap.updatePrintCaption(this.generateHeatmapCaptions());
     }
   }
 
@@ -116,6 +124,28 @@ class SamplesHeatmapVis extends React.Component {
       };
     });
   }
+
+  generateHeatmapCaptions = () => {
+    const { thresholdFilters } = this.props;
+
+    const numFilters = size(thresholdFilters);
+
+    if (numFilters == 0) {
+      return [];
+    }
+
+    const filterStrings = map(
+      filter => `${filter.metricDisplay} ${filter.operator} ${filter.value}`,
+      thresholdFilters
+    );
+
+    const fullString = `${numFilters} filter${
+      numFilters > 1 ? "s were" : " was"
+    } applied to the above heatmap: ${filterStrings.join(", ")}.
+      Non-conforming cells have been hidden or grayed out.`;
+
+    return splitIntoMultipleLines(fullString, CAPTION_LINE_WIDTH);
+  };
 
   handleMouseHoverMove = (_, currentEvent) => {
     if (currentEvent) {
@@ -174,14 +204,17 @@ class SamplesHeatmapVis extends React.Component {
   }
 
   getTooltipData(node) {
-    let sampleId = this.props.sampleIds[node.columnIndex];
-    let taxonId = this.props.taxonIds[node.rowIndex];
+    const { data, taxonFilterState, sampleIds, taxonIds } = this.props;
+    let sampleId = sampleIds[node.columnIndex];
+    let taxonId = taxonIds[node.rowIndex];
     let sampleDetails = this.props.sampleDetails[sampleId];
     let taxonDetails = this.props.taxonDetails[taxonId];
 
     let nodeHasData = this.metrics.some(
-      metric => !!this.props.data[metric.key][node.rowIndex][node.columnIndex]
+      metric => !!data[metric.key][node.rowIndex][node.columnIndex]
     );
+
+    const isFiltered = taxonFilterState[node.rowIndex][node.columnIndex];
 
     let values = null;
     if (nodeHasData) {
@@ -197,7 +230,24 @@ class SamplesHeatmapVis extends React.Component {
       });
     }
 
-    return [
+    let subtitle = null;
+
+    if (!nodeHasData) {
+      subtitle = "This taxon was not found in the sample.";
+    } else if (!isFiltered) {
+      subtitle = "This taxon does not satisfy the threshold filters.";
+    }
+
+    if (subtitle) {
+      subtitle = (
+        <div className={cs.warning}>
+          <AlertIcon className={cs.warningIcon} />
+          <div className={cs.warningText}>{subtitle}</div>
+        </div>
+      );
+    }
+
+    const sections = [
       {
         name: "Info",
         data: [
@@ -205,12 +255,22 @@ class SamplesHeatmapVis extends React.Component {
           ["Taxon", taxonDetails.name],
           ["Category", taxonDetails.category],
         ],
-      },
-      {
-        name: "Values",
-        data: nodeHasData ? values : [["", "Taxon not found in Sample"]],
+        disabled: !isFiltered,
       },
     ];
+
+    if (nodeHasData) {
+      sections.push({
+        name: "Values",
+        data: values,
+        disabled: !isFiltered,
+      });
+    }
+
+    return {
+      subtitle,
+      data: sections,
+    };
   }
 
   handleCellClick = (cell, currentEvent) => {
@@ -295,7 +355,7 @@ class SamplesHeatmapVis extends React.Component {
                 below: true,
               })}
             >
-              <DataTooltip data={nodeHoverInfo} />
+              <DataTooltip {...nodeHoverInfo} />
             </div>
           )}
         {columnMetadataLegend &&
@@ -343,6 +403,7 @@ SamplesHeatmapVis.propTypes = {
   scale: PropTypes.string,
   taxonDetails: PropTypes.object,
   taxonIds: PropTypes.array,
+  thresholdFilters: PropTypes.any,
 };
 
 export default SamplesHeatmapVis;

--- a/app/assets/src/components/views/compare/samples_heatmap_vis.scss
+++ b/app/assets/src/components/views/compare/samples_heatmap_vis.scss
@@ -22,5 +22,22 @@
     .data-tooltip__label {
       min-width: 100px;
     }
+
+    .warning {
+      display: flex;
+
+      .warningIcon {
+        height: 14px;
+        width: 14px;
+        margin-right: 6px;
+        // Vertical-align the svg element with the text.
+        transform: translateY(1px);
+      }
+
+      .warningText {
+        flex: 1 1 0;
+        min-width: 0;
+      }
+    }
   }
 }

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -122,9 +122,23 @@
     }
   }
 
+  .captionContainer {
+    .caption {
+      font-size: 12px;
+      fill: $medium-grey;
+      opacity: 0;
+    }
+  }
+
   &.printMode {
     .columnMetadataAdd {
       opacity: 0;
+    }
+
+    .captionContainer {
+      .caption {
+        opacity: 1;
+      }
     }
   }
 }

--- a/app/assets/src/helpers/strings.js
+++ b/app/assets/src/helpers/strings.js
@@ -28,3 +28,32 @@ export function humanize(key) {
     .map(str => str.charAt(0).toUpperCase() + str.slice(1))
     .join(" ");
 }
+
+// Split a string into multiple lines based on maxChars. Only split on white-space.
+export function splitIntoMultipleLines(string, maxChars) {
+  const words = string.split(" ");
+
+  const lines = [];
+  let curLine = "";
+
+  words.forEach(word => {
+    // If adding the next word overflows the line, start a new line.
+    if (curLine.length + 1 + word.length > maxChars && curLine.length > 0) {
+      lines.push(curLine);
+      curLine = "";
+    }
+
+    // If not the first word in the line, add a space first.
+    if (curLine.length > 0) {
+      curLine += " ";
+    }
+    curLine += word;
+  });
+
+  // Add the last line if it's non-empty.
+  if (curLine.length > 0) {
+    lines.push(curLine);
+  }
+
+  return lines;
+}

--- a/app/assets/src/styles/themes/_typography.scss
+++ b/app/assets/src/styles/themes/_typography.scss
@@ -77,6 +77,13 @@ $font-weight-heavy: 800;
   letter-spacing: 0.3px;
 }
 
+@mixin font-header-xxxs {
+  font-size: 11px;
+  line-height: 16px;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.3px;
+}
+
 @mixin font-header-accordion {
   font-size: 12px;
   line-height: 40px;


### PR DESCRIPTION
# Description

For heatmap cells that were grayed out due to the threshold filter, we now gray out the tooltip, and add an explanation notification at the top.

![Screen Shot 2019-08-13 at 6 19 50 PM](https://user-images.githubusercontent.com/837004/62988509-8953fd00-bdf9-11e9-84f3-9e4720863294.png)

We also change the styling for taxons that aren't present in a sample, for consistency.

![Screen Shot 2019-08-13 at 6 19 53 PM](https://user-images.githubusercontent.com/837004/62988629-e51e8600-bdf9-11e9-8e6e-7d2c8faaf160.png)

We also now show a caption at the bottom of the heatmap if threshold filters are present ONLY when the user is downloading the heatmap as a PNG or SVG.

![Screen Shot 2019-08-13 at 6 21 31 PM](https://user-images.githubusercontent.com/837004/62988630-e5b71c80-bdf9-11e9-80fd-8d4c84da568c.png)

![Screen Shot 2019-08-13 at 6 21 59 PM](https://user-images.githubusercontent.com/837004/62988634-e780e000-bdf9-11e9-83f4-b4fb323d28ac.png)

# Notes

Discussed with Jenn about design, in particular to put the caption text on one line.

Since there isn't support for text wrapping in svg, had to write a custom utility function to separate a string into multiple lines. Right now, we split into lines based on character count (as opposed to measuring the rendered dimensions of the text) as it's a simpler approach.

Also refactored the code in the placeContainers method in Heatmap.js to be easier to read.

# Testing
* Verified that caption doesn't show normally, and only shows when user is downloading an image.
* Verified that tooltips behave correctly.
* Verified that splitIntoMultipleStrings behaves correctly if passed a really long word.