### PR TITLE
Revoke Basespace access token after upload is complete.

### DIFF
--- a/app/jobs/transfer_basespace_files.rb
+++ b/app/jobs/transfer_basespace_files.rb
@@ -10,6 +10,11 @@ class TransferBasespaceFiles
     Rails.logger.info("Start TransferBasespaceFiles for sample id #{sample_id}")
     sample = Sample.find(sample_id)
     sample.transfer_basespace_files(basespace_dataset_id, basespace_access_token)
+
+    # Revoke the access token, so that it can no longer be used.
+    BasespaceHelper.revoke_access_token(basespace_access_token)
+
+    BasespaceHelper.verify_access_token_revoked(basespace_access_token)
   rescue => e
     Rails.logger.error(e)
   end


### PR DESCRIPTION
# Note

Revoke the Basespace access token after we're done with it for maximum security.

# Tests

* Added rspec tests.
* Verified via local basespace upload and Resque logging that access token DELETE call is successful and calling an endpoint with the access token works before the DELETE call and returns 401 after the call.