### PR TITLE
Remove pipeline version check for coverage viz on dag json templates

### DIFF
--- a/app/lib/dags/experimental.json.erb
+++ b/app/lib/dags/experimental.json.erb
@@ -8,18 +8,16 @@
       "gsnap.hitsummary.tab",
       "rapsearch2.hitsummary.tab"
     ],
-    <% if attribute_dict[:coverage_viz_enabled] %>
-      "refined_gsnap_in": [
-        "gsnap.reassigned.m8",
-        "gsnap.hitsummary2.tab",
-        "gsnap.blast.top.m8"
-      ],
-      "contig_in": [
-        "contig_coverage.json",
-        "contig_stats.json",
-        "contigs.fasta"
-      ],
-    <% end %>
+    "refined_gsnap_in": [
+      "gsnap.reassigned.m8",
+      "gsnap.hitsummary2.tab",
+      "gsnap.blast.top.m8"
+    ],
+    "contig_in": [
+      "contig_coverage.json",
+      "contig_stats.json",
+      "contigs.fasta"
+    ],
     "gsnap_m8": ["gsnap.deduped.m8"],
     "taxid_fasta_out": ["taxid_annot.fasta"],
     "taxid_locator_out": [
@@ -39,9 +37,7 @@
     ],
     "alignment_viz_out": ["align_viz.summary"],
     "srst2_out": ["out.log", "out__genes__ARGannot_r2__results.txt", "out__fullgenes__ARGannot_r2__results.txt", "amr_processed_results.csv", "amr_summary_results.csv", "output__.ARGannot_r2.sorted.bam"],
-    <% if attribute_dict[:coverage_viz_enabled] %>
-      "coverage_viz_out": ["coverage_viz_summary.json"],
-    <% end %>
+    "coverage_viz_out": ["coverage_viz_summary.json"],
     <% if @attribute_dict[:fastq2] %>
       "fastqs": ["<%= @attribute_dict[:fastq1] %>", "<%= @attribute_dict[:fastq2] %>"],
     <% else %>
@@ -111,18 +107,16 @@
         "file_ext": "<%= @attribute_dict[:file_ext] %>"
       }
     },
-    <% if attribute_dict[:coverage_viz_enabled] %>
-      {
-        "in": ["refined_gsnap_in", "contig_in", "gsnap_m8"],
-        "out": "coverage_viz_out",
-        "class": "PipelineStepGenerateCoverageViz",
-        "module": "idseq_dag.steps.generate_coverage_viz",
-        "additional_files": {
-          "info_db": "s3://idseq-database/alignment_data/2018-12-01/nt_info.sqlite3"
-        },
-        "additional_attributes": {}
+    {
+      "in": ["refined_gsnap_in", "contig_in", "gsnap_m8"],
+      "out": "coverage_viz_out",
+      "class": "PipelineStepGenerateCoverageViz",
+      "module": "idseq_dag.steps.generate_coverage_viz",
+      "additional_files": {
+        "info_db": "s3://idseq-database/alignment_data/2018-12-01/nt_info.sqlite3"
       },
-    <% end %>
+      "additional_attributes": {}
+    },
     {
       "in": ["fastqs", "nonhost_fasta"],
       "out": "nonhost_fastq_out",
@@ -139,14 +133,12 @@
     "gsnap_m8": {
       "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/results/<%= @attribute_dict[:pipeline_version] %>"
     },
-    <% if attribute_dict[:coverage_viz_enabled] %>
-      "refined_gsnap_in": {
-        "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/postprocess/<%= @attribute_dict[:pipeline_version] %>/assembly"
-      },
-      "contig_in": {
-        "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/postprocess/<%= @attribute_dict[:pipeline_version] %>/assembly"
-      },
-    <% end %>
+    "refined_gsnap_in": {
+      "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/postprocess/<%= @attribute_dict[:pipeline_version] %>/assembly"
+    },
+    "contig_in": {
+      "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/postprocess/<%= @attribute_dict[:pipeline_version] %>/assembly"
+    },
     "fastqs": {
       "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/fastqs"
     },

--- a/app/lib/dags/experimental.json.erb
+++ b/app/lib/dags/experimental.json.erb
@@ -8,7 +8,7 @@
       "gsnap.hitsummary.tab",
       "rapsearch2.hitsummary.tab"
     ],
-    <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+    <% if attribute_dict[:coverage_viz_enabled] %>
       "refined_gsnap_in": [
         "gsnap.reassigned.m8",
         "gsnap.hitsummary2.tab",
@@ -39,7 +39,7 @@
     ],
     "alignment_viz_out": ["align_viz.summary"],
     "srst2_out": ["out.log", "out__genes__ARGannot_r2__results.txt", "out__fullgenes__ARGannot_r2__results.txt", "amr_processed_results.csv", "amr_summary_results.csv", "output__.ARGannot_r2.sorted.bam"],
-    <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+    <% if attribute_dict[:coverage_viz_enabled] %>
       "coverage_viz_out": ["coverage_viz_summary.json"],
     <% end %>
     <% if @attribute_dict[:fastq2] %>
@@ -111,7 +111,7 @@
         "file_ext": "<%= @attribute_dict[:file_ext] %>"
       }
     },
-    <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+    <% if attribute_dict[:coverage_viz_enabled] %>
       {
         "in": ["refined_gsnap_in", "contig_in", "gsnap_m8"],
         "out": "coverage_viz_out",
@@ -139,7 +139,7 @@
     "gsnap_m8": {
       "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/results/<%= @attribute_dict[:pipeline_version] %>"
     },
-    <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+    <% if attribute_dict[:coverage_viz_enabled] %>
       "refined_gsnap_in": {
         "s3_dir": "s3://<%= @attribute_dict[:bucket] %>/samples/<%= @project_id %>/<%= @sample_id %>/postprocess/<%= @attribute_dict[:pipeline_version] %>/assembly"
       },

--- a/app/lib/dags/postprocess.json.erb
+++ b/app/lib/dags/postprocess.json.erb
@@ -38,7 +38,7 @@
       "assembly/gsnap.reassigned.m8",
       "assembly/gsnap.hitsummary2.tab",
       "assembly/refined_gsnap_counts.json",
-      <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+      <% if attribute_dict[:coverage_viz_enabled] %>
         "assembly/gsnap_contig_summary.json",
         "assembly/gsnap.blast.top.m8"
       <% else %>
@@ -50,7 +50,7 @@
       "assembly/rapsearch2.reassigned.m8",
       "assembly/rapsearch2.hitsummary2.tab",
       "assembly/refined_rapsearch2_counts.json",
-      <% if attribute_dict[:pipeline_version].to_f >= 3.6 %>
+      <% if attribute_dict[:coverage_viz_enabled] %>
         "assembly/rapsearch2_contig_summary.json",
         "assembly/rapsearch2.blast.top.m8"
       <% else %>

--- a/app/lib/dags/postprocess.json.erb
+++ b/app/lib/dags/postprocess.json.erb
@@ -38,24 +38,16 @@
       "assembly/gsnap.reassigned.m8",
       "assembly/gsnap.hitsummary2.tab",
       "assembly/refined_gsnap_counts.json",
-      <% if attribute_dict[:coverage_viz_enabled] %>
-        "assembly/gsnap_contig_summary.json",
-        "assembly/gsnap.blast.top.m8"
-      <% else %>
-        "assembly/gsnap_contig_summary.json"
-      <% end %>
+      "assembly/gsnap_contig_summary.json",
+      "assembly/gsnap.blast.top.m8"
     ],
     "refined_rapsearch2_out": [
       "assembly/rapsearch2.blast.m8",
       "assembly/rapsearch2.reassigned.m8",
       "assembly/rapsearch2.hitsummary2.tab",
       "assembly/refined_rapsearch2_counts.json",
-      <% if attribute_dict[:coverage_viz_enabled] %>
-        "assembly/rapsearch2_contig_summary.json",
-        "assembly/rapsearch2.blast.top.m8"
-      <% else %>
-        "assembly/rapsearch2_contig_summary.json"
-      <% end %>
+      "assembly/rapsearch2_contig_summary.json",
+      "assembly/rapsearch2.blast.top.m8"
     ],
     "refined_taxon_count_out": ["assembly/refined_taxon_counts.json"],
     "contig_summary_out": ["assembly/combined_contig_summary.json"],

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -304,7 +304,6 @@ class PipelineRunStage < ApplicationRecord
       nt_loc_db: alignment_config.s3_nt_loc_db_path,
       nr_db: alignment_config.s3_nr_db_path,
       nr_loc_db: alignment_config.s3_nr_loc_db_path,
-      coverage_viz_enabled: pipeline_run.after('3.6'),
     }
     dag_commands = prepare_dag(attribute_dict)
     batch_command = [install_pipeline(pipeline_run.pipeline_commit), dag_commands].join("; ")
@@ -328,7 +327,6 @@ class PipelineRunStage < ApplicationRecord
       nt_loc_db: alignment_config.s3_nt_loc_db_path,
       nr_db: alignment_config.s3_nr_db_path,
       nr_loc_db: alignment_config.s3_nr_loc_db_path,
-      coverage_viz_enabled: pipeline_run.after('3.6'),
     }
     attribute_dict[:fastq2] = sample.input_files[1].name if sample.input_files[1]
     dag_commands = prepare_dag(attribute_dict)

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -304,6 +304,7 @@ class PipelineRunStage < ApplicationRecord
       nt_loc_db: alignment_config.s3_nt_loc_db_path,
       nr_db: alignment_config.s3_nr_db_path,
       nr_loc_db: alignment_config.s3_nr_loc_db_path,
+      coverage_viz_enabled: pipeline_run.after('3.6'),
     }
     dag_commands = prepare_dag(attribute_dict)
     batch_command = [install_pipeline(pipeline_run.pipeline_commit), dag_commands].join("; ")
@@ -327,6 +328,7 @@ class PipelineRunStage < ApplicationRecord
       nt_loc_db: alignment_config.s3_nt_loc_db_path,
       nr_db: alignment_config.s3_nr_db_path,
       nr_loc_db: alignment_config.s3_nr_loc_db_path,
+      coverage_viz_enabled: pipeline_run.after('3.6'),
     }
     attribute_dict[:fastq2] = sample.input_files[1].name if sample.input_files[1]
     dag_commands = prepare_dag(attribute_dict)


### PR DESCRIPTION
### Description

* Remove all checks for pipeline version for coverage viz.

### Notes

* Makes it impossible running versions smaller than 3.6
* These versions were probably already not runnable due to other dag json changes (e.g. AMR)
* Once we decide on a method to keep dag json definition compatible with previous pipeline versions we can refer back to this PR to make it compatible.