### PR TITLE
Ensure idseq-cli deprecation warning gets error message

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -55,7 +55,7 @@ class SamplesController < ApplicationController
   MAX_PAGE_SIZE_V2 = 100
   MAX_BINS = 34
   MIN_CLI_VERSION = '0.7.3'.freeze
-  CLI_DEPRECATION_MSG = "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git` or with sudo + pip2/pip3 depending on your setup.".freeze
+  CLI_DEPRECATION_MSG = "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git` or with sudo + pip2/pip3 depending on your setup to update and try again.".freeze
 
   # GET /samples
   # GET /samples.json

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -55,7 +55,7 @@ class SamplesController < ApplicationController
   MAX_PAGE_SIZE_V2 = 100
   MAX_BINS = 34
   MIN_CLI_VERSION = '0.7.3'.freeze
-  CLI_DEPRECATION_MSG = "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.".freeze
+  CLI_DEPRECATION_MSG = "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git` or with sudo + pip2/pip3 depending on your setup.".freeze
 
   # GET /samples
   # GET /samples.json

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -55,6 +55,7 @@ class SamplesController < ApplicationController
   MAX_PAGE_SIZE_V2 = 100
   MAX_BINS = 34
   MIN_CLI_VERSION = '0.7.3'.freeze
+  CLI_DEPRECATION_MSG = "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.".freeze
 
   # GET /samples
   # GET /samples.json
@@ -521,7 +522,9 @@ class SamplesController < ApplicationController
     min_version = Gem::Version.new(MIN_CLI_VERSION)
     unless client && (client == "web" || Gem::Version.new(client) >= min_version)
       render json: {
-        message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.",
+        message: CLI_DEPRECATION_MSG,
+        # idseq-cli v0.6.0 only checks the 'errors' field, so ensure users see this.
+        errors: [CLI_DEPRECATION_MSG],
         status: :upgrade_required,
       }, status: :upgrade_required
       return
@@ -1023,7 +1026,9 @@ class SamplesController < ApplicationController
     min_version = Gem::Version.new(MIN_CLI_VERSION)
     unless client && (client == "web" || Gem::Version.new(client) >= min_version)
       render json: {
-        message: "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git ` or with sudo + pip2/pip3 depending on your setup.",
+        message: CLI_DEPRECATION_MSG,
+        # idseq-cli v0.6.0 only checks the 'errors' field, so ensure users see this.
+        errors: [CLI_DEPRECATION_MSG],
         status: :upgrade_required,
       }, status: :upgrade_required
       return


### PR DESCRIPTION
### Description
- This PR improves the idseq-cli deprecation notice to make sure that users of older versions will still see the prompt to upgrade.
- An older version of idseq-cli (v0.6.0) would only check if `len "errors" == 0` and not the status, so it would error on a later step without showing the proper message. (ex: https://github.com/chanzuckerberg/idseq-cli/commit/47507c1df65cd2e961d8b62db8b60f12da0b97a1 and `if len(resp.get("errors", {})) == 0:`)

### Tests
#### Before on v0.6.0
![Screen Shot 2019-08-16 at 5 19 06 PM](https://user-images.githubusercontent.com/5652739/63204377-e21ad400-c04b-11e9-808b-57a0ca7d011b.png)

#### After on v0.6.0
![Screen Shot 2019-08-16 at 5 25 20 PM](https://user-images.githubusercontent.com/5652739/63204378-e8a94b80-c04b-11e9-9950-39fc8b54953e.png)