### PR TITLE
Stronger file name patterns

### DIFF
--- a/app/models/input_file.rb
+++ b/app/models/input_file.rb
@@ -6,9 +6,9 @@ class InputFile < ApplicationRecord
   SOURCE_TYPE_S3 = 's3'.freeze
   SOURCE_TYPE_BASESPACE = 'basespace'.freeze
 
-  FILE_REGEX = /\A[-.A-Za-z0-9_]{1,120}\.(fastq|fq|fastq.gz|fq.gz|fasta|fa|fasta.gz|fa.gz)\z/
-  BULK_FILE_PAIRED_REGEX = /\A([-.A-Za-z0-9_]{1,120})_R(\d)(_001)?\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
-  BULK_FILE_SINGLE_REGEX = /\A([-.A-Za-z0-9_]{1,120})\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
+  FILE_REGEX = /\A[A-Za-z0-9_][-.A-Za-z0-9_]{0,119}\.(fastq|fq|fastq.gz|fq.gz|fasta|fa|fasta.gz|fa.gz)\z/
+  BULK_FILE_PAIRED_REGEX = /\A([A-Za-z0-9_][-.A-Za-z0-9_]{1,119})_R(\d)(_001)?\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
+  BULK_FILE_SINGLE_REGEX = /\A([A-Za-z0-9_][-.A-Za-z0-9_]{1,119})\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
   S3_CP_PIPE_ERROR = '[Errno 32] Broken pipe'.freeze
 
   validates :name, presence: true, format: { with: FILE_REGEX, message: "file must match format '#{FILE_REGEX}'" }


### PR DESCRIPTION
# Description

Files names should only start with a letter, a number or an underscore.

# Tests

* Manual tests
