### PR TITLE
[Release fix] Data Discovery bug fixes

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -859,10 +859,6 @@ class DiscoveryView extends React.Component {
   handleMapLevelChange = mapLevel => {
     const { rawMapLocationData, currentTab } = this.state;
 
-    if (!rawMapLocationData) {
-      return;
-    }
-
     const ids = currentTab === "samples" ? "sample_ids" : "project_ids";
     const clusteredData = {};
 
@@ -876,7 +872,7 @@ class DiscoveryView extends React.Component {
 
     const addToAncestor = (entry, ancestorLevel) => {
       const ancestorId = entry[`${ancestorLevel}_id`];
-      if (ancestorId) {
+      if (ancestorId && rawMapLocationData[ancestorId]) {
         if (!clusteredData[ancestorId]) {
           clusteredData[ancestorId] = copyLocation(
             rawMapLocationData[ancestorId]

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -547,7 +547,10 @@ class DiscoveryView extends React.Component {
         break;
       }
       case "project": {
-        this.handleProjectSelected({ project: this.projects.get(value) });
+        // this.handleProjectSelected({ project: this.projects.get(value) });
+        this.handleProjectSelected({
+          project: this.projects.get(value) || { id: value },
+        });
         break;
       }
       default: {
@@ -856,6 +859,10 @@ class DiscoveryView extends React.Component {
   handleMapLevelChange = mapLevel => {
     const { rawMapLocationData, currentTab } = this.state;
 
+    if (!rawMapLocationData) {
+      return;
+    }
+
     const ids = currentTab === "samples" ? "sample_ids" : "project_ids";
     const clusteredData = {};
 
@@ -947,7 +954,6 @@ class DiscoveryView extends React.Component {
       mapLevel,
       mapLocationData,
       mapPreviewedLocationId,
-      mapPreviewedSamples,
       sampleActiveColumns,
       selectedSampleIds,
       projectId,
@@ -1003,7 +1009,6 @@ class DiscoveryView extends React.Component {
                 mapLevel={mapLevel}
                 mapLocationData={mapLocationData}
                 mapPreviewedLocationId={mapPreviewedLocationId}
-                mapPreviewedSamples={mapPreviewedSamples}
                 mapTilerKey={mapTilerKey}
                 onActiveColumnsChange={this.handleSampleActiveColumnsChange}
                 onClearFilters={this.handleClearFilters}

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -547,7 +547,6 @@ class DiscoveryView extends React.Component {
         break;
       }
       case "project": {
-        // this.handleProjectSelected({ project: this.projects.get(value) });
         this.handleProjectSelected({
           project: this.projects.get(value) || { id: value },
         });

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -252,17 +252,9 @@ class SamplesView extends React.Component {
   };
 
   renderCollectionTrigger = () => {
-    const {
-      currentDisplay,
-      mapPreviewedSamples,
-      samples,
-      selectedSampleIds,
-    } = this.props;
+    const { samples, selectedSampleIds } = this.props;
 
-    // NOTE(jsheu): For mapSidebar sample names to appear in CollectionModal,
-    // they need to be presently loaded/fetched. Otherwise the ids work but says "and more..." for un-fetched samples.
-    const targetSamples =
-      currentDisplay === "map" ? mapPreviewedSamples : samples.loaded;
+    const targetSamples = samples.loaded;
     return selectedSampleIds.size < 2 ? (
       <SaveIcon
         className={cx(cs.icon, cs.disabled, cs.save)}
@@ -470,7 +462,6 @@ SamplesView.propTypes = {
   mapLevel: PropTypes.string,
   mapLocationData: PropTypes.objectOf(PropTypes.Location),
   mapPreviewedLocationId: PropTypes.number,
-  mapPreviewedSamples: PropTypes.array,
   mapTilerKey: PropTypes.string,
   onClearFilters: PropTypes.func,
   onActiveColumnsChange: PropTypes.func,


### PR DESCRIPTION
# Description

* Fixes a crash when clicking on a project on the search box results
* Fixes a bug when selecting samples and changing to the map view on samples views
* Mask an issue where location hierarchy is inconsistent (not easy to reproduce in development)

# Tests

* Start searching for a project that will not show up on the first 50 results of the project page. Click on the result below and verify it does not crash.
* Select two or more samples and switch to the map tab on the Samples view. Verify that it does not crash.
