### PR TITLE
Display <0.01% for samples with low NH read %

### DIFF
--- a/app/assets/src/components/views/discovery/TableRenderers.jsx
+++ b/app/assets/src/components/views/discovery/TableRenderers.jsx
@@ -130,17 +130,9 @@ class TableRenderers extends React.Component {
         <div className={cs.value}>
           {number && numberWithCommas(number.value)}
         </div>
-        {number && (
-          <BasicPopup
-            position="top center"
-            trigger={
-              <div className={cs.percentage}>
-                {TableRenderers.formatPercentage(number.percent)}
-              </div>
-            }
-            content={`${number.percent}%`}
-          />
-        )}
+        <div className={cs.percentage}>
+          {number && TableRenderers.formatPercentage(number.percent)}
+        </div>
       </div>
     );
   };

--- a/app/assets/src/components/views/discovery/TableRenderers.jsx
+++ b/app/assets/src/components/views/discovery/TableRenderers.jsx
@@ -130,9 +130,17 @@ class TableRenderers extends React.Component {
         <div className={cs.value}>
           {number && numberWithCommas(number.value)}
         </div>
-        <div className={cs.percentage}>
-          {number && TableRenderers.formatPercentage(number.percent)}
-        </div>
+        {number && (
+          <BasicPopup
+            position="top center"
+            trigger={
+              <div className={cs.percentage}>
+                {TableRenderers.formatPercentage(number.percent)}
+              </div>
+            }
+            content={`${number.percent}%`}
+          />
+        )}
       </div>
     );
   };
@@ -145,7 +153,8 @@ class TableRenderers extends React.Component {
 
   static formatPercentage = value => {
     if (!value) return value;
-    return `${TableRenderers.formatNumber(value)}%`;
+    const rounded = TableRenderers.formatNumber(value);
+    return rounded < 0.01 ? "<0.01%" : `${rounded}%`;
   };
 
   static formatDuration = runtime => {


### PR DESCRIPTION
# Description

Previously, low NH read % would be misleadingly be displayed as `0.00%` due to the value being rounded to 2 decimal places.

Low values will now be displayed as `<0.01%` on the sample table instead.

![Screen Shot 2019-09-16 at 3 02 00 PM](https://user-images.githubusercontent.com/53838890/64996647-5f2baa00-d893-11e9-9635-c2fa5aad1e3d.png)

# Tests

* Verified that sample table still renders properly
* Verified samples display the the intended rounded value for NH read %