### PR TITLE
[Data Discovery] Add data layer and generalize async row fetching

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryDataLayer.js
+++ b/app/assets/src/components/views/discovery/DiscoveryDataLayer.js
@@ -73,7 +73,7 @@ export default class DiscoveryDataLayer {
     }
     if (missingIdxs.length > 0) {
       // currently loads using limit and offset
-      // could eventually lead to redundant fetches if data is not requests in regular continuous chunks
+      // could eventually lead to redundant fetches if data is not requested in regular continuous chunks
       const minNeededIdx = missingIdxs[0];
       const maxNeededIdx = missingIdxs[missingIdxs.length - 1];
       let { fetchedObjects, fetchedObjectIds } = await apiFunction({

--- a/app/assets/src/components/views/discovery/DiscoveryDataLayer.js
+++ b/app/assets/src/components/views/discovery/DiscoveryDataLayer.js
@@ -16,16 +16,16 @@ export default class DiscoveryDataLayer {
 
   newObjectDb = () => ({
     entries: {},
-    order: null,
+    orderedIds: null,
     loading: true,
   });
   get = dataType => Object.values(this.data[dataType].entries);
-  getIds = dataType => this.data[dataType].order || [];
+  getIds = dataType => this.data[dataType].orderedIds || [];
   getLength = dataType => Object.keys(this.data[dataType].entries).length;
   isLoading = dataType => this.data[dataType].loading;
   reset = dataType => {
     const objectDb = this.data[dataType];
-    objectDb.order = null;
+    objectDb.orderedIds = null;
     objectDb.loading = true;
   };
 
@@ -62,13 +62,13 @@ export default class DiscoveryDataLayer {
     const apiFunction = this.apiFunctions[dataType];
     const domain = this.domain;
 
-    const minStopIndex = objects.order
-      ? Math.min(objects.order.length - 1, stopIndex)
+    const minStopIndex = objects.orderedIds
+      ? Math.min(objects.orderedIds.length - 1, stopIndex)
       : stopIndex;
     let missingIdxs = range(startIndex, minStopIndex + 1);
-    if (objects.order) {
+    if (objects.orderedIds) {
       missingIdxs = missingIdxs.filter(
-        idx => !(objects.order[idx] in objects.entries)
+        idx => !(objects.orderedIds[idx] in objects.entries)
       );
     }
     if (missingIdxs.length > 0) {
@@ -81,11 +81,11 @@ export default class DiscoveryDataLayer {
         ...conditions,
         limit: maxNeededIdx - minNeededIdx + 1,
         offset: minNeededIdx,
-        listAllIds: objects.order === null,
+        listAllIds: objects.orderedIds === null,
       });
 
       if (fetchedObjectIds) {
-        objects.order = fetchedObjectIds;
+        objects.orderedIds = fetchedObjectIds;
       }
 
       fetchedObjects.forEach(sample => {
@@ -96,8 +96,8 @@ export default class DiscoveryDataLayer {
     }
 
     const requestedObjects = range(startIndex, minStopIndex + 1)
-      .filter(idx => idx in objects.order)
-      .map(idx => objects.entries[objects.order[idx]]);
+      .filter(idx => idx in objects.orderedIds)
+      .map(idx => objects.entries[objects.orderedIds[idx]]);
     onDataLoaded && onDataLoaded(this);
     return requestedObjects;
   };

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -123,9 +123,9 @@ class DiscoveryView extends React.Component {
         projects: [],
         rawMapLocationData: {},
         sampleDimensions: [],
-        sampleIds: [],
-        samples: [],
-        samplesAllLoaded: false,
+        // sampleIds: [],
+        // samples: [],
+        // samplesAllLoaded: false,
         search: null,
         selectedSampleIds: new Set(),
         showFilters: true,
@@ -230,9 +230,9 @@ class DiscoveryView extends React.Component {
         loadingSamples: true,
         // instead of resetting projects we use the current project info, if selected
         projects: compact([project]),
-        sampleIds: [],
-        samples: [],
-        samplesAllLoaded: false,
+        // sampleIds: [],
+        // samples: [],
+        // samplesAllLoaded: false,
         visualizations: [],
       },
       () => {
@@ -590,52 +590,52 @@ class DiscoveryView extends React.Component {
     });
   };
 
-  handleLoadSampleRows = async ({ startIndex, stopIndex }) => {
-    const { domain } = this.props;
-    const {
-      projectId,
-      samples,
-      sampleIds,
-      samplesAllLoaded,
-      search,
-    } = this.state;
+  // handleLoadSampleRows = async ({ startIndex, stopIndex }) => {
+  //   const { domain } = this.props;
+  //   const {
+  //     projectId,
+  //     samples,
+  //     sampleIds,
+  //     samplesAllLoaded,
+  //     search,
+  //   } = this.state;
 
-    const previousLoadedSamples = samples.slice(startIndex, stopIndex + 1);
-    const neededStartIndex = Math.max(startIndex, samples.length);
+  //   const previousLoadedSamples = samples.slice(startIndex, stopIndex + 1);
+  //   const neededStartIndex = Math.max(startIndex, samples.length);
 
-    let newlyFetchedSamples = [];
-    if (!samplesAllLoaded && stopIndex >= neededStartIndex) {
-      const numRequestedSamples = stopIndex - neededStartIndex + 1;
-      let {
-        samples: fetchedSamples,
-        sampleIds: fetchedSampleIds,
-      } = await getDiscoverySamples({
-        domain,
-        filters: this.preparedFilters(),
-        projectId,
-        search,
-        limit: stopIndex - neededStartIndex + 1,
-        offset: neededStartIndex,
-        listAllIds: sampleIds.length === 0,
-      });
+  //   let newlyFetchedSamples = [];
+  //   if (!samplesAllLoaded && stopIndex >= neededStartIndex) {
+  //     const numRequestedSamples = stopIndex - neededStartIndex + 1;
+  //     let {
+  //       samples: fetchedSamples,
+  //       sampleIds: fetchedSampleIds,
+  //     } = await getDiscoverySamples({
+  //       domain,
+  //       filters: this.preparedFilters(),
+  //       projectId,
+  //       search,
+  //       limit: stopIndex - neededStartIndex + 1,
+  //       offset: neededStartIndex,
+  //       listAllIds: sampleIds.length === 0,
+  //     });
 
-      let newState = {
-        // add newly fetched samples to the list (assumes that samples are requested in order)
-        samples: samples.concat(fetchedSamples),
-        // if returned samples are less than requested, we assume all data was loaded
-        samplesAllLoaded: fetchedSamples.length < numRequestedSamples,
-        loadingSamples: false,
-      };
-      if (fetchedSampleIds) {
-        newState.sampleIds = fetchedSampleIds;
-      }
+  //     let newState = {
+  //       // add newly fetched samples to the list (assumes that samples are requested in order)
+  //       samples: samples.concat(fetchedSamples),
+  //       // if returned samples are less than requested, we assume all data was loaded
+  //       samplesAllLoaded: fetchedSamples.length < numRequestedSamples,
+  //       loadingSamples: false,
+  //     };
+  //     if (fetchedSampleIds) {
+  //       newState.sampleIds = fetchedSampleIds;
+  //     }
 
-      this.setState(newState);
-      newlyFetchedSamples = fetchedSamples;
-    }
+  //     this.setState(newState);
+  //     newlyFetchedSamples = fetchedSamples;
+  //   }
 
-    return previousLoadedSamples.concat(newlyFetchedSamples);
-  };
+  //   return previousLoadedSamples.concat(newlyFetchedSamples);
+  // };
 
   handleProjectSelected = ({ project }) => {
     const { mapSidebarTab } = this.state;
@@ -1001,8 +1001,8 @@ class DiscoveryView extends React.Component {
       selectedSampleIds,
       projectId,
       projects,
-      sampleIds,
-      samples,
+      // sampleIds,
+      // samples,
       visualizations,
     } = this.state;
     const { admin, allowedFeatures, mapTilerKey } = this.props;
@@ -1064,12 +1064,12 @@ class DiscoveryView extends React.Component {
                 onSelectedSamplesUpdate={this.handleSelectedSamplesUpdate}
                 projectId={projectId}
                 ref={samplesView => (this.samplesView = samplesView)}
-                samples={samples}
-                selectableIds={sampleIds}
+                samples={dataLayer.get("samples")}
+                selectableIds={dataLayer.getIds("samples")}
                 selectedSampleIds={selectedSampleIds}
               />
             </div>
-            {!samples.length &&
+            {!dataLayer.getLength("samples") &&
               !loadingSamples &&
               currentDisplay === "table" && (
                 <NoResultsBanner
@@ -1200,7 +1200,6 @@ class DiscoveryView extends React.Component {
       filters,
       project,
       projectId,
-      samples,
       search,
       showFilters,
       showStats,
@@ -1217,7 +1216,7 @@ class DiscoveryView extends React.Component {
           {projectId && (
             <ProjectHeader
               project={project || {}}
-              fetchedSamples={samples}
+              fetchedSamples={dataLayer.get("samples")}
               onProjectUpdated={this.handleProjectUpdated}
               onMetadataUpdated={this.refreshDataFromProjectChange}
             />

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -44,7 +44,7 @@ import SamplesView from "../samples/SamplesView";
 import VisualizationsView from "../visualizations/VisualizationsView";
 import DiscoverySidebar from "./DiscoverySidebar";
 import DiscoveryFilters from "./DiscoveryFilters";
-import DiscoveryDataLayer from "./discovery_data_layer";
+import DiscoveryDataLayer from "./DiscoveryDataLayer";
 import ProjectHeader from "./ProjectHeader";
 import {
   getDiscoverySyncData,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -44,6 +44,7 @@ import SamplesView from "../samples/SamplesView";
 import VisualizationsView from "../visualizations/VisualizationsView";
 import DiscoverySidebar from "./DiscoverySidebar";
 import DiscoveryFilters from "./DiscoveryFilters";
+import DiscoveryDataLayer from "./discovery_data_layer";
 import ProjectHeader from "./ProjectHeader";
 import {
   getDiscoverySyncData,
@@ -59,7 +60,6 @@ import NoResultsBanner from "./NoResultsBanner";
 import MapPreviewSidebar from "./mapping/MapPreviewSidebar";
 
 import cs from "./discovery_view.scss";
-import { DiscoveryDataLayer } from "./discovery_data_layer";
 
 // Data available
 // (A) non-filtered dimensions: for filter options

--- a/app/assets/src/components/views/discovery/discovery_data_layer.js
+++ b/app/assets/src/components/views/discovery/discovery_data_layer.js
@@ -5,83 +5,100 @@ export class DiscoveryDataLayer {
   constructor(domain) {
     this.domain = domain;
 
-    // storing the object by id
     this.data = {
-      samples: this.newObjectDB(),
+      samples: this.newObjectDb(),
     };
 
-    // Issues:
-  }
-
-  newObjectDB() {
-    return {
-      entries: {},
-      order: null,
+    this.apiFunctions = {
+      samples: this.fetchSamples,
     };
   }
 
-  get(data_type) {
-    return this.data[data_type].entries;
-  }
+  newObjectDb = () => ({
+    entries: {},
+    order: null,
+    loading: true,
+  });
+  get = dataType => Object.values(this.data[dataType].entries);
+  getIds = dataType => this.data[dataType].order || [];
+  getLength = dataType => Object.keys(this.data[dataType].entries).length;
+  isLoading = dataType => this.data[dataType].loading;
+  reset = dataType => {
+    const objectDb = this.data[dataType];
+    objectDb.order = null;
+    objectDb.loading = true;
+  };
 
-  getIds() {
-    return this.data[data_type].order || [];
-  }
+  handleLoadSampleRows = params => {
+    return this.handleLoadObjectRows({
+      objects: this.data.samples,
+      apiFunction: async params => {
+        let {
+          samples: fetchedObjects,
+          sampleIds: fetchedObjectIds,
+        } = await getDiscoverySamples(params);
+        return { fetchedObjects, fetchedObjectIds };
+      },
+      ...params,
+    });
+  };
 
-  handleLoadSampleRows = async ({
+  fetchSamples = async params => {
+    let {
+      samples: fetchedObjects,
+      sampleIds: fetchedObjectIds,
+    } = await getDiscoverySamples(params);
+    return { fetchedObjects, fetchedObjectIds };
+  };
+
+  handleLoadObjectRows = async ({
+    dataType,
     startIndex,
     stopIndex,
     conditions = {},
     onDataLoaded,
   }) => {
-    const { domain, samples } = this;
+    const objects = this.data[dataType];
+    const apiFunction = this.apiFunctions[dataType];
+    const domain = this.domain;
 
-    const { projectId, search, filters } = conditions;
-
-    const missingIdxs = range(startIndex, stopIndex).filter(
-      idx => !(idx in samples.entries)
-    );
-
+    const minStopIndex = objects.order
+      ? Math.min(objects.order.length - 1, stopIndex)
+      : stopIndex;
+    let missingIdxs = range(startIndex, minStopIndex + 1);
+    if (objects.order) {
+      missingIdxs = missingIdxs.filter(
+        idx => !(objects.order[idx] in objects.entries)
+      );
+    }
     if (missingIdxs.length > 0) {
+      // currently loads using limit and offset
+      // could eventually lead to redundant fetches if data is not requests in regular continuous chunks
       const minNeededIdx = missingIdxs[0];
       const maxNeededIdx = missingIdxs[missingIdxs.length - 1];
-
-      let {
-        samples: fetchedSamples,
-        sampleIds: fetchedSampleIds,
-      } = await getDiscoverySamples({
+      let { fetchedObjects, fetchedObjectIds } = await apiFunction({
         domain,
-        filters,
-        projectId,
-        search,
+        ...conditions,
         limit: maxNeededIdx - minNeededIdx + 1,
         offset: minNeededIdx,
-        listAllIds: samples.order === null,
+        listAllIds: objects.order === null,
       });
 
-      if (fetchedSampleIds) {
-        samples.order = fetchedSampleIds;
+      if (fetchedObjectIds) {
+        objects.order = fetchedObjectIds;
       }
 
-      fetchedSamples.forEach(sample => {
-        samples.entries[sample.id] = sample;
+      fetchedObjects.forEach(sample => {
+        objects.entries[sample.id] = sample;
       });
+
+      objects.loading = false;
     }
 
-    const requestedSamples = range(startIndex, stopIndex).map(
-      idx => samples.entries[samples.order[idx]]
-    );
-
+    const requestedObjects = range(startIndex, minStopIndex + 1)
+      .filter(idx => idx in objects.order)
+      .map(idx => objects.entries[objects.order[idx]]);
     onDataLoaded && onDataLoaded(this);
-
-    return requestedSamples;
+    return requestedObjects;
   };
 }
-
-// const handleLoadTableRows = async ({ startIndex, stopIndex }) => {
-
-// }
-
-// const handleLoadProjectRows = async ({startIndex, stopIndex}) => {
-
-// }

--- a/app/assets/src/components/views/discovery/discovery_data_layer.js
+++ b/app/assets/src/components/views/discovery/discovery_data_layer.js
@@ -1,7 +1,7 @@
 import { range } from "lodash/fp";
 import { getDiscoverySamples } from "./discovery_api";
 
-export class DiscoveryDataLayer {
+export default class DiscoveryDataLayer {
   constructor(domain) {
     this.domain = domain;
 

--- a/app/assets/src/components/views/discovery/discovery_data_layer.js
+++ b/app/assets/src/components/views/discovery/discovery_data_layer.js
@@ -1,0 +1,87 @@
+import { range } from "lodash/fp";
+import { getDiscoverySamples } from "./discovery_api";
+
+export class DiscoveryDataLayer {
+  constructor(domain) {
+    this.domain = domain;
+
+    // storing the object by id
+    this.data = {
+      samples: this.newObjectDB(),
+    };
+
+    // Issues:
+  }
+
+  newObjectDB() {
+    return {
+      entries: {},
+      order: null,
+    };
+  }
+
+  get(data_type) {
+    return this.data[data_type].entries;
+  }
+
+  getIds() {
+    return this.data[data_type].order || [];
+  }
+
+  handleLoadSampleRows = async ({
+    startIndex,
+    stopIndex,
+    conditions = {},
+    onDataLoaded,
+  }) => {
+    const { domain, samples } = this;
+
+    const { projectId, search, filters } = conditions;
+
+    const missingIdxs = range(startIndex, stopIndex).filter(
+      idx => !(idx in samples.entries)
+    );
+
+    if (missingIdxs.length > 0) {
+      const minNeededIdx = missingIdxs[0];
+      const maxNeededIdx = missingIdxs[missingIdxs.length - 1];
+
+      let {
+        samples: fetchedSamples,
+        sampleIds: fetchedSampleIds,
+      } = await getDiscoverySamples({
+        domain,
+        filters,
+        projectId,
+        search,
+        limit: maxNeededIdx - minNeededIdx + 1,
+        offset: minNeededIdx,
+        listAllIds: samples.order === null,
+      });
+
+      if (fetchedSampleIds) {
+        samples.order = fetchedSampleIds;
+      }
+
+      fetchedSamples.forEach(sample => {
+        samples.entries[sample.id] = sample;
+      });
+    }
+
+    const requestedSamples = range(startIndex, stopIndex).map(
+      idx => samples.entries[samples.order[idx]]
+    );
+
+    onDataLoaded && onDataLoaded(this);
+
+    return requestedSamples;
+  };
+}
+
+// const handleLoadTableRows = async ({ startIndex, stopIndex }) => {
+
+// }
+
+// const handleLoadProjectRows = async ({startIndex, stopIndex}) => {
+
+// }

--- a/app/assets/src/components/visualizations/table/InfiniteTable.jsx
+++ b/app/assets/src/components/visualizations/table/InfiniteTable.jsx
@@ -11,12 +11,11 @@ const STATUS_LOADED = 2;
 
 class InfiniteTable extends React.Component {
   // Encapsulates Table in an InfiniteLoader component.
-  // - Keeps track of rows for which a load request was made,
-  //   to avoid requesting the same row twice.
-  // TODO(tiago): Current limitations:
-  // - does not reload rows if they change; this can be addressed,
-  //   by having a function to clear some or all rows that client can call
-  //   through a ref to the component.
+  // Keeps track of rows for which a load request was made, to avoid requesting the same row twice.
+  // ATTENTION: This class does not automatically reload rows if data changes.
+  //            Reset function must be called explicitly by the client.
+  //            This happens also because react virtualized memoizes responses and
+  //            may not ask for the rows again.
 
   constructor(props) {
     super(props);
@@ -83,8 +82,8 @@ class InfiniteTable extends React.Component {
     );
   };
 
-  // !Attention!: reset function must be called if previously loaded data changes
   reset = () => {
+    // Reset function MUST be called if previously loaded data changes
     const { rowCount } = this.props;
     this.rows = [];
     this.loadedRowsMap = [];


### PR DESCRIPTION
# Description

This PR is the first step to make project and visualizations load data paginated data on-demand without redundant code
* Add a new data layer to hold and manage DD data 
* Move function that loads sample rows to the data layer and generalize

# Notes

* There should be no functionality changes.

# Tests

To test this change, we need to check the table behavior as we scroll or set any conditions that influence the rows to fetch (i.e. filters, search and project selection)/