### PR TITLE
Modify http helper functions to raise errors when http request fails.

### DIFF
--- a/app/controllers/basespace_controller.rb
+++ b/app/controllers/basespace_controller.rb
@@ -16,17 +16,19 @@ class BasespaceController < ApplicationController
        ENV["BASESPACE_OAUTH_REDIRECT_URI"] &&
        ENV["BASESPACE_CLIENT_ID"] &&
        ENV["BASESPACE_CLIENT_SECRET"]
-      response = HttpHelper.post_json(
-        "https://api.basespace.illumina.com/v1pre3/oauthv2/token",
-        "code" => params[:code],
-        "redirect_uri" => ENV["BASESPACE_OAUTH_REDIRECT_URI"],
-        "client_id" => ENV["BASESPACE_CLIENT_ID"],
-        "client_secret" => ENV["BASESPACE_CLIENT_SECRET"],
-        "grant_type" => "authorization_code"
-      )
 
-      if response.present?
+      begin
+        response = HttpHelper.post_json(
+          "https://api.basespace.illumina.com/v1pre3/oauthv2/token",
+          "code" => params[:code],
+          "redirect_uri" => ENV["BASESPACE_OAUTH_REDIRECT_URI"],
+          "client_id" => ENV["BASESPACE_CLIENT_ID"],
+          "client_secret" => ENV["BASESPACE_CLIENT_SECRET"],
+          "grant_type" => "authorization_code"
+        )
         @access_token = response["access_token"]
+      rescue
+        Rails.logger.warn("Failed to get basespace access token")
       end
     end
   end

--- a/app/helpers/http_helper.rb
+++ b/app/helpers/http_helper.rb
@@ -15,7 +15,7 @@ module HttpHelper
 
     unless response.is_a?(Net::HTTPSuccess)
       Rails.logger.warn("POST request to #{url} failed: #{response.message}")
-      return nil
+      raise "HTTP POST request failed"
     end
 
     begin
@@ -23,7 +23,7 @@ module HttpHelper
       JSON.parse(response.body)
     rescue JSON::ParserError
       Rails.logger.warn("POST response from #{url} was not valid JSON")
-      return nil
+      raise
     end
   end
 
@@ -47,7 +47,7 @@ module HttpHelper
       unless silence_errors
         Rails.logger.warn("GET request to #{url} failed: #{response.message}")
       end
-      return nil
+      raise "HTTP GET request failed"
     end
 
     begin
@@ -55,7 +55,7 @@ module HttpHelper
       JSON.parse(response.body)
     rescue JSON::ParserError
       Rails.logger.warn("GET response from #{url} was not valid JSON")
-      return nil
+      raise
     end
   end
 
@@ -76,7 +76,7 @@ module HttpHelper
 
     unless response.is_a?(Net::HTTPSuccess)
       Rails.logger.warn("DELETE request to #{url} failed: #{response.message}")
-      return nil
+      raise "HTTP DELETE request failed"
     end
 
     return nil

--- a/app/jobs/transfer_basespace_files.rb
+++ b/app/jobs/transfer_basespace_files.rb
@@ -12,9 +12,12 @@ class TransferBasespaceFiles
     sample.transfer_basespace_files(basespace_dataset_id, basespace_access_token)
 
     # Revoke the access token, so that it can no longer be used.
-    BasespaceHelper.revoke_access_token(basespace_access_token)
-
-    BasespaceHelper.verify_access_token_revoked(basespace_access_token)
+    begin
+      BasespaceHelper.revoke_access_token(basespace_access_token)
+      BasespaceHelper.verify_access_token_revoked(basespace_access_token)
+    rescue
+      Rails.logger.warn("BasespaceAccessTokenError Failed to revoke access token")
+    end
   rescue => e
     Rails.logger.error(e)
   end

--- a/spec/controllers/basespace_controller_spec.rb
+++ b/spec/controllers/basespace_controller_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe BasespaceController, type: :controller do
         end
 
         it "returns an error" do
-          expect(LogUtil).to receive(:log_err_and_airbrake).with("basespace_projects failed with error: Failed to list projects").exactly(1).times
+          expect(LogUtil).to receive(:log_err_and_airbrake).with("Fetch Basespace projects failed with error: Failed to list projects").exactly(1).times
           get :projects, params: { access_token: "123" }
 
           json_response = JSON.parse(response.body)
@@ -238,7 +238,7 @@ RSpec.describe BasespaceController, type: :controller do
         end
 
         it "returns an error" do
-          expect(LogUtil).to receive(:log_err_and_airbrake).with("samples_for_basespace_project failed with error: Failed to get samples for project").exactly(1).times
+          expect(LogUtil).to receive(:log_err_and_airbrake).with("Fetch samples for Basespace project failed with error: Failed to get samples for project").exactly(1).times
           get :samples_for_project, params: { access_token: "123", basespace_project_id: 77 }
 
           json_response = JSON.parse(response.body)

--- a/spec/helpers/http_helper_spec.rb
+++ b/spec/helpers/http_helper_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe HttpHelper, type: :helper do
       end
 
       it "returns nil on errors" do
-        response = HttpHelper.get_json("https://www.example.com", {}, {})
-
-        expect(response).to be_nil
+        expect do
+          HttpHelper.get_json("https://www.example.com", {}, {})
+        end.to raise_error(StandardError)
       end
     end
 
@@ -52,9 +52,9 @@ RSpec.describe HttpHelper, type: :helper do
       end
 
       it "returns nil on invalid JSON" do
-        response = HttpHelper.get_json("https://www.example.com", {}, {})
-
-        expect(response).to be_nil
+        expect do
+          HttpHelper.get_json("https://www.example.com", {}, {})
+        end.to raise_error(JSON::ParserError)
       end
     end
   end
@@ -96,9 +96,9 @@ RSpec.describe HttpHelper, type: :helper do
       end
 
       it "returns nil on invalid JSON" do
-        response = HttpHelper.post_json("https://www.example.com", {})
-
-        expect(response).to be_nil
+        expect do
+          HttpHelper.post_json("https://www.example.com", {})
+        end.to raise_error(JSON::ParserError)
       end
     end
   end


### PR DESCRIPTION
# Description


# Notes

These helper functions are only used by Basespace for now. These are for making http requests from Rails, which is fairly rare for our app.

Raising errors makes it easier for callers to distinguish HTTP errors from empty responses.

Also improved logging a bit.

# Tests

* Updated tests.
* Verify that Basespace uploading still works.
