### PR TITLE
Fix typo in analytics tracking czi_user

### DIFF
--- a/app/assets/src/api/analytics.js
+++ b/app/assets/src/api/analytics.js
@@ -25,7 +25,7 @@ export const logAnalyticsEvent = async (eventName, eventData = {}) => {
         // see traits_for_segment
         admin: traits.admin,
         biohub_user: traits.biohub_user,
-        czi_user: traits.biohub_user,
+        czi_user: traits.czi_user,
         demo_user: traits.demo_user,
         has_samples: traits.has_samples,
         git_version: window.GIT_VERSION,

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1294,7 +1294,7 @@ class PipelineRun < ApplicationRecord
 
   def contig_lineages(min_contig_size = MIN_CONTIG_SIZE)
     contigs.select("id, read_count, lineage_json")
-           .where("read_count >= #{min_contig_size}")
+           .where("read_count >= ?", min_contig_size)
            .where("lineage_json IS NOT NULL")
   end
 


### PR DESCRIPTION
### Description
- I noticed this bug while investigating erroneous data while looking at the maps analytics. Unfortunately this may have impacted previous analyses by not filtering out czi_users properly, but only when logAnalyticsEvent was called.
- Second change is an improvement to fetching contigs. Also tested.

### Tests
- Use Segment Debugger extension to see the request sent properly.