### PR TITLE
Switch to using http.rb and improve http error handling.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,3 +121,5 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "parallel", "~> 1.14"
+# HTTP library with a simpler, better designed API than the native Net::HTTP
+gem 'http'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1170,6 +1170,7 @@ DEPENDENCIES
   guard-rspec (~> 4.7)
   health_check (>= 2.7.0)
   honeycomb-rails (>= 0.8.1)
+  http
   http-2
   immigrant
   jbuilder (~> 2.5)

--- a/spec/helpers/basespace_helper_spec.rb
+++ b/spec/helpers/basespace_helper_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe BasespaceHelper, type: :helper do
 
       it "should call Basespace API to test access token" do
         expect(HttpHelper).to receive(:get_json).with(anything, anything, { "Authorization" => "Bearer #{fake_access_token}" }, anything)
-                                                .exactly(1).times.and_raise(StandardError)
+                                                .exactly(1).times.and_raise(HttpHelper::HttpError.new("HTTP Get request failed", 401))
         expect(LogUtil).to receive(:log_err_and_airbrake).with("BasespaceAccessTokenError: Failed to revoke access token for sample id 123abc")
                                                          .exactly(0).times
         expect(Rails.logger).to receive(:info).with("Revoke access token check succeeded").exactly(1).times

--- a/spec/helpers/http_helper_spec.rb
+++ b/spec/helpers/http_helper_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe HttpHelper, type: :helper do
     context "#a successful HTTP request" do
       before do
         stub_request(:get, "https://www.example.com")
-          .with(query: { "param_one" => ["a", "b"] })
+          .with(query: { "param_one" => "a" })
           .to_return(body: { "foo" => "bar" }.to_json)
       end
 
       def make_get_request
         HttpHelper.get_json("https://www.example.com", {
-                              "param_one" => ["a", "b"],
+                              "param_one" => "a",
                             }, "Authorization" => "Bearer abc")
       end
 
@@ -27,7 +27,7 @@ RSpec.describe HttpHelper, type: :helper do
 
         expect(
           a_request(:get, "https://www.example.com")
-            .with(headers: { "Authorization" => "Bearer abc" }, query: { "param_one" => ["a", "b"] })
+            .with(headers: { "Authorization" => "Bearer abc" }, query: { "param_one" => "a" })
         ).to have_been_made
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe HttpHelper, type: :helper do
       it "returns nil on errors" do
         expect do
           HttpHelper.get_json("https://www.example.com", {}, {})
-        end.to raise_error(StandardError)
+        end.to raise_error(HttpHelper::HttpError)
       end
     end
 


### PR DESCRIPTION
# Description

http.rb has a much simpler API and is a popular library. Switching to it makes our api code simpler.

Improved error handling so only specific errors that we expect are caught, based on feedback from David in https://github.com/chanzuckerberg/idseq-web/pull/2588.

# Tests

* Updated tests. Most existing tests still passed with the refactor, which improves confidence.
* Manually tested, including the edge case where revoke_access_token is called multiple times (see screenshot).

<img width="1264" alt="Screen Shot 2019-09-24 at 2 58 20 PM" src="https://user-images.githubusercontent.com/837004/65555213-c3c4b580-dee0-11e9-9c92-ba6f3de08fb5.png">
