### PR TITLE
Hide Upload from S3 option from non-admin, non-biohub users

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -136,6 +136,8 @@ class SampleUploadFlow extends React.Component {
           visible={this.state.currentStep === "uploadSamples"}
           basespaceClientId={this.props.basespaceClientId}
           basespaceOauthRedirectUri={this.props.basespaceOauthRedirectUri}
+          admin={this.props.admin}
+          biohubUser={this.props.biohub_user}
         />
         {this.state.samples && (
           <UploadMetadataStep
@@ -197,6 +199,7 @@ SampleUploadFlow.propTypes = {
   csrf: PropTypes.string,
   hostGenomes: PropTypes.arrayOf(PropTypes.HostGenome),
   admin: PropTypes.bool,
+  biohub_user: PropTypes.bool,
   basespaceClientId: PropTypes.string.isRequired,
   basespaceOauthRedirectUri: PropTypes.string.isRequired,
 };

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -137,7 +137,7 @@ class SampleUploadFlow extends React.Component {
           basespaceClientId={this.props.basespaceClientId}
           basespaceOauthRedirectUri={this.props.basespaceOauthRedirectUri}
           admin={this.props.admin}
-          biohubUser={this.props.biohub_user}
+          biohubUser={this.props.biohubUser}
         />
         {this.state.samples && (
           <UploadMetadataStep
@@ -199,7 +199,7 @@ SampleUploadFlow.propTypes = {
   csrf: PropTypes.string,
   hostGenomes: PropTypes.arrayOf(PropTypes.HostGenome),
   admin: PropTypes.bool,
-  biohub_user: PropTypes.bool,
+  biohubUser: PropTypes.bool,
   basespaceClientId: PropTypes.string.isRequired,
   basespaceOauthRedirectUri: PropTypes.string.isRequired,
 };

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -174,12 +174,13 @@ class UploadSampleStep extends React.Component {
   //*** Tab-related functions ***
 
   getUploadTabs = () => {
+    const { admin, biohubUser } = this.props;
     return compact([
       {
         value: LOCAL_UPLOAD,
         label: LOCAL_UPLOAD_LABEL,
       },
-      {
+      (admin || biohubUser) && {
         value: REMOTE_UPLOAD,
         label: REMOTE_UPLOAD_LABEL,
       },
@@ -795,6 +796,8 @@ UploadSampleStep.propTypes = {
   // Used to disable later steps the header navigation if the data in previous steps has changed.
   onDirty: PropTypes.func.isRequired,
   visible: PropTypes.bool,
+  admin: PropTypes.bool,
+  biohubUser: PropTypes.bool,
   basespaceClientId: PropTypes.string.isRequired,
   basespaceOauthRedirectUri: PropTypes.string.isRequired,
 };

--- a/app/views/samples/upload.html.erb
+++ b/app/views/samples/upload.html.erb
@@ -4,7 +4,7 @@
       csrf: '<%= form_authenticity_token %>',
       hostGenomes: JSON.parse('<%= raw escape_json(@host_genomes) %>'),
       admin: JSON.parse('<%= raw escape_json(current_user.admin) %>'),
-      biohub_user: JSON.parse('<%= raw escape_json(current_user.biohub_user?) %>'),
+      biohubUser: JSON.parse('<%= raw escape_json(current_user.biohub_user?) %>'),
       basespaceClientId: '<%= @basespace_client_id %>',
       basespaceOauthRedirectUri: '<%= @basespace_oauth_redirect_uri %>',
     }, 'upload_page', JSON.parse('<%= raw escape_json(request_context) %>'))

--- a/app/views/samples/upload.html.erb
+++ b/app/views/samples/upload.html.erb
@@ -4,6 +4,7 @@
       csrf: '<%= form_authenticity_token %>',
       hostGenomes: JSON.parse('<%= raw escape_json(@host_genomes) %>'),
       admin: JSON.parse('<%= raw escape_json(current_user.admin) %>'),
+      biohub_user: JSON.parse('<%= raw escape_json(current_user.biohub_user?) %>'),
       basespaceClientId: '<%= @basespace_client_id %>',
       basespaceOauthRedirectUri: '<%= @basespace_oauth_redirect_uri %>',
     }, 'upload_page', JSON.parse('<%= raw escape_json(request_context) %>'))


### PR DESCRIPTION
# Description
The `Upload from S3` tab [will not be displayed](https://jira.czi.team/browse/IDSEQ-1395) to users who are not not admins or have biohub email addresses.

![image](https://user-images.githubusercontent.com/53838890/65200293-23cbdf80-da3b-11e9-9337-ff5d580dc4be.png)

# Tests

* Verified a non-admin, non-biohub account could not see the `Upload from S3` tab
* Verified that an admin account or an account ending with either `czbiohub.org` or `ucsf.edu` can still access the `Upload from S3` tab
