### PR TITLE
Lift Basespace upload flag for new users

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -136,7 +136,6 @@ class SampleUploadFlow extends React.Component {
           visible={this.state.currentStep === "uploadSamples"}
           basespaceClientId={this.props.basespaceClientId}
           basespaceOauthRedirectUri={this.props.basespaceOauthRedirectUri}
-          admin={this.props.admin}
         />
         {this.state.samples && (
           <UploadMetadataStep

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -174,7 +174,7 @@ class UploadSampleStep extends React.Component {
 
   //*** Tab-related functions ***
 
-  getUploadTabs = allowedFeatures => {
+  getUploadTabs = () => {
     return compact([
       {
         value: LOCAL_UPLOAD,
@@ -725,18 +725,12 @@ class UploadSampleStep extends React.Component {
           </div>
           <div className={cs.fileUpload}>
             <div className={cs.title}>Upload Files</div>
-            <RequestContext.Consumer>
-              {({ allowedFeatures } = {}) => {
-                return (
-                  <Tabs
-                    className={cs.tabs}
-                    tabs={this.getUploadTabs(allowedFeatures)}
-                    value={this.state.currentTab}
-                    onChange={this.handleTabChange}
-                  />
-                );
-              }}
-            </RequestContext.Consumer>
+            <Tabs
+              className={cs.tabs}
+              tabs={this.getUploadTabs()}
+              value={this.state.currentTab}
+              onChange={this.handleTabChange}
+            />
             {this.renderTab()}
           </div>
           {this.state.currentTab === LOCAL_UPLOAD &&

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -175,7 +175,6 @@ class UploadSampleStep extends React.Component {
   //*** Tab-related functions ***
 
   getUploadTabs = allowedFeatures => {
-    const { admin } = this.props;
     return compact([
       {
         value: LOCAL_UPLOAD,
@@ -805,7 +804,6 @@ UploadSampleStep.propTypes = {
   visible: PropTypes.bool,
   basespaceClientId: PropTypes.string.isRequired,
   basespaceOauthRedirectUri: PropTypes.string.isRequired,
-  admin: PropTypes.bool,
 };
 
 export default UploadSampleStep;

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -185,7 +185,7 @@ class UploadSampleStep extends React.Component {
         value: REMOTE_UPLOAD,
         label: REMOTE_UPLOAD_LABEL,
       },
-      (admin || allowedFeatures.includes("basespace_upload_enabled")) && {
+      {
         value: BASESPACE_UPLOAD,
         label: BASESPACE_UPLOAD_LABEL,
       },

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -37,7 +37,6 @@ import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import ProjectCreationForm from "~/components/common/ProjectCreationForm";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import SecondaryButton from "~/components/ui/controls/buttons/SecondaryButton";
-import { RequestContext } from "~/components/common/RequestContext";
 
 import LocalSampleFileUpload from "./LocalSampleFileUpload";
 import RemoteSampleFileUpload from "./RemoteSampleFileUpload";

--- a/app/controllers/basespace_controller.rb
+++ b/app/controllers/basespace_controller.rb
@@ -4,10 +4,6 @@ class BasespaceController < ApplicationController
   include HttpHelper
   include BasespaceHelper
 
-  before_action do
-    allowed_feature_required("basespace_upload_enabled", true)
-  end
-
   def oauth
     disable_header_navigation
     @access_token = nil

--- a/spec/controllers/basespace_controller_spec.rb
+++ b/spec/controllers/basespace_controller_spec.rb
@@ -50,9 +50,9 @@ BASESPACE_NON_FASTQ_SAMPLE = {
 RSpec.describe BasespaceController, type: :controller do
   create_users
 
-  context "Admin user" do
+  context "non-admin user" do
     before do
-      sign_in @admin
+      sign_in @joe
     end
 
     describe "GET oauth" do
@@ -244,33 +244,6 @@ RSpec.describe BasespaceController, type: :controller do
           json_response = JSON.parse(response.body)
           expect(json_response).to include_json(error: "unable to fetch data from basespace")
         end
-      end
-    end
-  end
-
-  context "non-admin user" do
-    before do
-      sign_in @joe
-    end
-
-    describe "GET oauth" do
-      it "should redirect to the root" do
-        get :oauth, params: { code: "MOCK_CODE" }
-        expect(response).to redirect_to("/")
-      end
-    end
-
-    describe "GET projects" do
-      it "should redirect to the root" do
-        get :projects, params: { access_token: "123" }
-        expect(response).to redirect_to("/")
-      end
-    end
-
-    describe "GET samples_for_project" do
-      it "should redirect to the root" do
-        get :samples_for_project, params: { basespace_project_id: 77 }
-        expect(response).to redirect_to("/")
       end
     end
   end


### PR DESCRIPTION
### Description
- Came up during training that new users should also have access to Basespace uploading.
- No more matches to "basespace_upload_enabled" in the app.
- Faster to fix than file..

### Tests
All users see Basespace tab on the upload page:
<img width="684" alt="Screen Shot 2019-09-17 at 4 49 51 PM" src="https://user-images.githubusercontent.com/5652739/65087596-337bf300-d96b-11e9-8262-78092f1f2e48.png">