### PR TITLE
Change pathogen info histogram x-axis to log10 scale

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
@@ -5,6 +5,8 @@ import PropTypes from "prop-types";
 import { getTaxonDescriptions, getTaxonDistributionForBackground } from "~/api";
 import Histogram from "~/components/visualizations/Histogram";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
+import InfoCircleIcon from "~/components/ui/icons/InfoCircleIcon";
+import ColumnHeaderTooltip from "~/components/ui/containers/ColumnHeaderTooltip";
 
 import cs from "./taxon_details_mode.scss";
 
@@ -184,11 +186,11 @@ export default class TaxonDetailsMode extends React.Component {
       this.state.histogramRpmSeries,
       {
         seriesNames: ["NT", "NR"],
-        labelX: "rpm+1",
-        labelY: "count",
+        labelX: "rPM+1",
+        labelY: "# of Background Samples",
         refValues: [
           {
-            name: "sample",
+            name: "this sample",
             values: [
               this.props.taxonValues.NT.rpm,
               this.props.taxonValues.NR.rpm,
@@ -324,6 +326,17 @@ export default class TaxonDetailsMode extends React.Component {
           <div>
             <div className={cs.subtitle}>
               Reference Background: {this.props.background.name}
+              <ColumnHeaderTooltip
+                trigger={
+                  <span>
+                    <InfoCircleIcon className={cs.infoIcon} />
+                  </span>
+                }
+                content="This chart shows how abundant (rPM) this taxon is in your
+                sample compared to the other samples in the chosen Background Model.
+                The farther your sample line is to the right of the other samples, the
+                higher the likelihood that this taxon is unique to your sample."
+              />
             </div>
             <div
               className={cs.histogram}

--- a/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
@@ -184,7 +184,7 @@ export default class TaxonDetailsMode extends React.Component {
       this.state.histogramRpmSeries,
       {
         seriesNames: ["NT", "NR"],
-        labelX: "rpm",
+        labelX: "rpm+1",
         labelY: "count",
         refValues: [
           {
@@ -195,6 +195,8 @@ export default class TaxonDetailsMode extends React.Component {
             ],
           },
         ],
+        showStatistics: false,
+        xScaleLog: true,
       }
     );
     this.histogram.update();

--- a/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
@@ -184,7 +184,7 @@ export default class TaxonDetailsMode extends React.Component {
       this.state.histogramRpmSeries,
       {
         seriesNames: ["NT", "NR"],
-        labelX: "rpm+1",
+        labelX: "rpm",
         labelY: "count",
         refValues: [
           {

--- a/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/TaxonDetailsMode.jsx
@@ -184,7 +184,7 @@ export default class TaxonDetailsMode extends React.Component {
       this.state.histogramRpmSeries,
       {
         seriesNames: ["NT", "NR"],
-        labelX: "rpm",
+        labelX: "rpm+1",
         labelY: "count",
         refValues: [
           {

--- a/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/taxon_details_mode.scss
+++ b/app/assets/src/components/common/DetailsSidebar/TaxonDetailsMode/taxon_details_mode.scss
@@ -24,6 +24,14 @@
     padding-bottom: 10px;
     font-size: 14px;
     font-weight: 700;
+
+    .infoIcon {
+      margin-left: 4px;
+      margin-top: 4px;
+      height: 15px;
+      width: 15px;
+      fill: $medium-grey;
+    }
   }
 
   .histogram {

--- a/app/assets/src/components/ui/containers/ColumnHeaderTooltip.jsx
+++ b/app/assets/src/components/ui/containers/ColumnHeaderTooltip.jsx
@@ -10,7 +10,9 @@ class ColumnHeaderTooltip extends React.Component {
         {...this.props}
         content={
           <div className={cs.tooltip}>
-            <span className={cs.title}>{this.props.title}:</span>
+            {this.props.title && (
+              <span className={cs.title}>{this.props.title}:</span>
+            )}
             {this.props.content}
             {this.props.link && (
               <a

--- a/app/assets/src/components/visualizations/Histogram.js
+++ b/app/assets/src/components/visualizations/Histogram.js
@@ -75,6 +75,14 @@ export default class Histogram {
         `translate(0,${this.size.height - this.margins.bottom})`
       )
       .call(axisBottom(x).tickSizeOuter(0));
+
+    // if using log10 scale, set the number of ticks according to the size of
+    // the domain (in powers of 10) to prevent extra labels from showing up
+    if (this.options.xScaleLog) {
+      let nTicks = Math.log10(x.domain()[1]) + 1;
+      g.call(axisBottom(x).ticks(nTicks));
+    }
+
     g
       .append("text")
       .attr("x", this.size.width - this.margins.right)

--- a/app/assets/src/components/visualizations/Histogram.js
+++ b/app/assets/src/components/visualizations/Histogram.js
@@ -284,10 +284,16 @@ export default class Histogram {
     if (!this.data) return;
 
     let colors = this.getColors();
-
+    // cannot pass in 0 if using log scale, since log(0) is -Infinity,
+    // so increment everything by 1
+    if (this.options.xScaleLog) {
+      for (let i = 0; i < this.data.length; i++) {
+        this.data[i] = this.data[i].map(d => d + 1);
+      }
+    }
     const domain = this.getDomain();
 
-    let x = this.options.xScaleLog ? scaleLog().clamp(true) : scaleLinear();
+    let x = this.options.xScaleLog ? scaleLog() : scaleLinear();
     x
       .domain(domain)
       .nice()
@@ -387,18 +393,23 @@ export default class Histogram {
         let refs = this.svg.append("g").attr("class", "refs");
 
         for (let ref of this.options.refValues) {
+          // cannot pass in 0 if using log scale, since log(0) is -Infinity,
+          // so increment everything by 1
+          let xRef = this.options.xScaleLog
+            ? x(ref.values[i] + 1)
+            : x(ref.values[i]);
           refs
             .append("line")
             .attr("stroke", colors[i])
             .style("stroke-dasharray", "4, 4")
-            .attr("x1", x(ref.values[i]))
-            .attr("x2", x(ref.values[i]))
+            .attr("x1", xRef)
+            .attr("x2", xRef)
             .attr("y1", this.margins.top)
             .attr("y2", this.size.height - this.margins.bottom);
           refs
             .append("text")
             .attr("x", -this.margins.top)
-            .attr("y", x(ref.values[i]) - 4)
+            .attr("y", xRef - 4)
             .attr("transform", "rotate(-90)")
             .attr("text-anchor", "end")
             .attr("font-weight", "bold")

--- a/app/assets/src/components/visualizations/Histogram.js
+++ b/app/assets/src/components/visualizations/Histogram.js
@@ -85,10 +85,10 @@ export default class Histogram {
 
     g
       .append("text")
-      .attr("x", this.size.width - this.margins.right)
+      .attr("x", (this.size.width + this.margins.left) / 2 - 2)
       .attr("y", +30)
       .attr("fill", "#000")
-      .attr("font-weight", "bold")
+      .attr("font-weight", 600)
       .attr("text-anchor", "end")
       .attr("class", cs.labelX)
       .text(this.options.labelX);
@@ -115,11 +115,11 @@ export default class Histogram {
     g
       .select(".tick:last-of-type text")
       .clone()
-      .attr("x", 4)
+      .attr("x", 12)
       .attr("y", -30 - (this.options.labelYOffset || 0))
       .attr("transform", "rotate(-90)")
       .attr("text-anchor", "end")
-      .attr("font-weight", "bold")
+      .attr("font-weight", 600)
       .attr("class", cx(cs.labelY, this.options.labelYLarge && cs.large))
       .text(this.options.labelY);
   }
@@ -435,15 +435,15 @@ export default class Histogram {
       legend
         .append("rect")
         .attr("x", this.size.width - 5)
-        .attr("width", 20)
-        .attr("height", 20)
+        .attr("width", 14)
+        .attr("height", 14)
         .attr("fill", (_, i) => colors[i]);
 
       legend
         .append("text")
         .attr("x", this.size.width - 10)
         .attr("y", this.margins.top)
-        .attr("dy", -9)
+        .attr("dy", -11)
         .attr("alignment-baseline", "middle")
         .text(d => d);
     }

--- a/app/assets/src/components/visualizations/Histogram.js
+++ b/app/assets/src/components/visualizations/Histogram.js
@@ -284,16 +284,10 @@ export default class Histogram {
     if (!this.data) return;
 
     let colors = this.getColors();
-    // cannot pass in 0 if using log scale, since log(0) is -Infinity,
-    // so increment everything by 1
-    if (this.options.xScaleLog) {
-      for (let i = 0; i < this.data.length; i++) {
-        this.data[i] = this.data[i].map(d => d + 1);
-      }
-    }
+
     const domain = this.getDomain();
 
-    let x = this.options.xScaleLog ? scaleLog() : scaleLinear();
+    let x = this.options.xScaleLog ? scaleLog().clamp(true) : scaleLinear();
     x
       .domain(domain)
       .nice()
@@ -393,23 +387,18 @@ export default class Histogram {
         let refs = this.svg.append("g").attr("class", "refs");
 
         for (let ref of this.options.refValues) {
-          // cannot pass in 0 if using log scale, since log(0) is -Infinity,
-          // so increment everything by 1
-          let xRef = this.options.xScaleLog
-            ? x(ref.values[i] + 1)
-            : x(ref.values[i]);
           refs
             .append("line")
             .attr("stroke", colors[i])
             .style("stroke-dasharray", "4, 4")
-            .attr("x1", xRef)
-            .attr("x2", xRef)
+            .attr("x1", x(ref.values[i]))
+            .attr("x2", x(ref.values[i]))
             .attr("y1", this.margins.top)
             .attr("y2", this.size.height - this.margins.bottom);
           refs
             .append("text")
             .attr("x", -this.margins.top)
-            .attr("y", xRef - 4)
+            .attr("y", x(ref.values[i]) - 4)
             .attr("transform", "rotate(-90)")
             .attr("text-anchor", "end")
             .attr("font-weight", "bold")


### PR DESCRIPTION
# Description
The rpm counts histogram displayed on a taxon's sidebar previously used a linear scale; changing to a log10 scale to show more detail on the lower distribution.

- Example 1:
**Before (Linear Scale)**
![image](https://user-images.githubusercontent.com/53838890/65630709-ca0f6c00-df8a-11e9-9807-0de40ec04b38.png)
![Screen Shot 2019-09-24 at 3 29 16 PM](https://user-images.githubusercontent.com/53838890/65555711-34b89d00-dee2-11e9-9de8-0445533ee569.png)
**After (log10 Scale)**
![image](https://user-images.githubusercontent.com/53838890/65650143-6acb4f00-dfbe-11e9-96d8-f963a92e3950.png)


- Example 2:
![image](https://user-images.githubusercontent.com/53838890/65630672-b9f78c80-df8a-11e9-9e46-5a57a80c991e.png)
**Before (Linear Scale)**
![Screen Shot 2019-09-24 at 3 43 07 PM](https://user-images.githubusercontent.com/53838890/65555712-35513380-dee2-11e9-929d-99385b06c24b.png)
**After (log10 Scale)**
![image](https://user-images.githubusercontent.com/53838890/65650148-6f900300-dfbe-11e9-8c5a-e792ded4fe1e.png)

**Info Tooltip Added**
![image](https://user-images.githubusercontent.com/53838890/65650182-964e3980-dfbe-11e9-9b2a-9a288e4e450f.png)


# Notes

- Since the log(0) is undefined, all values were incremented by 1 to accommodate using the log scale. The x-axis label has been updated accordingly.
- Some statistics are no longer displayed (lines displaying average and lighter shaded boxes displaying standard deviation) because they were confusing with the log10 scale.
- Updated histogram component so bins have variable width if using the log10 scale.

# Tests

* Checked that histogram now uses a log10 scale for the x-axis and values are modified appropriately to prevent out of range (0) values from being passed in.
* Will need to check CoverageVizBottomSidebar on staging to ensure that the changes made to the Histogram component don't influence the histogram displayed there. Was unable to check on localhost.
