### PR TITLE
[Release Fix CP] Fix bug where tags were passed as keyword argumen… (#2637)

### DIFF
--- a/app/lib/timer.rb
+++ b/app/lib/timer.rb
@@ -22,18 +22,18 @@ class Timer
     end_timestamp = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     Rails.logger.debug("Timer:Total[#{@prefix}]: #{end_timestamp - @start_timestamp}")
-    MetricUtil.put_metric_now("#{@prefix}.timer", end_timestamp - @start_timestamp, tags: @tags.to_a)
+    MetricUtil.put_metric_now("#{@prefix}.timer", end_timestamp - @start_timestamp, @tags.to_a)
 
     previous_timestamp = @start_timestamp
     @splits.each do |name, split_timestamp|
       diff = split_timestamp - previous_timestamp
       Rails.logger.debug("Timer:Split[#{@prefix}.#{name}]: #{diff}}")
-      MetricUtil.put_metric_now("#{@prefix}.timer.splits", diff.round(6), tags: @tags.to_a + ["split:#{name}"])
+      MetricUtil.put_metric_now("#{@prefix}.timer.splits", diff.round(6), @tags.to_a + ["split:#{name}"])
       previous_timestamp = split_timestamp
     end
 
     unless @splits.empty?
-      MetricUtil.put_metric_now("#{@prefix}.timer.splits", (end_timestamp - previous_timestamp).round(6), tags: @tags.to_a + ["split:last"])
+      MetricUtil.put_metric_now("#{@prefix}.timer.splits", (end_timestamp - previous_timestamp).round(6), @tags.to_a + ["split:last"])
     end
   end
 end

--- a/spec/lib/timer_spec.rb
+++ b/spec/lib/timer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Timer do
         stub_clock([expected_elapsed])
 
         expect(MetricUtil).to receive(:put_metric_now)
-          .with("#{TIMER_PREFIX}.timer", expected_elapsed, tags: [])
+          .with("#{TIMER_PREFIX}.timer", expected_elapsed, [])
 
         subject_timer = Timer.new(TIMER_PREFIX)
         subject_timer.publish
@@ -33,10 +33,10 @@ RSpec.describe Timer do
         expected_elapsed_split_names = ["step_1", "step_2"]
 
         expect(MetricUtil).to receive(:put_metric_now)
-          .with("#{TIMER_PREFIX}.timer", expected_elapsed_splits.inject(:+), tags: [])
+          .with("#{TIMER_PREFIX}.timer", expected_elapsed_splits.inject(:+), [])
         (expected_elapsed_split_names + ["last"]).each_with_index do |split_name, idx|
           expect(MetricUtil).to receive(:put_metric_now)
-            .with("#{TIMER_PREFIX}.timer.splits", expected_elapsed_splits[idx], tags: ["split:#{split_name}"])
+            .with("#{TIMER_PREFIX}.timer.splits", expected_elapsed_splits[idx], ["split:#{split_name}"])
         end
 
         subject_timer = Timer.new(TIMER_PREFIX)
@@ -55,10 +55,10 @@ RSpec.describe Timer do
         expected_tags = ["tag_name:test_tag"]
 
         expect(MetricUtil).to receive(:put_metric_now)
-          .with("#{TIMER_PREFIX}.timer", anything, tags: array_including(expected_tags))
+          .with("#{TIMER_PREFIX}.timer", anything, array_including(expected_tags))
         (expected_elapsed_split_names + ["last"]).each do |_split_name|
           expect(MetricUtil).to receive(:put_metric_now)
-            .with("#{TIMER_PREFIX}.timer.splits", anything, tags: array_including(expected_tags))
+            .with("#{TIMER_PREFIX}.timer.splits", anything, array_including(expected_tags))
         end
 
         subject_timer = Timer.new(TIMER_PREFIX)
@@ -78,10 +78,10 @@ RSpec.describe Timer do
         expected_tags = ["tag_name:test_tag"]
 
         expect(MetricUtil).to receive(:put_metric_now)
-          .with("#{TIMER_PREFIX}.timer", anything, tags: contain_exactly(*expected_tags))
+          .with("#{TIMER_PREFIX}.timer", anything, contain_exactly(*expected_tags))
         (expected_elapsed_split_names + ["last"]).each do |split_name|
           expect(MetricUtil).to receive(:put_metric_now)
-            .with("#{TIMER_PREFIX}.timer.splits", anything, tags: contain_exactly(*(["split:#{split_name}"] + expected_tags)))
+            .with("#{TIMER_PREFIX}.timer.splits", anything, contain_exactly(*(["split:#{split_name}"] + expected_tags)))
         end
 
         subject_timer = Timer.new(TIMER_PREFIX, tags: expected_tags)


### PR DESCRIPTION
# Description

* Fix a bug where tags were passed as keyword arguments where the function was requiring a positional argument (default `=` vs `:`) and thus interpreted as hash

# Tests

* Verified metrics were being published and fixed unit tests
