### PR TITLE
Remove "maps" feature flag

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -7,7 +7,6 @@ import PropTypes from "~/components/utils/propTypes";
 import Input from "~/components/ui/controls/Input";
 import MetadataInput from "~/components/common/MetadataInput";
 import { logAnalyticsEvent } from "~/api/analytics";
-import { RequestContext } from "~/components/common/RequestContext";
 
 import MetadataSection from "./MetadataSection";
 import { SAMPLE_ADDITIONAL_INFO } from "./constants";

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/MetadataTab.jsx
@@ -181,29 +181,18 @@ class MetadataTab extends React.Component {
               />
             </div>
           )}
-        {
-          <RequestContext.Consumer>
-            {({ allowedFeatures } = {}) => {
-              return validKeys.map(key => {
-                // Hide the implicit v1 if you have 'maps'. Else hide v2.
-                // TODO(jsheu): Migrate all to location_v2 after release
-                if (allowedFeatures && allowedFeatures.includes("maps")) {
-                  if (key === "collection_location") return;
-                } else {
-                  if (key === "collection_location_v2") return;
-                }
-                return (
-                  <div className={cs.field} key={metadataTypes[key].key}>
-                    <div className={cs.label}>{metadataTypes[key].name}</div>
-                    {isSectionEditing
-                      ? this.renderInput(metadataTypes[key])
-                      : this.renderMetadataType(metadataTypes[key])}
-                  </div>
-                );
-              });
-            }}
-          </RequestContext.Consumer>
-        }
+        {validKeys.map(key => {
+          // Hide legacy collection_location (v1) field.
+          if (key === "collection_location") return;
+          return (
+            <div className={cs.field} key={metadataTypes[key].key}>
+              <div className={cs.label}>{metadataTypes[key].name}</div>
+              {isSectionEditing
+                ? this.renderInput(metadataTypes[key])
+                : this.renderMetadataType(metadataTypes[key])}
+            </div>
+          );
+        })}
       </div>
     );
   };

--- a/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
@@ -137,7 +137,6 @@ class DiscoveryFilters extends React.Component {
   render() {
     const {
       hostSelected,
-      locationSelected,
       locationV2Selected,
       taxonSelected,
       timeSelected,

--- a/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
@@ -146,11 +146,9 @@ class DiscoveryFilters extends React.Component {
     } = this.state;
 
     const {
-      allowedFeatures,
       className,
       domain,
       host,
-      location,
       locationV2,
       time,
       tissue,
@@ -167,29 +165,17 @@ class DiscoveryFilters extends React.Component {
           />
           {this.renderTags("taxon")}
         </div>
-        {allowedFeatures.includes("maps") ? (
-          <div className={cs.filterContainer}>
-            <LocationFilter
-              onChange={this.handleChange.bind(this, "locationV2Selected")}
-              selected={
-                locationV2 && locationV2.length ? locationV2Selected : null
-              }
-              options={locationV2}
-              label="Location"
-            />
-            {this.renderTags("locationV2")}
-          </div>
-        ) : (
-          <div className={cs.filterContainer}>
-            <BaseMultipleFilter
-              onChange={this.handleChange.bind(this, "locationSelected")}
-              selected={location && location.length ? locationSelected : null}
-              options={location}
-              label="Location"
-            />
-            {this.renderTags("location")}
-          </div>
-        )}
+        <div className={cs.filterContainer}>
+          <LocationFilter
+            onChange={this.handleChange.bind(this, "locationV2Selected")}
+            selected={
+              locationV2 && locationV2.length ? locationV2Selected : null
+            }
+            options={locationV2}
+            label="Location"
+          />
+          {this.renderTags("locationV2")}
+        </div>
         <div className={cs.filterContainer}>
           <BaseSingleFilter
             label="Timeframe"

--- a/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar.jsx
@@ -253,7 +253,7 @@ export default class DiscoverySidebar extends React.Component {
   }
 
   render() {
-    const { allowedFeatures, className, currentTab, loading } = this.props;
+    const { className, currentTab, loading } = this.props;
     if (!loading && !this.hasData()) {
       return (
         <div className={cx(className, cs.sidebar)}>
@@ -350,11 +350,7 @@ export default class DiscoverySidebar extends React.Component {
             </div>
             <div className={cs.hasBackground}>
               <span className={cs.rowLabel}>Location</span>
-              {this.buildMetadataRows(
-                allowedFeatures && allowedFeatures.includes("maps")
-                  ? "locationV2"
-                  : "location"
-              )}
+              {this.buildMetadataRows("locationV2")}
             </div>
           </Accordion>
         </div>

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -681,37 +681,30 @@ class DiscoveryView extends React.Component {
   };
 
   getClientSideSuggestions = async query => {
-    const { allowedFeatures } = this.props;
     const { projects } = this.state;
     const dimensions = this.getCurrentDimensions();
 
     let suggestions = {};
     const re = new RegExp(escapeRegExp(query), "i");
-    const allowedMaps = allowedFeatures && allowedFeatures.includes("maps");
-    ["host", "tissue", allowedMaps ? "locationV2" : "location"].forEach(
-      category => {
-        let dimension = find({ dimension: category }, dimensions);
-        if (dimension) {
-          const results = dimension.values
-            .filter(entry => re.test(entry.text))
-            .map(entry => ({
-              category,
-              id: entry.value,
-              title: entry.text,
-            }));
+    ["host", "tissue", "locationV2"].forEach(category => {
+      let dimension = find({ dimension: category }, dimensions);
+      if (dimension) {
+        const results = dimension.values
+          .filter(entry => re.test(entry.text))
+          .map(entry => ({
+            category,
+            id: entry.value,
+            title: entry.text,
+          }));
 
-          if (results.length) {
-            suggestions[category] = {
-              name:
-                allowedMaps && category === "locationV2"
-                  ? "location"
-                  : capitalize(category),
-              results,
-            };
-          }
+        if (results.length) {
+          suggestions[category] = {
+            name: category === "locationV2" ? "location" : capitalize(category),
+            results,
+          };
         }
       }
-    );
+    });
 
     const filteredProjects = projects.filter(project => re.test(project.name));
     if (filteredProjects.length) {

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -115,7 +115,6 @@ class ProjectsView extends React.Component {
 
   render() {
     const {
-      allowedFeatures,
       currentDisplay,
       currentTab,
       mapLevel,
@@ -146,9 +145,7 @@ class ProjectsView extends React.Component {
 
     return (
       <div className={cs.container}>
-        {allowedFeatures &&
-          allowedFeatures.includes("maps") &&
-          this.renderDisplaySwitcher()}
+        {this.renderDisplaySwitcher()}
         {currentDisplay === "table" ? (
           <BaseDiscoveryView
             columns={this.columns}

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -27,8 +27,6 @@ class SamplesView extends React.Component {
   constructor(props) {
     super(props);
 
-    const { allowedFeatures } = this.props;
-
     this.state = {
       phyloTreeCreationModalOpen: false,
     };

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -54,10 +54,7 @@ class SamplesView extends React.Component {
         className: cs.basicCell,
       },
       {
-        dataKey:
-          allowedFeatures && allowedFeatures.includes("maps")
-            ? "collectionLocationV2"
-            : "collectionLocation",
+        dataKey: "collectionLocationV2",
         label: "Location",
         flexGrow: 1,
         className: cs.basicCell,
@@ -303,12 +300,10 @@ class SamplesView extends React.Component {
   };
 
   renderToolbar = () => {
-    const { allowedFeatures, selectedSampleIds } = this.props;
+    const { selectedSampleIds } = this.props;
     return (
       <div className={cs.samplesToolbar}>
-        {allowedFeatures &&
-          allowedFeatures.includes("maps") &&
-          this.renderDisplaySwitcher()}
+        {this.renderDisplaySwitcher()}
         <div className={cs.fluidBlank} />
         <div className={cs.counterContainer}>
           <Label
@@ -344,18 +339,10 @@ class SamplesView extends React.Component {
   renderTable = () => {
     const {
       activeColumns,
-      allowedFeatures,
       onLoadRows,
       protectedColumns,
       selectedSampleIds,
     } = this.props;
-
-    // TODO(jsheu): Remove after full release of maps.
-    const updatedActiveColumns = Object.assign([], activeColumns);
-    if (allowedFeatures && allowedFeatures.includes("maps")) {
-      const i = updatedActiveColumns.indexOf("collectionLocation");
-      if (i !== -1) updatedActiveColumns[i] += "V2";
-    }
 
     // TODO(tiago): replace by automated cell height computing
     const rowHeight = 66;
@@ -366,7 +353,7 @@ class SamplesView extends React.Component {
           ref={infiniteTable => (this.infiniteTable = infiniteTable)}
           columns={this.columns}
           defaultRowHeight={rowHeight}
-          initialActiveColumns={updatedActiveColumns}
+          initialActiveColumns={activeColumns}
           loadingClassName={csTableRenderer.loading}
           onLoadRows={onLoadRows}
           onSelectAllRows={withAnalytics(
@@ -479,7 +466,7 @@ SamplesView.defaultProps = {
     "sample",
     "createdAt",
     "host",
-    "collectionLocation",
+    "collectionLocationV2",
     "nonHostReads",
     "qcPercent",
   ],

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -12,13 +12,6 @@ class LocationsController < ApplicationController
   before_action :authenticate_user_from_token!, only: TOKEN_AUTH_ACTIONS
 
   def external_search
-    unless feature_access?
-      render(json: {
-               status: :unauthorized,
-               message: "No feature access",
-             }, status: :unauthorized) && return
-    end
-
     results = []
     query = location_params[:query]
     limit = location_params[:limit]
@@ -51,13 +44,6 @@ class LocationsController < ApplicationController
   end
 
   def map_playground
-    unless feature_access?
-      render(json: {
-               status: :unauthorized,
-               message: "No feature access",
-             }, status: :unauthorized) && return
-    end
-
     # Show all viewable locations in a demo format
     field_id = MetadataField.find_by(name: "collection_location_v2").id
     sample_info = current_power.samples
@@ -83,13 +69,6 @@ class LocationsController < ApplicationController
   # Get location data for a set of samples with filters
   # TODO(jsheu): Consider consolidating if similar location data is loaded w/ data discovery tables.
   def sample_locations
-    unless feature_access?
-      render(json: {
-               status: :unauthorized,
-               message: "No feature access",
-             }, status: :unauthorized) && return
-    end
-
     # Get the samples
     domain = params[:domain]
     samples = samples_by_domain(domain) # access controlled
@@ -142,9 +121,5 @@ class LocationsController < ApplicationController
 
   def location_params
     params.permit(:query, :limit)
-  end
-
-  def feature_access?
-    current_user.admin? || current_user.allowed_feature_list.include?("maps")
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -501,11 +501,7 @@ class ProjectsController < ApplicationController
 
     # TODO(jsheu): Migrate all to location_v2 after release
     # Hide location_v2 unless you have 'maps'. Otherwise hide the implicit v1.
-    location_field = if current_user.allowed_feature?("maps")
-                       "collection_location"
-                     else
-                       "collection_location_v2"
-                     end
+    location_field = "collection_location_v2"
     results = results.reject { |f| f[:key] == location_field }
 
     render json: results

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -111,12 +111,6 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes results.keys, loc.state_id.to_s
   end
 
-  test "disallowed users cannot access sample_locations" do
-    post user_session_path, params: @non_admin_user_params
-    get sample_locations_locations_path, as: :json
-    assert_response 401
-  end
-
   # TODO: Uncomment and use non-admin user once released
   # test "joe cannot see someone else's private map playground results" do
   #   post user_session_path, params: @user_params


### PR DESCRIPTION
### Description
- Now that maps are stable, we can migrate out the "maps" feature flag (which was added to all users). This is so that we don't have to keep adding it to new users, and it should also help us avoid (further) bugs by consolidating the code paths.
- This PR makes the minimal change to remove the non-maps code path. There are no more references to `"maps"` anywhere in the code after this.
- For developers, you should already have "collection_location_v2" present from previous migrations, but if you don't it can be added locally!

### Tests
- Went through each of these flows as a user WITHOUT feature flags and verified displays.

![Aug-14-2019 13-38-49](https://user-images.githubusercontent.com/5652739/63055786-8578b700-be9b-11e9-9881-4d0ecabde356.gif)
![Screen Shot 2019-08-14 at 1 37 26 PM](https://user-images.githubusercontent.com/5652739/63055787-8578b700-be9b-11e9-8561-e4808bf64dce.png)
![Screen Shot 2019-08-14 at 1 41 12 PM](https://user-images.githubusercontent.com/5652739/63055789-86114d80-be9b-11e9-97b7-399b7b567543.png)
![Screen Shot 2019-08-14 at 1 42 02 PM](https://user-images.githubusercontent.com/5652739/63055792-86114d80-be9b-11e9-816e-b81d573d697b.png)
![Screen Shot 2019-08-14 at 1 42 58 PM](https://user-images.githubusercontent.com/5652739/63055793-86114d80-be9b-11e9-96f9-43dbde6f3971.png)