### PR TITLE
Remove Wiki link from user dropdown

### DIFF
--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -171,20 +171,6 @@ const UserMenuDropDown = ({
         }
       />,
       <BareDropdown.Item
-        key="5"
-        text={
-          <ExternalLink
-            className={cs.option}
-            href="https://github.com/chanzuckerberg/idseq-dag/wiki"
-            onClick={() =>
-              logAnalyticsEvent("Header_dropdown-wiki-option_clicked")
-            }
-          >
-            IDseq Wiki
-          </ExternalLink>
-        }
-      />,
-      <BareDropdown.Item
         key="6"
         text={
           <a


### PR DESCRIPTION
# Description

* Remove the Wiki link from the user dropdown menu as discussed on https://jira.czi.team/browse/IDSEQ-1433, since it's replaced by the Help Center

![image](https://user-images.githubusercontent.com/53838890/66525993-12ab4700-eaac-11e9-85e4-8dfd27b1b23a.png)
