### PR TITLE
Add space variables for margins, padding

### DIFF
--- a/app/assets/src/styles/themes/_elements.scss
+++ b/app/assets/src/styles/themes/_elements.scss
@@ -7,6 +7,14 @@ $box-shadow-dropdown-menu: 0 2px 4px 0 $box-shadow-lighter,
 $narrow-container-width: 1280px;
 $narrow-container-margin: 14px;
 
+$space-default: 10px;
+$space-xxs: 6px;
+$space-xs: 8px;
+$space-s: 10px;
+$space-m: 14px;
+$space-l: 26px;
+$space-xl: 40px;
+
 // Customized scroll bar
 @mixin scrollable {
   &::-webkit-scrollbar {


### PR DESCRIPTION
# Description

Adds scss variables for spacing, to be used for margin and padding.

# Notes

While the mocks originally split spacing into inset, inline, and stack, since the numbers at each sizing level (-xxs, -xs, -s, -m, -l, etc) are the same for all three, they have been combined together