### PR TITLE
Fix sidebar crash for projects without descriptions

### DIFF
--- a/app/assets/src/components/views/discovery/TableRenderers.jsx
+++ b/app/assets/src/components/views/discovery/TableRenderers.jsx
@@ -40,7 +40,8 @@ class TableRenderers extends React.Component {
             trigger={<div className={cs.itemName}>{nameRenderer(item)}</div>}
             content={nameRenderer(item)}
           />
-          {item &&
+          {descriptionRenderer &&
+            item &&
             item.description && (
               <BasicPopup
                 trigger={


### PR DESCRIPTION
### Description

The sidebar crashes when trying to display projects without descriptions.

### Tests

* Make sure you have a project with description
* Click map and projects tab on the sidebar
* Verify it does not crash
