### PR TITLE
Revert cli link to old instructions

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlowHeader.jsx
@@ -48,7 +48,7 @@ class SampleUploadFlowHeader extends React.Component {
                 <div className={cs.subtitle}>
                   Rather use our command-line interface?
                   <ExternalLink
-                    href="https://help.idseq.net/hc/en-us/articles/360034790414-Upload-with-Command-Line"
+                    href="/cli_user_instructions"
                     className={cs.link}
                   >
                     View CLI Instructions.


### PR DESCRIPTION
# Description

Revert the CLI instructions link to the in-app page.

(The change this reverts is[ here](https://github.com/chanzuckerberg/idseq-web/pull/2630/files#diff-73c0b9d5221565dffce83c34bf440589L50))