### PR TITLE
[Release fix] Fix typo in read counts table

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -13,6 +13,7 @@ import ColumnHeaderTooltip from "~/components/ui/containers/ColumnHeaderTooltip"
 import { PIPELINE_INFO_FIELDS, HOST_FILTERING_WIKI } from "./constants";
 import MetadataSection from "./MetadataSection";
 import cs from "./sample_details_mode.scss";
+import { pipeline } from "stream";
 
 class PipelineTab extends React.Component {
   state = {
@@ -149,8 +150,8 @@ class PipelineTab extends React.Component {
           open={this.state.sectionOpen.readsRemaining}
           title="Reads Remaining"
         >
-          {isEmpty(pipelineRun) ||
-          isEmpty(pipelineRun.totalReads) ||
+          {!pipelineRun ||
+          !pipelineRun.total_reads ||
           isEmpty(this.state.pipelineStepDict) ||
           isEmpty(this.state.pipelineStepDict["steps"]) ? (
             <div className={cs.field}>

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -13,7 +13,6 @@ import ColumnHeaderTooltip from "~/components/ui/containers/ColumnHeaderTooltip"
 import { PIPELINE_INFO_FIELDS, HOST_FILTERING_WIKI } from "./constants";
 import MetadataSection from "./MetadataSection";
 import cs from "./sample_details_mode.scss";
-import { pipeline } from "stream";
 
 class PipelineTab extends React.Component {
   state = {


### PR DESCRIPTION
# Description

* Previous release fix included a typo (`pipelineRun.totalReads` rather than `pipelineRun.total_reads`) and incorrect null checks, which caused `No data` to be displayed in the table even if the sample did have the data.

# Notes

* Will need to verify on staging that samples with pipeline run data properly displays the read counts table as expected.

# Tests

* Verified that `Waiting` and `Failed` samples should display `No data`.
