### PR TITLE
Heatmap zoom

### DIFF
--- a/app/assets/src/components/utils/tooltip.js
+++ b/app/assets/src/components/utils/tooltip.js
@@ -2,21 +2,27 @@ const TOOLTIP_BUFFER = 10;
 const TOOLTIP_MAX_WIDTH = 400;
 
 // Display the tooltip in the top left, unless it is too close
-// to the right side of the screen.
+// to the right side of the screen. If it is too close to the bottom, show it
+// above the curosr.
 export const getTooltipStyle = (location, params = {}) => {
   const buffer = params.buffer || TOOLTIP_BUFFER;
   const topBufferSign = params.below ? 1 : -1;
+  let top = location.top;
+
+  if (params.height && top + params.height > window.innerHeight) {
+    top = top - params.height;
+  }
 
   if (location.left > window.innerWidth - TOOLTIP_MAX_WIDTH) {
     const right = window.innerWidth - location.left;
     return {
       right: right + buffer,
-      top: location.top + topBufferSign * buffer,
+      top: top + topBufferSign * buffer,
     };
   } else {
     return {
       left: location.left + buffer,
-      top: location.top + topBufferSign * buffer,
+      top: top + topBufferSign * buffer,
     };
   }
 };

--- a/app/assets/src/components/views/PipelineViz/pipeline_viz.scss
+++ b/app/assets/src/components/views/PipelineViz/pipeline_viz.scss
@@ -257,6 +257,9 @@
   bottom: 50px;
   right: 15px;
   box-shadow: $box-shadow-dropdown-menu;
+  svg:hover {
+    background-color: darken(white, 5%);
+  }
 }
 
 .hovered {

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -363,11 +363,11 @@ class SamplesHeatmapVis extends React.Component {
       <div className={cs.samplesHeatmapVis}>
         <PlusMinusControl
           onPlusClick={withAnalytics(
-            this.handleZoom("in"),
+            () => this.handleZoom("in"),
             "SamplesHeatmapVis_zoom-in-control_clicked"
           )}
           onMinusClick={withAnalytics(
-            this.handleZoom("out"),
+            () => this.handleZoom("out"),
             "SamplesHeatmapVis_zoom-out-control_clicked"
           )}
           className={cs.plusMinusControl}

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -341,8 +341,8 @@ class SamplesHeatmapVis extends React.Component {
 
   handleZoom(increment) {
     const newZoom = Math.min(
-      3,
-      Math.max(0.1, this.heatmap.options.zoom + increment)
+      3, // max zoom factor
+      Math.max(0.2, this.heatmap.options.zoom + increment)
     );
     this.heatmap.updateZoom(newZoom);
   }
@@ -359,11 +359,11 @@ class SamplesHeatmapVis extends React.Component {
       <div className={cs.samplesHeatmapVis}>
         <PlusMinusControl
           onPlusClick={withAnalytics(
-            () => this.handleZoom(0.33),
+            () => this.handleZoom(0.25),
             "SamplesHeatmapVis_zoom-in-control_clicked"
           )}
           onMinusClick={withAnalytics(
-            () => this.handleZoom(-0.33),
+            () => this.handleZoom(-0.25),
             "SamplesHeatmapVis_zoom-out-control_clicked"
           )}
           className={cs.plusMinusControl}

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -84,9 +84,7 @@ class SamplesHeatmapVis extends React.Component {
         printCaption: this.generateHeatmapCaptions(),
         shouldSortColumns: this.props.sampleSortType === "alpha", // else cluster
         // Shrink to fit the viewport width
-        // See https://developer.mozilla.org/en-US/docs/Web/API/window/innerWidth
-        // TODO (gdingle): use computed value
-        maxWidth: window.innerWidth,
+        maxWidth: this.heatmapContainer.offsetWidth,
       }
     );
     this.heatmap.start();

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -86,6 +86,7 @@ class SamplesHeatmapVis extends React.Component {
         shouldSortColumns: this.props.sampleSortType === "alpha", // else cluster
         // Shrink to fit the viewport width
         // See https://developer.mozilla.org/en-US/docs/Web/API/window/innerWidth
+        // TODO (gdingle): use computed value
         maxWidth: window.innerWidth,
       }
     );
@@ -341,7 +342,9 @@ class SamplesHeatmapVis extends React.Component {
 
   handleZoom(increment) {
     const newZoom = Math.max(0.1, this.state.zoom + increment);
+    // TODO (gdingle): better way to trigger re-render?
     this.setState({ zoom: newZoom });
+    this.heatmap.updateZoom(newZoom);
   }
 
   render() {
@@ -368,7 +371,6 @@ class SamplesHeatmapVis extends React.Component {
         />
         <div
           className={cs.heatmapContainer}
-          style={{ zoom: zoom }}
           ref={container => {
             this.heatmapContainer = container;
           }}

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 import { size, map, keyBy } from "lodash/fp";
 
-import { logAnalyticsEvent } from "~/api/analytics";
+import { withAnalytics, logAnalyticsEvent } from "~/api/analytics";
 import { DataTooltip } from "~ui/containers";
 import { openUrl } from "~utils/links";
 import Heatmap from "~/components/visualizations/heatmap/Heatmap";
@@ -12,6 +12,7 @@ import MetadataLegend from "~/components/common/Heatmap/MetadataLegend";
 import MetadataSelector from "~/components/common/Heatmap/MetadataSelector";
 import { splitIntoMultipleLines } from "~/helpers/strings";
 import AlertIcon from "~ui/icons/AlertIcon";
+import PlusMinusControl from "~/components/ui/controls/PlusMinusControl";
 
 import cs from "./samples_heatmap_vis.scss";
 
@@ -27,6 +28,7 @@ class SamplesHeatmapVis extends React.Component {
       columnMetadataLegend: null,
       selectedMetadata: new Set(this.props.defaultMetadata),
       tooltipLocation: null,
+      zoom: null,
     };
 
     this.heatmap = null;
@@ -334,6 +336,21 @@ class SamplesHeatmapVis extends React.Component {
     });
   }
 
+  handleZoom(direction) {
+    this.setState({ zoom: direction });
+  }
+
+  getZoomStyle() {
+    const zoom = this.state.zoom;
+    if (zoom === null) {
+      return 1.0;
+    } else if (zoom === "in") {
+      return 1.5;
+    } else if (zoom === "out") {
+      return 0.5;
+    }
+  }
+
   render() {
     const {
       tooltipLocation,
@@ -344,8 +361,20 @@ class SamplesHeatmapVis extends React.Component {
     } = this.state;
     return (
       <div className={cs.samplesHeatmapVis}>
+        <PlusMinusControl
+          onPlusClick={withAnalytics(
+            this.handleZoom("in"),
+            "SamplesHeatmapVis_zoom-in-control_clicked"
+          )}
+          onMinusClick={withAnalytics(
+            this.handleZoom("out"),
+            "SamplesHeatmapVis_zoom-out-control_clicked"
+          )}
+          className={cs.plusMinusControl}
+        />
         <div
           className={cs.heatmapContainer}
+          style={{ zoom: this.getZoomStyle() }}
           ref={container => {
             this.heatmapContainer = container;
           }}

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -279,6 +279,7 @@ class SamplesHeatmapVis extends React.Component {
     return {
       subtitle,
       data: sections,
+      nodeHasData,
     };
   }
 
@@ -381,6 +382,8 @@ class SamplesHeatmapVis extends React.Component {
               style={getTooltipStyle(tooltipLocation, {
                 buffer: 20,
                 below: true,
+                // so we can show the tooltip above the cursor if need be
+                height: nodeHoverInfo.nodeHasData ? 300 : 180,
               })}
             >
               <DataTooltip {...nodeHoverInfo} />

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -28,7 +28,7 @@ class SamplesHeatmapVis extends React.Component {
       columnMetadataLegend: null,
       selectedMetadata: new Set(this.props.defaultMetadata),
       tooltipLocation: null,
-      zoom: null,
+      zoom: 1.0,
     };
 
     this.heatmap = null;
@@ -84,6 +84,9 @@ class SamplesHeatmapVis extends React.Component {
         scaleMin: 0,
         printCaption: this.generateHeatmapCaptions(),
         shouldSortColumns: this.props.sampleSortType === "alpha", // else cluster
+        // Shrink to fit the viewport width
+        // See https://developer.mozilla.org/en-US/docs/Web/API/window/innerWidth
+        maxWidth: window.innerWidth,
       }
     );
     this.heatmap.start();
@@ -336,19 +339,9 @@ class SamplesHeatmapVis extends React.Component {
     });
   }
 
-  handleZoom(direction) {
-    this.setState({ zoom: direction });
-  }
-
-  getZoomStyle() {
-    const zoom = this.state.zoom;
-    if (zoom === null) {
-      return 1.0;
-    } else if (zoom === "in") {
-      return 1.5;
-    } else if (zoom === "out") {
-      return 0.5;
-    }
+  handleZoom(increment) {
+    const newZoom = Math.max(0.1, this.state.zoom + increment);
+    this.setState({ zoom: newZoom });
   }
 
   render() {
@@ -358,23 +351,24 @@ class SamplesHeatmapVis extends React.Component {
       columnMetadataLegend,
       addMetadataTrigger,
       selectedMetadata,
+      zoom,
     } = this.state;
     return (
       <div className={cs.samplesHeatmapVis}>
         <PlusMinusControl
           onPlusClick={withAnalytics(
-            () => this.handleZoom("in"),
+            () => this.handleZoom(0.33),
             "SamplesHeatmapVis_zoom-in-control_clicked"
           )}
           onMinusClick={withAnalytics(
-            () => this.handleZoom("out"),
+            () => this.handleZoom(-0.33),
             "SamplesHeatmapVis_zoom-out-control_clicked"
           )}
           className={cs.plusMinusControl}
         />
         <div
           className={cs.heatmapContainer}
-          style={{ zoom: this.getZoomStyle() }}
+          style={{ zoom: zoom }}
           ref={container => {
             this.heatmapContainer = container;
           }}

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -28,7 +28,6 @@ class SamplesHeatmapVis extends React.Component {
       columnMetadataLegend: null,
       selectedMetadata: new Set(this.props.defaultMetadata),
       tooltipLocation: null,
-      zoom: 1.0,
     };
 
     this.heatmap = null;
@@ -341,9 +340,10 @@ class SamplesHeatmapVis extends React.Component {
   }
 
   handleZoom(increment) {
-    const newZoom = Math.max(0.1, this.state.zoom + increment);
-    // TODO (gdingle): better way to trigger re-render?
-    this.setState({ zoom: newZoom });
+    const newZoom = Math.min(
+      3,
+      Math.max(0.1, this.heatmap.options.zoom + increment)
+    );
     this.heatmap.updateZoom(newZoom);
   }
 
@@ -354,7 +354,6 @@ class SamplesHeatmapVis extends React.Component {
       columnMetadataLegend,
       addMetadataTrigger,
       selectedMetadata,
-      zoom,
     } = this.state;
     return (
       <div className={cs.samplesHeatmapVis}>

--- a/app/assets/src/components/views/compare/samples_heatmap_vis.scss
+++ b/app/assets/src/components/views/compare/samples_heatmap_vis.scss
@@ -5,16 +5,24 @@
 .samplesHeatmapVis {
   .plusMinusControl {
     position: absolute;
-    // Offset from the viewport ot line up with the controls. This will need to
-    // be adjusted if the position of the controls changes.
-    top: 220px;
-    right: calc(50% - 700px);
+    // Offset from the viewport to line up with the filter controls. This will
+    // need to be adjusted if the position of the controls changes.
+    top: 360px;
+    right: 40px;
     box-shadow: $box-shadow-dropdown-menu;
+
+    svg:hover {
+      background-color: darken(white, 5%);
+    }
   }
 
   .heatmapContainer {
     overflow-x: auto;
-    margin-bottom: 300px;
+    // Set the height to force the horizontal scrollbar to appear at the bottom
+    // of the viewport instead of the bottom of the page. 360px is the height
+    // of the all the elements above the heatmapContainer. It *will* need to
+    // change if the height of the elements above ever change.
+    height: calc(100vh - 360px);
 
     svg {
       display: block;

--- a/app/assets/src/components/views/compare/samples_heatmap_vis.scss
+++ b/app/assets/src/components/views/compare/samples_heatmap_vis.scss
@@ -11,6 +11,7 @@
     right: 40px;
     box-shadow: $box-shadow-dropdown-menu;
 
+    background-color: white;
     svg:hover {
       background-color: darken(white, 5%);
     }

--- a/app/assets/src/components/views/compare/samples_heatmap_vis.scss
+++ b/app/assets/src/components/views/compare/samples_heatmap_vis.scss
@@ -3,12 +3,12 @@
 @import "~styles/themes/elements";
 
 .samplesHeatmapVis {
-  position: relative; // for plusMinusControl
-
   .plusMinusControl {
     position: absolute;
-    top: 0px;
-    right: 160px;
+    // Offset from the viewport ot line up with the controls. This will need to
+    // be adjusted if the position of the controls changes.
+    top: 220px;
+    right: calc(50% - 700px);
     box-shadow: $box-shadow-dropdown-menu;
   }
 

--- a/app/assets/src/components/views/compare/samples_heatmap_vis.scss
+++ b/app/assets/src/components/views/compare/samples_heatmap_vis.scss
@@ -1,6 +1,17 @@
 @import "~styles/themes/colors";
+@import "~styles/themes/typography";
+@import "~styles/themes/elements";
 
 .samplesHeatmapVis {
+  position: relative; // for plusMinusControl
+
+  .plusMinusControl {
+    position: absolute;
+    top: 0px;
+    right: 160px;
+    box-shadow: $box-shadow-dropdown-menu;
+  }
+
   .heatmapContainer {
     overflow-x: auto;
     margin-bottom: 300px;

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -46,7 +46,7 @@ export default class Heatmap {
         minCellHeight: 26,
         minWidth: 1240,
         maxWidth: 1600, // used for shrink-to-fit
-        zoom: 1.0, // multiplier for zooming in and out
+        zoom: null, // multiplier for zooming in and out
         minHeight: 500,
         clustering: true,
         shouldSortColumns: true,
@@ -339,15 +339,13 @@ export default class Heatmap {
 
     this.svg.attr("viewBox", `0 0 ${this.width} ${this.height}`);
 
-    const defaultZoom =
-      Math.min(this.width, this.options.maxWidth) / this.width;
-    const zoom = this.options.zoom || defaultZoom;
+    this.options.zoom = this.getZoomFactor();
 
     // If we make these numbers larger than the viewport dimensions we’ll
     // effectively zoom out, and if we make them smaller we’ll zoom in.
     this.svg
-      .attr("width", this.width * zoom)
-      .attr("height", this.height * zoom);
+      .attr("width", this.width * this.options.zoom)
+      .attr("height", this.height * this.options.zoom);
 
     this.g.attr(
       "transform",
@@ -1347,5 +1345,14 @@ export default class Heatmap {
     } else {
       return this.metadataColors[value];
     }
+  }
+
+  getZoomFactor() {
+    if (this.options.zoom !== null) return this.options.zoom;
+    // Decrease the max width slightly to avoid zooming slightly too much, which
+    // would produce a useless horizontal scrollbar.
+    const adjustedMaxWidth = this.options.maxWidth - 8;
+    // Shrink to fit
+    return Math.min(this.width, adjustedMaxWidth) / this.width;
   }
 }

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -45,6 +45,7 @@ export default class Heatmap {
         minCellWidth: 26,
         minCellHeight: 26,
         minWidth: 1240,
+        maxWidth: 1600, // used for shrink-to-fit
         minHeight: 500,
         clustering: true,
         shouldSortColumns: true,
@@ -250,10 +251,7 @@ export default class Heatmap {
       .append("svg")
       .attr("class", cs.heatmap)
       .attr("id", "visualization")
-      .attr("xmlns", "http://www.w3.org/2000/svg")
-      // Not standard but it works for downloads and svgsaver. See:
-      // https://stackoverflow.com/questions/11293026/default-background-color-of-svg-root-element
-      .attr("style", `background-color: ${this.options.svgBackgroundColor}`);
+      .attr("xmlns", "http://www.w3.org/2000/svg");
 
     this.g = this.svg.append("g");
     this.gRowLabels = this.g.append("g").attr("class", cs.rowLabels);
@@ -327,6 +325,15 @@ export default class Heatmap {
       this.options.spacing;
 
     this.svg.attr("width", this.width).attr("height", this.height);
+
+    const zoom = Math.min(this.width, this.options.maxWidth) / this.width;
+
+    // Not standard but it works for downloads and svgsaver. See:
+    // https://stackoverflow.com/questions/11293026/default-background-color-of-svg-root-element
+    this.svg.attr(
+      "style",
+      `background-color: ${this.options.svgBackgroundColor}; zoom: ${zoom}`
+    );
 
     this.g.attr(
       "transform",

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -46,7 +46,7 @@ export default class Heatmap {
         minCellHeight: 26,
         minWidth: 1240,
         maxWidth: 1600, // used for shrink-to-fit
-        zoom: null, // multiplier for zooming in and out
+        zoom: 1.0, // multiplier for zooming in and out
         minHeight: 500,
         clustering: true,
         shouldSortColumns: true,
@@ -337,15 +337,17 @@ export default class Heatmap {
       this.options.marginBottom +
       this.options.spacing;
 
-    // TODO (gdingle): why initial zoom too much?
+    this.svg.attr("viewBox", `0 0 ${this.width} ${this.height}`);
+
     const defaultZoom =
       Math.min(this.width, this.options.maxWidth) / this.width;
     const zoom = this.options.zoom || defaultZoom;
 
-    // If we make the viewbox numbers larger than the viewport dimensions we’ll
+    // If we make these numbers larger than the viewport dimensions we’ll
     // effectively zoom out, and if we make them smaller we’ll zoom in.
-    this.svg.attr("viewBox", `0 0 ${this.width / zoom} ${this.height / zoom}`);
-    this.svg.attr("width", this.width).attr("height", this.height);
+    this.svg
+      .attr("width", this.width * zoom)
+      .attr("height", this.height * zoom);
 
     this.g.attr(
       "transform",


### PR DESCRIPTION
# Description

See https://jira.czi.team/browse/IDSEQ-1233

This adds zoom to heatmap so that users can see more or less of a heatmap as they wish. In addition, it adds shrink-to-fit so that all samples of a heatmap are visible on initial load. 

To keep the scrollbars in view on zoom, I changed the heatmap container to have a fixed height. A side effect of this is to lose the semi-fixed page header on scroll. Now scrolling controls the content of the heatmap only, and the content above does not move, so it is effectively the same, except that the black idseq header and other content above the filters does not disappear. This change also fixes the visual issue where the fixed filter bar did not cover the whole width of the screen, leaving awkward patches of heatmap on either side of it. If any of this is not clear enough, please ask for me a demo. 

Lastly, the fixed height container revealed a latent issue where tooltips at the bottom got clipped on hover. I fixed this by extending @MarkAZhang 's fix for the same issue on the right side of page -- the tooltips now show above when close to the bottom. Note that the fix assumes two constant heights of the tooltips. I'm not sure how to get the height of the content before it has rendered. 

## Zoom out
![image](https://user-images.githubusercontent.com/28797/63134742-9dc20200-bf7f-11e9-8a78-39f50bd3617c.png)

## Zoom in
![image](https://user-images.githubusercontent.com/28797/63134751-aadef100-bf7f-11e9-922e-9160e349d687.png)

## Zoom control
![image](https://user-images.githubusercontent.com/28797/63301922-ad4b8e80-c290-11e9-9576-d9e2316c0900.png)


## Flip tooltip at bottom of page
![image](https://user-images.githubusercontent.com/28797/63301878-91e08380-c290-11e9-8592-3030a35a0405.png)

![image](https://user-images.githubusercontent.com/28797/63301881-9311b080-c290-11e9-8dfa-011490193acb.png)

# Notes

* While the text becomes too small to read, the hover tooltip is still at normal size, allowing a user to read the contents of a cell
* The +/- control is the same one used on the map and pipeline viz

# Tests

**Zoom in and out**
Load a heatmap

Click on the plus 
See the heatmap expand up to the max

Click on the minus
See the heatmap shrink
See the heatmap stop shrinking at the smallest size

**Shrink-to-fit**
Shrink the size of your browser to <1000px wide
Load a large heatmap
See the heatmap fit in the width
Enlarge the browser to full screen
Reload
See the heatmap at the default size (1300px)
