### PR TITLE
Fix bug in SampleUpload Flow caused by Tooltip changes

### DIFF
--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -94,17 +94,18 @@ class BaseTable extends React.Component {
   }) {
     return (
       <div className={cs.sortableHeader}>
-        <ColumnHeaderTooltip
-          trigger={<div className={cs.label}>{label}</div>}
-          title={label}
-          content={columnData.tooltip}
-          link={columnData.link}
-        />
+        {columnData ? (
+          <ColumnHeaderTooltip
+            trigger={<div className={cs.label}>{label}</div>}
+            title={label}
+            content={columnData.tooltip}
+            link={columnData.link}
+          />
         ) : (
-        <BasicPopup
-          trigger={<div className={cs.label}>{label}</div>}
-          content={label}
-        />
+          <BasicPopup
+            trigger={<div className={cs.label}>{label}</div>}
+            content={label}
+          />
         )}
         <SortIcon
           sortDirection={sortDirection === "ASC" ? "ascending" : "descending"}

--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -67,12 +67,21 @@ class BaseTable extends React.Component {
 
   basicHeaderRenderer({ columnData, label }) {
     return (
-      <ColumnHeaderTooltip
-        trigger={<span className={cs.label}>{label}</span>}
-        title={label}
-        content={columnData.tooltip}
-        link={columnData.link}
-      />
+      <div>
+        {columnData ? (
+          <ColumnHeaderTooltip
+            trigger={<span className={cs.label}>{label}</span>}
+            title={label}
+            content={columnData.tooltip}
+            link={columnData.link}
+          />
+        ) : (
+          <BasicPopup
+            trigger={<span className={cs.label}>{label}</span>}
+            content={label}
+          />
+        )}
+      </div>
     );
   }
 
@@ -91,6 +100,12 @@ class BaseTable extends React.Component {
           content={columnData.tooltip}
           link={columnData.link}
         />
+        ) : (
+        <BasicPopup
+          trigger={<div className={cs.label}>{label}</div>}
+          content={label}
+        />
+        )}
         <SortIcon
           sortDirection={sortDirection === "ASC" ? "ascending" : "descending"}
           className={cx(cs.sortIcon, sortBy === dataKey && cs.active)}


### PR DESCRIPTION
# Description

* The function parameters for `basicHeaderRenderer` and `_sortableHeaderRenderer` in the `BaseTable` file were modified to allow for more descriptive tooltips for column headers, passed in via `columnData`.
* However, the Metadata page during the sample upload flow also uses `BaseTable` and does not pass in any `columnData`, so a user would encounter a blank page due to a null error.
* Those functions have been modified to check the existence of `columnData` before attempting to access it to construct the tooltip.

# Tests

* Verified that users can upload samples as before.