### PR TITLE
Tweak styles for upload progress modal.

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/upload_progress_modal.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/upload_progress_modal.scss
@@ -36,7 +36,10 @@
       }
 
       .checkmarkIcon {
-        margin-bottom: 4px;
+        width: 25px;
+        height: 25px;
+        margin-right: 6px;
+        fill: $success;
       }
     }
 
@@ -44,16 +47,14 @@
       @include font-body-s;
 
       .helpLink {
-        @include font-label-s;
         color: $primary-light !important;
       }
     }
 
     .instructions {
       @include font-body-s;
-      color: $medium-grey;
       max-width: 500px;
-      margin: 40px auto;
+      margin: 8px auto 40px;
     }
   }
 
@@ -98,15 +99,15 @@
           fill: $error;
           width: 14px;
           height: 14px;
-          margin-right: 4px;
+          margin-right: 5px;
           margin-bottom: 2px;
         }
 
         .checkmarkIcon {
-          width: 13px;
-          height: 12px;
-          margin-right: 4px;
-          margin-bottom: 6px;
+          width: 16px;
+          height: 16px;
+          margin-right: 5px;
+          fill: $success;
         }
       }
     }
@@ -128,9 +129,8 @@
 
   .failedSamples {
     @include font-body-s;
-    color: $medium-grey;
     max-width: 500px;
-    margin: 40px auto;
+    margin: 8px auto 40px;
     text-align: center;
   }
 


### PR DESCRIPTION
# Description

Tweak styling of the upload progress modal.

When one local sample fails:

![Screen Shot 2019-08-14 at 3 29 47 PM](https://user-images.githubusercontent.com/837004/63061052-cf1bce80-bea8-11e9-82fb-62bc78498826.png)

During the upload:
![Screen Shot 2019-08-14 at 3 29 44 PM](https://user-images.githubusercontent.com/837004/63061070-d6db7300-bea8-11e9-81e8-60b91a29850e.png)

Basespace or remote upload success:
![Screen Shot 2019-08-14 at 3 27 46 PM](https://user-images.githubusercontent.com/837004/63061091-e490f880-bea8-11e9-9297-e9a8d39595b2.png)

Basespace or remote upload failure:
![Screen Shot 2019-08-14 at 3 28 27 PM](https://user-images.githubusercontent.com/837004/63061099-ece93380-bea8-11e9-9bd7-ed01012c084f.png)


# Notes

The following requests were addressed:
- Show the number of samples in the failure message instead of saying "some samples".
- Remove the "..." in the "uploading 5kb of 10kb" message.
- Switch to the green circle checkmark success icon.
- Change the styling of Contact Us for Help. No more uppercase. Same styling as the other subtitles.
- Remove the gray in the larger blobs of text (for Basespace/remote uploads) and reduce the margin-top to 8px.
 