### PR TITLE
Add initial files for BulkDownloadModal.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -341,6 +341,8 @@ const getSamplesLocations = ({ domain, filters, projectId, search }) =>
 const getSamplePipelineResults = id =>
   get(`/samples/${id}/results_folder.json`);
 
+const getBulkDownloadTypes = () => get("/bulk_downloads/types");
+
 export {
   bulkImportRemoteSamples,
   bulkUploadRemoteSamples,
@@ -350,6 +352,7 @@ export {
   deleteSample,
   getAlignmentData,
   getAllHostGenomes,
+  getBulkDownloadTypes,
   getContigsSequencesByByteranges,
   getCoverageVizData,
   getCoverageVizSummary,

--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { set } from "lodash/fp";
+
+import { getBulkDownloadTypes } from "~/api";
+import Modal from "~ui/containers/Modal";
+
+import ChooseStep from "./ChooseStep";
+
+class BulkDownloadModal extends React.Component {
+  state = {
+    bulkDownloadTypes: null,
+    // We save the options for ALL download types.
+    // If the user clicks between different download types, all their selections are saved.
+    selectedOptions: {},
+    selectedDownloadType: null,
+  };
+
+  async componentDidMount() {
+    const bulkDownloadTypes = await getBulkDownloadTypes();
+
+    this.setState({
+      bulkDownloadTypes,
+    });
+  }
+
+  onSelectDownloadType = selectedDownloadType => {
+    this.setState({
+      selectedDownloadType,
+    });
+  };
+
+  onOptionSelect = (downloadType, optionType, value) => {
+    this.setState({
+      selectedOptions: set(
+        [downloadType, optionType],
+        value,
+        this.state.selectedOptions
+      ),
+    });
+  };
+
+  render() {
+    const { open } = this.props;
+    const {
+      bulkDownloadTypes,
+      selectedDownloadType,
+      selectedOptions,
+    } = this.state;
+
+    return (
+      <Modal narrow open={open} tall onClose={this.props.onClose}>
+        <ChooseStep
+          downloadTypes={bulkDownloadTypes}
+          selectedDownloadType={selectedDownloadType}
+          onSelect={this.onSelectDownloadType}
+          selectedOptions={selectedOptions}
+          onOptionSelect={this.onOptionSelect}
+        />
+      </Modal>
+    );
+  }
+}
+
+BulkDownloadModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool,
+};
+
+export default BulkDownloadModal;

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -1,0 +1,136 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { filter, get } from "lodash/fp";
+import cx from "classnames";
+
+import Dropdown from "~ui/controls/dropdowns/Dropdown";
+import LoadingIcon from "~ui/icons/LoadingIcon";
+import RadioButton from "~ui/controls/RadioButton";
+import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
+
+import cs from "./choose_step.scss";
+
+class ChooseStep extends React.Component {
+  renderOption = (downloadType, option) => {
+    const { selectedOptions, onOptionSelect } = this.props;
+    const selectedOption = get(
+      [downloadType.type, option.type],
+      selectedOptions
+    );
+    let dropdownOptions;
+
+    switch (option.type) {
+      case "file_format":
+        dropdownOptions = option.options.map(option => ({
+          text: option,
+          value: option,
+        }));
+
+        return (
+          <div className={cs.option}>
+            <div className={cs.label}>File Format:</div>
+            <Dropdown
+              fluid
+              options={dropdownOptions}
+              onChange={value =>
+                onOptionSelect(downloadType.type, option.type, value)
+              }
+              value={selectedOption}
+            />
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  renderDownloadType = downloadType => {
+    const { selectedDownloadType, onSelect } = this.props;
+    const selected = selectedDownloadType === downloadType.type;
+    return (
+      <div
+        className={cx(cs.downloadType, selected && cs.selected)}
+        key={downloadType.type}
+        onClick={() => onSelect(downloadType.type)}
+      >
+        <RadioButton className={cs.radioButton} selected={selected} />
+        <div className={cs.content}>
+          <div className={cs.name}>{downloadType.display_name}</div>
+          <div className={cs.description}>{downloadType.description}</div>
+          <div className={cs.options}>
+            {selected &&
+              downloadType.options &&
+              downloadType.options.map(option =>
+                this.renderOption(downloadType, option)
+              )}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  renderDownloadTypes = () => {
+    const { downloadTypes } = this.props;
+
+    if (!downloadTypes) {
+      return (
+        <div className={cs.loadingMessage}>
+          <LoadingIcon className={cs.loadingIcon} />Loading download types...
+        </div>
+      );
+    }
+
+    const reportTypes = filter(["category", "report"], downloadTypes);
+    const rawTypes = filter(["category", "raw"], downloadTypes);
+
+    return (
+      <React.Fragment>
+        <div className={cs.category}>
+          <div className={cs.title}>Reports</div>
+          {reportTypes.map(this.renderDownloadType)}
+        </div>
+        <div className={cs.category}>
+          <div className={cs.title}>Raw Data</div>
+          {rawTypes.map(this.renderDownloadType)}
+        </div>
+      </React.Fragment>
+    );
+  };
+
+  render() {
+    return (
+      <div className={cs.chooseStep}>
+        <div className={cs.header}>
+          <div className={cs.title}>Choose a Download</div>
+          <div className={cs.tagline}>Learn More</div>
+        </div>
+        <div className={cs.downloadTypeContainer}>
+          {this.renderDownloadTypes()}
+        </div>
+        <div className={cs.footer}>
+          <PrimaryButton disabled text="Continue" />
+          <div className={cs.downloadDisclaimer}>
+            Downloads for larger files can take multiple hours to generate.
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ChooseStep.propTypes = {
+  downloadTypes: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.string,
+      display_name: PropTypes.string,
+      description: PropTypes.string,
+      category: PropTypes.string,
+    })
+  ).isRequired,
+  selectedDownloadType: PropTypes.string,
+  onSelect: PropTypes.func.isRequired,
+  selectedOptions: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
+  onOptionSelect: PropTypes.func.isRequired,
+};
+
+export default ChooseStep;

--- a/app/assets/src/components/views/bulk_download/choose_step.scss
+++ b/app/assets/src/components/views/bulk_download/choose_step.scss
@@ -1,0 +1,94 @@
+@import "~styles/themes/typography";
+@import "~styles/themes/colors";
+
+.chooseStep {
+  height: calc(85vh - 80px);
+  max-height: 700px;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  .title {
+    @include font-header-xxl;
+  }
+
+  .tagline {
+    @include font-header-xs;
+    color: $primary-light;
+  }
+}
+
+.loadingMessage {
+  color: $dark-grey;
+
+  .loadingIcon {
+    margin-right: 4px;
+  }
+}
+
+.downloadTypeContainer {
+  margin-top: 20px;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: auto;
+
+  .category {
+    &:not(:first-child) {
+      margin-top: 40px;
+    }
+
+    .title {
+      @include font-label-s;
+      color: $medium-grey;
+    }
+  }
+}
+
+.downloadType {
+  padding: 10px 18px;
+  display: flex;
+  cursor: pointer;
+
+  &:hover,
+  &.selected {
+    background-color: $off-white;
+  }
+
+  .radioButton {
+    margin-right: 10px;
+    margin-top: 4px;
+  }
+
+  .name {
+    @include font-header-xs;
+  }
+
+  .description {
+    @include font-body-xxs;
+    color: $dark-grey;
+  }
+}
+
+.options {
+  margin-top: 12px;
+
+  .option {
+    width: calc(50% - 20px);
+
+    .label {
+      @include font-body-xs;
+      margin-bottom: 2px;
+    }
+  }
+}
+
+.footer {
+  margin-top: 40px;
+
+  .downloadDisclaimer {
+    @include font-body-xxs;
+    color: $medium-grey;
+    margin-top: 6px;
+  }
+}

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -3,8 +3,10 @@ import { difference, isEmpty, union } from "lodash/fp";
 import React from "react";
 
 import BareDropdown from "~ui/controls/dropdowns/BareDropdown";
+import BulkDownloadModal from "~/components/views/bulk_download/BulkDownloadModal";
 import CollectionModal from "~/components/views/samples/CollectionModal";
 import DiscoveryMap from "~/components/views/discovery/mapping/DiscoveryMap";
+import DownloadIcon from "~ui/icons/DownloadIcon";
 import HeatmapIcon from "~ui/icons/HeatmapIcon";
 import InfiniteTable from "~/components/visualizations/table/InfiniteTable";
 import Label from "~ui/labels/Label";
@@ -32,6 +34,7 @@ class SamplesView extends React.Component {
 
     this.state = {
       phyloTreeCreationModalOpen: false,
+      bulkDownloadModalOpen: false,
     };
 
     this.columns = [
@@ -283,6 +286,21 @@ class SamplesView extends React.Component {
     );
   };
 
+  renderBulkDownloadTrigger = () => {
+    const downloadIcon = <DownloadIcon className={cx(cs.icon, cs.download)} />;
+    return (
+      <ToolbarIcon
+        className={cs.action}
+        icon={downloadIcon}
+        popupText="Download"
+        onClick={withAnalytics(
+          this.handleBulkDownloadModalOpen,
+          "SamplesView_bulk-download-modal-open_clicked"
+        )}
+      />
+    );
+  };
+
   renderCollectionTrigger = () => {
     const { samples, selectedSampleIds } = this.props;
 
@@ -315,7 +333,7 @@ class SamplesView extends React.Component {
   };
 
   renderToolbar = () => {
-    const { selectedSampleIds } = this.props;
+    const { selectedSampleIds, allowedFeatures } = this.props;
     return (
       <div className={cs.samplesToolbar}>
         {this.renderDisplaySwitcher()}
@@ -338,6 +356,8 @@ class SamplesView extends React.Component {
           {this.renderHeatmapTrigger()}
           {this.renderPhyloTreeTrigger()}
           {this.renderDownloadTrigger()}
+          {allowedFeatures.includes("bulk_downloads") &&
+            this.renderBulkDownloadTrigger()}
         </div>
       </div>
     );
@@ -434,6 +454,14 @@ class SamplesView extends React.Component {
     this.setState({ phyloTreeCreationModalOpen: false });
   };
 
+  handleBulkDownloadModalOpen = () => {
+    this.setState({ bulkDownloadModalOpen: true });
+  };
+
+  handleBulkDownloadModalClose = () => {
+    this.setState({ bulkDownloadModalOpen: false });
+  };
+
   handleRowClick = ({ event, rowData }) => {
     const { onSampleSelected, samples } = this.props;
     const sample = samples.get(rowData.id);
@@ -445,8 +473,8 @@ class SamplesView extends React.Component {
   };
 
   render() {
-    const { currentDisplay } = this.props;
-    const { phyloTreeCreationModalOpen } = this.state;
+    const { currentDisplay, allowedFeatures } = this.props;
+    const { phyloTreeCreationModalOpen, bulkDownloadModalOpen } = this.state;
     return (
       <div className={cs.container}>
         {currentDisplay === "table" ? (
@@ -462,6 +490,15 @@ class SamplesView extends React.Component {
             onClose={withAnalytics(
               this.handlePhyloModalClose,
               "SamplesView_phylo-tree-modal_closed"
+            )}
+          />
+        )}
+        {allowedFeatures.includes("bulk_downloads") && (
+          <BulkDownloadModal
+            open={bulkDownloadModalOpen}
+            onClose={withAnalytics(
+              this.handleBulkDownloadModalClose,
+              "SamplesView_bulk-download-modal_closed"
             )}
           />
         )}

--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -1,0 +1,9 @@
+
+class BulkDownloadsController < ApplicationController
+  include BulkDownloadTypesHelper
+
+  # GET /bulk_downloads/types
+  def types
+    render json: BulkDownloadTypesHelper::BULK_DOWNLOAD_TYPES
+  end
+end

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -1,0 +1,64 @@
+module BulkDownloadTypesHelper
+  BULK_DOWNLOAD_TYPES = [
+    {
+      type: "sample_overview",
+      display_name: "Sample Overview",
+      description: "Sample metadata and QC metrics",
+      category: "report",
+    },
+    {
+      type: "sample_taxon_report",
+      display_name: "Sample Taxon Report",
+      description: "Metrics (e.g. total reads, rPM) and metadata for each taxon identified in the sample",
+      category: "report",
+    },
+    {
+      type: "combined_sample_taxon_results",
+      display_name: "Combined Sample Taxon Results",
+      description: "The value of a particular metric (e.g. total reads, rPM) for all taxons in all selected samples, in a single data table",
+      category: "report",
+      options: [
+        {
+          type: "file_format",
+          options: [".csv", ".biom"],
+        },
+      ],
+    },
+    {
+      type: "contig_summary_report",
+      display_name: "Contig Summary Report",
+      description: "Contig metadata and QC metrics",
+      category: "report",
+    },
+    {
+      type: "host_gene_counts",
+      display_name: "Host Gene Counts",
+      description: "Host gene count output from STAR",
+      category: "report",
+    },
+    {
+      type: "reads_non_host",
+      display_name: "Reads (Non-host)",
+      description: "Reads with host data subtracted",
+      category: "raw",
+    },
+    {
+      type: "contigs_non_host",
+      display_name: "Contigs (Non-host)",
+      description: "Contigs with host data subtracted",
+      category: "raw",
+    },
+    {
+      type: "unmapped_reads",
+      display_name: "Unmapped Reads",
+      description: "Reads that didn’t map to any taxa",
+      category: "raw",
+    },
+    {
+      type: "original_input_file",
+      display_name: "Original Input File",
+      description: "Original file you submitted to IDseq",
+      category: "raw",
+    },
+  ].freeze
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
 
   get 'samples/:sample_id/pipeline_viz(/:pipeline_version)', to: 'pipeline_viz#show',
                                                              constraints: { pipeline_version: /\d+\.\d+/ } # To allow period in pipeline version parameter
+  get 'bulk_downloads/types', to: 'bulk_downloads#types'
 
   resources :host_genomes
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]


### PR DESCRIPTION
Guarded by "bulk_downloads" feature flag.
![Screen Shot 2019-10-07 at 7 23 37 PM](https://user-images.githubusercontent.com/837004/66362532-01d9c480-e938-11e9-9a38-f18aecf41abc.png)

![Screen Shot 2019-10-07 at 7 23 09 PM](https://user-images.githubusercontent.com/837004/66362528-ff776a80-e937-11e9-847f-034151635280.png)

# Notes

* The download type options are not complete. Will flesh those out as I work on each download type.
* I did not enable this for all admins because admins might still need the existing download features while this is being worked on.
* This is just the first screen. The continue button is always disabled for now.

# Tests

* Verify that user without flag doesn't see anything (and there are no hidden renders or fetches)
* Verify that modal behaves as expected. Download types can be selected, selected options are remembered properly.
