### PR TITLE
Add check for a substantial annotation when loading amr counts

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -550,18 +550,23 @@ class PipelineRun < ApplicationRecord
     unless File.size?(amr_results) < 10
       amr_results_table = CSV.read(amr_results, headers: true)
       amr_results_table.each do |row|
-        amr_counts_array << {
+        amr_count_for_gene = {
           gene: row["gene"],
           allele: row["allele"],
           coverage: row["coverage"],
           depth: row["depth"],
-          annotation_gene: row["annotation"].split(";")[2],
-          genbank_accession: row["annotation"].split(";")[4],
           drug_family: row["gene_family"],
           total_reads: row["total_reads"],
           rpm: row["rpm"],
           dpm: row["dpm"],
         }
+        if row["annotation"].present?
+          if row["annotation"].split(";").length >= 5
+            amr_count_for_gene[:annotation_gene] = row["annotation"].split(";")[2]
+            amr_count_for_gene[:genbank_accession] = row["annotation"].split(";")[4]
+          end
+        end
+        amr_counts_array << amr_count_for_gene
       end
     end
     update(amr_counts_attributes: amr_counts_array)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -561,9 +561,10 @@ class PipelineRun < ApplicationRecord
           dpm: row["dpm"],
         }
         if row["annotation"].present?
-          if row["annotation"].split(";").length >= 5
-            amr_count_for_gene[:annotation_gene] = row["annotation"].split(";")[2]
-            amr_count_for_gene[:genbank_accession] = row["annotation"].split(";")[4]
+          split_annotation = row["annotation"].split(";")
+          if split_annotation.length >= 5
+            amr_count_for_gene[:annotation_gene] = split_annotation[2]
+            amr_count_for_gene[:genbank_accession] = split_annotation[4]
           end
         end
         amr_counts_array << amr_count_for_gene

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -553,10 +553,10 @@ class PipelineRun < ApplicationRecord
       amr_results_table = CSV.read(amr_results, headers: true)
       amr_results_table.each do |row|
         amr_count_for_gene = {}
-        amr_counts_keys.each_with_index do |_counts_key, index|
+        amr_counts_keys.each_with_index do |counts_key, index|
           result_value = row[amr_results_keys[index]]
           if result_value.present?
-            amr_count_for_gene[amr_counts_keys[index]] = result_value
+            amr_count_for_gene[counts_key] = result_value
           end
         end
         if row["annotation"].present?

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -546,20 +546,19 @@ class PipelineRun < ApplicationRecord
       return
     end
     amr_counts_array = []
+    amr_counts_keys = [:gene, :allele, :coverage, :depth, :drug_family, :total_reads, :rpm, :dpm]
+    amr_results_keys = %w[gene allele coverage depth gene_family total_reads rpm dpm]
     # results can be as small as ~80 bytes, so play it safe; empty results are 1 byte files
     unless File.size?(amr_results) < 10
       amr_results_table = CSV.read(amr_results, headers: true)
       amr_results_table.each do |row|
-        amr_count_for_gene = {
-          gene: row["gene"],
-          allele: row["allele"],
-          coverage: row["coverage"],
-          depth: row["depth"],
-          drug_family: row["gene_family"],
-          total_reads: row["total_reads"],
-          rpm: row["rpm"],
-          dpm: row["dpm"],
-        }
+        amr_count_for_gene = {}
+        amr_counts_keys.each_with_index do |_counts_key, index|
+          result_value = row[amr_results_keys[index]]
+          if result_value.present?
+            amr_count_for_gene[amr_counts_keys[index]] = result_value
+          end
+        end
         if row["annotation"].present?
           split_annotation = row["annotation"].split(";")
           if split_annotation.length >= 5

--- a/spec/factories/amr_counts.rb
+++ b/spec/factories/amr_counts.rb
@@ -6,5 +6,8 @@ FactoryBot.define do
     sequence(:depth) { |n| 0.5 + (n / 1000) }
     sequence(:pipeline_run_id) { |n| n }
     sequence(:drug_family) { |n| "DruG_#{n}" }
+    sequence(:total_reads) { |n| n }
+    sequence(:rpm) { |n| n * 5 / 100 }
+    sequence(:dpm) { |n| n * 2 / 10 }
   end
 end

--- a/spec/models/pipeline_run_spec.rb
+++ b/spec/models/pipeline_run_spec.rb
@@ -212,17 +212,20 @@ RSpec.describe PipelineRun, type: :model do
       end
     end
   end
+
   context "ensure that loading amr counts works properly" do
     let(:user) { build_stubbed(:user) }
     let(:sample) { build_stubbed(:sample, user: user) }
     let(:pipeline_run) { build_stubbed(:pipeline_run, sample: sample, pipeline_version: "3.9") }
     let(:results_path) { "amr_processed_results.csv" }
+
     context "No AMR counts file exists on S3 (PipelineRun.download_file() returned nil)" do
       before do
         # Test case nil
         allow(PipelineRun).to receive(:download_file).and_return(nil)
         allow(Rails.logger).to receive(:error)
       end
+
       it "should log an error and simply return" do
         pipeline_run.db_load_amr_counts()
 
@@ -230,6 +233,7 @@ RSpec.describe PipelineRun, type: :model do
         expect(pipeline_run.amr_counts).to eq([])
       end
     end
+
     context "AMR counts file exists, but is empty (results found no amr counts)" do
       before do
         pseudofile = StringIO.new("\n")
@@ -238,6 +242,7 @@ RSpec.describe PipelineRun, type: :model do
         allow(CSV).to receive(:read).and_return(CSV.new(pseudofile.read, headers: true))
         allow(pipeline_run).to receive(:update).and_return(true)
       end
+
       it "should update amr counts as an empty array" do
         pipeline_run.db_load_amr_counts()
 
@@ -245,6 +250,7 @@ RSpec.describe PipelineRun, type: :model do
         expect(pipeline_run.amr_counts).to eq([])
       end
     end
+
     context "AMR counts file exists, but lines are malformed" do
       before do
         csv_write_string = CSV.generate do |csv|
@@ -267,6 +273,7 @@ RSpec.describe PipelineRun, type: :model do
           pipeline_run.amr_counts = amr_counts
         end
       end
+
       it "should properly handle a malformed csv file" do
         pipeline_run.db_load_amr_counts()
 
@@ -274,6 +281,7 @@ RSpec.describe PipelineRun, type: :model do
         expect(JSON.parse(pipeline_run.amr_counts[0].to_json)).to include(MALFORMED_AMR_COUNTS[0])
       end
     end
+
     context "Properly handle a good AMR result" do
       before do
         pipeline_run.amr_counts = []
@@ -297,6 +305,7 @@ RSpec.describe PipelineRun, type: :model do
           pipeline_run.amr_counts = amr_counts
         end
       end
+
       it "should properly handle a good csv file" do
         pipeline_run.db_load_amr_counts()
 


### PR DESCRIPTION
# Description

Meant to handle this error in `pipeline_run.rb`, method `db_load_amr_counts`:

```
irb(main):003:0> Sample.find(26995).pipeline_runs[0].db_load_amr_counts
Traceback (most recent call last):
        3: from (irb):3
        2: from app/models/pipeline_run.rb:552:in `db_load_amr_counts'
        1: from app/models/pipeline_run.rb:558:in `block in db_load_amr_counts'
NoMethodError (undefined method `split' for nil:NilClass)
```

It appears that there are sequences without annotations in the ARG Annot database. This pr handles that case and adds error checking for _every_ key it tries to read.

Also, too, I added more Rspec tests specifically to make sure `db_load_amr_counts()` can handle what we can throw at it.

# Tests

* Run rspec test with `docker-compose run --rm web "RAILS_ENV=test rspec spec/models/pipeline_run_spec.rb"`