### PR TITLE
IDSEQ-1442 Fix buggy Basespace upload counter.

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_table.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_table.scss
@@ -40,6 +40,13 @@
   .cell,
   .header {
     @include font-body-xs;
+  }
+
+  .cell {
     text-align: left;
+  }
+
+  .header {
+    justify-content: left;
   }
 }


### PR DESCRIPTION
Also fix header text alignment on upload table.

# Description

Before:
<img width="1271" alt="Screen Shot 2019-10-01 at 6 21 23 PM" src="https://user-images.githubusercontent.com/837004/66011549-72846b00-e478-11e9-829c-b6b38fa9f2ad.png">

After:
<img width="1281" alt="Screen Shot 2019-10-01 at 6 19 57 PM" src="https://user-images.githubusercontent.com/837004/66011552-74e6c500-e478-11e9-90ec-4bc2c9bb0538.png">


# Notes

This was caused by buggy logic around handling the selected sample ids when merging in new samples. This PR fixes the bad logic.

I also added comments and tried to rename the variables a bit to make it more clear.

A recent change also caused the table header to be center aligned instead of left aligned. Fixed that as well.

# Tests
* Verified that clicking "Connect to Project" multiple times doesn't increase the upload counter incorrectly.
* Verified that if Sample 1 is selected, Sample 2 is not selected, and I try to add Sample 1, Sample 2, and Sample 3 (via Connect to Project), the counter shows "3 samples" and Sample 2 is still not selected (as expected)
* Verified that table headers are correctly aligned for all 3 sample upload tables (local, S3, basespace)
