### PR TITLE
Tweak margins on new heatmap zoom feature.

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -537,7 +537,7 @@ class SamplesHeatmapView extends React.Component {
 
   renderVisualization() {
     return (
-      <div className="row visualization-content">
+      <div className="visualization-content">
         {this.state.loading ? this.renderLoading() : this.renderHeatmap()}
       </div>
     );

--- a/app/assets/src/components/views/compare/samples_heatmap_vis.scss
+++ b/app/assets/src/components/views/compare/samples_heatmap_vis.scss
@@ -20,10 +20,11 @@
   .heatmapContainer {
     overflow-x: auto;
     // Set the height to force the horizontal scrollbar to appear at the bottom
-    // of the viewport instead of the bottom of the page. 360px is the height
+    // of the viewport instead of the bottom of the page. 334px is the height
     // of the all the elements above the heatmapContainer. It *will* need to
     // change if the height of the elements above ever change.
-    height: calc(100vh - 360px);
+    // TODO(mark): Use flexbox instead of hard-coding the offset.
+    height: calc(100vh - 334px);
 
     svg {
       display: block;

--- a/app/assets/src/styles/themes/_elements.scss
+++ b/app/assets/src/styles/themes/_elements.scss
@@ -20,6 +20,7 @@ $space-xl: 40px;
   &::-webkit-scrollbar {
     // Overwrite semantic ui.
     width: 8px !important;
+    height: 8px !important;
   }
 
   &::-webkit-scrollbar-track {


### PR DESCRIPTION
The feature has a couple tiny styling issues. There's a gap below the zoom area, and the horizontal scrollbar is a little fatter than the vertical one.

Verified that style fixes are correct. (and no double scrollbar appears)

<img width="1000" alt="Screen Shot 2019-08-22 at 8 55 45 AM" src="https://user-images.githubusercontent.com/837004/63531794-1fed8180-c4be-11e9-8935-8a9cd169e0b7.png">

<img width="1674" alt="Screen Shot 2019-08-22 at 9 19 32 AM" src="https://user-images.githubusercontent.com/837004/63531797-21b74500-c4be-11e9-97e7-f8ef2800f94b.png">
