### PR TITLE
Add pipeline_run_id to cache key

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -730,7 +730,8 @@ class SamplesController < ApplicationController
 
   # The json response here should be precached in PipelineRun.
   def report_info
-    MetricUtil.put_metric_now("samples.cache.requested", 1)
+    skip_cache = params[:skip_cache] || false
+    MetricUtil.put_metric_now("samples.cache.requested", 1) unless skip_cache
 
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
     if pipeline_run.nil?
@@ -752,18 +753,23 @@ class SamplesController < ApplicationController
     # This allows 304 Not Modified to be returned so that the client can use its
     # local cache and avoid the large download.
     httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
-    response.headers["Last-Modified"] = httpdate
+    response.headers["Last-Modified"] = httpdate unless skip_cache
     # This is a custom header for testing and debugging
-    response.headers["X-IDseq-Cache"] = 'requested'
-    response.headers["X-IDseq-Cache-Key"] = cache_key
-    Rails.logger.info("Requesting report_info #{cache_key}")
+    response.headers["X-IDseq-Cache"] = 'requested' unless skip_cache
+    response.headers["X-IDseq-Cache-Key"] = cache_key unless skip_cache
+    Rails.logger.info("Requesting report_info #{cache_key}") unless skip_cache
 
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
-    json = Rails.cache.fetch(cache_key, expires_in: 30.days) do
-      MetricUtil.put_metric_now("samples.cache.miss", 1)
-      response.headers["X-IDseq-Cache"] = 'missed'
-      ReportHelper.report_info_json(pipeline_run, params[:background_id])
-    end
+    json =
+      if skip_cache
+        ReportHelper.report_info_json(pipeline_run, params[:background_id])
+      else
+        Rails.cache.fetch(cache_key, expires_in: 30.days) do
+          MetricUtil.put_metric_now("samples.cache.miss", 1)
+          response.headers["X-IDseq-Cache"] = 'missed'
+          ReportHelper.report_info_json(pipeline_run, params[:background_id])
+        end
+      end
 
     render json: json
   end
@@ -1249,7 +1255,7 @@ class SamplesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def samples_params
-    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name, :basespace_dataset_id, :basespace_access_token,
+    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name, :basespace_dataset_id, :basespace_access_token, :skip_cache,
                                          input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts],])
     new_params[:samples] if new_params
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -744,7 +744,9 @@ class SamplesController < ApplicationController
 
     cache_key = ReportHelper.report_info_cache_key(
       request.path,
-      params.permit(report_info_params.keys)
+      params
+        .permit(report_info_params.keys)
+        .merge(pipeline_run_id: pipeline_run.id)
     )
 
     # This allows 304 Not Modified to be returned so that the client can use its

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -755,6 +755,7 @@ class SamplesController < ApplicationController
     response.headers["Last-Modified"] = httpdate
     # This is a custom header for testing and debugging
     response.headers["X-IDseq-Cache"] = 'requested'
+    response.headers["X-IDseq-Cache-Key"] = cache_key
     Rails.logger.info("Requesting report_info #{cache_key}")
 
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -76,7 +76,7 @@ module ReportHelper
   }.freeze
 
   # Example cache key:
-  # /samples/12303/report_info?background_id=93&format=json&pipeline_version=3.3&report_ts=1549504990
+  # /samples/12303/report_info?background_id=93&format=json&pipeline_version=3.3&report_ts=1549504990&pipeline_run_id=39185
   def self.report_info_cache_key(path, kvs)
     kvs = kvs.to_h.sort.to_h
     # Increment this if you ever change the response structure of report_info

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1422,9 +1422,9 @@ class PipelineRun < ApplicationRecord
   def report_info_params
     {
       pipeline_version: pipeline_version || PipelineRun::PIPELINE_VERSION_WHEN_NULL,
-      # Default background is complicated... see get_background_id. In any case,
-      # we precache all backgrounds. See precache_report_info below.
+      # background should be set by caller
       background_id: nil,
+      pipeline_run_id: id,
       # For invalidation if underlying data changes. This should only happen in
       # exceptional situations, such as manual DB edits.
       report_ts: max_updated_at.utc.beginning_of_day.to_i,


### PR DESCRIPTION
# Description

A new pipeline run of a sample that was run with the same version on the same day would not create a new cache key. This fixes that issue by including the run id in the cache key. 

I also added a `skip_cache` param. 

# Tests

cache test
* open a report in local
* see `pipeline_run_id` in the cache key
* see cache hit on second load

precache test
* open a pipeline run in the console
* run `precache_report_info`
* see pipeline_run_id in cache key 
* see success

skip_cache
* open a report
* add the param
* see no x-idseq headers in response
* remove the param
* see x-idseq headers in response