### PR TITLE
[Data Discovery] Stop saving current tab to local storage

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -184,21 +184,15 @@ class DiscoveryView extends React.Component {
 
   updateBrowsingHistory = (action = "push") => {
     const { domain } = this.props;
-    const { projectId } = this.state;
 
-    const localFields = [
-      ...(projectId ? [] : ["currentTab"]),
-      "sampleActiveColumns",
-      "showFilters",
-      "showStats",
-    ];
+    const localFields = ["sampleActiveColumns", "showFilters", "showStats"];
 
     const sessionFields = concat(localFields, [
       "currentDisplay",
       "mapSidebarTab",
     ]);
     const urlFields = concat(sessionFields, [
-      ...(projectId ? ["currentTab"] : []),
+      "currentTab",
       "filters",
       "projectId",
       "search",


### PR DESCRIPTION
### Description

Stop saving current tab to local storage.
User found it confusing to be redirected to the same tab you were before instead of projects.

