### PR TITLE
Add ReviewStep to BulkDownloadModal.

### DIFF
--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -1,19 +1,34 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { set } from "lodash/fp";
+import { find, get, set } from "lodash/fp";
+import memoize from "memoize-one";
 
 import { getBulkDownloadTypes } from "~/api";
 import Modal from "~ui/containers/Modal";
 
 import ChooseStep from "./ChooseStep";
+import ReviewStep from "./ReviewStep";
+
+const assembleSelectedDownload = memoize(
+  (selectedDownloadTypeName, allSelectedFields, sampleIds) => {
+    const fields = get(selectedDownloadTypeName, allSelectedFields);
+
+    return {
+      type: selectedDownloadTypeName,
+      fields,
+      sampleIds: Array.from(sampleIds),
+    };
+  }
+);
 
 class BulkDownloadModal extends React.Component {
   state = {
     bulkDownloadTypes: null,
-    // We save the options for ALL download types.
+    // We save the fields for ALL download types.
     // If the user clicks between different download types, all their selections are saved.
-    selectedOptions: {},
-    selectedDownloadType: null,
+    selectedFields: {},
+    selectedDownloadTypeName: null,
+    currentStep: "choose",
   };
 
   async componentDidMount() {
@@ -24,39 +39,90 @@ class BulkDownloadModal extends React.Component {
     });
   }
 
-  onSelectDownloadType = selectedDownloadType => {
+  componentDidUpdate(prevProps, prevState) {
+    // If the user has just closed the modal, reset it.
+    if (prevProps.open && !this.props.open) {
+      this.setState({
+        selectedDownloadTypeName: null,
+        currentStep: "choose",
+        selectedFields: {},
+      });
+    }
+  }
+
+  onSelectDownloadType = selectedDownloadTypeName => {
     this.setState({
-      selectedDownloadType,
+      selectedDownloadTypeName,
     });
   };
 
-  onOptionSelect = (downloadType, optionType, value) => {
+  onFieldSelect = (downloadType, fieldType, value) => {
     this.setState({
-      selectedOptions: set(
-        [downloadType, optionType],
+      selectedFields: set(
+        [downloadType, fieldType],
         value,
-        this.state.selectedOptions
+        this.state.selectedFields
       ),
     });
   };
 
+  onChooseStepContinue = () => {
+    this.setState({ currentStep: "review" });
+  };
+  handleBackClick = () => {
+    this.setState({ currentStep: "choose" });
+  };
+
+  renderStep = () => {
+    const { selectedSampleIds } = this.props;
+    const {
+      currentStep,
+      bulkDownloadTypes,
+      selectedDownloadTypeName,
+      selectedFields,
+    } = this.state;
+
+    if (currentStep === "choose") {
+      return (
+        <ChooseStep
+          downloadTypes={bulkDownloadTypes}
+          selectedDownloadTypeName={selectedDownloadTypeName}
+          onSelect={this.onSelectDownloadType}
+          selectedFields={selectedFields}
+          onFieldSelect={this.onFieldSelect}
+          onContinue={this.onChooseStepContinue}
+        />
+      );
+    }
+
+    if (currentStep === "review") {
+      const selectedDownload = assembleSelectedDownload(
+        selectedDownloadTypeName,
+        selectedFields,
+        selectedSampleIds
+      );
+
+      const selectedDownloadType = find(
+        ["type", selectedDownloadTypeName],
+        bulkDownloadTypes
+      );
+
+      return (
+        <ReviewStep
+          selectedDownload={selectedDownload}
+          downloadType={selectedDownloadType}
+          onBackClick={this.handleBackClick}
+        />
+      );
+    }
+  };
+
   render() {
     const { open } = this.props;
-    const {
-      bulkDownloadTypes,
-      selectedDownloadType,
-      selectedOptions,
-    } = this.state;
 
     return (
       <Modal narrow open={open} tall onClose={this.props.onClose}>
-        <ChooseStep
-          downloadTypes={bulkDownloadTypes}
-          selectedDownloadType={selectedDownloadType}
-          onSelect={this.onSelectDownloadType}
-          selectedOptions={selectedOptions}
-          onOptionSelect={this.onOptionSelect}
-        />
+        {this.renderStep()}
       </Modal>
     );
   }
@@ -65,6 +131,7 @@ class BulkDownloadModal extends React.Component {
 BulkDownloadModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   open: PropTypes.bool,
+  selectedSampleIds: PropTypes.arrayOf(PropTypes.number),
 };
 
 export default BulkDownloadModal;

--- a/app/assets/src/components/views/bulk_download/ReviewStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ReviewStep.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { get, find } from "lodash/fp";
+import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
+
+import cs from "./review_step.scss";
+
+class ReviewStep extends React.Component {
+  renderDownloadField = (field, value) => {
+    const { downloadType } = this.props;
+    const fieldDisplayName =
+      get("display_name", find(["type", field], downloadType.fields)) || "";
+
+    return (
+      <div className={cs.field}>
+        <div className={cs.name}>{fieldDisplayName}</div>
+        <div className={cs.value}>{value}</div>
+      </div>
+    );
+  };
+
+  render() {
+    const { selectedDownload, downloadType, onBackClick } = this.props;
+
+    return (
+      <div className={cs.reviewStep}>
+        <div className={cs.header}>
+          <div className={cs.title}>Review Your Download</div>
+          <div className={cs.editLink} onClick={onBackClick}>
+            Edit download
+          </div>
+        </div>
+        <div className={cs.selectedDownload}>
+          <div className={cs.title}>
+            <div className={cs.name}>{downloadType.display_name}</div>
+            <div className={cs.numSamples}>
+              &nbsp;for {selectedDownload.sampleIds.length} samples
+            </div>
+          </div>
+          {selectedDownload.fields && (
+            <div className={cs.fields}>
+              {Object.entries(selectedDownload.fields).map(([key, value]) =>
+                this.renderDownloadField(key, value)
+              )}
+            </div>
+          )}
+        </div>
+        <div className={cs.footer}>
+          <PrimaryButton text="Start Generating Download" />
+          <div className={cs.downloadDisclaimer}>
+            Downloads for larger files can take multiple hours to generate.
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ReviewStep.propTypes = {
+  selectedDownload: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    fields: PropTypes.object,
+    sampleIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  }).isRequired,
+  downloadType: PropTypes.shape({
+    type: PropTypes.string,
+    display_name: PropTypes.string,
+    description: PropTypes.string,
+    category: PropTypes.string,
+    fields: PropTypes.arrayOf(
+      PropTypes.shape({
+        type: PropTypes.string,
+        display_name: PropTypes.string,
+      })
+    ),
+  }),
+  onBackClick: PropTypes.func.isRequired,
+};
+
+export default ReviewStep;

--- a/app/assets/src/components/views/bulk_download/choose_step.scss
+++ b/app/assets/src/components/views/bulk_download/choose_step.scss
@@ -70,10 +70,10 @@
   }
 }
 
-.options {
+.fields {
   margin-top: 12px;
 
-  .option {
+  .field {
     width: calc(50% - 20px);
 
     .label {

--- a/app/assets/src/components/views/bulk_download/review_step.scss
+++ b/app/assets/src/components/views/bulk_download/review_step.scss
@@ -1,0 +1,65 @@
+@import "~styles/themes/colors";
+@import "~styles/themes/typography";
+
+.reviewStep {
+  .header {
+    .title {
+      @include font-header-xxl;
+    }
+
+    .editLink {
+      @include font-body-xs;
+      color: $primary-light;
+      cursor: pointer;
+    }
+  }
+
+  .selectedDownload {
+    background-color: $off-white;
+    padding: 14px;
+    margin-top: 20px;
+
+    .title {
+      display: flex;
+
+      .name {
+        @include font-header-xs;
+      }
+
+      .numSamples {
+        @include font-body-xs;
+        color: $medium-grey;
+      }
+    }
+
+    .fields {
+      display: flex;
+      margin: 10px 0 15px;
+
+      .field {
+        flex: 1 1 0;
+        min-width: 0;
+
+        .name {
+          @include font-body-xs;
+        }
+
+        .value {
+          @include font-body-xs;
+          color: $medium-grey;
+          margin-top: -2px;
+        }
+      }
+    }
+  }
+
+  .footer {
+    margin-top: 40px;
+
+    .downloadDisclaimer {
+      @include font-body-xxs;
+      color: $medium-grey;
+      margin-top: 6px;
+    }
+  }
+}

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -287,12 +287,14 @@ class SamplesView extends React.Component {
   };
 
   renderBulkDownloadTrigger = () => {
+    const { selectedSampleIds } = this.props;
     const downloadIcon = <DownloadIcon className={cx(cs.icon, cs.download)} />;
     return (
       <ToolbarIcon
         className={cs.action}
         icon={downloadIcon}
         popupText="Download"
+        disabled={selectedSampleIds.size === 0}
         onClick={withAnalytics(
           this.handleBulkDownloadModalOpen,
           "SamplesView_bulk-download-modal-open_clicked"
@@ -473,7 +475,7 @@ class SamplesView extends React.Component {
   };
 
   render() {
-    const { currentDisplay, allowedFeatures } = this.props;
+    const { currentDisplay, allowedFeatures, selectedSampleIds } = this.props;
     const { phyloTreeCreationModalOpen, bulkDownloadModalOpen } = this.state;
     return (
       <div className={cs.container}>
@@ -500,6 +502,7 @@ class SamplesView extends React.Component {
               this.handleBulkDownloadModalClose,
               "SamplesView_bulk-download-modal_closed"
             )}
+            selectedSampleIds={selectedSampleIds}
           />
         )}
       </div>

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -17,8 +17,9 @@ module BulkDownloadTypesHelper
       display_name: "Combined Sample Taxon Results",
       description: "The value of a particular metric (e.g. total reads, rPM) for all taxons in all selected samples, in a single data table",
       category: "report",
-      options: [
+      fields: [
         {
+          display_name: "File Format",
           type: "file_format",
           options: [".csv", ".biom"],
         },


### PR DESCRIPTION
Rename downloadType to downloadTypeMetadata.
Rename download "options" to download "fields".

# Description

Also small changes like:
* Disable download button if no samples selected.
* Pass selected sampleIds into bulk download modal and display in review step.
* When the user re-opens the modal, everything is reset.

![Screen Shot 2019-10-09 at 2 24 40 PM](https://user-images.githubusercontent.com/837004/66521770-b42c9b80-eaa0-11e9-9dc6-9963417d0ecd.png)

![Screen Shot 2019-10-09 at 2 24 47 PM](https://user-images.githubusercontent.com/837004/66521773-b55dc880-eaa0-11e9-96de-09894b5cc42f.png)

# Tests
* Download button is only enabled if a sample is chosen.
* Correct information is displayed in review step.
* Modal is reset if modal is closed.
