### PR TITLE
[Data Discovery] Persist DD options into local and session storage

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -8,7 +8,6 @@ import {
   clone,
   compact,
   concat,
-  defaults,
   escapeRegExp,
   find,
   findIndex,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -198,7 +198,8 @@ class DiscoveryView extends React.Component {
       urlQuery = `?${urlQuery}`;
     }
 
-    // History state may include some fields that enable faster loading of previous pages (e.g. project)
+    // History state may include some small fields that enable direct loading of previous pages
+    // from browser history without having to request those fields from server (e.g. project)
     if (action === "push") {
       history.pushState(
         historyState,

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -86,6 +86,7 @@ class DiscoveryView extends React.Component {
     const { projectId } = this.props;
 
     this.urlParser = new UrlQueryParser({
+      sampleActiveColumns: "object",
       filters: "object",
       projectId: "number",
       showFilters: "boolean",
@@ -96,10 +97,8 @@ class DiscoveryView extends React.Component {
     let sessionState = this.loadState(sessionStorage, "DiscoveryViewOptions");
     let localState = this.loadState(localStorage, "DiscoveryViewOptions");
 
-    // values are copied from left to rigth to the last argument (left elements have priority)
-    const savedState = defaults(urlState, sessionState, localState, {});
-
-    this.state = defaults(
+    // values are copied from left to right to the first argument (last arguments override previous)
+    this.state = Object.assign(
       {
         currentDisplay: "table",
         currentTab:
@@ -138,7 +137,9 @@ class DiscoveryView extends React.Component {
         showStats: true,
         visualizations: [],
       },
-      savedState
+      localState,
+      sessionState,
+      urlState
     );
     this.dataLayer = new DiscoveryDataLayer(this.props.domain);
     this.updateBrowsingHistory("replace");
@@ -157,12 +158,13 @@ class DiscoveryView extends React.Component {
 
   loadState = (store, key) => {
     try {
-      return JSON.parse(store.getItem(key));
+      return JSON.parse(store.getItem(key)) || {};
     } catch (e) {
       // Avoid possible bad transient state related crash
       // eslint-disable-next-line no-console
       console.warn(`Bad state: ${e}`);
     }
+    return {};
   };
 
   updateBrowsingHistory = (action = "push") => {

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -198,7 +198,7 @@ class DiscoveryView extends React.Component {
       urlQuery = `?${urlQuery}`;
     }
 
-    // History state may include some fields that enable fast loading of previous pages (e.g. project)
+    // History state may include some fields that enable faster loading of previous pages (e.g. project)
     if (action === "push") {
       history.pushState(
         historyState,

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -346,6 +346,7 @@ class SamplesView extends React.Component {
   renderTable = () => {
     const {
       activeColumns,
+      onActiveColumnsChange,
       onLoadRows,
       protectedColumns,
       selectedSampleIds,
@@ -362,6 +363,7 @@ class SamplesView extends React.Component {
           defaultRowHeight={rowHeight}
           initialActiveColumns={activeColumns}
           loadingClassName={csTableRenderer.loading}
+          onActiveColumnsChange={onActiveColumnsChange}
           onLoadRows={onLoadRows}
           onSelectAllRows={withAnalytics(
             this.handleSelectAllRows,
@@ -493,6 +495,7 @@ SamplesView.propTypes = {
   mapPreviewedSamples: PropTypes.array,
   mapTilerKey: PropTypes.string,
   onClearFilters: PropTypes.func,
+  onActiveColumnsChange: PropTypes.func,
   onDisplaySwitch: PropTypes.func,
   onLoadRows: PropTypes.func.isRequired,
   onMapClick: PropTypes.func,

--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -116,8 +116,12 @@ class BaseTable extends React.Component {
   }
 
   handleColumnChange = selectedColumns => {
-    const { protectedColumns } = this.props;
-    this.setState({ activeColumns: concat(protectedColumns, selectedColumns) });
+    const { onActiveColumnsChange, protectedColumns } = this.props;
+    this.setState(
+      { activeColumns: concat(protectedColumns, selectedColumns) },
+      () =>
+        onActiveColumnsChange && onActiveColumnsChange(this.state.activeColumns)
+    );
     logAnalyticsEvent("BaseTable_column-selector_changed", {
       selectedColumns: selectedColumns.length,
       protectedColumns: protectedColumns.length,
@@ -313,6 +317,7 @@ BaseTable.propTypes = {
   headerClassName: PropTypes.string,
   // Set of dataKeys of columns to be shown by default
   initialActiveColumns: PropTypes.arrayOf(PropTypes.string),
+  onActiveColumnsChange: PropTypes.func,
   onRowClick: PropTypes.func,
   onRowsRendered: PropTypes.func,
   onSort: PropTypes.func,


### PR DESCRIPTION
# Description

* Persist all DD options (e.g. UX config, filters search) into session storage
* Persist UX options (show/hide sidebars, current tab, selected columns) into local storage
* The new stored fields are not sensitive data

# Tests

* Load DD and change filters, search or UX options
* Click my data again or go to the report page and comeback, and see the same configuration
* Close the browser and reopen and see that only UX config changes are still active
