### PR TITLE
IDSEQ-1152 - Avoid corrupted upload files (idseq-web)

### DIFF
--- a/app/lib/log_util.rb
+++ b/app/lib/log_util.rb
@@ -1,10 +1,16 @@
+# frozen_string_literal: true
+
 class LogUtil
-  def self.log_err_and_airbrake(msg)
-    Rails.logger.error(msg)
+  def self.log_err_and_airbrake(msg, exception = nil)
+    LogUtil.log_backtrace(exception, msg)
     Airbrake.notify(msg)
   end
 
-  def self.log_backtrace(exception)
-    Rails.logger.error("Backtrace:\n\t#{exception.backtrace.join("\n\t")}")
+  def self.log_backtrace(exception, msg = nil)
+    if exception.respond_to? :backtrace
+      Rails.logger.error("#{msg}. Exception: #{exception.try(:message)}. Backtrace:\n\t#{exception.try(:backtrace).try(:join, "\n\t")}")
+    else
+      Rails.logger.error("#{msg}. Exception:\n\t#{exception}")
+    end
   end
 end

--- a/app/lib/log_util.rb
+++ b/app/lib/log_util.rb
@@ -6,11 +6,7 @@ class LogUtil
     Airbrake.notify(msg)
   end
 
-  def self.log_backtrace(exception, msg = nil)
-    if msg.nil?
-      Rails.logger.error("Exception message: #{exception.try(:message)}. Backtrace:\n\t#{exception.try(:backtrace).try(:join, "\n\t")}")
-    else
-      Rails.logger.error("Error message: #{msg}. Exception message: #{exception.try(:message)}. Backtrace:\n\t#{exception.try(:backtrace).try(:join, "\n\t")}")
-    end
+  def self.log_backtrace(exception)
+    Rails.logger.error("Backtrace:\n\t#{exception.backtrace.join("\n\t")}")
   end
 end

--- a/app/lib/log_util.rb
+++ b/app/lib/log_util.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 class LogUtil
-  def self.log_err_and_airbrake(msg, exception = nil)
-    LogUtil.log_backtrace(exception, msg)
+  def self.log_err_and_airbrake(msg)
+    Rails.logger.error(msg)
     Airbrake.notify(msg)
   end
 
   def self.log_backtrace(exception, msg = nil)
-    if exception.respond_to? :backtrace
-      Rails.logger.error("#{msg}. Exception: #{exception.try(:message)}. Backtrace:\n\t#{exception.try(:backtrace).try(:join, "\n\t")}")
+    if msg.nil?
+      Rails.logger.error("Exception message: #{exception.try(:message)}. Backtrace:\n\t#{exception.try(:backtrace).try(:join, "\n\t")}")
     else
-      Rails.logger.error("#{msg}. Exception:\n\t#{exception}")
+      Rails.logger.error("Error message: #{msg}. Exception message: #{exception.try(:message)}. Backtrace:\n\t#{exception.try(:backtrace).try(:join, "\n\t")}")
     end
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -363,7 +363,9 @@ class Sample < ApplicationRecord
     self.status = STATUS_UPLOADED
     save! # this triggers pipeline command
   rescue => e
-    LogUtil.log_err_and_airbrake("SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id}): #{e}", e)
+    err_msg = "SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id})"
+    LogUtil.log_err_and_airbrake("#{err_msg}: #{e}")
+    LogUtil.log_backtrace(e, err_msg)
     self.status = STATUS_CHECKED
     self.upload_error = Sample::UPLOAD_ERROR_S3_UPLOAD_FAILED
     save!

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -363,9 +363,7 @@ class Sample < ApplicationRecord
     self.status = STATUS_UPLOADED
     save! # this triggers pipeline command
   rescue => e
-    err_msg = "SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id})"
-    LogUtil.log_err_and_airbrake("#{err_msg}: #{e}")
-    LogUtil.log_backtrace(e, err_msg)
+    LogUtil.log_err_and_airbrake("SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id}): #{e}")
     self.status = STATUS_CHECKED
     self.upload_error = Sample::UPLOAD_ERROR_S3_UPLOAD_FAILED
     save!

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -59,6 +59,13 @@ class Sample < ApplicationRecord
                      :sample_template, # this refers to nucleotide type (RNA or DNA)
                      :sample_library, :sample_sequencer, :sample_notes, :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection,].freeze
 
+  # Maximum allowed line length in characters for fastq/fasta files
+  MAX_LINE_LENGTH = 10_000
+  # Error message to identify parse errors from fastq-fasta-line-validation.awk
+  PARSE_ERROR_MESSAGE = 'PARSE ERROR'.freeze
+  # Script parameters
+  FASTQ_FASTA_LINE_VALIDATION_AWK_SCRIPT = File.expand_path("../../scripts/fastq-fasta-line-validation.awk", __dir__)
+
   # These are temporary variables that are not saved to the database. They only persist for the lifetime of the Sample object.
   attr_accessor :bulk_mode, :basespace_dataset_id, :basespace_access_token
 
@@ -290,23 +297,25 @@ class Sample < ApplicationRecord
         # Run the piped commands and save stderr
         err_read, err_write = IO.pipe
         if fastq =~ /\.gz/
-          _proc_download, _proc_unzip, proc_head, proc_zip, proc_upload = Open3.pipeline(
+          _proc_download, _proc_unzip, proc_head, proc_validation, proc_zip, proc_upload = Open3.pipeline(
             ["aws", "s3", "cp", fastq, "-"],
-            "gzip -dc",
+            ["gzip", "-dc"],
             ["head", "-n", max_lines.to_s],
-            "gzip -c",
+            ["awk", "-f", FASTQ_FASTA_LINE_VALIDATION_AWK_SCRIPT, "-v", "max_line_length=#{Sample::MAX_LINE_LENGTH}"],
+            ["gzip", "-c"],
             ["aws", "s3", "cp", "-", "#{sample_input_s3_path}/#{input_file.name}"],
             err: err_write
           )
-          to_check = [proc_head, proc_zip, proc_upload]
+          to_check = [proc_head, proc_zip, proc_validation, proc_upload]
         else
-          _proc_download, proc_head, proc_upload = Open3.pipeline(
+          _proc_download, proc_head, proc_validation, proc_upload = Open3.pipeline(
             ["aws", "s3", "cp", fastq, "-"],
             ["head", "-n", max_lines.to_s],
+            ["awk", "-f", FASTQ_FASTA_LINE_VALIDATION_AWK_SCRIPT, "-v", "max_line_length=#{Sample::MAX_LINE_LENGTH}"],
             ["aws", "s3", "cp", "-", "#{sample_input_s3_path}/#{input_file.name}"],
             err: err_write
           )
-          to_check = [proc_head, proc_upload]
+          to_check = [proc_head, proc_validation, proc_upload]
         end
         err_write.close
         stderr = err_read.read
@@ -316,6 +325,11 @@ class Sample < ApplicationRecord
         # we still want to see errs like HeadObject Forbidden.
         if to_check.all? { |p| p && p.exitstatus && p.exitstatus.zero? } && (stderr.empty? || stderr.include?(InputFile::S3_CP_PIPE_ERROR))
           # Success
+          break
+        elsif !proc_validation.exitstatus.zero? && stderr.include?(Sample::PARSE_ERROR_MESSAGE)
+          error_msg = "Error parsing upload of S3 sample '#{name}' (#{id}) file '#{fastq}' failed with: #{stderr}"
+          Rails.logger.error(error_msg)
+          stderr_array << error_msg
           break
         else
           # Try again
@@ -349,7 +363,7 @@ class Sample < ApplicationRecord
     self.status = STATUS_UPLOADED
     save! # this triggers pipeline command
   rescue => e
-    LogUtil.log_err_and_airbrake("SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id}): #{e}")
+    LogUtil.log_err_and_airbrake("SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id}): #{e}", e)
     self.status = STATUS_CHECKED
     self.upload_error = Sample::UPLOAD_ERROR_S3_UPLOAD_FAILED
     save!

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -64,7 +64,7 @@ class Sample < ApplicationRecord
   # Error message to identify parse errors from fastq-fasta-line-validation.awk
   PARSE_ERROR_MESSAGE = 'PARSE ERROR'.freeze
   # Script parameters
-  FASTQ_FASTA_LINE_VALIDATION_AWK_SCRIPT = File.expand_path("../../scripts/fastq-fasta-line-validation.awk", __dir__)
+  FASTQ_FASTA_LINE_VALIDATION_AWK_SCRIPT = Rails.root.join("scripts", "fastq-fasta-line-validation.awk").to_s
 
   # These are temporary variables that are not saved to the database. They only persist for the lifetime of the Sample object.
   attr_accessor :bulk_mode, :basespace_dataset_id, :basespace_access_token

--- a/scripts/fastq-fasta-line-validation.awk
+++ b/scripts/fastq-fasta-line-validation.awk
@@ -1,0 +1,16 @@
+# Validates line length and checks if all characters are part of ascii set
+# Required input variables:
+#    max_line_length: This is the max allowed length for each line
+# usage example:
+#    cat somefile.fastq | awk -f "../scripts/fastq-fasta-line-validation.awk" -v max_line_length=10000
+{
+  if ($0 ~ /[^\x20-\x7F\x01\x09]/) {
+    printf "PARSE ERROR: not an ascii file. Line %d contains non-ascii characters.\n", FILENAME, NR > "/dev/stderr";
+    exit 1;
+  }
+  if (length > max_line_length) {
+    printf "PARSE ERROR: invalid line length. Line %d is %d characters long, and it exceeds max line length of %d.\n",  NR, length, max_line_length > "/dev/stderr";
+    exit 1;
+  }
+  print $0;
+}


### PR DESCRIPTION
# Description

Adds stronger validations when decompressing gzip files to avoid undesired behaviors when decompressing corrupted files.

Refer to ticket IDSEQ-1152 in Jira for more deails.

# Tests

Manual tests using regular and corrupted files uploaded from S3 and local (web).

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*
* *See also [IDseq PR Guidelines](https://github.com/chanzuckerberg/idseq-web/blob/master/PR_GUIDELINES.md)*
