### PR TITLE
Add IDseq wiki option to user dropdown menu

### DIFF
--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -160,6 +160,22 @@ const UserMenuDropDown = ({
         text={
           <a
             className={cs.option}
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/chanzuckerberg/idseq-dag/wiki"
+            onClick={() =>
+              logAnalyticsEvent("Header_dropdown-wiki-option_clicked")
+            }
+          >
+            IDseq Wiki
+          </a>
+        }
+      />,
+      <BareDropdown.Item
+        key="5"
+        text={
+          <a
+            className={cs.option}
             href={`mailto:${email}?Subject=Report%20Feedback`}
             onClick={() =>
               logAnalyticsEvent("Header_dropdown-feedback-option_clicked")
@@ -170,7 +186,7 @@ const UserMenuDropDown = ({
         }
       />,
       <BareDropdown.Item
-        key="5"
+        key="6"
         text={
           <a
             className={cs.option}
@@ -186,7 +202,7 @@ const UserMenuDropDown = ({
         }
       />,
       <BareDropdown.Item
-        key="6"
+        key="7"
         text={
           <a
             className={cs.option}
@@ -202,28 +218,12 @@ const UserMenuDropDown = ({
         }
       />,
       <BareDropdown.Item
-        key="7"
+        key="8"
         text="Logout"
         onClick={withAnalytics(
           signOut,
           "Header_dropdown-logout-option_clicked"
         )}
-      />,
-      <BareDropdown.Item
-        key="8"
-        text={
-          <a
-            className={cs.option}
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://github.com/chanzuckerberg/idseq-dag/wiki"
-            onClick={() =>
-              logAnalyticsEvent("Header_dropdown-wiki-option_clicked")
-            }
-          >
-            IDseq Wiki
-          </a>
-        }
       />
     );
     return userDropdownItems;

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -208,6 +208,22 @@ const UserMenuDropDown = ({
           signOut,
           "Header_dropdown-logout-option_clicked"
         )}
+      />,
+      <BareDropdown.Item
+        key="8"
+        text={
+          <a
+            className={cs.option}
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/chanzuckerberg/idseq-dag/wiki"
+            onClick={() =>
+              logAnalyticsEvent("Header_dropdown-wiki-option_clicked")
+            }
+          >
+            IDseq Wiki
+          </a>
+        }
       />
     );
     return userDropdownItems;


### PR DESCRIPTION
# Description

Add a link to the IDseq Wiki (https://github.com/chanzuckerberg/idseq-dag/wiki) in the dropdown menu after a user clicks on their name.

![image](https://user-images.githubusercontent.com/53838890/63891446-0e164d80-c99a-11e9-80f9-a51f43848be3.png)


# Tests

* A new tab to the IDseq Wiki is opened after the link is clicked.
