### PR TITLE
Fix an email typo

### DIFF
--- a/app/assets/src/components/views/samples/PublicSampleNotification.jsx
+++ b/app/assets/src/components/views/samples/PublicSampleNotification.jsx
@@ -28,7 +28,7 @@ class PublicSampleNotification extends React.Component {
           privacy policy
         </a>
         &nbsp;or{" "}
-        <a className={cs.emailLink} href="mailto:help@idseq.com">
+        <a className={cs.emailLink} href="mailto:help@idseq.net">
           email us
         </a>
       </React.Fragment>


### PR DESCRIPTION
### Description
s/idseq.com/idseq.net

### Tests
- Render a PublicSampleNotification, hover, and see the correct mailto link.