### PR TITLE
Cleanup redundant :authenticate_user! invocations from controllers

### DIFF
--- a/app/controllers/backgrounds_controller.rb
+++ b/app/controllers/backgrounds_controller.rb
@@ -1,7 +1,6 @@
 class BackgroundsController < ApplicationController
   include BackgroundsHelper
   before_action :login_required
-  before_action :authenticate_user!
   before_action :no_demo_user
   before_action :admin_required, except: [:create, :show_taxon_dist]
   before_action :set_background, only: [:show, :edit, :update, :destroy, :show_taxon_dist]

--- a/app/controllers/benchmarks_controller.rb
+++ b/app/controllers/benchmarks_controller.rb
@@ -1,7 +1,6 @@
 class BenchmarksController < ApplicationController
   include BenchmarksHelper
 
-  before_action :authenticate_user!
   before_action :admin_required
 
   def index

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -8,8 +8,7 @@ class LocationsController < ApplicationController
 
   TOKEN_AUTH_ACTIONS = [:external_search].freeze
 
-  before_action :authenticate_user!, except: TOKEN_AUTH_ACTIONS
-  before_action :authenticate_user_from_token!, only: TOKEN_AUTH_ACTIONS
+  prepend_before_action :authenticate_user_from_token!, only: TOKEN_AUTH_ACTIONS
 
   def external_search
     results = []

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -3,6 +3,7 @@ class MetadataController < ApplicationController
 
   # Token auth needed for CLI uploads
   TOKEN_AUTH_METHODS = [:validate_csv_for_new_samples].freeze
+  skip_before_action :verify_authenticity_token, only: TOKEN_AUTH_METHODS
   prepend_before_action :authenticate_user_from_token!, only: TOKEN_AUTH_METHODS
 
   def dictionary

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -2,13 +2,8 @@ class MetadataController < ApplicationController
   include MetadataHelper
 
   # Token auth needed for CLI uploads
-  skip_before_action :verify_authenticity_token, only: [:validate_csv_for_new_samples]
-  before_action :authenticate_user!, except: [:validate_csv_for_new_samples]
-  before_action :authenticate_user_from_token!, only: [:validate_csv_for_new_samples]
-
-  current_power do # Needed for CLI
-    Power.new(current_user)
-  end
+  TOKEN_AUTH_METHODS = [:validate_csv_for_new_samples].freeze
+  prepend_before_action :authenticate_user_from_token!, only: TOKEN_AUTH_METHODS
 
   def dictionary
   end

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -5,7 +5,6 @@ class PhyloTreesController < ApplicationController
   include ElasticsearchHelper
   include ParameterSanitization
 
-  before_action :authenticate_user!
   before_action :no_demo_user, only: :create
 
   ########################################

--- a/app/controllers/pipeline_viz_controller.rb
+++ b/app/controllers/pipeline_viz_controller.rb
@@ -1,8 +1,6 @@
 class PipelineVizController < ApplicationController
   include PipelineOutputsHelper
 
-  before_action :authenticate_user!
-
   # GET /sample/:sample_id/pipeline_viz/:pipeline_version
   # GET /sample/:sample_id/pipeline_viz/:pipeline_version.json
   def show

--- a/app/controllers/playground_controller.rb
+++ b/app/controllers/playground_controller.rb
@@ -1,6 +1,5 @@
 class PlaygroundController < ApplicationController
   before_action :login_required
-  before_action :authenticate_user!
   before_action :no_demo_user
   before_action :admin_required
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -26,6 +26,7 @@ class ProjectsController < ApplicationController
 
   # Required for token auth for CLI actions
   prepend_before_action :authenticate_user_from_token!, only: TOKEN_AUTH_METHODS
+  skip_before_action :verify_authenticity_token, only: TOKEN_AUTH_METHODS
 
   power :projects, map: { EDIT_ACTIONS => :updatable_projects }, as: :projects_scope
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -22,14 +22,10 @@ class ProjectsController < ApplicationController
   ].freeze
   EDIT_ACTIONS = [:edit, :update, :destroy, :add_user, :all_users, :update_project_visibility, :upload_metadata, :validate_metadata_csv].freeze
   OTHER_ACTIONS = [:choose_project, :create, :dimensions, :index, :metadata_fields, :new, :send_project_csv].freeze
+  TOKEN_AUTH_METHODS = [:index, :create].freeze
 
   # Required for token auth for CLI actions
-  skip_before_action :verify_authenticity_token, only: [:index, :create]
-  before_action :authenticate_user!, except: [:index, :create]
-  before_action :authenticate_user_from_token!, only: [:index, :create]
-  current_power do
-    Power.new(current_user)
-  end
+  prepend_before_action :authenticate_user_from_token!, only: TOKEN_AUTH_METHODS
 
   power :projects, map: { EDIT_ACTIONS => :updatable_projects }, as: :projects_scope
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -39,9 +39,6 @@ class SamplesController < ApplicationController
   before_action :admin_required, only: [:reupload_source, :resync_prod_data_to_staging, :kickoff_pipeline, :retry_pipeline, :pipeline_runs]
   before_action :no_demo_user, only: [:create, :bulk_new, :bulk_upload, :bulk_import, :new]
 
-  current_power do # Put this here for CLI
-    Power.new(current_user)
-  end
   # Read actions are mapped to viewable_samples scope and Edit actions are mapped to updatable_samples.
   power :samples, map: { EDIT_ACTIONS => :updatable_samples }, as: :samples_scope
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -17,7 +17,6 @@ class SamplesController < ApplicationController
   #                access control should still be checked as neccessary through current_power
   #
   ##########################################
-  skip_before_action :verify_authenticity_token, only: [:create, :update, :bulk_upload_with_metadata]
 
   # Read action meant for single samples with set_sample before_action
   READ_ACTIONS = [:show, :report_info, :report_csv, :assembly, :show_taxid_fasta, :nonhost_fasta, :unidentified_fasta,
@@ -34,6 +33,7 @@ class SamplesController < ApplicationController
   TOKEN_AUTH_ACTIONS = [:create, :update, :bulk_upload, :bulk_upload_with_metadata].freeze
 
   # For API-like access
+  skip_before_action :verify_authenticity_token, only: TOKEN_AUTH_ACTIONS
   prepend_before_action :authenticate_user_from_token!, only: TOKEN_AUTH_ACTIONS
 
   before_action :admin_required, only: [:reupload_source, :resync_prod_data_to_staging, :kickoff_pipeline, :retry_pipeline, :pipeline_runs]

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -31,11 +31,10 @@ class SamplesController < ApplicationController
                    :dimensions, :all, :show_sample_names, :cli_user_instructions, :metadata_fields, :samples_going_public,
                    :search_suggestions, :stats, :upload, :validate_sample_files,].freeze
   OWNER_ACTIONS = [:raw_results_folder].freeze
+  TOKEN_AUTH_ACTIONS = [:create, :update, :bulk_upload, :bulk_upload_with_metadata].freeze
 
   # For API-like access
-  TOKEN_AUTH_ACTIONS = [:create, :update, :bulk_upload, :bulk_upload_with_metadata].freeze
-  before_action :authenticate_user!, except: TOKEN_AUTH_ACTIONS
-  before_action :authenticate_user_from_token!, only: TOKEN_AUTH_ACTIONS
+  prepend_before_action :authenticate_user_from_token!, only: TOKEN_AUTH_ACTIONS
 
   before_action :admin_required, only: [:reupload_source, :resync_prod_data_to_staging, :kickoff_pipeline, :retry_pipeline, :pipeline_runs]
   before_action :no_demo_user, only: [:create, :bulk_new, :bulk_upload, :bulk_import, :new]


### PR DESCRIPTION
# Description

Cleanup redundant :authenticate_user! invocations from controllers. Adding these extra calls to `before_action authenticate_user!` changes the order of execution of that method, which can cause some issues with `current_power do ... end` blocks, specially when you have authentication using tokens.

# Notes

This cleanup is required as part of implementing auth0.

# Tests

* Automated tests passed
* Manual tests (including CLI)
