### PR TITLE
Switch back to shelve/BerkleyDB

### DIFF
--- a/db/migrate/20190911200352_pipeline_config_change_sqlite_to_shelve.rb
+++ b/db/migrate/20190911200352_pipeline_config_change_sqlite_to_shelve.rb
@@ -1,0 +1,10 @@
+class PipelineConfigChangeSqliteToShelve < ActiveRecord::Migration[5.1]
+  def change
+    AlignmentConfig.where(name: "2018-12-01").update_all(
+      s3_nt_loc_db_path: "s3://idseq-database/alignment_data/2018-12-01/nt_loc.db",
+      s3_nr_loc_db_path: "s3://idseq-database/alignment_data/2018-12-01/nr_loc.db",
+      s3_lineage_path: "s3://idseq-database/taxonomy/2018-12-01/taxid-lineages.db",
+      s3_accession2taxid_path: "s3://idseq-database/alignment_data/2018-12-01/accession2taxid.db"
+    )
+  end
+end


### PR DESCRIPTION
# Description

Change the configs to use the shelve/Berkley DB format instead of the sqlite format. This is to resolve an issue where sqlite3 hangs.

# Tests

- Ran the migration locally
- Will deploy to staging and test the pipeline
- Will monitor the pipeline with cloudwatch
