### PR TITLE
Update all previous graph when new stage is included, not just previous

### DIFF
--- a/app/assets/src/components/views/PipelineViz/PipelineViz.jsx
+++ b/app/assets/src/components/views/PipelineViz/PipelineViz.jsx
@@ -106,14 +106,18 @@ class PipelineViz extends React.Component {
             });
           } else {
             // A new stage has started and needs to be drawn.
-            if (stageIndex > 0) {
-              // Modify previous stage's graph to create edges to new stage
-              const prevGraph = this.graphs[stageIndex - 1];
-              this.generateEdgeData(stageIndex - 1).forEach(edge => {
+            for (
+              let prevStageIndex = 0;
+              prevStageIndex < stageIndex;
+              prevStageIndex++
+            ) {
+              const prevGraph = this.graphs[prevStageIndex];
+              this.generateEdgeData(prevStageIndex).forEach(edge => {
                 const { id, ...options } = edge;
                 prevGraph.updateEdges([id], options);
               });
             }
+
             this.drawStageGraph(stageIndex);
           }
         }

--- a/app/services/retrieve_pipeline_viz_graph_data_service.rb
+++ b/app/services/retrieve_pipeline_viz_graph_data_service.rb
@@ -42,6 +42,7 @@ class RetrievePipelineVizGraphDataService
       end
     end
     @remove_host_filtering_urls = remove_host_filtering_urls
+    @see_experimental = see_experimental
   end
 
   def call
@@ -129,7 +130,11 @@ class RetrievePipelineVizGraphDataService
   end
 
   def pipeline_job_status(stages)
-    stage_job_status(stages.map { |stage| stage[:jobStatus] })
+    existing_stages_status = stage_job_status(stages.map { |stage| stage[:jobStatus] })
+    if existing_stages_status == "finished" && @all_dag_jsons.length != (@see_experimental ? 4 : 3)
+      return "inProgress"
+    end
+    return existing_stages_status
   end
 
   def create_edges


### PR DESCRIPTION
# Description

Since a step may depend on files from not just their previous stage, but ones before them, we should update all stages before the newly added stage when updating the pipeline viz.

Fixed pipeline status method on controller (all the statuses for the existing stages may be finished, but the entire pipeline might not be since some stages might not have kicked off yet)

# Tests

* Ran a sample through and made sure that it still worked as expected.
