### PR TITLE
[Data Discovery] Bug fix - project name on refresh project page 

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -135,7 +135,7 @@ class DiscoveryView extends React.Component {
     this.samples = this.dataLayer.samples.createView({ conditions });
     this.projects = this.dataLayer.projects.createView({
       conditions,
-      onViewChange: this.refreshProjectStats,
+      onViewChange: this.refreshProjectData,
     });
     this.visualizations = this.dataLayer.visualizations.createView({
       conditions,
@@ -184,13 +184,15 @@ class DiscoveryView extends React.Component {
 
   updateBrowsingHistory = (action = "push") => {
     const { domain } = this.props;
+    const { projectId } = this.state;
 
     const localFields = [
-      "currentTab",
+      ...(projectId ? [] : ["currentTab"]),
       "sampleActiveColumns",
       "showFilters",
       "showStats",
     ];
+
     const sessionFields = concat(localFields, [
       "currentDisplay",
       "mapSidebarTab",
@@ -377,6 +379,19 @@ class DiscoveryView extends React.Component {
         count: this.projects.length,
       },
     });
+  };
+
+  refreshProject = () => {
+    const { projectId } = this.state;
+
+    this.setState({
+      project: this.projects.get(projectId),
+    });
+  };
+
+  refreshProjectData = () => {
+    this.refreshProject();
+    this.refreshProjectStats();
   };
 
   refreshFilteredDimensions = async () => {


### PR DESCRIPTION
### Description
* Fix issue where project state variable was not filled after server load on refresh.
* Fix weird UX navigation where upon returning to my data after selecting the project, user would be redirected to the samples tab.

### Test
* Click project and refresh. Verify name is shown.
* Click my data. Verify you are redirected to the projects tab.