### PR TITLE
[release fix] Update aegea version to 2.7.8 (#2638)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aegea==2.7.6
+aegea==2.7.8
 pyOpenSSL==19.0.0
 setuptools==41.0.1


### PR DESCRIPTION
Fixup for aa975b8d369cb1bc50b79ae0f3c48bb37f751373

# Description

Incorporates https://github.com/kislyuk/aegea/commit/fe3688621c2bb9ec8610543547cfe10bcf1455f1 which fixes installation incompatibilities between the aegea batch ebs shellcode and the idseq-dag Docker image.

# Tests

Tested manually by running batch jobs in the idseq-dag container.