### PR TITLE
Fix location string in CSV downloads

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -22,6 +22,11 @@ module SamplesHelper
         db_sample = sample_info[:db_sample]
         run_info = sample_info[:run_info]
         metadata = sample_info[:metadata]
+        collection_location = if metadata && metadata[:collection_location_v2]
+                                metadata[:collection_location_v2].is_a?(Hash) ? metadata[:collection_location_v2].dig(:name) : metadata[:collection_location_v2]
+                              else
+                                ''
+                              end
         data_values = { sample_name: db_sample ? db_sample[:name] : '',
                         uploader: sample_info[:uploader] ? sample_info[:uploader][:name] : '',
                         upload_date: db_sample ? db_sample[:created_at] : '',
@@ -41,11 +46,7 @@ module SamplesHelper
                         sample_type: metadata && metadata[:sample_type] ? metadata[:sample_type] : '',
                         nucleotide_type: metadata && metadata[:nucleotide_type] ? metadata[:nucleotide_type] : '',
                         # Handle both location objects w/name and strings
-                        collection_location: if metadata && metadata[:collection_location_v2]
-                                               metadata[:collection_location_v2].is_a?(Hash) ? metadata[:collection_location_v2].dig(:name) : metadata[:collection_location_v2]
-                                             else
-                                               ''
-                                             end,
+                        collection_location: collection_location,
                         host_genome: derived_output && derived_output[:host_genome_name] ? derived_output[:host_genome_name] : '',
                         notes: db_sample && db_sample[:sample_notes] ? db_sample[:sample_notes] : '', }
         attributes_as_symbols = attributes.map(&:to_sym)

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -41,7 +41,11 @@ module SamplesHelper
                         sample_type: metadata && metadata[:sample_type] ? metadata[:sample_type] : '',
                         nucleotide_type: metadata && metadata[:nucleotide_type] ? metadata[:nucleotide_type] : '',
                         # Handle both location objects w/name and strings
-                        collection_location: metadata && metadata[:collection_location_v2] && (metadata[:collection_location_v2].is_a?(Hash) ? metadata[:collection_location_v2].dig(:name) : metadata[:collection_location_v2]) || '',
+                        collection_location: if metadata && metadata[:collection_location_v2]
+                                               metadata[:collection_location_v2].is_a?(Hash) ? metadata[:collection_location_v2].dig(:name) : metadata[:collection_location_v2]
+                                             else
+                                               ''
+                                             end,
                         host_genome: derived_output && derived_output[:host_genome_name] ? derived_output[:host_genome_name] : '',
                         notes: db_sample && db_sample[:sample_notes] ? db_sample[:sample_notes] : '', }
         attributes_as_symbols = attributes.map(&:to_sym)

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -40,7 +40,8 @@ module SamplesHelper
                         reads_after_cdhitdup: (derived_output[:summary_stats] || {})[:reads_after_cdhitdup] || '',
                         sample_type: metadata && metadata[:sample_type] ? metadata[:sample_type] : '',
                         nucleotide_type: metadata && metadata[:nucleotide_type] ? metadata[:nucleotide_type] : '',
-                        collection_location: metadata && metadata[:collection_location_v2] ? metadata[:collection_location_v2] : '',
+                        # Handle both location objects w/name and strings
+                        collection_location: metadata && metadata[:collection_location_v2] && (metadata[:collection_location_v2].is_a?(Hash) ? metadata[:collection_location_v2].dig(:name) : metadata[:collection_location_v2]) || '',
                         host_genome: derived_output && derived_output[:host_genome_name] ? derived_output[:host_genome_name] : '',
                         notes: db_sample && db_sample[:sample_notes] ? db_sample[:sample_notes] : '', }
         attributes_as_symbols = attributes.map(&:to_sym)


### PR DESCRIPTION
### Description
- Fix a bug in location values in CSVs. Before they might see `{:name=>"Yolo   County, California, USA", :geo_level=>"subdivision" ...}` in the spreadsheet.
- Looks like this is the only CSV download we have with this metadata.

### Tests
Before and After (works on nil values, string values, and hash values):
![Screen Shot 2019-08-23 at 3 51 34 PM](https://user-images.githubusercontent.com/5652739/63627890-7f32bb00-c5be-11e9-8c98-3920c6696b33.png)