### PR TITLE
Control to sort taxa by genus in heatmap

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -420,7 +420,7 @@ class PipelineSampleReport extends React.Component {
           taxon.category_name == "Uncategorized" &&
           parseInt(taxon.tax_id) == -200
         ) {
-          // the 'All taxa without genus classification' taxon
+          // the 'all taxa without genus classification' taxon
           const uncat_taxon = taxon;
           const filtered_children = [];
           i++;

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -218,6 +218,31 @@ export default class SamplesHeatmapControls extends React.Component {
     );
   }
 
+  onSortTaxaChange = order => {
+    if (order === this.props.selectedOptions.taxaSortType) {
+      return;
+    }
+
+    this.props.onSelectedOptionsChange({ taxaSortType: order });
+    logAnalyticsEvent("SamplesHeatmapControls_sort-taxa-select_changed", {
+      taxaSortType: order,
+    });
+  };
+
+  renderSortTaxaSelect() {
+    return (
+      <Dropdown
+        fluid
+        rounded
+        options={this.props.options.taxaSortTypeOptions}
+        value={this.props.selectedOptions.taxaSortType}
+        label="Sort Taxa"
+        onChange={this.onSortTaxaChange}
+        disabled={!this.props.data}
+      />
+    );
+  }
+
   onDataScaleChange = scaleIdx => {
     if (scaleIdx == this.props.selectedOptions.dataScaleIdx) {
       return;
@@ -397,6 +422,7 @@ export default class SamplesHeatmapControls extends React.Component {
           <div className="col s3">{this.renderTaxonLevelSelect()}</div>
           <div className="col s3">{this.renderCategoryFilter()}</div>
           <div className="col s2">{this.renderSortSamplesSelect()}</div>
+          <div className="col s2">{this.renderSortTaxaSelect()}</div>
           <div className="col s2">{this.renderMetricSelect()}</div>
           <div className="col s2">{this.renderBackgroundSelect()}</div>
         </div>
@@ -450,6 +476,12 @@ SamplesHeatmapControls.propTypes = {
         value: PropTypes.string,
       })
     ),
+    taxaSortTypeOptions: PropTypes.arrayOf(
+      PropTypes.shape({
+        text: PropTypes.string,
+        value: PropTypes.string,
+      })
+    ),
     sortTaxaOptions: PropTypes.arrayOf(
       PropTypes.shape({
         text: PropTypes.string,
@@ -483,6 +515,7 @@ SamplesHeatmapControls.propTypes = {
     ),
     readSpecificity: PropTypes.number,
     sampleSortType: PropTypes.string,
+    taxaSortType: PropTypes.string,
     dataScaleIdx: PropTypes.number,
     taxonsPerSample: PropTypes.number,
   }),

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -419,10 +419,10 @@ export default class SamplesHeatmapControls extends React.Component {
       <div className={cs.menu}>
         <Divider />
         <div className={`${cs.filterRow} row`}>
-          <div className="col s3">{this.renderTaxonLevelSelect()}</div>
-          <div className="col s3">{this.renderCategoryFilter()}</div>
-          <div className="col s2">{this.renderSortSamplesSelect()}</div>
+          <div className="col s2">{this.renderTaxonLevelSelect()}</div>
+          <div className="col s2">{this.renderCategoryFilter()}</div>
           <div className="col s2">{this.renderSortTaxaSelect()}</div>
+          <div className="col s2">{this.renderSortSamplesSelect()}</div>
           <div className="col s2">{this.renderMetricSelect()}</div>
           <div className="col s2">{this.renderBackgroundSelect()}</div>
         </div>

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -427,8 +427,8 @@ export default class SamplesHeatmapControls extends React.Component {
           <div className="col s2">{this.renderBackgroundSelect()}</div>
         </div>
         <div className={`${cs.filterRow} row`}>
-          <div className="col s3">{this.renderThresholdFilterSelect()}</div>
-          <div className="col s3">{this.renderSpecificityFilter()}</div>
+          <div className="col s2">{this.renderThresholdFilterSelect()}</div>
+          <div className="col s2">{this.renderSpecificityFilter()}</div>
           <div className="col s2">{this.renderScaleSelect()}</div>
           <div className="col s2">{this.renderTaxonsPerSampleSlider()}</div>
           <div className="col s2">{this.renderLegend()}</div>

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -35,7 +35,7 @@ const SORT_SAMPLES_OPTIONS = [
   { text: "Alphabetical", value: "alpha" },
   { text: "Cluster", value: "cluster" },
 ];
-const TAXA_SAMPLES_OPTIONS = [
+const SORT_TAXA_OPTIONS = [
   { text: "Genus", value: "genus" },
   { text: "Cluster", value: "cluster" },
 ];
@@ -521,7 +521,7 @@ class SamplesHeatmapView extends React.Component {
     // Client side options
     scales: SCALE_OPTIONS,
     sampleSortTypeOptions: SORT_SAMPLES_OPTIONS,
-    taxaSortTypeOptions: TAXA_SAMPLES_OPTIONS,
+    taxaSortTypeOptions: SORT_TAXA_OPTIONS,
     taxonsPerSample: TAXONS_PER_SAMPLE_RANGE,
     specificityOptions: SPECIFICITY_OPTIONS,
   });

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -35,6 +35,10 @@ const SORT_SAMPLES_OPTIONS = [
   { text: "Alphabetical", value: "alpha" },
   { text: "Cluster", value: "cluster" },
 ];
+const TAXA_SAMPLES_OPTIONS = [
+  { text: "Genus", value: "genus" },
+  { text: "Cluster", value: "cluster" },
+];
 const TAXONS_PER_SAMPLE_RANGE = {
   min: 0,
   max: 100,
@@ -73,6 +77,7 @@ class SamplesHeatmapView extends React.Component {
         ),
         species: parseAndCheckInt(this.urlParams.species, 1),
         sampleSortType: this.urlParams.sampleSortType || "cluster",
+        taxaSortType: this.urlParams.sampleSortType || "cluster",
         thresholdFilters: this.urlParams.thresholdFilters || [],
         dataScaleIdx: parseAndCheckInt(this.urlParams.dataScaleIdx, 0),
         taxonsPerSample: parseAndCheckInt(this.urlParams.taxonsPerSample, 30),
@@ -516,12 +521,13 @@ class SamplesHeatmapView extends React.Component {
     // Client side options
     scales: SCALE_OPTIONS,
     sampleSortTypeOptions: SORT_SAMPLES_OPTIONS,
+    taxaSortTypeOptions: TAXA_SAMPLES_OPTIONS,
     taxonsPerSample: TAXONS_PER_SAMPLE_RANGE,
     specificityOptions: SPECIFICITY_OPTIONS,
   });
 
   handleSelectedOptionsChange = newOptions => {
-    const excluding = ["dataScaleIdx", "sampleSortType"];
+    const excluding = ["dataScaleIdx", "sampleSortType", "taxaSortType"];
     const shouldRefetchData = difference(keys(newOptions), excluding).length;
     this.setState(
       {
@@ -594,6 +600,7 @@ class SamplesHeatmapView extends React.Component {
           taxonFilterState={this.state.taxonFilterState}
           thresholdFilters={this.state.selectedOptions.thresholdFilters}
           sampleSortType={this.state.selectedOptions.sampleSortType}
+          taxaSortType={this.state.selectedOptions.taxaSortType}
         />
       </ErrorBoundary>
     );

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -130,10 +130,11 @@ class SamplesHeatmapVis extends React.Component {
 
   extractTaxonLabels() {
     return this.props.taxonIds.map(id => {
+      const name = this.props.taxonDetails[id].name;
       return {
-        label: this.props.taxonDetails[id].name,
-        // TODO (gdingle): can we use parentLabel here?
-        parentId: this.props.taxonDetails[id].parentId, // used for sorting
+        // Moves missing to the top in "genus" sort.
+        // See MISSING_GENUS_ID in TaxonLineage.
+        label: id === -200 ? "* " + name : name,
       };
     });
   }

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -128,6 +128,7 @@ class SamplesHeatmapVis extends React.Component {
     return this.props.taxonIds.map(id => {
       return {
         label: this.props.taxonDetails[id].name,
+        parentId: this.props.taxonDetails[id].parentId, // used for sorting
       };
     });
   }

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -83,6 +83,7 @@ class SamplesHeatmapVis extends React.Component {
         scaleMin: 0,
         printCaption: this.generateHeatmapCaptions(),
         shouldSortColumns: this.props.sampleSortType === "alpha", // else cluster
+        shouldSortRows: this.props.taxaSortType === "genus", // else cluster
         // Shrink to fit the viewport width
         maxWidth: this.heatmapContainer.offsetWidth,
       }
@@ -106,6 +107,9 @@ class SamplesHeatmapVis extends React.Component {
     if (this.props.sampleSortType !== prevProps.sampleSortType) {
       this.heatmap.updateSortColumns(this.props.sampleSortType === "alpha");
     }
+    if (this.props.taxaSortType !== prevProps.taxaSortType) {
+      this.heatmap.updateSortRows(this.props.taxaSortType === "genus");
+    }
   }
 
   extractSampleLabels() {
@@ -128,6 +132,7 @@ class SamplesHeatmapVis extends React.Component {
     return this.props.taxonIds.map(id => {
       return {
         label: this.props.taxonDetails[id].name,
+        // TODO (gdingle): can we use parentLabel here?
         parentId: this.props.taxonDetails[id].parentId, // used for sorting
       };
     });
@@ -435,6 +440,7 @@ SamplesHeatmapVis.propTypes = {
   taxonIds: PropTypes.array,
   thresholdFilters: PropTypes.any,
   sampleSortType: PropTypes.string,
+  taxaSortType: PropTypes.string,
 };
 
 export default SamplesHeatmapVis;

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -130,11 +130,8 @@ class SamplesHeatmapVis extends React.Component {
 
   extractTaxonLabels() {
     return this.props.taxonIds.map(id => {
-      const name = this.props.taxonDetails[id].name;
       return {
-        // Moves missing to the top in "genus" sort.
-        // See MISSING_GENUS_ID in TaxonLineage.
-        label: id === -200 ? "* " + name : name,
+        label: this.props.taxonDetails[id].name,
       };
     });
   }

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -598,17 +598,13 @@ export default class Heatmap {
     );
   }
 
-  // This is hardcoded to sort by lineage
   sortRows(direction) {
     this.rowClustering = null;
-    orderBy(
-      this.rowLabels,
-      // TODO (gdingle): what about unknown genus?
-      label => label.category + "-" + label.parentId + "-" + label.label, // kingdom then genus then species
-      direction
-    ).forEach((label, idx) => {
-      label.pos = idx;
-    });
+    orderBy(this.rowLabels, label => label.label, direction).forEach(
+      (label, idx) => {
+        label.pos = idx;
+      }
+    );
   }
 
   range(n) {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -422,7 +422,10 @@ export default class Heatmap {
   }
 
   cluster() {
-    if (this.options.clustering) {
+    // TODO (gdingle): replace shouldSortColumns by shouldSortRows
+    if (this.options.shouldSortColumns) {
+      this.sortRows("asc");
+    } else if (this.options.clustering) {
       this.clusterRows();
     }
 
@@ -442,8 +445,9 @@ export default class Heatmap {
     this.renderColumnMetadata();
 
     if (this.options.clustering) {
-      this.renderRowDendrogram();
-      this.renderColumnDendrogram();
+      // TODO (gdingle): replace with shouldSortRows
+      this.options.shouldSortColumns || this.renderRowDendrogram();
+      this.options.shouldSortColumns || this.renderColumnDendrogram();
     }
 
     this.options.onUpdateFinished && this.options.onUpdateFinished();
@@ -588,6 +592,17 @@ export default class Heatmap {
         label.pos = idx;
       }
     );
+  }
+
+  sortRows(direction) {
+    this.rowClustering = null;
+    orderBy(
+      this.rowLabels,
+      label => label.category + "-" + label.parentId + "-" + label.label, // kingdom then genus then species
+      direction
+    ).forEach((label, idx) => {
+      label.pos = idx;
+    });
   }
 
   range(n) {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -49,7 +49,8 @@ export default class Heatmap {
         zoom: null, // multiplier for zooming in and out
         minHeight: 500,
         clustering: true,
-        shouldSortColumns: true,
+        shouldSortColumns: false,
+        shouldSortRows: false,
         defaultClusterStep: 6,
         maxRowClusterWidth: 100,
         maxColumnClusterHeight: 100,
@@ -149,6 +150,11 @@ export default class Heatmap {
 
   updateSortColumns(shouldSortColumns) {
     this.options.shouldSortColumns = shouldSortColumns;
+    this.processData("cluster");
+  }
+
+  updateSortRows(shouldSortRows) {
+    this.options.shouldSortRows = shouldSortRows;
     this.processData("cluster");
   }
 
@@ -422,8 +428,7 @@ export default class Heatmap {
   }
 
   cluster() {
-    // TODO (gdingle): replace shouldSortColumns by shouldSortRows
-    if (this.options.shouldSortColumns) {
+    if (this.options.shouldSortRows) {
       this.sortRows("asc");
     } else if (this.options.clustering) {
       this.clusterRows();
@@ -445,8 +450,7 @@ export default class Heatmap {
     this.renderColumnMetadata();
 
     if (this.options.clustering) {
-      // TODO (gdingle): replace with shouldSortRows
-      this.options.shouldSortColumns || this.renderRowDendrogram();
+      this.options.shouldSortRows || this.renderRowDendrogram();
       this.options.shouldSortColumns || this.renderColumnDendrogram();
     }
 
@@ -594,10 +598,12 @@ export default class Heatmap {
     );
   }
 
+  // This is hardcoded to sort by lineage
   sortRows(direction) {
     this.rowClustering = null;
     orderBy(
       this.rowLabels,
+      // TODO (gdingle): what about unknown genus?
       label => label.category + "-" + label.parentId + "-" + label.label, // kingdom then genus then species
       direction
     ).forEach((label, idx) => {

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -503,7 +503,8 @@ module ReportHelper
 
   def self.validate_names!(tax_2d)
     # This converts superkingdom_id to category_name and makes up
-    # suitable names for missing and blacklisted genera and species.
+    # suitable names for missing and blacklisted genera and species. Such
+    # made-up names should be lowercase so they are sorted below proper names.
     category = {}
     ALL_CATEGORIES.each do |c|
       category[c['taxid']] = c['name']
@@ -516,7 +517,8 @@ module ReportHelper
       if tax_id < 0
         # Usually -1 means accession number did not resolve to species.
         # TODO: Can we keep the accession numbers to show in these cases?
-        tax_info['name'] = "All taxa with neither family nor genus classification"
+        # NOTE: important to be lowercase for sorting below uppercase valid genuses
+        tax_info['name'] = "all taxa with neither family nor genus classification"
 
         if tax_id < TaxonLineage::INVALID_CALL_BASE_ID && species_or_genus(tax_info['tax_level'])
           parent_id = convert_neg_taxid(tax_id)
@@ -528,15 +530,15 @@ module ReportHelper
             parent_name = "taxon #{parent_id}"
             parent_level = ""
           end
-          tax_info['name'] = "Non-#{level_str}-specific reads in #{parent_level} #{parent_name}"
+          tax_info['name'] = "non-#{level_str}-specific reads in #{parent_level} #{parent_name}"
         elsif tax_id == TaxonLineage::BLACKLIST_GENUS_ID
-          tax_info['name'] = "All artificial constructs"
+          tax_info['name'] = "all artificial constructs"
         elsif !(TaxonLineage::MISSING_LINEAGE_ID.values.include? tax_id) && tax_id != TaxonLineage::MISSING_SPECIES_ID_ALT
           tax_info['name'] += " #{tax_id}"
         end
       elsif !tax_info['name']
         missing_names.add(tax_id)
-        tax_info['name'] = "Unnamed #{level_str} taxon #{tax_id}"
+        tax_info['name'] = "unnamed #{level_str} taxon #{tax_id}"
       end
       category_id = tax_info.delete('superkingdom_taxid')
       tax_info['category_name'] = category[category_id] || 'Uncategorized'


### PR DESCRIPTION
# Description

Users have asked for the ability to sort the rows in the heatmap instead of clustering them. This add that ability alongside the new "sort samples" control. 

![image](https://user-images.githubusercontent.com/28797/64299983-11787e80-cf30-11e9-9e46-1bdc2144601f.png)

![image](https://user-images.githubusercontent.com/28797/64299903-c78f9880-cf2f-11e9-87b1-ad1f0c782a57.png)

![image](https://user-images.githubusercontent.com/28797/64299913-d24a2d80-cf2f-11e9-96fd-705914bd9b92.png)


# Notes

I shrunk the "taxon level" and "taxon categories" controls to make room for the new control. Another solution would be to remove the little used "read specificity" control. 

There are a bunch of weird rows that I did not know how to sort
```
Non-genus-specific reads in family Anelloviridae
All taxa with neither family nor genus classification
uncultured gamma proteobacterium
Vector pAAV-hSyn1-GCaMP6s-P2A-mRuby3
```
I lower cased "all taxa with neither family nor genus classification" so it would be sorted to the bottom like other unclassified rows.


Originally I used the parentId for sorting species but I found an instance where the species parent ID is not the same as the genus:
```
category: "Eukaryota"
id: 340412
index: 23
name: "Aspergillus novofumigatus"
parentId: -1900340412
phage: false
---
category: "Eukaryota"
id: 746128
index: 26
name: "Aspergillus fumigatus"
parentId: -1900746128
phage: false (edited) 
```
I expected the parent IDs to be the same because they are both in the genus "Aspergillus"

# Tests

* Open a variety of heatmaps
* See that the default taxa sort is "cluster"
* Click on "sort taxa: genus"
* See that rows are alphabetical
* Try "genus" taxon level, see alphabetical sorting
* See that "All taxa with neither..." is at the top