### PR TITLE
IDSEQ-1178 - Stronger validation for input filenames

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
@@ -131,7 +131,7 @@ class LocalSampleFileUpload extends React.Component {
               </li>
               <li>
                 File names must be no longer than 120 characters and can only
-                contain letters from English alphabet (A-Z, upper and lower
+                contain letters from the English alphabet (A-Z, upper and lower
                 case), numbers (0-9), periods (.), hyphens (-) and underscores
                 (_). Spaces are not allowed.
               </li>

--- a/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/LocalSampleFileUpload.jsx
@@ -129,6 +129,12 @@ class LocalSampleFileUpload extends React.Component {
                 Paired files must be labeled with &quot;_R1&quot; or
                 &quot;_R2&quot; at the end of the basename.
               </li>
+              <li>
+                File names must be no longer than 120 characters and can only
+                contain letters from English alphabet (A-Z, upper and lower
+                case), numbers (0-9), periods (.), hyphens (-) and underscores
+                (_). Spaces are not allowed.
+              </li>
             </ul>
           </div>
         )}

--- a/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
@@ -135,7 +135,7 @@ class RemoteSampleFileUpload extends React.Component {
               </li>
               <li>
                 File names must be no longer than 120 characters and can only
-                contain letters from English alphabet (A-Z, upper and lower
+                contain letters from the English alphabet (A-Z, upper and lower
                 case), numbers (0-9), periods (.), hyphens (-) and underscores
                 (_). Spaces are not allowed.
               </li>

--- a/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
@@ -139,7 +139,6 @@ class RemoteSampleFileUpload extends React.Component {
                 case), numbers (0-9), periods (.), hyphens (-) and underscores
                 (_). Spaces are not allowed.
               </li>
-              <li>File names must be no longer than 140 characters.</li>
             </ul>
           </div>
         )}

--- a/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/RemoteSampleFileUpload.jsx
@@ -133,6 +133,13 @@ class RemoteSampleFileUpload extends React.Component {
                 Paired files must be labeled with &quot;_R1&quot; or
                 &quot;_R2&quot; at the end of the basename.
               </li>
+              <li>
+                File names must be no longer than 120 characters and can only
+                contain letters from English alphabet (A-Z, upper and lower
+                case), numbers (0-9), periods (.), hyphens (-) and underscores
+                (_). Spaces are not allowed.
+              </li>
+              <li>File names must be no longer than 140 characters.</li>
             </ul>
           </div>
         )}

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'csv'
+require 'aws-sdk-s3'
 
 module SamplesHelper
   include PipelineOutputsHelper
@@ -142,14 +143,26 @@ module SamplesHelper
     default_attributes = { project_id: project_id.to_i,
                            host_genome_id: host_genome_id,
                            status: 'created', }
-    s3_path.chomp!('/')
-    s3_bucket = 's3://' + s3_path.sub('s3://', '').split('/')[0]
-    s3_output, _stderr, status = Open3.capture3("aws", "s3", "ls", "--recursive", "#{s3_path}/")
-    return unless status.exitstatus.zero?
-    s3_output.chomp!
-    entries = s3_output.split("\n").reject { |line| line.include? "Undetermined" }
+
+    parsed_uri = URI.parse(s3_path)
+    return unless parsed_uri.scheme == "s3"
+
+    s3_bucket_name = parsed_uri.host
+    return if s3_bucket_name.nil?
+
+    s3_prefix = parsed_uri.path.sub(%r{^/(.*?)/?$}, '\1/')
+
+    client = Aws::S3::Client.new
+    begin
+      entries = client.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
+    rescue Aws::S3::Errors::ServiceError => e # Covers all S3 access errors (AccessDenied/NoSuchBucket/AllAccessDisabled)
+      Rails.logger.info("parsed_samples_for_s3_path Aws::S3::Errors::ServiceError. s3_path: #{s3_path}, error_class: #{e.class.name}, error_message: #{e.message} ")
+      return
+    end
+
     samples = {}
-    entries.each do |file_name|
+    entries.each do |s3_entry|
+      file_name = File.basename(s3_entry)
       matched_paired = InputFile::BULK_FILE_PAIRED_REGEX.match(file_name)
       matched_single = InputFile::BULK_FILE_SINGLE_REGEX.match(file_name)
       if matched_paired
@@ -161,12 +174,11 @@ module SamplesHelper
       else
         next
       end
-      source = matched[0]
-      name = matched[1].split('/')[-1]
+      name = matched[1]
       samples[name] ||= default_attributes.clone
       samples[name][:input_files_attributes] ||= []
-      samples[name][:input_files_attributes][read_idx] = { name: source.split('/')[-1],
-                                                           source: "#{s3_bucket}/#{source}",
+      samples[name][:input_files_attributes][read_idx] = { name: file_name,
+                                                           source: "s3://#{s3_bucket_name}/#{s3_entry}",
                                                            source_type: InputFile::SOURCE_TYPE_S3, }
     end
 

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -156,6 +156,8 @@ module SamplesHelper
 
     begin
       entries = S3_CLIENT.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
+      # ignore illumina Undetermined FASTQ files (ex: "Undetermined_AAA_R1_001.fastq.gz")
+      entries = entries.reject { |line| line.include? "Undetermined" }
     rescue Aws::S3::Errors::ServiceError => e # Covers all S3 access errors (AccessDenied/NoSuchBucket/AllAccessDisabled)
       Rails.logger.info("parsed_samples_for_s3_path Aws::S3::Errors::ServiceError. s3_path: #{s3_path}, error_class: #{e.class.name}, error_message: #{e.message} ")
       return

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -147,7 +147,7 @@ module SamplesHelper
                            status: 'created', }
 
     parsed_uri = URI.parse(s3_path)
-    return unless parsed_uri.scheme == "s3"
+    return if parsed_uri.scheme != "s3"
 
     s3_bucket_name = parsed_uri.host
     return if s3_bucket_name.nil?

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -6,6 +6,8 @@ module SamplesHelper
   include PipelineOutputsHelper
   include ErrorHelper
 
+  S3_CLIENT = Aws::S3::Client.new
+
   def generate_sample_list_csv(formatted_samples)
     attributes = %w[sample_name uploader upload_date overall_job_status runtime_seconds
                     total_reads nonhost_reads nonhost_reads_percent total_ercc_reads subsampled_fraction
@@ -152,9 +154,8 @@ module SamplesHelper
 
     s3_prefix = parsed_uri.path.sub(%r{^/(.*?)/?$}, '\1/')
 
-    client = Aws::S3::Client.new
     begin
-      entries = client.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
+      entries = S3_CLIENT.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
     rescue Aws::S3::Errors::ServiceError => e # Covers all S3 access errors (AccessDenied/NoSuchBucket/AllAccessDisabled)
       Rails.logger.info("parsed_samples_for_s3_path Aws::S3::Errors::ServiceError. s3_path: #{s3_path}, error_class: #{e.class.name}, error_message: #{e.message} ")
       return

--- a/app/models/input_file.rb
+++ b/app/models/input_file.rb
@@ -6,9 +6,9 @@ class InputFile < ApplicationRecord
   SOURCE_TYPE_S3 = 's3'.freeze
   SOURCE_TYPE_BASESPACE = 'basespace'.freeze
 
-  FILE_REGEX = %r{\A[^\s\/]+\.(fastq|fq|fastq.gz|fq.gz|fasta|fa|fasta.gz|fa.gz)\z}
-  BULK_FILE_PAIRED_REGEX = /([^ ]*)_R(\d)(_001)?.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
-  BULK_FILE_SINGLE_REGEX = /([^ ]*).(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
+  FILE_REGEX = /\A[-.A-Za-z0-9_]{1,120}\.(fastq|fq|fastq.gz|fq.gz|fasta|fa|fasta.gz|fa.gz)\z/
+  BULK_FILE_PAIRED_REGEX = /\A([-.A-Za-z0-9_]{1,120})_R(\d)(_001)?\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
+  BULK_FILE_SINGLE_REGEX = /\A([-.A-Za-z0-9_]{1,120})\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
   S3_CP_PIPE_ERROR = '[Errno 32] Broken pipe'.freeze
 
   validates :name, presence: true, format: { with: FILE_REGEX, message: "file must match format '#{FILE_REGEX}'" }


### PR DESCRIPTION
# Description

Add stronger validation for input file names. 

File names must be no longer than 120 characters and can only contain letters from English alphabet (A-Z, upper and lower case), numbers (0-9), periods (.), hyphens (-) and underscores (_). Spaces are not allowed.

I'm also replacing a few aws cli commands by their AWS ruby SDK counterparts.

# Tests

* Manual tests
