### PR TITLE
Bump aegea version dependency to v2.3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aegea==2.3.6
+aegea==2.3.7
 pyOpenSSL==19.0.0
 setuptools==41.0.1


### PR DESCRIPTION
Patch version bump required for the migration from r3 to r5 series instances.

    aegea batch: EBS vol mgr shellcode: Set method in http metadata fetch

    - For some reason, httpie wants to send a POST by default here even
      though no data is given

    - The metadata server in r5 class instances does not seem to accept
      POST, while the metadata server in previous class instances does

# Description

*The intended change, motivation and consequences.*

# Notes

*Optional observations, comments or explanations.*

# Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*
* *See also [IDseq PR Guidelines](https://github.com/chanzuckerberg/idseq-web/blob/master/PR_GUIDELINES.md)*
