### PR TITLE
Add check for nil annotation in amr results

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -560,11 +560,11 @@ class PipelineRun < ApplicationRecord
           rpm: row["rpm"],
           dpm: row["dpm"],
         }
-        if row["annotation"].present?
-          if row["annotation"].split(";").length >= 5
-            amr_count_for_sequence[:annotation_gene] = row["annotation"].split(";")[2]
-            amr_count_for_sequence[:genbank_accession] = row["annotation"].split(";")[4]
-          end
+        annotation_data = /(?:.+);(?:.+);(.+);(?:.+);(.+)/.match(row["annotation"])
+        if annotation_data.present?
+          annotation_captures = annotation_data.captures
+          amr_count_for_sequence[:annotation_gene] = annotation_captures[0]
+          amr_count_for_sequence[:genbank_accession] = annotation_captures[1]
         end
         amr_counts_array << amr_count_for_sequence
       end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -561,8 +561,10 @@ class PipelineRun < ApplicationRecord
           dpm: row["dpm"],
         }
         if row["annotation"].present?
-          amr_count_for_sequence[:annotation_gene] = row["annotation"].split(";")[2]
-          amr_count_for_sequence[:genbank_accession] = row["annotation"].split(";")[4]
+          if row["annotation"].split(";").length >= 5
+            amr_count_for_sequence[:annotation_gene] = row["annotation"].split(";")[2]
+            amr_count_for_sequence[:genbank_accession] = row["annotation"].split(";")[4]
+          end
         end
         amr_counts_array << amr_count_for_sequence
       end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -560,7 +560,7 @@ class PipelineRun < ApplicationRecord
           rpm: row["rpm"],
           dpm: row["dpm"],
         }
-        if row["annotation"].nil? == false
+        if row["annotation"]
           amr_counts_array << {
             annotation_gene: row["annotation"].split(";")[2],
             genbank_accession: row["annotation"].split(";")[4],

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -550,7 +550,7 @@ class PipelineRun < ApplicationRecord
     unless File.size?(amr_results) < 10
       amr_results_table = CSV.read(amr_results, headers: true)
       amr_results_table.each do |row|
-        amr_counts_array << {
+        amr_count_for_sequence = {
           gene: row["gene"],
           allele: row["allele"],
           coverage: row["coverage"],
@@ -561,11 +561,10 @@ class PipelineRun < ApplicationRecord
           dpm: row["dpm"],
         }
         if row["annotation"]
-          amr_counts_array << {
-            annotation_gene: row["annotation"].split(";")[2],
-            genbank_accession: row["annotation"].split(";")[4],
-          }
+          amr_count_for_sequence[:annotation_gene] = row["annotation"].split(";")[2]
+          amr_count_for_sequence[:genbank_accession] = row["annotation"].split(";")[4]
         end
+        amr_counts_array << amr_count_for_sequence
       end
     end
     update(amr_counts_attributes: amr_counts_array)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -555,13 +555,17 @@ class PipelineRun < ApplicationRecord
           allele: row["allele"],
           coverage: row["coverage"],
           depth: row["depth"],
-          annotation_gene: row["annotation"].split(";")[2],
-          genbank_accession: row["annotation"].split(";")[4],
           drug_family: row["gene_family"],
           total_reads: row["total_reads"],
           rpm: row["rpm"],
           dpm: row["dpm"],
         }
+        if row["annotation"].nil? == false
+          amr_counts_array << {
+            annotation_gene: row["annotation"].split(";")[2],
+            genbank_accession: row["annotation"].split(";")[4],
+          }
+        end
       end
     end
     update(amr_counts_attributes: amr_counts_array)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -560,7 +560,7 @@ class PipelineRun < ApplicationRecord
           rpm: row["rpm"],
           dpm: row["dpm"],
         }
-        if row["annotation"]
+        if row["annotation"].present?
           amr_count_for_sequence[:annotation_gene] = row["annotation"].split(";")[2]
           amr_count_for_sequence[:genbank_accession] = row["annotation"].split(";")[4]
         end


### PR DESCRIPTION
# Description

Meant to handle this error in `pipeline_run.rb`, method `db_load_amr_counts`:

```
irb(main):003:0> Sample.find(26995).pipeline_runs[0].db_load_amr_counts
Traceback (most recent call last):
        3: from (irb):3
        2: from app/models/pipeline_run.rb:552:in `db_load_amr_counts'
        1: from app/models/pipeline_run.rb:558:in `block in db_load_amr_counts'
NoMethodError (undefined method `split' for nil:NilClass)
```

It appears that there are sequences without annotations in the ARG Annot database. This pr handles that case.

# Tests

* Rpsec test to be added. Should add one for the whole function.
