### PR TITLE
IDSEQ-1201 - Enable S3 transfer acceleration on presigned URLs

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -149,7 +149,7 @@ class Sample < ApplicationRecord
         parts = f.parts.split(", ")
         presigned_urls = parts.map do |part|
           S3_PRESIGNER.presigned_url(:put_object, expires_in: 86_400, bucket: SAMPLES_BUCKET_NAME,
-                                                  key: File.join(File.dirname(f.file_path), File.basename(part)))
+                                                  key: File.join(File.dirname(f.file_path), File.basename(part)), use_accelerate_endpoint: true)
         end
         f.update(presigned_url: presigned_urls.join(", "))
       end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -143,11 +143,11 @@ class Sample < ApplicationRecord
   end
 
   def set_presigned_url_for_local_upload
-    accel_response = S3_CLIENT.get_bucket_accelerate_configuration(bucket: SAMPLES_BUCKET_NAME)
-    use_acceleration = accel_response && accel_response[:status] == "Enabled"
-
     input_files.each do |f|
       if f.source_type == InputFile::SOURCE_TYPE_LOCAL && f.parts
+        accel_response = S3_CLIENT.get_bucket_accelerate_configuration(bucket: SAMPLES_BUCKET_NAME)
+        use_acceleration = accel_response && accel_response[:status] == "Enabled"
+
         # TODO: investigate the content-md5 stuff https://github.com/aws/aws-sdk-js/issues/151 https://gist.github.com/algorist/385616
         parts = f.parts.split(", ")
         presigned_urls = parts.map do |part|

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -143,13 +143,16 @@ class Sample < ApplicationRecord
   end
 
   def set_presigned_url_for_local_upload
+    accel_response = S3_CLIENT.get_bucket_accelerate_configuration(bucket: SAMPLES_BUCKET_NAME)
+    use_acceleration = accel_response && accel_response[:status] == "Enabled"
+
     input_files.each do |f|
       if f.source_type == InputFile::SOURCE_TYPE_LOCAL && f.parts
         # TODO: investigate the content-md5 stuff https://github.com/aws/aws-sdk-js/issues/151 https://gist.github.com/algorist/385616
         parts = f.parts.split(", ")
         presigned_urls = parts.map do |part|
           S3_PRESIGNER.presigned_url(:put_object, expires_in: 86_400, bucket: SAMPLES_BUCKET_NAME,
-                                                  key: File.join(File.dirname(f.file_path), File.basename(part)), use_accelerate_endpoint: true)
+                                                  key: File.join(File.dirname(f.file_path), File.basename(part)), use_accelerate_endpoint: use_acceleration)
         end
         f.update(presigned_url: presigned_urls.join(", "))
       end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -143,10 +143,13 @@ class Sample < ApplicationRecord
   end
 
   def set_presigned_url_for_local_upload
+    use_acceleration = nil
     input_files.each do |f|
       if f.source_type == InputFile::SOURCE_TYPE_LOCAL && f.parts
-        accel_response = S3_CLIENT.get_bucket_accelerate_configuration(bucket: SAMPLES_BUCKET_NAME)
-        use_acceleration = accel_response && accel_response[:status] == "Enabled"
+        if use_acceleration.nil?
+          accel_response = S3_CLIENT.get_bucket_accelerate_configuration(bucket: SAMPLES_BUCKET_NAME)
+          use_acceleration = accel_response && accel_response[:status] == "Enabled"
+        end
 
         # TODO: investigate the content-md5 stuff https://github.com/aws/aws-sdk-js/issues/151 https://gist.github.com/algorist/385616
         parts = f.parts.split(", ")


### PR DESCRIPTION
### Description
- This adds S3 transfer acceleration on presigned URLs. I looked at the high-priority ticket as part of on call duties and feeling the pain of user upload issues again.
- First call get_bucket_accelerate_configuration to check if bucket acceleration is enabled. This makes it deploy-safe because it will just use the regular S3 endpoint if bucket acceleration is disabled. Note that using the `accelerate` endpoint is always optional, so it is also backwards compatible.
- Corresponding infra PR: https://github.com/chanzuckerberg/idseq-infra/pull/230

### Tests
- Went through the flows of uploading with acceleration enabled and disabled.
- SCREENSHOTS: https://docs.google.com/document/d/1Q45t-jF--eIfMcUdRewbatA1Kjep2uC4enZRltX65-k/edit?usp=sharing

- I plan on testing the same flows manually on staging.
- For capturing the actual impact, I have some ideas for uploading large files from EC2 instances in other regions, although I'm not sure it will replicate our end user issues.