### PR TITLE
Make project descriptions editable in the DiscoverySidebar

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -252,6 +252,11 @@ const createProject = params =>
     project: params,
   });
 
+const saveProjectDescription = (projectId, description) =>
+  putWithCSRF(`/projects/${projectId}.json`, {
+    description: description,
+  });
+
 const validateSampleNames = (projectId, sampleNames) => {
   if (!projectId) {
     return Promise.resolve(sampleNames);
@@ -349,6 +354,7 @@ export {
   getTaxonDistributionForBackground,
   getVisualizations,
   markSampleUploaded,
+  saveProjectDescription,
   saveSampleName,
   saveSampleNotes,
   saveVisualization,

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
@@ -88,7 +88,7 @@ class ProjectDescription extends React.Component {
     return (
       <MetadataSection
         editable={this.props.project.editable}
-        onEditToggle={() => this.toggleEditing()}
+        onEditToggle={this.toggleEditing}
         editing={this.state.editing}
         title="Description"
         savePending={this.state.savePending}
@@ -100,7 +100,7 @@ class ProjectDescription extends React.Component {
           <div className={cs.descriptionContainer}>
             <Textarea
               onChange={val => this.handleDescriptionChange(val)}
-              onBlur={() => this.handleDescriptionSave()}
+              onBlur={this.handleDescriptionSave}
               value={description}
               className={cs.textarea}
               maxLength={MAX_DESCRIPTION_LENGTH}

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
@@ -3,8 +3,10 @@ import cx from "classnames";
 import cs from "./project_description.scss";
 
 import PropTypes from "prop-types";
-import { Accordion } from "~/components/layout";
+import Textarea from "~ui/controls/Textarea";
+import MetadataSection from "~/components/common/DetailsSidebar/SampleDetailsMode/MetadataSection";
 
+import { saveProjectDescription } from "~/api";
 import { MAX_DESCRIPTION_LENGTH } from "~/components/views/projects/constants";
 
 class ProjectDescription extends React.Component {
@@ -12,16 +14,69 @@ class ProjectDescription extends React.Component {
     super(props);
 
     this.toggleDisplayDescription = this.toggleDisplayDescription.bind(this);
+    this.toggleEditing = this.toggleEditing.bind(this);
 
     this.state = {
       description: props.project.description,
+      lastValidDescription: props.project.description,
       showLess: true,
+      editing: false,
+      changed: false,
+      savePending: false,
     };
   }
 
   toggleDisplayDescription() {
     this.setState(prevState => ({ showLess: !prevState.showLess }));
   }
+
+  toggleEditing() {
+    this.setState(prevState => ({ editing: !prevState.editing }));
+  }
+
+  handleDescriptionChange = value => {
+    this.setState({
+      description: value,
+      changed: true,
+    });
+  };
+
+  handleDescriptionSave = async () => {
+    if (this.state.changed) {
+      this.setState(
+        {
+          changed: false,
+        },
+        () => {
+          this._save(this.props.project.id, this.state.description);
+        }
+      );
+    }
+  };
+
+  _save = async (projectId, value) => {
+    this.setState({
+      savePending: true,
+    });
+
+    let lastValidDescription = this.state.lastValidDescription;
+
+    const response = await saveProjectDescription(projectId, value);
+
+    // If save fails, revert to last valid description value.
+    if (response.status === 422) {
+      this.setState({ description: lastValidDescription });
+    } else {
+      this.setState({
+        description: value,
+        lastValidDescription: value,
+      });
+    }
+
+    this.setState({
+      savePending: false,
+    });
+  };
 
   render() {
     const { description, showLess } = this.state;
@@ -31,34 +86,56 @@ class ProjectDescription extends React.Component {
       : false;
 
     return (
-      <Accordion
-        className={cs.descriptionContainer}
-        bottomContentPadding
+      <MetadataSection
+        editable={this.props.project.editable}
+        onEditToggle={() => this.toggleEditing()}
+        editing={this.state.editing}
+        title="Description"
+        savePending={this.state.savePending}
+        alwaysShowEditLink={this.props.project.editable}
         open={true}
-        header={<div className={cs.title}>Description</div>}
+        toggleable={true}
       >
-        {description ? (
-          <div>
-            <div
-              className={cx(
-                shouldTruncateDescription && showLess && cs.truncated
-              )}
-            >
-              {description}
+        {this.state.editing ? (
+          <div className={cs.descriptionContainer}>
+            <Textarea
+              onChange={val => this.handleDescriptionChange(val)}
+              onBlur={() => this.handleDescriptionSave()}
+              value={description}
+              className={cs.textarea}
+              maxLength={MAX_DESCRIPTION_LENGTH}
+            />
+            <div className={cs.charCounter}>
+              {MAX_DESCRIPTION_LENGTH - description.length}/
+              {MAX_DESCRIPTION_LENGTH} characters remaining
             </div>
-            {shouldTruncateDescription && (
-              <div
-                className={cs.showHide}
-                onClick={this.toggleDisplayDescription}
-              >
-                {showLess ? "Show More" : "Show Less"}
-              </div>
-            )}
           </div>
         ) : (
-          <div>No description.</div>
+          <div className={cs.descriptionContainer}>
+            {description ? (
+              <div>
+                <div
+                  className={cx(
+                    shouldTruncateDescription && showLess && cs.truncated
+                  )}
+                >
+                  {description}
+                </div>
+                {shouldTruncateDescription && (
+                  <div
+                    className={cs.showHide}
+                    onClick={this.toggleDisplayDescription}
+                  >
+                    {showLess ? "Show More" : "Show Less"}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div>No description.</div>
+            )}
+          </div>
         )}
-      </Accordion>
+      </MetadataSection>
     );
   }
 }

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
@@ -23,6 +23,7 @@ class ProjectDescription extends React.Component {
       editing: false,
       changed: false,
       savePending: false,
+      errors: null,
     };
   }
 
@@ -38,6 +39,7 @@ class ProjectDescription extends React.Component {
     this.setState({
       description: value,
       changed: true,
+      errors: null,
     });
   };
 
@@ -64,8 +66,11 @@ class ProjectDescription extends React.Component {
     const response = await saveProjectDescription(projectId, value);
 
     // If save fails, revert to last valid description value.
-    if (response.status === 422) {
-      this.setState({ description: lastValidDescription });
+    if (response.status === "failed") {
+      this.setState({
+        description: lastValidDescription,
+        errors: response.message,
+      });
     } else {
       this.setState({
         description: value,
@@ -79,7 +84,7 @@ class ProjectDescription extends React.Component {
   };
 
   render() {
-    const { description, showLess } = this.state;
+    const { description, showLess, errors } = this.state;
     const cutoffLength = MAX_DESCRIPTION_LENGTH / 2;
     const shouldTruncateDescription = description
       ? description.length > cutoffLength
@@ -88,7 +93,7 @@ class ProjectDescription extends React.Component {
     return (
       <MetadataSection
         editable={this.props.project.editable}
-        onEditToggle={this.toggleEditing}
+        onEditToggle={() => this.toggleEditing()}
         editing={this.state.editing}
         title="Description"
         savePending={this.state.savePending}
@@ -100,7 +105,7 @@ class ProjectDescription extends React.Component {
           <div className={cs.descriptionContainer}>
             <Textarea
               onChange={val => this.handleDescriptionChange(val)}
-              onBlur={this.handleDescriptionSave}
+              onBlur={() => this.handleDescriptionSave()}
               value={description}
               className={cs.textarea}
               maxLength={MAX_DESCRIPTION_LENGTH}
@@ -109,6 +114,7 @@ class ProjectDescription extends React.Component {
               {MAX_DESCRIPTION_LENGTH - description.length}/
               {MAX_DESCRIPTION_LENGTH} characters remaining
             </div>
+            {errors && <div className={cs.error}>{errors}</div>}
           </div>
         ) : (
           <div className={cs.descriptionContainer}>

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
@@ -93,7 +93,7 @@ class ProjectDescription extends React.Component {
     return (
       <MetadataSection
         editable={this.props.project.editable}
-        onEditToggle={() => this.toggleEditing()}
+        onEditToggle={this.toggleEditing}
         editing={this.state.editing}
         title="Description"
         savePending={this.state.savePending}
@@ -105,7 +105,7 @@ class ProjectDescription extends React.Component {
           <div className={cs.descriptionContainer}>
             <Textarea
               onChange={val => this.handleDescriptionChange(val)}
-              onBlur={() => this.handleDescriptionSave()}
+              onBlur={this.handleDescriptionSave}
               value={description}
               className={cs.textarea}
               maxLength={MAX_DESCRIPTION_LENGTH}

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/project_description.scss
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/project_description.scss
@@ -31,6 +31,11 @@
     cursor: pointer;
   }
 
+  .charCounter {
+    @include font-body-xxs;
+    color: $medium-grey;
+  }
+
   .error {
     @include font-body-xxs;
     color: $error;

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/project_description.scss
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/project_description.scss
@@ -30,4 +30,9 @@
     color: $primary-light;
     cursor: pointer;
   }
+
+  .error {
+    @include font-body-xxs;
+    color: $error;
+  }
 }

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/project_description.scss
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/project_description.scss
@@ -21,4 +21,13 @@
     height: 200px;
     resize: vertical;
   }
+
+  .showHide {
+    @include font-body-xxs;
+    text-transform: uppercase;
+    display: inline-block;
+    margin: $space-xxs 0 $space-default 0;
+    color: $primary-light;
+    cursor: pointer;
+  }
 }

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/project_description.scss
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/project_description.scss
@@ -6,12 +6,6 @@
   color: $dark-grey;
   padding-left: $space-default;
 
-  .title {
-    @include font-header-accordion;
-    color: $black;
-    height: 40px;
-  }
-
   .truncated {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -20,12 +14,11 @@
     -webkit-box-orient: vertical;
   }
 
-  .showHide {
-    @include font-body-xxs;
-    text-transform: uppercase;
-    display: inline-block;
-    margin: $space-xxs 0 $space-default 0;
-    color: $primary-light;
-    cursor: pointer;
+  .textarea {
+    @include font-body-xs;
+    margin-top: 5px;
+    padding: 5px;
+    height: 200px;
+    resize: vertical;
   }
 }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -429,7 +429,7 @@ class ProjectsController < ApplicationController
         format.json { render :show, status: :ok, location: @project }
       else
         format.html { render :edit }
-        format.json { render json: @project.errors.full_messages, status: :unprocessable_entity }
+        format.json { render json: @project.errors.full_messages, status: "failed" }
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
     put :remove_favorite, on: :member
     put :update_project_visibility, on: :member
     put :add_user, on: :member
+    put :update, on: :member
     post :validate_metadata_csv, on: :member
     post :upload_metadata, on: :member
     post :validate_sample_names, on: :member


### PR DESCRIPTION
# Description

Users can now edit the descriptions of projects they have access to by clicking the grey "Edit" button in the DiscoverySidebar after a project has been selected.

![image](https://user-images.githubusercontent.com/53838890/64278118-dad73f80-cf00-11e9-94b8-f083b9a304e0.png)

The component follows the pattern of the editable MetadataSections in the sample details sidebar.

![image](https://user-images.githubusercontent.com/53838890/64278114-d874e580-cf00-11e9-8aa1-fe85967eac0b.png)

Users will not be able to edit the project descriptions of any project (public or private) that they have not been added to. The grey "Edit" button will not appear in these cases

Without access to a public project:

![image](https://user-images.githubusercontent.com/53838890/64278111-d6128b80-cf00-11e9-81c7-89010e630e4e.png)

Without access to a private project:

![image](https://user-images.githubusercontent.com/53838890/64278124-dca10300-cf00-11e9-945d-e5116400a922.png)

# Tests

* Verified that users cannot edit project descriptions to be over 700 characters.
* Verified that HTML tags are removed from project descriptions.
* Created non-admin test account and verified that it cannot edit project descriptions without project access
    * On the front-end: the "Edit" button will not be displayed
    * On the back-end: the "update" action will be ignored if the current user does not have update access to the project
