### PR TITLE
[DD] Fix: Remove fields from data persistence for a session

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -169,28 +169,23 @@ class DiscoveryView extends React.Component {
   updateBrowsingHistory = (action = "push") => {
     const { domain } = this.props;
 
-    const sessionFields = [
-      "currentDisplay",
-      "currentTab",
-      "mapSidebarTab",
-      "sampleActiveColumns",
-      "showFilters",
-      "showStats",
-    ];
-    const urlFields = concat(sessionFields, ["filters", "search", "projectId"]);
-    const stateFields = concat(urlFields, ["project"]);
-
     const localFields = [
       "currentTab",
       "sampleActiveColumns",
       "showFilters",
       "showStats",
     ];
+    const sessionFields = concat(sessionFields, [
+      "currentDisplay",
+      "mapSidebarTab",
+    ]);
+    const urlFields = concat(sessionFields, ["filters", "projectId", "search"]);
+    const stateFields = concat(urlFields, ["project"]);
 
-    const sessionState = pick(sessionFields, this.state);
-    const historyState = pick(stateFields, this.state);
-    const urlState = pick(urlFields, this.state);
     const localState = pick(localFields, this.state);
+    const sessionState = pick(sessionFields, this.state);
+    const urlState = pick(urlFields, this.state);
+    const historyState = pick(stateFields, this.state);
 
     // Saving on URL enables sharing current view with other users
     let urlQuery = this.urlParser.stringify(urlState);

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -175,7 +175,7 @@ class DiscoveryView extends React.Component {
       "showFilters",
       "showStats",
     ];
-    const sessionFields = concat(sessionFields, [
+    const sessionFields = concat(localFields, [
       "currentDisplay",
       "mapSidebarTab",
     ]);

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -169,18 +169,17 @@ class DiscoveryView extends React.Component {
   updateBrowsingHistory = (action = "push") => {
     const { domain } = this.props;
 
-    const urlFields = [
+    const sessionFields = [
       "currentDisplay",
       "currentTab",
-      "filters",
       "mapSidebarTab",
-      "projectId",
       "sampleActiveColumns",
-      "search",
       "showFilters",
       "showStats",
     ];
+    const urlFields = concat(sessionFields, ["filters", "search", "projectId"]);
     const stateFields = concat(urlFields, ["project"]);
+
     const localFields = [
       "currentTab",
       "sampleActiveColumns",
@@ -188,6 +187,7 @@ class DiscoveryView extends React.Component {
       "showStats",
     ];
 
+    const sessionState = pick(sessionFields, this.state);
     const historyState = pick(stateFields, this.state);
     const urlState = pick(urlFields, this.state);
     const localState = pick(localFields, this.state);
@@ -215,7 +215,10 @@ class DiscoveryView extends React.Component {
     }
 
     // We want to persist all options when user navigates to other pages within the same session
-    sessionStorage.setItem("DiscoveryViewOptions", JSON.stringify(urlState));
+    sessionStorage.setItem(
+      "DiscoveryViewOptions",
+      JSON.stringify(sessionState)
+    );
 
     // We want to persist some options when user returns to the page on a different session
     localStorage.setItem("DiscoveryViewOptions", JSON.stringify(localState));


### PR DESCRIPTION
# Description

Too many fields being persisted for a session (equivalent to URL). This prevented users from getting out of the project page, for instance.
We create a smaller subset of fields to be persisted.

# Tests

* Check that you can select a project and go back to the main page by clicking my data.

