### PR TITLE
Change taxon sort name to "alphabetical"

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -36,7 +36,11 @@ const SORT_SAMPLES_OPTIONS = [
   { text: "Cluster", value: "cluster" },
 ];
 const SORT_TAXA_OPTIONS = [
-  { text: "Genus", value: "genus" },
+  // NOTE: "genus" sort was renamed to "alphabetical" because that is currently
+  // more accurate. To sort by genus, we should sort by taxon parent ID,
+  // which is currently not always accurate, and we should show what the genus
+  // is for viruses, which is not currently shown.
+  { text: "Alphabetical", value: "genus" },
   { text: "Cluster", value: "cluster" },
 ];
 const TAXONS_PER_SAMPLE_RANGE = {
@@ -77,7 +81,7 @@ class SamplesHeatmapView extends React.Component {
         ),
         species: parseAndCheckInt(this.urlParams.species, 1),
         sampleSortType: this.urlParams.sampleSortType || "cluster",
-        taxaSortType: this.urlParams.sampleSortType || "cluster",
+        taxaSortType: this.urlParams.taxaSortType || "cluster",
         thresholdFilters: this.urlParams.thresholdFilters || [],
         dataScaleIdx: parseAndCheckInt(this.urlParams.dataScaleIdx, 0),
         taxonsPerSample: parseAndCheckInt(this.urlParams.taxonsPerSample, 30),

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -40,7 +40,7 @@ const SORT_TAXA_OPTIONS = [
   // more accurate. To sort by genus, we should sort by taxon parent ID,
   // which is currently not always accurate, and we should show what the genus
   // is for viruses, which is not currently shown.
-  { text: "Alphabetical", value: "genus" },
+  { text: "Alphabetical", value: "alpha" },
   { text: "Cluster", value: "cluster" },
 ];
 const TAXONS_PER_SAMPLE_RANGE = {

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -83,7 +83,7 @@ class SamplesHeatmapVis extends React.Component {
         scaleMin: 0,
         printCaption: this.generateHeatmapCaptions(),
         shouldSortColumns: this.props.sampleSortType === "alpha", // else cluster
-        shouldSortRows: this.props.taxaSortType === "genus", // else cluster
+        shouldSortRows: this.props.taxaSortType === "alpha", // else cluster
         // Shrink to fit the viewport width
         maxWidth: this.heatmapContainer.offsetWidth,
       }
@@ -108,7 +108,7 @@ class SamplesHeatmapVis extends React.Component {
       this.heatmap.updateSortColumns(this.props.sampleSortType === "alpha");
     }
     if (this.props.taxaSortType !== prevProps.taxaSortType) {
-      this.heatmap.updateSortRows(this.props.taxaSortType === "genus");
+      this.heatmap.updateSortRows(this.props.taxaSortType === "alpha");
     }
   }
 

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -10,6 +10,11 @@ class TaxonLineage < ApplicationRecord
   end
   include TaxonLineageHelper
 
+  # We use an artificial negative taxon ID if we have determined that
+  # the alignment is not specific at the taxonomy level under
+  # consideration. This happens when a read's multiple reference matches
+  # do not agree on taxon ID at the given level.
+  # See idseq-dag for more info.
   INVALID_CALL_BASE_ID = -100_000_000 # don't run into -2e9 limit (not common, mostly a concern for fp32 or int32)
   MISSING_SPECIES_ID = -100
   MISSING_SPECIES_ID_ALT = -1


### PR DESCRIPTION
# Description

Following discussion with @happyimadesignr , we decided to change the name of the recently added feature to be more accurate.

![image](https://user-images.githubusercontent.com/28797/65002864-98bbdf80-d8aa-11e9-9910-beb49379f701.png)

# Notes

I also fixed a bug I noticed which caused the save to be inaccurate. 

# Tests

naming
* open a heatmap
* see the change name in the dropdown

saving
* change to alphabetical
* save
* reload
* see alphabetical persist