### PR TITLE
[IDSEQ-1441] Move required MetadataFields to front of CSV template + Fix location values in template

### DIFF
--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -122,8 +122,13 @@ module MetadataHelper
             elsif project.nil?
               generate_metadata_default_value(field, sample[:host_genome_name])
             else
-              puts "FIELD INFO: 3:25pm", sample[:metadata][field.name]
-              sample[:metadata][field.name] ? sample[:metadata][field.name].raw_value : nil
+              datum = sample[:metadata][field.name]
+              if datum
+                val = datum.validated_value
+                # Special-case for object values (e.g. Location types)
+                # rubocop:disable Metrics/BlockNesting
+                val.is_a?(Hash) ? val[:name] : val
+              end
             end
           end
         end

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -125,6 +125,7 @@ module MetadataHelper
               datum = sample[:metadata][field.name]
               if datum
                 base_type = datum.metadata_field.base_type
+
                 # rubocop:disable Metrics/BlockNesting
                 if base_type == Metadatum::LOCATION_TYPE
                   # Special-case for Location types

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -122,6 +122,7 @@ module MetadataHelper
             elsif project.nil?
               generate_metadata_default_value(field, sample[:host_genome_name])
             else
+              puts "FIELD INFO: 3:25pm", sample[:metadata][field.name]
               sample[:metadata][field.name] ? sample[:metadata][field.name].raw_value : nil
             end
           end

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -124,10 +124,15 @@ module MetadataHelper
             else
               datum = sample[:metadata][field.name]
               if datum
-                val = datum.validated_value
-                # Special-case for object values (e.g. Location types)
+                base_type = datum.metadata_field.base_type
                 # rubocop:disable Metrics/BlockNesting
-                val.is_a?(Hash) ? val[:name] : val
+                if base_type == Metadatum::LOCATION_TYPE
+                  # Special-case for Location types
+                  val = datum.validated_value
+                  val.is_a?(Hash) ? val[:name] : val
+                else
+                  datum.raw_value
+                end
               end
             end
           end

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -122,19 +122,7 @@ module MetadataHelper
             elsif project.nil?
               generate_metadata_default_value(field, sample[:host_genome_name])
             else
-              datum = sample[:metadata][field.name]
-              if datum
-                base_type = datum.metadata_field.base_type
-
-                # rubocop:disable Metrics/BlockNesting
-                if base_type == Metadatum::LOCATION_TYPE
-                  # Special-case for Location types
-                  val = datum.validated_value
-                  val.is_a?(Hash) ? val[:name] : val
-                else
-                  datum.raw_value
-                end
-              end
+              sample[:metadata][field.name]&.csv_template_value
             end
           end
         end

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -72,6 +72,13 @@ module MetadataHelper
                project.metadata_fields.includes(:host_genomes).reject { |field| (field.host_genome_ids & host_genome_ids).empty? }
              end
 
+    # Show fields with is_required=1 first in the CSV, but otherwise keep the default order.
+    fields = fields.sort_by { |f| [-f.is_required, f.id] }
+
+    # Hide legacy collection_location (v1) field from CSV templates.
+    # TODO(jsheu): Remove legacy field and swap in collection_location_v2.
+    fields = fields.reject { |f| f.name == "collection_location" }
+
     field_names = ["Sample Name"] + (include_host_genome ? ["Host Genome"] : []) + fields.pluck(:display_name)
 
     host_genomes_by_name = HostGenome.all.includes(:metadata_fields).reject { |x| x.metadata_fields.empty? }.index_by(&:name)

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -311,6 +311,18 @@ class Metadatum < ApplicationRecord
     validated_values
   end
 
+  # CSV-friendly string value for filling metadata templates
+  def csv_template_value
+    # Special case for Location objects
+    if metadata_field.base_type == Metadatum::LOCATION_TYPE
+      location_id ? location.name : string_validated_value
+    else
+      # Use raw_value, the user's original string input, to avoid conversion errors with
+      # dates/numbers.
+      raw_value
+    end
+  end
+
   def self.by_sample_ids(sample_ids)
     includes(:metadata_field, :location)
       .where(sample_id: sample_ids)


### PR DESCRIPTION
### Description
- JIRA: https://jira.czi.team/browse/IDSEQ-1441
- This is about the metadata CSV template that users can download when uploading samples or when editing on a project level later.

- Two changes in this ticket:
(1) Move is_required fields to the leftmost of the CSV but otherwise keep the order. Also hide the legacy location field.
(2) Get location names to show up in the template CSVs. Before they were showing as blank.

### Tests
- Go to URLs like `http://localhost:3000/metadata/metadata_template_csv?project_id=i` to download the sample templates. See collection_location in one of the first columns and see existing location names in the CSV as well.

![Screen Shot 2019-10-08 at 4 51 56 PM](https://user-images.githubusercontent.com/5652739/66442767-f39baf00-e9f0-11e9-93d4-db7e8c5f5a97.png)