### PR TITLE
Revert taxa sort feature

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -420,7 +420,7 @@ class PipelineSampleReport extends React.Component {
           taxon.category_name == "Uncategorized" &&
           parseInt(taxon.tax_id) == -200
         ) {
-          // the 'all taxa without genus classification' taxon
+          // the 'All taxa without genus classification' taxon
           const uncat_taxon = taxon;
           const filtered_children = [];
           i++;

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -218,31 +218,6 @@ export default class SamplesHeatmapControls extends React.Component {
     );
   }
 
-  onSortTaxaChange = order => {
-    if (order === this.props.selectedOptions.taxaSortType) {
-      return;
-    }
-
-    this.props.onSelectedOptionsChange({ taxaSortType: order });
-    logAnalyticsEvent("SamplesHeatmapControls_sort-taxa-select_changed", {
-      taxaSortType: order,
-    });
-  };
-
-  renderSortTaxaSelect() {
-    return (
-      <Dropdown
-        fluid
-        rounded
-        options={this.props.options.taxaSortTypeOptions}
-        value={this.props.selectedOptions.taxaSortType}
-        label="Sort Taxa"
-        onChange={this.onSortTaxaChange}
-        disabled={!this.props.data}
-      />
-    );
-  }
-
   onDataScaleChange = scaleIdx => {
     if (scaleIdx == this.props.selectedOptions.dataScaleIdx) {
       return;
@@ -419,16 +394,15 @@ export default class SamplesHeatmapControls extends React.Component {
       <div className={cs.menu}>
         <Divider />
         <div className={`${cs.filterRow} row`}>
-          <div className="col s2">{this.renderTaxonLevelSelect()}</div>
-          <div className="col s2">{this.renderCategoryFilter()}</div>
-          <div className="col s2">{this.renderSortTaxaSelect()}</div>
+          <div className="col s3">{this.renderTaxonLevelSelect()}</div>
+          <div className="col s3">{this.renderCategoryFilter()}</div>
           <div className="col s2">{this.renderSortSamplesSelect()}</div>
           <div className="col s2">{this.renderMetricSelect()}</div>
           <div className="col s2">{this.renderBackgroundSelect()}</div>
         </div>
         <div className={`${cs.filterRow} row`}>
-          <div className="col s2">{this.renderThresholdFilterSelect()}</div>
-          <div className="col s2">{this.renderSpecificityFilter()}</div>
+          <div className="col s3">{this.renderThresholdFilterSelect()}</div>
+          <div className="col s3">{this.renderSpecificityFilter()}</div>
           <div className="col s2">{this.renderScaleSelect()}</div>
           <div className="col s2">{this.renderTaxonsPerSampleSlider()}</div>
           <div className="col s2">{this.renderLegend()}</div>
@@ -476,12 +450,6 @@ SamplesHeatmapControls.propTypes = {
         value: PropTypes.string,
       })
     ),
-    taxaSortTypeOptions: PropTypes.arrayOf(
-      PropTypes.shape({
-        text: PropTypes.string,
-        value: PropTypes.string,
-      })
-    ),
     sortTaxaOptions: PropTypes.arrayOf(
       PropTypes.shape({
         text: PropTypes.string,
@@ -515,7 +483,6 @@ SamplesHeatmapControls.propTypes = {
     ),
     readSpecificity: PropTypes.number,
     sampleSortType: PropTypes.string,
-    taxaSortType: PropTypes.string,
     dataScaleIdx: PropTypes.number,
     taxonsPerSample: PropTypes.number,
   }),

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -35,10 +35,6 @@ const SORT_SAMPLES_OPTIONS = [
   { text: "Alphabetical", value: "alpha" },
   { text: "Cluster", value: "cluster" },
 ];
-const SORT_TAXA_OPTIONS = [
-  { text: "Genus", value: "genus" },
-  { text: "Cluster", value: "cluster" },
-];
 const TAXONS_PER_SAMPLE_RANGE = {
   min: 0,
   max: 100,
@@ -77,7 +73,6 @@ class SamplesHeatmapView extends React.Component {
         ),
         species: parseAndCheckInt(this.urlParams.species, 1),
         sampleSortType: this.urlParams.sampleSortType || "cluster",
-        taxaSortType: this.urlParams.sampleSortType || "cluster",
         thresholdFilters: this.urlParams.thresholdFilters || [],
         dataScaleIdx: parseAndCheckInt(this.urlParams.dataScaleIdx, 0),
         taxonsPerSample: parseAndCheckInt(this.urlParams.taxonsPerSample, 30),
@@ -521,13 +516,12 @@ class SamplesHeatmapView extends React.Component {
     // Client side options
     scales: SCALE_OPTIONS,
     sampleSortTypeOptions: SORT_SAMPLES_OPTIONS,
-    taxaSortTypeOptions: SORT_TAXA_OPTIONS,
     taxonsPerSample: TAXONS_PER_SAMPLE_RANGE,
     specificityOptions: SPECIFICITY_OPTIONS,
   });
 
   handleSelectedOptionsChange = newOptions => {
-    const excluding = ["dataScaleIdx", "sampleSortType", "taxaSortType"];
+    const excluding = ["dataScaleIdx", "sampleSortType"];
     const shouldRefetchData = difference(keys(newOptions), excluding).length;
     this.setState(
       {
@@ -600,7 +594,6 @@ class SamplesHeatmapView extends React.Component {
           taxonFilterState={this.state.taxonFilterState}
           thresholdFilters={this.state.selectedOptions.thresholdFilters}
           sampleSortType={this.state.selectedOptions.sampleSortType}
-          taxaSortType={this.state.selectedOptions.taxaSortType}
         />
       </ErrorBoundary>
     );

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -36,11 +36,7 @@ const SORT_SAMPLES_OPTIONS = [
   { text: "Cluster", value: "cluster" },
 ];
 const SORT_TAXA_OPTIONS = [
-  // NOTE: "genus" sort was renamed to "alphabetical" because that is currently
-  // more accurate. To sort by genus, we should sort by taxon parent ID,
-  // which is currently not always accurate, and we should show what the genus
-  // is for viruses, which is not currently shown.
-  { text: "Alphabetical", value: "alpha" },
+  { text: "Genus", value: "genus" },
   { text: "Cluster", value: "cluster" },
 ];
 const TAXONS_PER_SAMPLE_RANGE = {
@@ -81,7 +77,7 @@ class SamplesHeatmapView extends React.Component {
         ),
         species: parseAndCheckInt(this.urlParams.species, 1),
         sampleSortType: this.urlParams.sampleSortType || "cluster",
-        taxaSortType: this.urlParams.taxaSortType || "cluster",
+        taxaSortType: this.urlParams.sampleSortType || "cluster",
         thresholdFilters: this.urlParams.thresholdFilters || [],
         dataScaleIdx: parseAndCheckInt(this.urlParams.dataScaleIdx, 0),
         taxonsPerSample: parseAndCheckInt(this.urlParams.taxonsPerSample, 30),

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -83,7 +83,6 @@ class SamplesHeatmapVis extends React.Component {
         scaleMin: 0,
         printCaption: this.generateHeatmapCaptions(),
         shouldSortColumns: this.props.sampleSortType === "alpha", // else cluster
-        shouldSortRows: this.props.taxaSortType === "genus", // else cluster
         // Shrink to fit the viewport width
         maxWidth: this.heatmapContainer.offsetWidth,
       }
@@ -106,9 +105,6 @@ class SamplesHeatmapVis extends React.Component {
     }
     if (this.props.sampleSortType !== prevProps.sampleSortType) {
       this.heatmap.updateSortColumns(this.props.sampleSortType === "alpha");
-    }
-    if (this.props.taxaSortType !== prevProps.taxaSortType) {
-      this.heatmap.updateSortRows(this.props.taxaSortType === "genus");
     }
   }
 
@@ -438,7 +434,6 @@ SamplesHeatmapVis.propTypes = {
   taxonIds: PropTypes.array,
   thresholdFilters: PropTypes.any,
   sampleSortType: PropTypes.string,
-  taxaSortType: PropTypes.string,
 };
 
 export default SamplesHeatmapVis;

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -83,7 +83,7 @@ class SamplesHeatmapVis extends React.Component {
         scaleMin: 0,
         printCaption: this.generateHeatmapCaptions(),
         shouldSortColumns: this.props.sampleSortType === "alpha", // else cluster
-        shouldSortRows: this.props.taxaSortType === "alpha", // else cluster
+        shouldSortRows: this.props.taxaSortType === "genus", // else cluster
         // Shrink to fit the viewport width
         maxWidth: this.heatmapContainer.offsetWidth,
       }
@@ -108,7 +108,7 @@ class SamplesHeatmapVis extends React.Component {
       this.heatmap.updateSortColumns(this.props.sampleSortType === "alpha");
     }
     if (this.props.taxaSortType !== prevProps.taxaSortType) {
-      this.heatmap.updateSortRows(this.props.taxaSortType === "alpha");
+      this.heatmap.updateSortRows(this.props.taxaSortType === "genus");
     }
   }
 

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -49,8 +49,7 @@ export default class Heatmap {
         zoom: null, // multiplier for zooming in and out
         minHeight: 500,
         clustering: true,
-        shouldSortColumns: false,
-        shouldSortRows: false,
+        shouldSortColumns: true,
         defaultClusterStep: 6,
         maxRowClusterWidth: 100,
         maxColumnClusterHeight: 100,
@@ -150,11 +149,6 @@ export default class Heatmap {
 
   updateSortColumns(shouldSortColumns) {
     this.options.shouldSortColumns = shouldSortColumns;
-    this.processData("cluster");
-  }
-
-  updateSortRows(shouldSortRows) {
-    this.options.shouldSortRows = shouldSortRows;
     this.processData("cluster");
   }
 
@@ -428,9 +422,7 @@ export default class Heatmap {
   }
 
   cluster() {
-    if (this.options.shouldSortRows) {
-      this.sortRows("asc");
-    } else if (this.options.clustering) {
+    if (this.options.clustering) {
       this.clusterRows();
     }
 
@@ -450,8 +442,8 @@ export default class Heatmap {
     this.renderColumnMetadata();
 
     if (this.options.clustering) {
-      this.options.shouldSortRows || this.renderRowDendrogram();
-      this.options.shouldSortColumns || this.renderColumnDendrogram();
+      this.renderRowDendrogram();
+      this.renderColumnDendrogram();
     }
 
     this.options.onUpdateFinished && this.options.onUpdateFinished();
@@ -592,15 +584,6 @@ export default class Heatmap {
   sortColumns(direction) {
     this.columnClustering = null;
     orderBy(this.columnLabels, label => label.label, direction).forEach(
-      (label, idx) => {
-        label.pos = idx;
-      }
-    );
-  }
-
-  sortRows(direction) {
-    this.rowClustering = null;
-    orderBy(this.rowLabels, label => label.label, direction).forEach(
       (label, idx) => {
         label.pos = idx;
       }

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -503,8 +503,7 @@ module ReportHelper
 
   def self.validate_names!(tax_2d)
     # This converts superkingdom_id to category_name and makes up
-    # suitable names for missing and blacklisted genera and species. Such
-    # made-up names should be lowercase so they are sorted below proper names.
+    # suitable names for missing and blacklisted genera and species.
     category = {}
     ALL_CATEGORIES.each do |c|
       category[c['taxid']] = c['name']
@@ -517,8 +516,7 @@ module ReportHelper
       if tax_id < 0
         # Usually -1 means accession number did not resolve to species.
         # TODO: Can we keep the accession numbers to show in these cases?
-        # NOTE: important to be lowercase for sorting below uppercase valid genuses
-        tax_info['name'] = "all taxa with neither family nor genus classification"
+        tax_info['name'] = "All taxa with neither family nor genus classification"
 
         if tax_id < TaxonLineage::INVALID_CALL_BASE_ID && species_or_genus(tax_info['tax_level'])
           parent_id = convert_neg_taxid(tax_id)
@@ -530,15 +528,15 @@ module ReportHelper
             parent_name = "taxon #{parent_id}"
             parent_level = ""
           end
-          tax_info['name'] = "non-#{level_str}-specific reads in #{parent_level} #{parent_name}"
+          tax_info['name'] = "Non-#{level_str}-specific reads in #{parent_level} #{parent_name}"
         elsif tax_id == TaxonLineage::BLACKLIST_GENUS_ID
-          tax_info['name'] = "all artificial constructs"
+          tax_info['name'] = "All artificial constructs"
         elsif !(TaxonLineage::MISSING_LINEAGE_ID.values.include? tax_id) && tax_id != TaxonLineage::MISSING_SPECIES_ID_ALT
           tax_info['name'] += " #{tax_id}"
         end
       elsif !tax_info['name']
         missing_names.add(tax_id)
-        tax_info['name'] = "unnamed #{level_str} taxon #{tax_id}"
+        tax_info['name'] = "Unnamed #{level_str} taxon #{tax_id}"
       end
       category_id = tax_info.delete('superkingdom_taxid')
       tax_info['category_name'] = category[category_id] || 'Uncategorized'

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -10,11 +10,6 @@ class TaxonLineage < ApplicationRecord
   end
   include TaxonLineageHelper
 
-  # We use an artificial negative taxon ID if we have determined that
-  # the alignment is not specific at the taxonomy level under
-  # consideration. This happens when a read's multiple reference matches
-  # do not agree on taxon ID at the given level.
-  # See idseq-dag for more info.
   INVALID_CALL_BASE_ID = -100_000_000 # don't run into -2e9 limit (not common, mostly a concern for fp32 or int32)
   MISSING_SPECIES_ID = -100
   MISSING_SPECIES_ID_ALT = -1


### PR DESCRIPTION
# Description

This removes the feature added in #2553, so we can add some more critical elements, as described in https://jira.czi.team/browse/IDSEQ-1265 . 

![image](https://user-images.githubusercontent.com/28797/65007451-15ef5080-d8bb-11e9-83ba-a2456b12af66.png)


# Tests

* open heatmap
* see no more taxa sort