### PR TITLE
Fix S3 upload SIGPIPE issue for large files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -131,6 +131,15 @@ Style/RedundantReturn:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/NumericPredicate:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Performance/RegexpMatch:
+  Enabled: false
+
 Rails/FindEach:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -50,7 +50,7 @@ AllCops:
     - vendor/**/*
     - bin/*
     - node_modules/**/*
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
 
 ClassLength:
   Enabled: false
@@ -126,6 +126,9 @@ Style/MethodCallWithoutArgsParentheses:
   Enabled: false
 
 Style/RedundantReturn:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
   Enabled: false
 
 Rails/FindEach:

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -298,7 +298,7 @@ class Sample < ApplicationRecord
       while try < max_tries
         # Run the piped commands and save stderr
         err_read, err_write = IO.pipe
-        if fastq =~ /\.gz/
+        if fastq.match?(/\.gz/)
           proc_download, proc_unzip, proc_cut, proc_head, proc_validation, proc_zip, proc_upload = Open3.pipeline(
             ["aws", "s3", "cp", fastq, "-"],
             ["gzip", "-dc"],
@@ -344,10 +344,10 @@ class Sample < ApplicationRecord
            to_check[:no_errors].all? { |p| p&.exitstatus&.zero? }
           # Success
           break
-        elsif to_check.values.flatten.all? { |p| p.exitstatus.zero? }
+        elsif to_check.values.flatten.all? { |p| p&.exitstatus&.zero? }
           # Success
           break
-        elsif !proc_validation.exitstatus.zero? && stderr.include?(Sample::PARSE_ERROR_MESSAGE)
+        elsif proc_validation&.exitstatus&.nonzero? && stderr.include?(Sample::PARSE_ERROR_MESSAGE)
           error_msg = "Error parsing upload of S3 sample '#{name}' (#{id}) file '#{fastq}' failed with: #{stderr}"
           Rails.logger.error(error_msg)
           stderr_array << error_msg

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -344,7 +344,7 @@ class Sample < ApplicationRecord
           to_check[:no_errors].all? { |p| p&.exitstatus&.zero? }
           # Success
           break
-        elsif to_check.values.flatten.all? { |p| p.exitstatus.zero? }
+        elsif to_check.values.flatten.all? { |p| p&.exitstatus&.zero? }
           # Success
           break
         elsif !proc_validation.exitstatus.zero? && stderr.include?(Sample::PARSE_ERROR_MESSAGE)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -59,6 +59,8 @@ class Sample < ApplicationRecord
                      :sample_template, # this refers to nucleotide type (RNA or DNA)
                      :sample_library, :sample_sequencer, :sample_notes, :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection,].freeze
 
+  SLEEP_SECONDS_BETWEEN_RETRIES = 10
+
   # Maximum allowed line length in characters for fastq/fasta files
   MAX_LINE_LENGTH = 10_000
   # Error message to identify parse errors from fastq-fasta-line-validation.awk
@@ -297,7 +299,7 @@ class Sample < ApplicationRecord
         # Run the piped commands and save stderr
         err_read, err_write = IO.pipe
         if fastq =~ /\.gz/
-          _proc_download, _proc_unzip, proc_cut, proc_head, proc_validation, proc_zip, proc_upload = Open3.pipeline(
+          proc_download, proc_unzip, proc_cut, proc_head, proc_validation, proc_zip, proc_upload = Open3.pipeline(
             ["aws", "s3", "cp", fastq, "-"],
             ["gzip", "-dc"],
             ["cut", "-c", "-#{Sample::MAX_LINE_LENGTH + 1}"],
@@ -307,9 +309,12 @@ class Sample < ApplicationRecord
             ["aws", "s3", "cp", "-", "#{sample_input_s3_path}/#{input_file.name}"],
             err: err_write
           )
-          to_check = [proc_cut, proc_head, proc_zip, proc_validation, proc_upload]
+          to_check = {
+            sig_pipe: [proc_unzip, proc_cut],
+            no_errors: [proc_head, proc_validation, proc_zip, proc_upload],
+          }
         else
-          _proc_download, proc_cut, proc_head, proc_validation, proc_upload = Open3.pipeline(
+          proc_download, proc_cut, proc_head, proc_validation, proc_upload = Open3.pipeline(
             ["aws", "s3", "cp", fastq, "-"],
             ["cut", "-c", "-#{Sample::MAX_LINE_LENGTH + 1}"],
             ["head", "-n", max_lines.to_s],
@@ -317,15 +322,29 @@ class Sample < ApplicationRecord
             ["aws", "s3", "cp", "-", "#{sample_input_s3_path}/#{input_file.name}"],
             err: err_write
           )
-          to_check = [proc_cut, proc_head, proc_validation, proc_upload]
+          to_check = {
+            sig_pipe: [proc_cut],
+            no_errors: [proc_head, proc_validation, proc_upload],
+          }
         end
         err_write.close
         stderr = err_read.read
 
-        # Ignore proc_download and proc_unzip status because they will always throw exit 1 and
-        # SIGPIPE 13 'pipe broken' unless the entire file was headed. Ignore pipe error in stderr but
-        # we still want to see errs like HeadObject Forbidden.
-        if to_check.all? { |p| p && p.exitstatus && p.exitstatus.zero? } && (stderr.empty? || stderr.include?(InputFile::S3_CP_PIPE_ERROR))
+        # Whenever the file has more lines than the accepted limit,
+        # head command interrupts the stream and all previous commands receive a
+        # SIGPIPE 13 'pipe broken'. This is an expected condition that shouldn't be
+        # considered as an error.
+        if (
+            # exitstatus is 0 when input file is small enough to be read in a single fetch
+            (proc_download.exitstatus == 0) ||
+            # exitstatus is 1 when input file is too big and aws cp still have its connection open
+            (proc_download.exitstatus == 1 && stderr.include?(InputFile::S3_CP_PIPE_ERROR))
+          ) &&
+          to_check[:sig_pipe].all? { |p| p&.termsig == 13 } &&
+          to_check[:no_errors].all? { |p| p&.exitstatus&.zero? }
+          # Success
+          break
+        elsif to_check.values.flatten.all? { |p| p.exitstatus.zero? }
           # Success
           break
         elsif !proc_validation.exitstatus.zero? && stderr.include?(Sample::PARSE_ERROR_MESSAGE)
@@ -340,7 +359,7 @@ class Sample < ApplicationRecord
 
           # Record final stderr if exceeding max tries
           stderr_array << stderr if try == max_tries
-          sleep(10)
+          sleep(Sample::SLEEP_SECONDS_BETWEEN_RETRIES)
         end
       end
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -335,16 +335,16 @@ class Sample < ApplicationRecord
         # SIGPIPE 13 'pipe broken'. This is an expected condition that shouldn't be
         # considered as an error.
         if (
-            # exitstatus is 0 when input file is small enough to be read in a single fetch
-            (proc_download.exitstatus == 0) ||
-            # exitstatus is 1 when input file is too big and aws cp still have its connection open
-            (proc_download.exitstatus == 1 && stderr.include?(InputFile::S3_CP_PIPE_ERROR))
-          ) &&
-          to_check[:sig_pipe].all? { |p| p&.termsig == 13 } &&
-          to_check[:no_errors].all? { |p| p&.exitstatus&.zero? }
+             # exitstatus is 0 when input file is small enough to be read in a single fetch
+             proc_download&.exitstatus&.zero? ||
+             # exitstatus is 1 when input file is too big and aws cp still have its connection open
+             (proc_download&.exitstatus == 1 && stderr.include?(InputFile::S3_CP_PIPE_ERROR))
+        ) &&
+           to_check[:sig_pipe].all? { |p| p&.termsig == 13 } &&
+           to_check[:no_errors].all? { |p| p&.exitstatus&.zero? }
           # Success
           break
-        elsif to_check.values.flatten.all? { |p| p&.exitstatus&.zero? }
+        elsif to_check.values.flatten.all? { |p| p.exitstatus.zero? }
           # Success
           break
         elsif !proc_validation.exitstatus.zero? && stderr.include?(Sample::PARSE_ERROR_MESSAGE)


### PR DESCRIPTION
More specific error handling pattern for SIGPIPE

# Description

Fix an issue with large files upload that was generating "[Errno 32] Broken pipe" message

# Tests

* Multiple manual tests