### PR TITLE
Fix visual alignment in report version selector

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -116,6 +116,7 @@ class BareDropdown extends React.Component {
       arrowInsideTrigger,
       className,
       hideArrow,
+      smallArrow,
       menuLabel,
       search,
       closeOnClick,
@@ -133,7 +134,8 @@ class BareDropdown extends React.Component {
       !hideArrow &&
         (arrowInsideTrigger ? cs.arrowInsideTrigger : cs.arrowOutsideTrigger),
       className,
-      hideArrow && cs.hideArrow
+      hideArrow && cs.hideArrow,
+      smallArrow && cs.smallArrow
     );
 
     const { filterString } = this.state;
@@ -237,6 +239,7 @@ BareDropdown.propTypes = forbidExtraProps({
   // whether the arrow should be displayed outside the trigger or inside it.
   arrowInsideTrigger: PropTypes.bool,
   hideArrow: PropTypes.bool,
+  smallArrow: PropTypes.bool,
   menuLabel: PropTypes.string,
   // whether the dropdown should close when you click on the menu. Useful for custom dropdown menus.
   closeOnClick: PropTypes.bool,

--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -36,6 +36,12 @@
     }
   }
 
+  &.smallArrow {
+    i:global(.dropdown) {
+      font-size: 16px;
+    }
+  }
+
   :global(.item) {
     font-size: 13px;
     font-weight: 400;

--- a/app/assets/src/components/views/SampleView/PipelineVersionSelect.jsx
+++ b/app/assets/src/components/views/SampleView/PipelineVersionSelect.jsx
@@ -36,6 +36,7 @@ class PipelineVersionSelect extends React.Component {
         className={cs.pipelineVersionDropdown}
         options={options}
         onChange={this.props.onPipelineVersionSelect}
+        smallArrow
       />
     );
   };


### PR DESCRIPTION
### Description
- Minor fix for report version selector alignment style. The arrow size was larger than the line size so it would throw the alignment off.
- Kept noticing this during the demos with the Medical Detectives project..

### Tests
#### Before
![Screen Shot 2019-09-11 at 11 38 43 AM](https://user-images.githubusercontent.com/5652739/64725137-d1158500-d488-11e9-9f77-dbf9551ba277.png)

#### After
![Screen Shot 2019-09-11 at 11 39 16 AM](https://user-images.githubusercontent.com/5652739/64725141-d4107580-d488-11e9-8a6a-5a83ee4b9850.png)