### PR TITLE
[Bug:JIRA-1468] Refresh project page changes selected tab

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -197,7 +197,12 @@ class DiscoveryView extends React.Component {
       "currentDisplay",
       "mapSidebarTab",
     ]);
-    const urlFields = concat(sessionFields, ["filters", "projectId", "search"]);
+    const urlFields = concat(sessionFields, [
+      ...(projectId ? ["currentTab"] : []),
+      "filters",
+      "projectId",
+      "search",
+    ]);
     const stateFields = concat(urlFields, ["project"]);
 
     const localState = pick(localFields, this.state);


### PR DESCRIPTION
### Description

This bug was created due to a previous change that did not save the last active tab to local storage if in the project page. This aims to guarantee that when we click a different domain (my data, public) we do remain in the samples page.

This fix maintains that behavior but saves the active tab to url.

# Tests

* Click a project
* Refresh and check that it remains in the samples tab and shows list of samples
* Click some other domain. Check that you it will display the projects tab for that domain.
