### PR TITLE
Fix typo in DataTooltip

### DIFF
--- a/app/assets/src/components/ui/containers/DataTooltip.jsx
+++ b/app/assets/src/components/ui/containers/DataTooltip.jsx
@@ -33,7 +33,7 @@ const DataTooltip = ({ data, subtitle, title, singleColumn }) => {
                     {/* Use .name if value is an object (e.g. location object) 
                     with a name property. Display React elements normally. */}
                     {isObject(keyValuePair[1]) &&
-                    keyValuePair.hasOwnProperty("name")
+                    keyValuePair[1].hasOwnProperty("name")
                       ? keyValuePair[1].name
                       : keyValuePair[1]}
                   </div>


### PR DESCRIPTION
### Description
- Fix a bug introduced in #2513 Need to check if `keyValuePair[1].hasOwnProperty("name")`, not `keyValuePair.hasOwnProperty("name")`.

### Tests
- Go to a phylo tree with collection_location, hover over the tooltip and see it show up.