### PR TITLE
[Release fix CP] Fix typo in read counts table (#2645)

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -149,8 +149,8 @@ class PipelineTab extends React.Component {
           open={this.state.sectionOpen.readsRemaining}
           title="Reads Remaining"
         >
-          {isEmpty(pipelineRun) ||
-          isEmpty(pipelineRun.totalReads) ||
+          {!pipelineRun ||
+          !pipelineRun.total_reads ||
           isEmpty(this.state.pipelineStepDict) ||
           isEmpty(this.state.pipelineStepDict["steps"]) ? (
             <div className={cs.field}>


### PR DESCRIPTION
# Description

* Previous release fix included a typo (`pipelineRun.totalReads` rather than `pipelineRun.total_reads`) and incorrect null checks, which caused `No data` to be displayed in the table even if the sample did have the data.

# Tests

* Verified that `Waiting` and `Failed` samples should display `No data`.
* Verified on staging that samples with pipeline run data properly displays the read counts table as expected.