### PR TITLE
Remove revoke basespace token until better solution can be found.

### DIFF
--- a/app/jobs/transfer_basespace_files.rb
+++ b/app/jobs/transfer_basespace_files.rb
@@ -11,13 +11,8 @@ class TransferBasespaceFiles
     sample = Sample.find(sample_id)
     sample.transfer_basespace_files(basespace_dataset_id, basespace_access_token)
 
-    # Revoke the access token, so that it can no longer be used.
-    begin
-      BasespaceHelper.revoke_access_token(basespace_access_token)
-      BasespaceHelper.verify_access_token_revoked(basespace_access_token)
-    rescue
-      Rails.logger.warn("BasespaceAccessTokenError Failed to revoke access token")
-    end
+    # TODO: Revoke the access token, so that it can no longer be used.
+    # Need to do this after ALL samples that use the access token can be uploaded.
   rescue => e
     Rails.logger.error(e)
   end


### PR DESCRIPTION
# Description

There was a serious bug with the previous code, which is that multiple samples share the same access token, but the first sample that finished uploading would revoke the token.

Reverting this change for now, since the proper fix is a little complicated (we need to detect somehow when all samples have finished their asynchronous upload and revoke the token after) Will tackle that in a subsequent change.

# Tests

* Uploaded 4 medium-samples simultaneously and ensured that they all uploaded successfully.
