### PR TITLE
Make order of list of users in projects list response deterministic

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -109,7 +109,7 @@ class ProjectsController < ApplicationController
           group_concat_host = "GROUP_CONCAT(DISTINCT host_genomes.name SEPARATOR '::') AS hosts"
           group_concat_sample_type = "GROUP_CONCAT(DISTINCT CASE WHEN metadata_fields.name = 'sample_type' THEN metadata.string_validated_value ELSE NULL END SEPARATOR '::') AS tissues"
           group_concat_location = "GROUP_CONCAT(DISTINCT CASE WHEN metadata_fields.name = 'collection_location' THEN IFNULL(locations.name, metadata.string_validated_value) ELSE NULL END SEPARATOR '::') AS locations"
-          group_concat_users = "GROUP_CONCAT(DISTINCT CONCAT(users.name,'|',users.email) SEPARATOR '::') AS users"
+          group_concat_users = "GROUP_CONCAT(DISTINCT CONCAT(users.name,'|',users.email) ORDER_BY users.name SEPARATOR '::') AS users"
           editable = "BIT_OR(IF(users.id=#{current_user.id}, 1, 0)) AS editable"
           uploaders = "GROUP_CONCAT(DISTINCT users_samples.name ORDER BY samples.id SEPARATOR '::') AS uploaders"
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -109,7 +109,7 @@ class ProjectsController < ApplicationController
           group_concat_host = "GROUP_CONCAT(DISTINCT host_genomes.name SEPARATOR '::') AS hosts"
           group_concat_sample_type = "GROUP_CONCAT(DISTINCT CASE WHEN metadata_fields.name = 'sample_type' THEN metadata.string_validated_value ELSE NULL END SEPARATOR '::') AS tissues"
           group_concat_location = "GROUP_CONCAT(DISTINCT CASE WHEN metadata_fields.name = 'collection_location' THEN IFNULL(locations.name, metadata.string_validated_value) ELSE NULL END SEPARATOR '::') AS locations"
-          group_concat_users = "GROUP_CONCAT(DISTINCT CONCAT(users.name,'|',users.email) ORDER_BY users.name SEPARATOR '::') AS users"
+          group_concat_users = "GROUP_CONCAT(DISTINCT CONCAT(users.name,'|',users.email) ORDER BY users.name SEPARATOR '::') AS users"
           editable = "BIT_OR(IF(users.id=#{current_user.id}, 1, 0)) AS editable"
           uploaders = "GROUP_CONCAT(DISTINCT users_samples.name ORDER BY samples.id SEPARATOR '::') AS uploaders"
 

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -419,6 +419,7 @@ RSpec.describe ProjectsController, type: :controller do
             expect(json_response["projects"].pluck("id")).to eq(expected_projects.pluck("id"))
 
             response_project = json_response["projects"][0]
+            expected_users = (extra_users.as_json + [@user.as_json]).map { |u| u.slice("name", "email") }.sort_by { |u| u["name"] }
             expect(response_project).to include_json(id: expected_projects[0].id,
                                                      name: expected_projects[0].name,
                                                      created_at: expected_projects[0].created_at.as_json,
@@ -429,7 +430,7 @@ RSpec.describe ProjectsController, type: :controller do
                                                      locations: ["San Francisco, USA"],
                                                      owner: extra_users[0].name,
                                                      editable: true,
-                                                     users: (extra_users.as_json + [@user.as_json]).map { |u| u.slice("name", "email") })
+                                                     users: expected_users)
           end
 
           it "sees all only limited fields when setting basic mode" do


### PR DESCRIPTION
### Description

The order of the list of users is return by the projects index endpoint is not deterministic.

# Tests

* Issue was detected by integration test. Run test multiple times to verify that result is the same.
