### PR TITLE
[AMR Heatmap] Change admin check to feature flag

### DIFF
--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -176,7 +176,10 @@ class SamplesView extends React.Component {
   renderHeatmapTrigger = () => {
     const { selectedSampleIds } = this.props;
 
-    if (this.props.admin) {
+    if (
+      this.props.allowedFeatures.includes("amr_heatmap") ||
+      this.props.admin
+    ) {
       const heatmapOptions = [
         { text: "Taxon Heatmap", value: "/visualizations/heatmap" },
         { text: "AMR Heatmap", value: "/amr_heatmap" },

--- a/app/controllers/amr_heatmap_controller.rb
+++ b/app/controllers/amr_heatmap_controller.rb
@@ -32,6 +32,15 @@ class AmrHeatmapController < ApplicationController
   # },
 
   def amr_counts
+    feature_allowed = current_user.allowed_feature_list.include?("amr_heatmap")
+
+    unless feature_allowed || current_user.admin?
+      render(json: {
+               status: :unauthorized,
+               message: "Cannot access feature",
+             }) && return
+    end
+
     sample_ids = params[:sampleIds].map(&:to_i)
     samples = current_power.viewable_samples.where(id: sample_ids)
     good_sample_ids = {}
@@ -72,6 +81,15 @@ class AmrHeatmapController < ApplicationController
   end
 
   def fetch_ontology
+    feature_allowed = current_user.allowed_feature_list.include?("amr_heatmap")
+
+    unless feature_allowed || current_user.admin?
+      render(json: {
+               status: :unauthorized,
+               message: "Cannot access feature",
+             }) && return
+    end
+
     gene_name = params[:geneName]
     ontology = {
       "accession" => "",

--- a/app/controllers/amr_heatmap_controller.rb
+++ b/app/controllers/amr_heatmap_controller.rb
@@ -11,7 +11,6 @@ class AmrHeatmapController < ApplicationController
 
   def index
     @sample_ids = params[:sampleIds].map(&:to_i)
-    render 'index'
   end
 
   # GET /amr_heatmap/amr_counts.json

--- a/app/controllers/amr_heatmap_controller.rb
+++ b/app/controllers/amr_heatmap_controller.rb
@@ -5,10 +5,14 @@ S3_JSON_PREFIX = "amr/ontology/".freeze
 class AmrHeatmapController < ApplicationController
   include S3Util
 
-  before_action :admin_required
-
   def index
-    @sample_ids = params[:sampleIds].map(&:to_i)
+    feature_allowed = current_user.allowed_feature_list.include?("amr_heatmap")
+    if feature_allowed || current_user.admin?
+      @sample_ids = params[:sampleIds].map(&:to_i)
+      render 'index'
+    else
+      redirect_to controller: "home", action: "my_data", status: :unauthorized
+    end
   end
 
   # GET /amr_heatmap/amr_counts.json

--- a/app/controllers/amr_heatmap_controller.rb
+++ b/app/controllers/amr_heatmap_controller.rb
@@ -6,7 +6,7 @@ class AmrHeatmapController < ApplicationController
   include S3Util
 
   before_action do
-    allowed_feature_required("basespace_upload_enabled", true)
+    allowed_feature_required("amr_heatmap", true)
   end
 
   def index

--- a/app/controllers/amr_heatmap_controller.rb
+++ b/app/controllers/amr_heatmap_controller.rb
@@ -5,14 +5,13 @@ S3_JSON_PREFIX = "amr/ontology/".freeze
 class AmrHeatmapController < ApplicationController
   include S3Util
 
+  before_action do
+    allowed_feature_required("basespace_upload_enabled", true)
+  end
+
   def index
-    feature_allowed = current_user.allowed_feature_list.include?("amr_heatmap")
-    if feature_allowed || current_user.admin?
-      @sample_ids = params[:sampleIds].map(&:to_i)
-      render 'index'
-    else
-      redirect_to controller: "home", action: "my_data", status: :unauthorized
-    end
+    @sample_ids = params[:sampleIds].map(&:to_i)
+    render 'index'
   end
 
   # GET /amr_heatmap/amr_counts.json
@@ -32,15 +31,6 @@ class AmrHeatmapController < ApplicationController
   # },
 
   def amr_counts
-    feature_allowed = current_user.allowed_feature_list.include?("amr_heatmap")
-
-    unless feature_allowed || current_user.admin?
-      render(json: {
-               status: :unauthorized,
-               message: "Cannot access feature",
-             }) && return
-    end
-
     sample_ids = params[:sampleIds].map(&:to_i)
     samples = current_power.viewable_samples.where(id: sample_ids)
     good_sample_ids = {}
@@ -81,15 +71,6 @@ class AmrHeatmapController < ApplicationController
   end
 
   def fetch_ontology
-    feature_allowed = current_user.allowed_feature_list.include?("amr_heatmap")
-
-    unless feature_allowed || current_user.admin?
-      render(json: {
-               status: :unauthorized,
-               message: "Cannot access feature",
-             }) && return
-    end
-
     gene_name = params[:geneName]
     ontology = {
       "accession" => "",


### PR DESCRIPTION
# Description

Changes the AMR Heatmap feature to be behind a feature flag, instead of only accessible to admin users. Will remain accessible to all admin users.

# Tests

* Server-side tests pass
* Client-side code tested by going to Discovery View, selecting samples, and trying the heatmap icon; entering the url directly in the browser also correctly blocked a non-feature-flagged user.
