### PR TITLE
Revoke Basespace access token once all file transfer is complete.

### DIFF
--- a/app/helpers/basespace_helper.rb
+++ b/app/helpers/basespace_helper.rb
@@ -17,13 +17,13 @@ module BasespaceHelper
     )
   end
 
-  def verify_access_token_revoked(access_token)
+  def verify_access_token_revoked(access_token, sample_id)
     # Verify that the token was revoked by using it to call an API endpoint.
     # The API endpoint should return a 401.
 
     fetch_from_basespace(BASESPACE_CURRENT_PROJECTS_URL, access_token, {}, true)
 
-    LogUtil.log_err_and_airbrake("BasespaceAccessTokenError Revoke access token check failed")
+    LogUtil.log_err_and_airbrake("BasespaceAccessTokenError: Failed to revoke access token for sample id #{sample_id}")
   rescue
     # The call should fail.
     Rails.logger.info("Revoke access token check succeeded")

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -69,7 +69,7 @@ class Sample < ApplicationRecord
   FASTQ_FASTA_LINE_VALIDATION_AWK_SCRIPT = Rails.root.join("scripts", "fastq-fasta-line-validation.awk").to_s
 
   # These are temporary variables that are not saved to the database. They only persist for the lifetime of the Sample object.
-  attr_accessor :bulk_mode, :basespace_dataset_id, :basespace_access_token
+  attr_accessor :bulk_mode, :basespace_dataset_id
 
   belongs_to :project
   # This is the user who uploaded the sample, possibly distinct from the user(s) owning the sample's project

--- a/db/migrate/20190920012312_add_basespace_access_token_to_sample.rb
+++ b/db/migrate/20190920012312_add_basespace_access_token_to_sample.rb
@@ -1,0 +1,5 @@
+class AddBasespaceAccessTokenToSample < ActiveRecord::Migration[5.1]
+  def change
+    add_column :samples, :basespace_access_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_823_223_316) do
+ActiveRecord::Schema.define(version: 20_190_920_003_723) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -370,6 +370,7 @@ ActiveRecord::Schema.define(version: 20_190_823_223_316) do
     t.integer "max_input_fragments"
     t.datetime "client_updated_at"
     t.integer "uploaded_from_basespace", limit: 1, default: 0
+    t.string "basespace_access_token"
     t.string "upload_error"
     t.index ["host_genome_id"], name: "samples_host_genome_id_fk"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true

--- a/spec/helpers/basespace_helper_spec.rb
+++ b/spec/helpers/basespace_helper_spec.rb
@@ -140,21 +140,21 @@ RSpec.describe BasespaceHelper, type: :helper do
       it "should call Basespace API to test access token" do
         expect(HttpHelper).to receive(:get_json).with(anything, anything, { "Authorization" => "Bearer #{fake_access_token}" }, anything)
                                                 .exactly(1).times.and_raise(StandardError)
-        expect(LogUtil).to receive(:log_err_and_airbrake).with("BasespaceAccessTokenError Revoke access token check failed")
+        expect(LogUtil).to receive(:log_err_and_airbrake).with("BasespaceAccessTokenError: Failed to revoke access token for sample id 123abc")
                                                          .exactly(0).times
         expect(Rails.logger).to receive(:info).with("Revoke access token check succeeded").exactly(1).times
 
-        BasespaceHelper.verify_access_token_revoked(fake_access_token)
+        BasespaceHelper.verify_access_token_revoked(fake_access_token, "123abc")
       end
 
       it "should log an error if Basespace API call unexpectedly succeeds" do
         expect(HttpHelper).to receive(:get_json).with(anything, anything, { "Authorization" => "Bearer #{fake_access_token}" }, anything)
                                                 .exactly(1).times.and_return("foo" => "bar")
-        expect(LogUtil).to receive(:log_err_and_airbrake).with("BasespaceAccessTokenError Revoke access token check failed")
+        expect(LogUtil).to receive(:log_err_and_airbrake).with("BasespaceAccessTokenError: Failed to revoke access token for sample id 123abc")
                                                          .exactly(1).times
         expect(Rails.logger).to receive(:info).with("Revoke access token check succeeded").exactly(0).times
 
-        BasespaceHelper.verify_access_token_revoked(fake_access_token)
+        BasespaceHelper.verify_access_token_revoked(fake_access_token, "123abc")
       end
     end
   end


### PR DESCRIPTION
# Description
This is a follow-up to https://github.com/chanzuckerberg/idseq-web/pull/2548

See also https://docs.google.com/document/d/1FKy_bXtDBI-1Uqplv2XHfXfaz2IqYPVxHdpQ1kKaGsM/edit

# Tests

* Verified that multiple samples are uploaded successfully.
* Verified that the token is successfully revoked after multiple samples are uploaded.


