### PR TITLE
Re-enable analytics for logged-out, fix bug

### DIFF
--- a/app/views/layouts/_page_header.html.erb
+++ b/app/views/layouts/_page_header.html.erb
@@ -24,7 +24,7 @@
     <%= javascript_tag do %>
       react_component('Header', {
         userSignedIn: false,
-        showBlank: <%= @show_blank_header %>
+        showBlank: <%= @show_blank_header || false %>
       }, 'page_header')
     <% end %>
   <% end %>

--- a/app/views/layouts/_segment_analytics.html.erb
+++ b/app/views/layouts/_segment_analytics.html.erb
@@ -1,4 +1,4 @@
-<% if ENV["SEGMENT_JS_ID"] && current_user %>
+<% if ENV["SEGMENT_JS_ID"] %>
   <!-- Global site tags for Segment analytics-->
   <script>
     // Snippet from https://segment.com/docs/sources/website/analytics.js/quickstart/


### PR DESCRIPTION
# Description

See https://github.com/chanzuckerberg/idseq-web/pull/1964. 

We should re-enable this now that we have more public presence. 

I also noticed an error in the JS console which I fixed, but I did not see any effect of the call to `react_component('Header', ... )`, so please advise. 

# Tests

open icognito window
load home page
see no more error
see request to segment in console