### PR TITLE
Add info_db to alignment config.

### DIFF
--- a/app/lib/dags/experimental.json.erb
+++ b/app/lib/dags/experimental.json.erb
@@ -113,7 +113,7 @@
       "class": "PipelineStepGenerateCoverageViz",
       "module": "idseq_dag.steps.generate_coverage_viz",
       "additional_files": {
-        "info_db": "s3://idseq-database/alignment_data/2018-12-01/nt_info.sqlite3"
+        "info_db": "<%= @attribute_dict[:nt_info_db] %>"
       },
       "additional_attributes": {}
     },

--- a/app/lib/dags/experimental.json.jbuilder
+++ b/app/lib/dags/experimental.json.jbuilder
@@ -120,7 +120,7 @@ json.steps do
     class: "PipelineStepGenerateCoverageViz",
     module: "idseq_dag.steps.generate_coverage_viz",
     additional_files: {
-      info_db: "s3://idseq-database/alignment_data/2018-12-01/nt_info.sqlite3",
+      info_db: attr[:nt_info_db],
     },
     additional_attributes: {},
   }

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -29,6 +29,9 @@ class PipelineRunStage < ApplicationRecord
   DAG_NAME_POSTPROCESS = "postprocess".freeze
   DAG_NAME_EXPERIMENTAL = "experimental".freeze
 
+  # Older alignment configs might not have an s3_nt_info_db_path field, so use a reasonable default in this case.
+  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/2019-09-17/nt_info.sqlite3".freeze
+
   STAGE_INFO = {
     1 => {
       name: HOST_FILTERING_STAGE_NAME,
@@ -336,6 +339,7 @@ class PipelineRunStage < ApplicationRecord
       nt_loc_db: alignment_config.s3_nt_loc_db_path,
       nr_db: alignment_config.s3_nr_db_path,
       nr_loc_db: alignment_config.s3_nr_loc_db_path,
+      nt_info_db: alignment_config.s3_nt_info_db_path || DEFAULT_S3_NT_INFO_DB_PATH,
     }
     attribute_dict[:fastq2] = sample.input_files[1].name if sample.input_files[1]
     dag_commands = prepare_dag(attribute_dict)

--- a/db/migrate/20191002195108_add_nt_info_to_alignment_config.rb
+++ b/db/migrate/20191002195108_add_nt_info_to_alignment_config.rb
@@ -1,0 +1,5 @@
+class AddNtInfoToAlignmentConfig < ActiveRecord::Migration[5.1]
+  def change
+    add_column :alignment_configs, :s3_nt_info_db_path, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_920_003_723) do
+ActiveRecord::Schema.define(version: 20_191_002_195_108) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 20_190_920_003_723) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "lineage_version", limit: 2
+    t.text "s3_nt_info_db_path"
   end
 
   create_table "amr_counts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/lib/tasks/create_alignment_config.rake
+++ b/lib/tasks/create_alignment_config.rake
@@ -21,6 +21,9 @@ task create_alignment_config: :environment do
     s3_nt_loc_db_path: "#{bucket}/alignment_data/#{name}/nt_loc.#{db_file_ext}",
     s3_nr_db_path: "#{bucket}/alignment_data/#{name}/nr",
     s3_nr_loc_db_path: "#{bucket}/alignment_data/#{name}/nr_loc.#{db_file_ext}",
+    # TODO(mark): Convert nt_info to use BDB.
+    # Involves modifying generate_coverage_viz pipeline step to accept both formats.
+    s3_nt_info_db_path: "#{bucket}/alignment_data/#{name}/nt_info.sqlite3",
     s3_accession2taxid_path: "#{bucket}/alignment_data/#{name}/accession2taxid.#{db_file_ext}",
 
     s3_lineage_path: "#{bucket}/taxonomy/#{name}/taxid-lineages.#{db_file_ext}",


### PR DESCRIPTION
# Description

Previously, we were hard-coding the info_db s3 path when passing it to the coverage viz step. Now we pass it dynamically. We also add a default if no info_db value can be found.

Also change the create alignment config rake task to populate info_db.

# Notes

If we want to change the info_db from sqlite3 to BDB in the future, we can modify the coverage viz step to accept both file formats temporarily. This doesn't preclude that change from happening in the future.

If @jshoe's PR 2621 gets in before mine, will need to update the jbuilder as well.

# Tests

* Verified that rake task works.
* Verified that the default is used when the current alignment config has no info_db value.

Need to test with additional samples in staging, including the samples that were failing before.
