### PR TITLE
[Release fix] Fix bugs in sidebar read counts table (#2640)

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -94,9 +94,11 @@ class PipelineTab extends React.Component {
     const { sampleId } = this.props;
     const pipelineResults = await getSamplePipelineResults(sampleId);
 
-    this.setState({
-      pipelineStepDict: pipelineResults["displayed_data"]["Host Filtering"],
-    });
+    if (pipelineResults && pipelineResults["displayed_data"]) {
+      this.setState({
+        pipelineStepDict: pipelineResults["displayed_data"]["Host Filtering"],
+      });
+    }
   };
 
   renderReadCountsTable = stepKey => {
@@ -147,7 +149,9 @@ class PipelineTab extends React.Component {
           open={this.state.sectionOpen.readsRemaining}
           title="Reads Remaining"
         >
-          {isEmpty(this.state.pipelineStepDict) ||
+          {isEmpty(pipelineRun) ||
+          isEmpty(pipelineRun.totalReads) ||
+          isEmpty(this.state.pipelineStepDict) ||
           isEmpty(this.state.pipelineStepDict["steps"]) ? (
             <div className={cs.field}>
               <div className={cx(cs.label, cs.emptyValue)}>No data</div>

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -981,7 +981,7 @@ class SamplesController < ApplicationController
   def results_folder
     can_see_stage1_results = (current_user.id == @sample.user_id)
     @exposed_raw_results_url = can_see_stage1_results ? raw_results_folder_sample_url(@sample) : nil
-    @file_list = @sample.first_pipeline_run.outputs_by_step(can_see_stage1_results)
+    @file_list = @sample.first_pipeline_run ? @sample.first_pipeline_run.outputs_by_step(can_see_stage1_results) : []
     @file_path = "#{@sample.sample_path}/results/"
     respond_to do |format|
       format.html do


### PR DESCRIPTION
[Release fix] Fix bugs in sidebar read counts table

# Description

* Fix `NoMethodError` for `Waiting` samples caused by attempting to fetch the pipeline results file when a sample hasn't had a pipeline run yet.
* Fix bug for `Failed` samples caused by attempting to convert a `null` value (nonexistent read counts) into a string.

# Tests

* Open sample with `Waiting` status and open sample details sidebar to the pipeline tab, verify that error doesn't occur.
* Open sample with `Failed` status and open sample details sidebar to the pipeline tab, verify that page does not crash.
