### PR TITLE
Create an "on/off" switch for the automatic pipeline restart

### DIFF
--- a/app/helpers/app_config_helper.rb
+++ b/app/helpers/app_config_helper.rb
@@ -1,8 +1,10 @@
 module AppConfigHelper
-  def get_app_config(key)
+  module_function
+
+  def get_app_config(key, default_value = nil)
     app_config = AppConfig.find_by(key: key)
 
-    return app_config.present? ? app_config.value : nil
+    return app_config.present? ? app_config.value : default_value
   end
 
   def set_app_config(key, value)
@@ -13,5 +15,16 @@ module AppConfigHelper
     end
 
     app_config.update(value: value)
+  end
+
+  def get_json_app_config(key, default_value = nil, raise_error = false)
+    value = get_app_config(key)
+    begin
+      return JSON.parse(value) if value.present? && value.strip != ""
+    rescue JSON::ParserError => e
+      Rails.logger.error("AppConfigHelper error parsing JSON config key '#{key}'. Error: #{e.message}")
+      raise if raise_error
+    end
+    default_value
   end
 end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -3,4 +3,6 @@ class AppConfig < ApplicationRecord
   DISABLE_SITE_FOR_MAINTENANCE = 'disable_site_for_maintenance'.freeze
   # When this is "1", the Video Tour banner on the landing page will be shown.
   SHOW_LANDING_VIDEO_BANNER = 'show_landing_video_banner'.freeze
+  # JSON array containing the number of the stages allowed to auto restart. Ex: [1, 3]
+  AUTO_RESTART_ALLOWED_STAGES = 'auto_restart_allowed_stages'.freeze
 end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -869,8 +869,9 @@ class PipelineRun < ApplicationRecord
   end
 
   def automatic_restart_allowed?
-    return false unless pipeline_branch.nil? || pipeline_branch == "master"
-    previous_pipeline_runs_same_version.to_a.none?(&:failed?)
+    (pipeline_branch.nil? || pipeline_branch == "master") \
+    && AppConfigHelper.get_json_app_config(AppConfig::AUTO_RESTART_ALLOWED_STAGES, []).include?(active_stage&.step_number) \
+    && previous_pipeline_runs_same_version.to_a.none?(&:failed?)
   end
 
   def previous_pipeline_runs_same_version

--- a/spec/factories/pipeline_run_stages.rb
+++ b/spec/factories/pipeline_run_stages.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
     # Host Filtering, GSNAPLgcRAPSEARCH alignment,
     # Post Processing, Experimental
     step_number { 1 }
-    name { "Host Filtering" }
-    job_status { "COMPLETED" }
+    name { PipelineRunStage::HOST_FILTERING_STAGE_NAME }
+    job_status { PipelineRunStage::STATUS_SUCCEEDED }
     dag_json do
       {
         output_dir_s3: "s3:gc/someBucket/samples/theProjectId/theSampleId/results",


### PR DESCRIPTION
# Description

Adding a new configuration value `AppConfig::AUTO_RESTART_ALLOWED_STAGES` to enable/disables automatic pipeline restart individually per stage number (ex: you may want to enable it just for stages 3 - Post processing).

# Notes

This PR is also fixing an issue in `PipelineRunStages` factory that had an invalid default value

# Tests

- Automated tests