### PR TITLE
Allow users to add descriptions to existing projects

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
@@ -17,8 +17,10 @@ class ProjectDescription extends React.Component {
     this.toggleEditing = this.toggleEditing.bind(this);
 
     this.state = {
-      description: props.project.description,
-      lastValidDescription: props.project.description,
+      description: props.project.description ? props.project.description : "",
+      lastValidDescription: props.project.description
+        ? props.project.description
+        : "",
       showLess: true,
       editing: false,
       changed: false,


### PR DESCRIPTION
# Description

Discovered a bug with the project description character counter that caused an error if users tried to edit the description that was created prior to the migration that added project descriptions.

Because the project description field didn't exist, attempting to get the length of the description in the character counter would cause a null error.

Fixed by checking if the project description exists before rendering it to the sidebar, and initializes it to an empty string if it does not.

# Tests

* Verified that users can now add descriptions to old projects.
