### PR TITLE
Fix bug in processLocationSelection

### DIFF
--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -33,7 +33,7 @@ export const processLocationSelection = (result, isHuman) => {
     }
 
     warning = LOCATION_PRIVACY_WARNING;
-  } else if (!result.geo_level) {
+  } else if (!result || !result.geo_level) {
     warning = LOCATION_UNRESOLVED_WARNING;
   }
   return { result, warning };


### PR DESCRIPTION
### Description
- `console error: TypeError: Cannot read property 'geo_level' of undefined
  at exports.processLocationSelection`
- Fix a minor JS bug. Extra conditional check if result is undefined.

### Notes
- We've seen a few of these in the alert channel: https://app.datadoghq.com/logs?cols=&from_ts=1568495346737&index=main&live=true&messageDisplay=inline&query=Cannot+read+property+%27geo_level%27+of+undefined&stream_sort=desc&to_ts=1571087346737

### Tests
- Call the method with a null result (for whatever reason) and don't see the error.