### PR TITLE
IDSEQ-1151 - Start switching dag templates from erb to jbuilder

### DIFF
--- a/app/lib/dag_generator.rb
+++ b/app/lib/dag_generator.rb
@@ -23,7 +23,7 @@ class DagGenerator
     if File.extname(@template_file) == ".jbuilder"
       rendered = ActionController::Base.new.render_to_string(
         file: @template_file,
-        :locals => {:attr => @attribute_dict},
+        locals: { attr: @attribute_dict }
       )
       # Couldn't find a more direct way to prettify from template
       json_object = JSON.parse(rendered)

--- a/app/lib/dag_generator.rb
+++ b/app/lib/dag_generator.rb
@@ -21,10 +21,13 @@ class DagGenerator
 
   def render
     if File.extname(@template_file) == ".jbuilder"
-      ActionController::Base.new.render_to_string(
+      rendered = ActionController::Base.new.render_to_string(
         file: @template_file,
         :locals => {:attr => @attribute_dict},
       )
+      # Couldn't find a more direct way to prettify from template
+      json_object = JSON.parse(rendered)
+      JSON.pretty_generate(json_object)
     else
       ERB.new(@template).result(binding)
     end

--- a/app/lib/dag_generator.rb
+++ b/app/lib/dag_generator.rb
@@ -6,14 +6,28 @@ class DagGenerator
   def initialize(template_file, project_id, sample_id, host_genome, attribute_dict, dag_vars_dict)
     @project_id = project_id
     @sample_id = sample_id
-    @template = File.open(template_file, 'r').read
+    @template = File.open(template_file, "r").read
+    @template_file = template_file
     @host_genome = host_genome
+
+    # Add to attribute_dict values for Jbuilder templates
+    attribute_dict[:host_genome] = host_genome
+    attribute_dict[:project_id] = project_id
+    attribute_dict[:sample_id] = sample_id
+
     @attribute_dict = attribute_dict
     @dag_vars_dict = dag_vars_dict
   end
 
   def render
-    ERB.new(@template).result(binding)
+    if File.extname(@template_file) == ".jbuilder"
+      ActionController::Base.new.render_to_string(
+        file: @template_file,
+        :locals => {:attr => @attribute_dict},
+      )
+    else
+      ERB.new(@template).result(binding)
+    end
   end
 
   def save(file)

--- a/app/lib/dag_generator.rb
+++ b/app/lib/dag_generator.rb
@@ -6,11 +6,11 @@ class DagGenerator
   def initialize(template_file, project_id, sample_id, host_genome, attribute_dict, dag_vars_dict)
     @project_id = project_id
     @sample_id = sample_id
-    @template = File.open(template_file, "r").read
+    @template = File.open(template_file, 'r').read
     @template_file = template_file
     @host_genome = host_genome
 
-    # Add to attribute_dict values for Jbuilder templates
+    # Add to attribute_dict values for Jbuilder templates for portability
     attribute_dict[:host_genome] = host_genome
     attribute_dict[:project_id] = project_id
     attribute_dict[:sample_id] = sample_id
@@ -20,6 +20,7 @@ class DagGenerator
   end
 
   def render
+    # Interoperable between .jbuilder and .erb templates
     if File.extname(@template_file) == ".jbuilder"
       rendered = ActionController::Base.new.render_to_string(
         file: @template_file,

--- a/app/lib/dag_generator.rb
+++ b/app/lib/dag_generator.rb
@@ -19,6 +19,7 @@ class DagGenerator
     @dag_vars_dict = dag_vars_dict
   end
 
+  # See our dag templates in app/lib/dags.
   def render
     # Interoperable between .jbuilder and .erb templates
     if File.extname(@template_file) == ".jbuilder"

--- a/app/lib/dags/host_filter.json.jbuilder
+++ b/app/lib/dags/host_filter.json.jbuilder
@@ -5,7 +5,7 @@ json.output_dir_s3 "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:s
 json.targets do
   json.fastqs [attr[:fastq1], attr[:fastq2]].compact
 
-  validate_input_out = ["validate_input_summary.json", "valid_input1.#{attr[:file_ext]}"]
+  validate_input_out = ['validate_input_summary.json', "valid_input1.#{attr[:file_ext]}"]
   validate_input_out << "valid_input2.#{attr[:file_ext]}" if attr[:fastq2]
   json.validate_input_out validate_input_out
 
@@ -17,144 +17,144 @@ json.targets do
   trimmomatic_out << "trimmomatic2.#{attr[:file_ext]}" if attr[:fastq2]
   json.trimmomatic_out trimmomatic_out
 
-  priceseq_out = ["priceseq1.fa"]
-  priceseq_out << "priceseq2.fa" if attr[:fastq2]
+  priceseq_out = ['priceseq1.fa']
+  priceseq_out << 'priceseq2.fa' if attr[:fastq2]
   json.priceseq_out priceseq_out
 
-  cdhitdup_out = ["dedup1.fa"]
-  cdhitdup_out << "dedup2.fa" if attr[:fastq2]
+  cdhitdup_out = ['dedup1.fa']
+  cdhitdup_out << 'dedup2.fa' if attr[:fastq2]
   json.cdhitdup_out cdhitdup_out
 
-  lzw_out = ["lzw1.fa"]
-  lzw_out << "lzw2.fa" if attr[:fastq2]
+  lzw_out = ['lzw1.fa']
+  lzw_out << 'lzw2.fa' if attr[:fastq2]
   json.lzw_out lzw_out
 
-  bowtie2_out = ["bowtie2_1.fa"]
-  bowtie2_out += ["bowtie2_2.fa", "bowtie2_merged.fa"] if attr[:fastq2]
+  bowtie2_out = ['bowtie2_1.fa']
+  bowtie2_out += ['bowtie2_2.fa', 'bowtie2_merged.fa'] if attr[:fastq2]
   json.bowtie2_out bowtie2_out
 
-  subsampled_out = ["subsampled_1.fa"]
-  subsampled_out += ["subsampled_2.fa", "subsampled_merged.fa"] if attr[:fastq2]
+  subsampled_out = ['subsampled_1.fa']
+  subsampled_out += ['subsampled_2.fa', 'subsampled_merged.fa'] if attr[:fastq2]
   json.subsampled_out subsampled_out
 
-  if attr[:host_genome] != "human"
-    star_human_out = ["unmapped_human_1.fa"]
-    star_human_out << "unmapped_human_2.fa" if attr[:fastq2]
+  if attr[:host_genome] != 'human'
+    star_human_out = ['unmapped_human_1.fa']
+    star_human_out << 'unmapped_human_2.fa' if attr[:fastq2]
     json.star_human_out star_human_out
 
-    bowtie2_human_out = ["bowtie2_human_1.fa"]
-    bowtie2_human_out += ["bowtie2_human_2.fa", "bowtie2_human_merged.fa"] if attr[:fastq2]
+    bowtie2_human_out = ['bowtie2_human_1.fa']
+    bowtie2_human_out += ['bowtie2_human_2.fa', 'bowtie2_human_merged.fa'] if attr[:fastq2]
     json.bowtie2_human_out bowtie2_human_out
   end
 
-  gsnap_filter_out = ["gsnap_filter_1.fa"]
-  gsnap_filter_out += ["gsnap_filter_2.fa", "gsnap_filter_merged.fa"] if attr[:fastq2]
+  gsnap_filter_out = ['gsnap_filter_1.fa']
+  gsnap_filter_out += ['gsnap_filter_2.fa', 'gsnap_filter_merged.fa'] if attr[:fastq2]
   json.gsnap_filter_out gsnap_filter_out
 end
 
 json.steps do
   steps = []
   steps << {
-    :in => ["fastqs"],
-    :out => "validate_input_out",
-    :class => "PipelineStepRunValidateInput",
-    :module => "idseq_dag.steps.run_validate_input",
-    :additional_files => {},
-    :additional_attributes => {
-      :truncate_fragments_to => attr[:max_fragments],
-      :file_ext => attr[:file_ext],
+    in: ['fastqs'],
+    out: 'validate_input_out',
+    class: 'PipelineStepRunValidateInput',
+    module: 'idseq_dag.steps.run_validate_input',
+    additional_files: {},
+    additional_attributes: {
+      truncate_fragments_to: attr[:max_fragments],
+      file_ext: attr[:file_ext]
+    }
+  }
+  steps << {
+    in: ['validate_input_out'],
+    out: 'star_out',
+    class: 'PipelineStepRunStar',
+    module: 'idseq_dag.steps.run_star',
+    additional_files: { star_genome: attr[:star_genome] },
+    additional_attributes: { output_gene_file: 'reads_per_gene.star.tab' }
+  }
+  steps << {
+    in: ['star_out'],
+    out: 'trimmomatic_out',
+    class: 'PipelineStepRunTrimmomatic',
+    module: 'idseq_dag.steps.run_trimmomatic',
+    additional_files: { adapter_fasta: attr[:adapter_fasta] },
+    additional_attributes: {}
+  }
+  steps << {
+    in: ['trimmomatic_out'],
+    out: 'priceseq_out',
+    class: 'PipelineStepRunPriceSeq',
+    module: 'idseq_dag.steps.run_priceseq',
+    additional_files: {},
+    additional_attributes: {}
+  }
+  steps << {
+    in: ['priceseq_out'],
+    out: 'cdhitdup_out',
+    class: 'PipelineStepRunCDHitDup',
+    module: 'idseq_dag.steps.run_cdhitdup',
+    additional_files: {},
+    additional_attributes: {}
+  }
+  steps << {
+    in: ['cdhitdup_out'],
+    out: 'lzw_out',
+    class: 'PipelineStepRunLZW',
+    module: 'idseq_dag.steps.run_lzw',
+    additional_files: {},
+    additional_attributes: {
+      thresholds: [0.45, 0.42],
+      threshold_readlength: 150
+    }
+  }
+  steps << {
+    in: ['lzw_out'],
+    out: 'bowtie2_out',
+    class: 'PipelineStepRunBowtie2',
+    module: 'idseq_dag.steps.run_bowtie2',
+    additional_files: {
+      bowtie2_genome: attr[:bowtie2_genome]
     },
+    additional_attributes: { output_sam_file: 'bowtie2.sam' }
   }
   steps << {
-    :in => ["validate_input_out"],
-    :out => "star_out",
-    :class => "PipelineStepRunStar",
-    :module => "idseq_dag.steps.run_star",
-    :additional_files => {:star_genome => attr[:star_genome]},
-    :additional_attributes => {:output_gene_file => "reads_per_gene.star.tab"},
-  }
-  steps << {
-    :in => ["star_out"],
-    :out => "trimmomatic_out",
-    :class => "PipelineStepRunTrimmomatic",
-    :module => "idseq_dag.steps.run_trimmomatic",
-    :additional_files => {:adapter_fasta => attr[:adapter_fasta]},
-    :additional_attributes => {},
-  }
-  steps << {
-    :in => ["trimmomatic_out"],
-    :out => "priceseq_out",
-    :class => "PipelineStepRunPriceSeq",
-    :module => "idseq_dag.steps.run_priceseq",
-    :additional_files => {},
-    :additional_attributes => {},
-  }
-  steps << {
-    :in => ["priceseq_out"],
-    :out => "cdhitdup_out",
-    :class => "PipelineStepRunCDHitDup",
-    :module => "idseq_dag.steps.run_cdhitdup",
-    :additional_files => {},
-    :additional_attributes => {},
-  }
-  steps << {
-    :in => ["cdhitdup_out"],
-    :out => "lzw_out",
-    :class => "PipelineStepRunLZW",
-    :module => "idseq_dag.steps.run_lzw",
-    :additional_files => {},
-    :additional_attributes => {
-      :thresholds => [0.45, 0.42],
-      :threshold_readlength => 150,
-    },
-  }
-  steps << {
-    :in => ["lzw_out"],
-    :out => "bowtie2_out",
-    :class => "PipelineStepRunBowtie2",
-    :module => "idseq_dag.steps.run_bowtie2",
-    :additional_files => {
-      :bowtie2_genome => attr[:bowtie2_genome],
-    },
-    :additional_attributes => {:output_sam_file => "bowtie2.sam"},
-  }
-  steps << {
-    :in => ["bowtie2_out"],
-    :out => "subsampled_out",
-    :class => "PipelineStepRunSubsample",
-    :module => "idseq_dag.steps.run_subsample",
-    :additional_files => {},
-    :additional_attributes => {:max_fragments => attr[:max_subsample_frag]},
+    in: ['bowtie2_out'],
+    out: 'subsampled_out',
+    class: 'PipelineStepRunSubsample',
+    module: 'idseq_dag.steps.run_subsample',
+    additional_files: {},
+    additional_attributes: { max_fragments: attr[:max_subsample_frag] }
   }
 
-  if attr[:host_genome] != "human"
+  if attr[:host_genome] != 'human'
     steps << {
-      :in => ["subsampled_out", "validate_input_out"],
-      :out => "star_human_out",
-      :class => "PipelineStepRunStarDownstream",
-      :module => "idseq_dag.steps.run_star_downstream",
-      :additional_files => {:star_genome => attr[:human_star_genome]},
-      :additional_attributes => {},
+      in: %w[subsampled_out validate_input_out],
+      out: 'star_human_out',
+      class: 'PipelineStepRunStarDownstream',
+      module: 'idseq_dag.steps.run_star_downstream',
+      additional_files: { star_genome: attr[:human_star_genome] },
+      additional_attributes: {}
     }
     steps << {
-      :in => ["star_human_out"],
-      :out => "bowtie2_human_out",
-      :class => "PipelineStepRunBowtie2",
-      :module => "idseq_dag.steps.run_bowtie2",
-      :additional_files => {:bowtie2_genome => attr[:human_bowtie2_genome]},
-      :additional_attributes => {:output_sam_file => "bowtie2_human.sam"},
+      in: ['star_human_out'],
+      out: 'bowtie2_human_out',
+      class: 'PipelineStepRunBowtie2',
+      module: 'idseq_dag.steps.run_bowtie2',
+      additional_files: { bowtie2_genome: attr[:human_bowtie2_genome] },
+      additional_attributes: { output_sam_file: 'bowtie2_human.sam' }
     }
   end
 
   steps << {
-    :in => [(attr[:host_genome] != "human") ? "bowtie2_human_out" : "subsampled_out"],
-    :out => "gsnap_filter_out",
-    :class => "PipelineStepRunGsnapFilter",
-    :module => "idseq_dag.steps.run_gsnap_filter",
-    :additional_files => {
-      :gsnap_genome => "s3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar",
+    in: [attr[:host_genome] != 'human' ? 'bowtie2_human_out' : 'subsampled_out'],
+    out: 'gsnap_filter_out',
+    class: 'PipelineStepRunGsnapFilter',
+    module: 'idseq_dag.steps.run_gsnap_filter',
+    additional_files: {
+      gsnap_genome: 's3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar'
     },
-    :additional_attributes => {:output_sam_file => "gsnap_filter.sam"},
+    additional_attributes: { output_sam_file: 'gsnap_filter.sam' }
   }
 
   json.array! steps

--- a/app/lib/dags/host_filter.json.jbuilder
+++ b/app/lib/dags/host_filter.json.jbuilder
@@ -62,8 +62,8 @@ json.steps do
     additional_files: {},
     additional_attributes: {
       truncate_fragments_to: attr[:max_fragments],
-      file_ext: attr[:file_ext]
-    }
+      file_ext: attr[:file_ext],
+    },
   }
   steps << {
     in: ['validate_input_out'],
@@ -71,7 +71,7 @@ json.steps do
     class: 'PipelineStepRunStar',
     module: 'idseq_dag.steps.run_star',
     additional_files: { star_genome: attr[:star_genome] },
-    additional_attributes: { output_gene_file: 'reads_per_gene.star.tab' }
+    additional_attributes: { output_gene_file: 'reads_per_gene.star.tab' },
   }
   steps << {
     in: ['star_out'],
@@ -79,7 +79,7 @@ json.steps do
     class: 'PipelineStepRunTrimmomatic',
     module: 'idseq_dag.steps.run_trimmomatic',
     additional_files: { adapter_fasta: attr[:adapter_fasta] },
-    additional_attributes: {}
+    additional_attributes: {},
   }
   steps << {
     in: ['trimmomatic_out'],
@@ -87,7 +87,7 @@ json.steps do
     class: 'PipelineStepRunPriceSeq',
     module: 'idseq_dag.steps.run_priceseq',
     additional_files: {},
-    additional_attributes: {}
+    additional_attributes: {},
   }
   steps << {
     in: ['priceseq_out'],
@@ -95,7 +95,7 @@ json.steps do
     class: 'PipelineStepRunCDHitDup',
     module: 'idseq_dag.steps.run_cdhitdup',
     additional_files: {},
-    additional_attributes: {}
+    additional_attributes: {},
   }
   steps << {
     in: ['cdhitdup_out'],
@@ -105,8 +105,8 @@ json.steps do
     additional_files: {},
     additional_attributes: {
       thresholds: [0.45, 0.42],
-      threshold_readlength: 150
-    }
+      threshold_readlength: 150,
+    },
   }
   steps << {
     in: ['lzw_out'],
@@ -114,9 +114,9 @@ json.steps do
     class: 'PipelineStepRunBowtie2',
     module: 'idseq_dag.steps.run_bowtie2',
     additional_files: {
-      bowtie2_genome: attr[:bowtie2_genome]
+      bowtie2_genome: attr[:bowtie2_genome],
     },
-    additional_attributes: { output_sam_file: 'bowtie2.sam' }
+    additional_attributes: { output_sam_file: 'bowtie2.sam' },
   }
   steps << {
     in: ['bowtie2_out'],
@@ -124,7 +124,7 @@ json.steps do
     class: 'PipelineStepRunSubsample',
     module: 'idseq_dag.steps.run_subsample',
     additional_files: {},
-    additional_attributes: { max_fragments: attr[:max_subsample_frag] }
+    additional_attributes: { max_fragments: attr[:max_subsample_frag] },
   }
 
   if attr[:host_genome] != 'human'
@@ -134,7 +134,7 @@ json.steps do
       class: 'PipelineStepRunStarDownstream',
       module: 'idseq_dag.steps.run_star_downstream',
       additional_files: { star_genome: attr[:human_star_genome] },
-      additional_attributes: {}
+      additional_attributes: {},
     }
     steps << {
       in: ['star_human_out'],
@@ -142,7 +142,7 @@ json.steps do
       class: 'PipelineStepRunBowtie2',
       module: 'idseq_dag.steps.run_bowtie2',
       additional_files: { bowtie2_genome: attr[:human_bowtie2_genome] },
-      additional_attributes: { output_sam_file: 'bowtie2_human.sam' }
+      additional_attributes: { output_sam_file: 'bowtie2_human.sam' },
     }
   end
 
@@ -152,9 +152,9 @@ json.steps do
     class: 'PipelineStepRunGsnapFilter',
     module: 'idseq_dag.steps.run_gsnap_filter',
     additional_files: {
-      gsnap_genome: 's3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar'
+      gsnap_genome: 's3://idseq-database/host_filter/human/2018-02-15-utc-1518652800-unixtime__2018-02-15-utc-1518652800-unixtime/hg38_pantro5_k16.tar',
     },
-    additional_attributes: { output_sam_file: 'gsnap_filter.sam' }
+    additional_attributes: { output_sam_file: 'gsnap_filter.sam' },
   }
 
   json.array! steps

--- a/app/lib/dags/host_filter.json.jbuilder
+++ b/app/lib/dags/host_filter.json.jbuilder
@@ -5,16 +5,126 @@ json.output_dir_s3 "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:s
 json.targets do
   json.fastqs [attr[:fastq1], attr[:fastq2]].compact
 
-  json.validate_input_out [
-                              "validate_input_summary.json",
-                              "valid_input1.#{attr[:file_ext]}",
-                              attr[:fastq2] ? "valid_input2.#{attr[:file_ext]}" : nil
-                          ].compact
+  validate_input_out = ["validate_input_summary.json", "valid_input1.#{attr[:file_ext]}"]
+  validate_input_out << "valid_input2.#{attr[:file_ext]}" if attr[:fastq2]
+  json.validate_input_out validate_input_out
 
-  json.star_out [
-                    "unmapped1.#{attr[:file_ext]}",
-                    attr[:fastq2] ? "unmapped2.#{attr[:file_ext]}" : nil
-                ].compact
+  star_out = ["unmapped1.#{attr[:file_ext]}"]
+  star_out << "unmapped2.#{attr[:file_ext]}" if attr[:fastq2]
+  json.star_out star_out
 
+  trimmomatic_out = ["trimmomatic1.#{attr[:file_ext]}"]
+  trimmomatic_out << "trimmomatic2.#{attr[:file_ext]}" if attr[:fastq2]
+  json.trimmomatic_out trimmomatic_out
 
+  priceseq_out = ["priceseq1.fa"]
+  priceseq_out << "priceseq2.fa" if attr[:fastq2]
+  json.priceseq_out priceseq_out
+
+  cdhitdup_out = ["dedup1.fa"]
+  cdhitdup_out << "dedup2.fa" if attr[:fastq2]
+  json.cdhitdup_out cdhitdup_out
+
+  lzw_out = ["lzw1.fa"]
+  lzw_out << "lzw2.fa" if attr[:fastq2]
+  json.lzw_out lzw_out
+
+  bowtie2_out = ["bowtie2_1.fa"]
+  bowtie2_out += ["bowtie2_2.fa", "bowtie2_merged.fa"] if attr[:fastq2]
+  json.bowtie2_out bowtie2_out
+
+  subsampled_out = ["subsampled_1.fa"]
+  subsampled_out += ["subsampled_2.fa", "subsampled_merged.fa"] if attr[:fastq2]
+  json.subsampled_out subsampled_out
+
+  if attr[:host_genome] != "human"
+    star_human_out = ["unmapped_human_1.fa"]
+    star_human_out << "unmapped_human_2.fa" if attr[:fastq2]
+    json.star_human_out star_human_out
+
+    bowtie2_human_out = ["bowtie2_human_1.fa"]
+    bowtie2_human_out += ["bowtie2_human_2.fa", "bowtie2_human_merged.fa"] if attr[:fastq2]
+    json.bowtie2_human_out bowtie2_human_out
+  end
+
+  gsnap_filter_out = ["gsnap_filter_1.fa"]
+  gsnap_filter_out += ["gsnap_filter_2.fa", "gsnap_filter_merged.fa"] if attr[:fastq2]
+  json.gsnap_filter_out gsnap_filter_out
+end
+
+json.steps do
+  steps = []
+  steps << {
+      :in => ["fastqs"],
+      :out => "validate_input_out",
+      :class => "PipelineStepRunValidateInput",
+      :module => "idseq_dag.steps.run_validate_input",
+      :additional_files => {},
+      :additional_attributes => {
+          :truncate_fragments_to => attr[:max_fragments],
+          :file_ext => attr[:file_ext]
+      }
+  }
+  steps << {
+      :in => ["validate_input_out"],
+      :out => "star_out",
+      :class => "PipelineStepRunStar",
+      :module => "idseq_dag.steps.run_star",
+      :additional_files => {:star_genome => attr[:star_genome]},
+      :additional_attributes => {:output_gene_file => "reads_per_gene.star.tab"}
+  }
+  steps << {
+      :in => ["star_out"],
+      :out => "trimmomatic_out",
+      :class => "PipelineStepRunTrimmomatic",
+      :module => "idseq_dag.steps.run_trimmomatic",
+      :additional_files => {:adapter_fasta => attr[:adapter_fasta]},
+      :additional_attributes => {}
+  }
+  steps << {
+      :in => ["trimmomatic_out"],
+      :out => "priceseq_out",
+      :class => "PipelineStepRunPriceSeq",
+      :module => "idseq_dag.steps.run_priceseq",
+      :additional_files => {},
+      :additional_attributes => {}
+  }
+      {
+          "in": ["priceseq_out"],
+          "out": "cdhitdup_out",
+          "class": "PipelineStepRunCDHitDup",
+          "module": "idseq_dag.steps.run_cdhitdup",
+          "additional_files": {},
+      "additional_attributes": {}
+  },
+      {
+          "in": ["cdhitdup_out"],
+          "out": "lzw_out",
+          "class": "PipelineStepRunLZW",
+          "module": "idseq_dag.steps.run_lzw",
+          "additional_files": {},
+      "additional_attributes": {
+      "thresholds": [0.45, 0.42],
+      "threshold_readlength": 150
+  }
+  },
+      {
+          "in": ["lzw_out"],
+          "out": "bowtie2_out",
+          "class": "PipelineStepRunBowtie2",
+          "module": "idseq_dag.steps.run_bowtie2",
+          "additional_files": {
+              "bowtie2_genome": "<%= @attribute_dict[:bowtie2_genome] %>"
+      },
+      "additional_attributes": { "output_sam_file": "bowtie2.sam" }
+  }
+  ,
+      {
+          "in": ["bowtie2_out"],
+          "out": "subsampled_out",
+          "class": "PipelineStepRunSubsample",
+          "module": "idseq_dag.steps.run_subsample",
+          "additional_files": {},
+      "additional_attributes": { "max_fragments": <%= @attribute_dict[:max_subsample_frag] %> }
+    },
 end

--- a/app/lib/dags/host_filter.json.jbuilder
+++ b/app/lib/dags/host_filter.json.jbuilder
@@ -1,0 +1,20 @@
+json.name attr[:dag_name]
+
+json.output_dir_s3 "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results"
+
+json.targets do
+  json.fastqs [attr[:fastq1], attr[:fastq2]].compact
+
+  json.validate_input_out [
+                              "validate_input_summary.json",
+                              "valid_input1.#{attr[:file_ext]}",
+                              attr[:fastq2] ? "valid_input2.#{attr[:file_ext]}" : nil
+                          ].compact
+
+  json.star_out [
+                    "unmapped1.#{attr[:file_ext]}",
+                    attr[:fastq2] ? "unmapped2.#{attr[:file_ext]}" : nil
+                ].compact
+
+
+end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -5,4 +5,6 @@ class AppConfig < ApplicationRecord
   SHOW_LANDING_VIDEO_BANNER = 'show_landing_video_banner'.freeze
   # JSON array containing the number of the stages allowed to auto restart. Ex: [1, 3]
   AUTO_RESTART_ALLOWED_STAGES = 'auto_restart_allowed_stages'.freeze
+  # When this is "1", dag generation will use jbuilder templates instead of erb templates.
+  USE_JBUILDER_TEMPLATES = 'use_jbuilder_templates'.freeze
 end

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -244,6 +244,7 @@ class PhyloTree < ApplicationRecord
     aegea_batch_submit_command(base_command)
   end
 
+  # See our dag templates in app/lib/dags.
   def prepare_dag(dag_name, attribute_dict)
     dag_s3 = "#{phylo_tree_output_s3_path}/#{dag_name}.json"
     dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.erb",

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -214,27 +214,24 @@ class PipelineRunStage < ApplicationRecord
     dag_s3 = "#{sample.sample_output_s3_path}/#{dag_name}.json"
     attribute_dict[:dag_name] = dag_name
     attribute_dict[:bucket] = SAMPLES_BUCKET_NAME
-    # dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.erb",
-    #                        sample.project_id,
-    #                        sample.id,
-    #                        sample.host_genome_name.downcase,
-    #                        attribute_dict,
-    #                        pipeline_run.parse_dag_vars)
+    dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.erb",
+                           sample.project_id,
+                           sample.id,
+                           sample.host_genome_name.downcase,
+                           attribute_dict,
+                           pipeline_run.parse_dag_vars)
+    self.dag_json = dag.render
+    puts "ERB 5:25pm:", self.dag_json
 
-    res = ActionController::Base.new.render_to_string(file: Rails.root.join('lib/dags/host_filter.json.jbuilder'), locals: { attr: attribute_dict })
-    puts "4:47pm: ", res
+    dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.jbuilder",
+                           sample.project_id,
+                           sample.id,
+                           sample.host_genome_name.downcase,
+                           attribute_dict,
+                           pipeline_run.parse_dag_vars)
+    self.dag_json = dag.render
+    puts "JBUILDER 5:25pm:", self.dag_json
 
-    # res = render_to_string(template: "app/lib/dags/host_filter.json.jbuilder")
-
-    # dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.jbuilder",
-    #                        sample.project_id,
-    #                        sample.id,
-    #                        sample.host_genome_name.downcase,
-    #                        attribute_dict,
-    #                        pipeline_run.parse_dag_vars)
-    # self.dag_json = dag.render
-    puts "dag json 4:03pm", dag_json, "END"
-    puts "class: ", dag_json.class
     copy_done_file = "echo done | aws s3 cp - #{sample.sample_output_s3_path}/\\$AWS_BATCH_JOB_ID.#{JOB_SUCCEEDED_FILE_SUFFIX}"
     upload_dag_json_and_return_job_command(dag_json, dag_s3, dag_name, key_s3_params, copy_done_file)
   end

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -221,6 +221,7 @@ class PipelineRunStage < ApplicationRecord
               else
                 "erb"
               end
+    # See our dag templates in app/lib/dags.
     dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.#{dag_ext}",
                            sample.project_id,
                            sample.id,

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -216,7 +216,7 @@ class PipelineRunStage < ApplicationRecord
     attribute_dict[:bucket] = SAMPLES_BUCKET_NAME
 
     # Temp flag for rolling out jbuilder templates
-    dag_ext = if get_app_config(AppConfig::USE_JBUILDER_TEMPLATES) == "1" && step_number == 1
+    dag_ext = if AppConfigHelper.get_app_config(AppConfig::USE_JBUILDER_TEMPLATES) == "1" && step_number == 1
                 "jbuilder"
               else
                 "erb"

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -220,8 +220,8 @@ class PipelineRunStage < ApplicationRecord
                            attribute_dict,
                            pipeline_run.parse_dag_vars)
     self.dag_json = dag.render
-    puts "dag json 4:03pm", self.dag_json, "END"
-    puts "class: ", self.dag_json.class
+    puts "dag json 4:03pm", dag_json, "END"
+    puts "class: ", dag_json.class
     copy_done_file = "echo done | aws s3 cp - #{sample.sample_output_s3_path}/\\$AWS_BATCH_JOB_ID.#{JOB_SUCCEEDED_FILE_SUFFIX}"
     upload_dag_json_and_return_job_command(dag_json, dag_s3, dag_name, key_s3_params, copy_done_file)
   end

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -212,6 +212,7 @@ class PipelineRunStage < ApplicationRecord
   def prepare_dag(attribute_dict, key_s3_params = nil)
     sample = pipeline_run.sample
     dag_s3 = "#{sample.sample_output_s3_path}/#{dag_name}.json"
+    attribute_dict[:dag_name] = dag_name
     attribute_dict[:bucket] = SAMPLES_BUCKET_NAME
     # dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.erb",
     #                        sample.project_id,

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -220,11 +220,10 @@ class PipelineRunStage < ApplicationRecord
     #                        attribute_dict,
     #                        pipeline_run.parse_dag_vars)
 
-    res = ActionController::Base.new.render_to_string(file: Rails.root.join('lib/dags/host_filter.json.jbuilder'), :locals => { :attr => attribute_dict })
+    res = ActionController::Base.new.render_to_string(file: Rails.root.join('lib/dags/host_filter.json.jbuilder'), locals: { attr: attribute_dict })
     puts "4:47pm: ", res
 
     # res = render_to_string(template: "app/lib/dags/host_filter.json.jbuilder")
-
 
     # dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.jbuilder",
     #                        sample.project_id,

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -213,13 +213,27 @@ class PipelineRunStage < ApplicationRecord
     sample = pipeline_run.sample
     dag_s3 = "#{sample.sample_output_s3_path}/#{dag_name}.json"
     attribute_dict[:bucket] = SAMPLES_BUCKET_NAME
-    dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.erb",
-                           sample.project_id,
-                           sample.id,
-                           sample.host_genome_name.downcase,
-                           attribute_dict,
-                           pipeline_run.parse_dag_vars)
-    self.dag_json = dag.render
+    # dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.erb",
+    #                        sample.project_id,
+    #                        sample.id,
+    #                        sample.host_genome_name.downcase,
+    #                        attribute_dict,
+    #                        pipeline_run.parse_dag_vars)
+
+    prepend_view_path( Rails.root.join('app/templates') )
+    res = ActionController::Base.new.render_to_string(template: "../lib/dags/host_filter.json.jbuilder", formats: :json)
+    puts "1:34pm: ", res
+
+    # res = render_to_string(template: "app/lib/dags/host_filter.json.jbuilder")
+
+
+    # dag = DagGenerator.new("app/lib/dags/#{dag_name}.json.jbuilder",
+    #                        sample.project_id,
+    #                        sample.id,
+    #                        sample.host_genome_name.downcase,
+    #                        attribute_dict,
+    #                        pipeline_run.parse_dag_vars)
+    # self.dag_json = dag.render
     puts "dag json 4:03pm", dag_json, "END"
     puts "class: ", dag_json.class
     copy_done_file = "echo done | aws s3 cp - #{sample.sample_output_s3_path}/\\$AWS_BATCH_JOB_ID.#{JOB_SUCCEEDED_FILE_SUFFIX}"

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -220,9 +220,8 @@ class PipelineRunStage < ApplicationRecord
     #                        attribute_dict,
     #                        pipeline_run.parse_dag_vars)
 
-    prepend_view_path( Rails.root.join('app/templates') )
-    res = ActionController::Base.new.render_to_string(template: "../lib/dags/host_filter.json.jbuilder", formats: :json)
-    puts "1:34pm: ", res
+    res = ActionController::Base.new.render_to_string(file: Rails.root.join('lib/dags/host_filter.json.jbuilder'), :locals => { :attr => attribute_dict })
+    puts "4:47pm: ", res
 
     # res = render_to_string(template: "app/lib/dags/host_filter.json.jbuilder")
 

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -220,6 +220,8 @@ class PipelineRunStage < ApplicationRecord
                            attribute_dict,
                            pipeline_run.parse_dag_vars)
     self.dag_json = dag.render
+    puts "dag json 4:03pm", self.dag_json, "END"
+    puts "class: ", self.dag_json.class
     copy_done_file = "echo done | aws s3 cp - #{sample.sample_output_s3_path}/\\$AWS_BATCH_JOB_ID.#{JOB_SUCCEEDED_FILE_SUFFIX}"
     upload_dag_json_and_return_job_command(dag_json, dag_s3, dag_name, key_s3_params, copy_done_file)
   end


### PR DESCRIPTION
### Description
- JIRA: https://jira.czi.team/browse/IDSEQ-1151
- We decided to switch the dag templates from ERB to Jbuilder, which is the default Rails tool for constructing JSON responses. This makes constructing the dags cleaner and less fault-prone.
- This is the first PR to do setup work + convert the host_filter dag to start.

### Notes
- The code will work with both .jbuilder and .erb now, although after rollout we can discard the old code.
- For operational safety, I decided to try and flag it with `AppConfig::USE_JBUILDER_TEMPLATES`. After I add all the next templates, I'll start to switch it on to roll out.
- To verify the template, you should read side-by-side with the original file: https://github.com/chanzuckerberg/idseq-web/blob/master/app/lib/dags/host_filter.json.erb

### Tests
- Verified a variety of samples in local development and compared the outputs (ex: `Sample.find(i).pipeline_runs[0].pipeline_run_stages[0].host_filtering_command`). Outputs were identical with tools like jsondiff.com.
- Submitted multiple local samples and had successful host filter runs: https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logEventViewer:group=/aws/batch/job;stream=aegea_batch_job_57d721c3/default/f463c0da-dace-4c99-a4f9-95998f8cadb9