### PR TITLE
Modify "Add Metadata" on heatmap to be more obvious

### DIFF
--- a/app/assets/src/components/utils/d3/svg.js
+++ b/app/assets/src/components/utils/d3/svg.js
@@ -1,0 +1,32 @@
+import d3 from "d3";
+
+// Creates a color matrix that can recolor a black icon via a filter. See:
+// https://semisignal.com/using-fecolormatrix-to-dynamically-recolor-icons-part-1-single-color-icons/
+function generateColorMatrix(rgb) {
+  let rScaled = rgb[0] / 255.0;
+  let gScaled = rgb[1] / 255.0;
+  let bScaled = rgb[2] / 255.0;
+  return `0 0 0 0 ${rScaled}
+          0 0 0 0 ${gScaled}
+          0 0 0 0 ${bScaled}
+          0 0 0 1 0`;
+}
+
+// Convert hex string to rgb array
+function hexToRgb(hex) {
+  var r = parseInt(hex.slice(1, 3), 16),
+    g = parseInt(hex.slice(3, 5), 16),
+    b = parseInt(hex.slice(5, 7), 16);
+  return [r, g, b];
+}
+
+export default function addSvgColorFilter(defs, id, color) {
+  defs
+    .append("filter")
+    .attr("id", id)
+    .append("feColorMatrix")
+    .attr("color-interpolation-filters", "sRGB")
+    .attr("type", "matrix")
+    .attr("values", generateColorMatrix(hexToRgb(color)));
+  return defs;
+}

--- a/app/assets/src/components/utils/d3/svg.js
+++ b/app/assets/src/components/utils/d3/svg.js
@@ -1,5 +1,3 @@
-import d3 from "d3";
-
 // Creates a color matrix that can recolor a black icon via a filter. See:
 // https://semisignal.com/using-fecolormatrix-to-dynamically-recolor-icons-part-1-single-color-icons/
 function generateColorMatrix(rgb) {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -11,6 +11,9 @@ import cx from "classnames";
 import symlog from "../../utils/d3/scales/symlog.js";
 import cs from "./heatmap.scss";
 import { CategoricalColormap } from "../../utils/colormaps/CategoricalColormap.js";
+import addSvgColorFilter from "../../utils/d3/svg.js";
+// used for filter to make plus icon blue
+const COLOR_HOVER_LINK = "#3867fa";
 
 // TODO(tcarvalho): temporary hack to send elements to the back.
 // Remove once code is ported to d3 v4, which contains this function.
@@ -55,7 +58,6 @@ export default class Heatmap {
         maxColumnClusterHeight: 100,
         spacing: 10,
         metadataAddLinkHeight: 14,
-        colorHoverLink: "#2b52cd", // used for filter to make icon blue
         transitionDuration: 200,
         nullValue: 0,
         columnMetadata: [],
@@ -269,37 +271,8 @@ export default class Heatmap {
     );
 
     const defs = this.svg.append("defs");
-
-    // Creates a color matrix that can recolor a black icon via a filter. See:
-    // https://semisignal.com/using-fecolormatrix-to-dynamically-recolor-icons-part-1-single-color-icons/
-    const generateColorMatrix = function(rgb) {
-      let rScaled = rgb[0] / 255.0;
-      let gScaled = rgb[1] / 255.0;
-      let bScaled = rgb[2] / 255.0;
-      return `0 0 0 0 ${rScaled}
-              0 0 0 0 ${gScaled}
-              0 0 0 0 ${bScaled}
-              0 0 0 1 0`;
-    };
-
-    // Convert hex string to rgb array
-    const hexToRgb = function(hex) {
-      var r = parseInt(hex.slice(1, 3), 16),
-        g = parseInt(hex.slice(3, 5), 16),
-        b = parseInt(hex.slice(5, 7), 16);
-      return [r, g, b];
-    };
-
     // Create a blue color filter to match $primary-light.
-    defs
-      .append("filter")
-      .attr("id", "blue")
-      .append("feColorMatrix")
-      .attr("type", "matrix")
-      .attr(
-        "values",
-        generateColorMatrix(hexToRgb(this.options.colorHoverLink))
-      );
+    addSvgColorFilter(defs, "blue", COLOR_HOVER_LINK);
 
     this.g = this.svg.append("g");
     this.gRowLabels = this.g.append("g").attr("class", cs.rowLabels);

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -13,7 +13,7 @@ import cs from "./heatmap.scss";
 import { CategoricalColormap } from "../../utils/colormaps/CategoricalColormap.js";
 import addSvgColorFilter from "../../utils/d3/svg.js";
 // used for filter to make plus icon blue
-const COLOR_HOVER_LINK = "#3867fa";
+const COLOR_HOVER_LINK = cs.primaryLight;
 
 // TODO(tcarvalho): temporary hack to send elements to the back.
 // Remove once code is ported to d3 v4, which contains this function.

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -54,7 +54,8 @@ export default class Heatmap {
         maxRowClusterWidth: 100,
         maxColumnClusterHeight: 100,
         spacing: 10,
-        columnMetadataAddHeight: 14,
+        metadataAddLinkHeight: 14,
+        colorHoverLink: "#2b52cd", // used for filter to make icon blue
         transitionDuration: 200,
         nullValue: 0,
         columnMetadata: [],
@@ -271,14 +272,22 @@ export default class Heatmap {
 
     // Creates a color matrix that can recolor a black icon via a filter. See:
     // https://semisignal.com/using-fecolormatrix-to-dynamically-recolor-icons-part-1-single-color-icons/
-    const generateColorMatrix = function(r, g, b) {
-      let rScaled = r / 255.0;
-      let gScaled = g / 255.0;
-      let bScaled = b / 255.0;
+    const generateColorMatrix = function(rgb) {
+      let rScaled = rgb[0] / 255.0;
+      let gScaled = rgb[1] / 255.0;
+      let bScaled = rgb[2] / 255.0;
       return `0 0 0 0 ${rScaled}
-                0 0 0 0 ${gScaled}
-                0 0 0 0 ${bScaled}
-                0 0 0 1 0`;
+              0 0 0 0 ${gScaled}
+              0 0 0 0 ${bScaled}
+              0 0 0 1 0`;
+    };
+
+    // Convert hex string to rgb array
+    const hexToRgb = function(hex) {
+      var r = parseInt(hex.slice(1, 3), 16),
+        g = parseInt(hex.slice(3, 5), 16),
+        b = parseInt(hex.slice(5, 7), 16);
+      return [r, g, b];
     };
 
     // Create a blue color filter to match $primary-light.
@@ -287,7 +296,10 @@ export default class Heatmap {
       .attr("id", "blue")
       .append("feColorMatrix")
       .attr("type", "matrix")
-      .attr("values", generateColorMatrix(0x2b, 0x52, 0xcd));
+      .attr(
+        "values",
+        generateColorMatrix(hexToRgb(this.options.colorHoverLink))
+      );
 
     this.g = this.svg.append("g");
     this.gRowLabels = this.g.append("g").attr("class", cs.rowLabels);
@@ -338,7 +350,7 @@ export default class Heatmap {
     const totalColumnLabelsHeight = this.columnLabelsHeight;
     const totalMetadataHeight =
       this.options.columnMetadata.length * this.options.minCellHeight +
-      this.options.columnMetadataAddHeight;
+      this.options.metadataAddLinkHeight;
     const totalCellHeight = this.cell.height * this.filteredRowLabels.length;
     const totalColumnClusterHeight = this.options.clustering
       ? this.columnClusterHeight + this.options.spacing * 2
@@ -1127,7 +1139,7 @@ export default class Heatmap {
         .append("g")
         .attr("class", cs.columnMetadataAdd);
 
-      let yPos = this.options.columnMetadataAddHeight / 2;
+      let yPos = this.options.metadataAddLinkHeight / 2;
 
       addLinkEnter.append("rect");
 
@@ -1149,8 +1161,8 @@ export default class Heatmap {
       addMetadataTrigger
         .append("svg:image")
         .attr("class", cs.metadataAddIcon)
-        .attr("width", this.options.columnMetadataAddHeight)
-        .attr("height", this.options.columnMetadataAddHeight)
+        .attr("width", this.options.metadataAddLinkHeight)
+        .attr("height", this.options.metadataAddLinkHeight)
         .attr("x", this.rowLabelsWidth - 20)
         .attr("xlink:href", `${this.options.iconPath}/plus.svg`);
 
@@ -1171,7 +1183,7 @@ export default class Heatmap {
           "width",
           this.rowLabelsWidth + this.columnLabels.length * this.cell.width
         )
-        .attr("height", this.options.columnMetadataAddHeight);
+        .attr("height", this.options.metadataAddLinkHeight);
 
       addLink
         .select(`.${cs.metadataAddLine}`)

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -54,6 +54,7 @@ export default class Heatmap {
         maxRowClusterWidth: 100,
         maxColumnClusterHeight: 100,
         spacing: 10,
+        columnMetadataAddHeight: 14,
         transitionDuration: 200,
         nullValue: 0,
         columnMetadata: [],
@@ -266,6 +267,28 @@ export default class Heatmap {
       `background-color: ${this.options.svgBackgroundColor}`
     );
 
+    const defs = this.svg.append("defs");
+
+    // Creates a color matrix that can recolor a black icon via a filter. See:
+    // https://semisignal.com/using-fecolormatrix-to-dynamically-recolor-icons-part-1-single-color-icons/
+    const generateColorMatrix = function(r, g, b) {
+      let rScaled = r / 255.0;
+      let gScaled = g / 255.0;
+      let bScaled = b / 255.0;
+      return `0 0 0 0 ${rScaled}
+                0 0 0 0 ${gScaled}
+                0 0 0 0 ${bScaled}
+                0 0 0 1 0`;
+    };
+
+    // Create a blue color filter to match $primary-light.
+    defs
+      .append("filter")
+      .attr("id", "blue")
+      .append("feColorMatrix")
+      .attr("type", "matrix")
+      .attr("values", generateColorMatrix(0x2b, 0x52, 0xcd));
+
     this.g = this.svg.append("g");
     this.gRowLabels = this.g.append("g").attr("class", cs.rowLabels);
     this.gColumnLabels = this.g.append("g").attr("class", cs.columnLabels);
@@ -315,7 +338,7 @@ export default class Heatmap {
     const totalColumnLabelsHeight = this.columnLabelsHeight;
     const totalMetadataHeight =
       this.options.columnMetadata.length * this.options.minCellHeight +
-      this.options.spacing;
+      this.options.columnMetadataAddHeight;
     const totalCellHeight = this.cell.height * this.filteredRowLabels.length;
     const totalColumnClusterHeight = this.options.clustering
       ? this.columnClusterHeight + this.options.spacing * 2
@@ -1104,7 +1127,7 @@ export default class Heatmap {
         .append("g")
         .attr("class", cs.columnMetadataAdd);
 
-      let yPos = this.options.spacing / 2;
+      let yPos = this.options.columnMetadataAddHeight / 2;
 
       addLinkEnter.append("rect");
 
@@ -1114,8 +1137,8 @@ export default class Heatmap {
         .append("text")
         .text(() => "Add Metadata")
         .attr("class", cs.metadataAddLabel)
-        .attr("x", this.rowLabelsWidth - 20)
-        .attr("y", 9)
+        .attr("x", this.rowLabelsWidth - 25)
+        .attr("y", 11)
         .on("click", handleAddColumnMetadataClick);
 
       let addMetadataTrigger = addLinkEnter
@@ -1126,10 +1149,9 @@ export default class Heatmap {
       addMetadataTrigger
         .append("svg:image")
         .attr("class", cs.metadataAddIcon)
-        .attr("width", 10)
-        .attr("height", 10)
-        .attr("x", this.rowLabelsWidth - 15)
-        .attr("y", yPos - 5)
+        .attr("width", this.options.columnMetadataAddHeight)
+        .attr("height", this.options.columnMetadataAddHeight)
+        .attr("x", this.rowLabelsWidth - 20)
         .attr("xlink:href", `${this.options.iconPath}/plus.svg`);
 
       // setup triggers
@@ -1149,7 +1171,7 @@ export default class Heatmap {
           "width",
           this.rowLabelsWidth + this.columnLabels.length * this.cell.width
         )
-        .attr("height", this.options.spacing);
+        .attr("height", this.options.columnMetadataAddHeight);
 
       addLink
         .select(`.${cs.metadataAddLine}`)

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -1,5 +1,7 @@
 @import "~styles/themes/colors";
 @import "~styles/themes/typography";
+@value colors: "../../../styles/themes/_colors.scss";
+@value primaryLight from colors;
 
 .heatmap {
   .cells {

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -99,24 +99,25 @@
       }
 
       .metadataAddLabel {
-        @include font-label-xs;
+        @include font-label-s;
         fill: $medium-grey;
-        opacity: 0;
         cursor: pointer;
         text-anchor: end;
       }
 
       &:hover {
         .metadataAddLine {
-          stroke: $medium-grey;
+          stroke: $primary-light;
         }
 
         .metadataAddIcon {
-          opacity: 0.5;
+          // The filter is defined in heatmap.js
+          filter: url("#blue");
+          opacity: 1;
         }
 
         .metadataAddLabel {
-          opacity: 1;
+          fill: $primary-light;
         }
       }
     }

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -1,7 +1,8 @@
 @import "~styles/themes/colors";
 @import "~styles/themes/typography";
-@value colors: "../../../styles/themes/_colors.scss";
-@value primaryLight from colors;
+:export {
+  primaryLight: $primary-light;
+}
 
 .heatmap {
   .cells {

--- a/app/assets/src/styles/themes/_colors.scss
+++ b/app/assets/src/styles/themes/_colors.scss
@@ -1,7 +1,6 @@
 $primary-lightest: #eff2fc;
 $primary-lighter: #5887fa;
 $primary-light: #3867fa;
-@value primaryLight: #3867fa;
 $primary-medium: #2b52cd;
 $primary-dark: #223f9c;
 

--- a/app/assets/src/styles/themes/_colors.scss
+++ b/app/assets/src/styles/themes/_colors.scss
@@ -1,6 +1,7 @@
 $primary-lightest: #eff2fc;
 $primary-lighter: #5887fa;
 $primary-light: #3867fa;
+@value primaryLight: #3867fa;
 $primary-medium: #2b52cd;
 $primary-dark: #223f9c;
 


### PR DESCRIPTION
# Description

* The `Add Metadata` text is now always showing.
* Plus icon has been made slightly bigger.
* Spacing has been increased.
* Icon, text, and line have a hover state of primary blue.

![image](https://user-images.githubusercontent.com/53838890/65173718-442c7780-da04-11e9-83e7-8b43854ad930.png)

![image](https://user-images.githubusercontent.com/53838890/65185776-199ae880-da1d-11e9-8a57-2a2c21a2ed52.png)


# Notes

The plus icon's blue hover state is created by applying a filter to the svg. See:
* https://semisignal.com/using-fecolormatrix-to-dynamically-recolor-icons-part-1-single-color-icons/
* https://alistapart.com/article/finessing-fecolormatrix/

# Tests

* Verified that heatmap behaves as expected when zooming in/out and metadata columns are added or removed.
* Verified that the `Add Metadata` text and icon are not present when the heatmap is downloaded as an svg or png.
![image](https://user-images.githubusercontent.com/53838890/65180140-113cb080-da11-11e9-8f4c-208902311372.png)

