### PR TITLE
IDSEQ-1624 - Fix an issue when escaping AWS_BATCH_JOB_ID environment variable

### DIFF
--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -232,7 +232,7 @@ class PipelineRunStage < ApplicationRecord
                            attribute_dict,
                            pipeline_run.parse_dag_vars)
     self.dag_json = dag.render
-    copy_done_file = "echo done | aws s3 cp - #{sample.sample_output_s3_path}/\\$AWS_BATCH_JOB_ID.#{JOB_SUCCEEDED_FILE_SUFFIX}"
+    copy_done_file = "echo done | aws s3 cp - #{Shellwords.escape(sample.sample_output_s3_path)}/\"$AWS_BATCH_JOB_ID\".#{JOB_SUCCEEDED_FILE_SUFFIX}"
     upload_dag_json_and_return_job_command(dag_json, dag_s3, dag_name, key_s3_params, copy_done_file)
   end
 


### PR DESCRIPTION
# Description

Pipeline monitor checks for early completion of aegea jobs by polling a s3 file named with the _batch id_ + the suffix `.succeed`. The batch id is retrieved through the variable `AWS_BATCH_JOB_ID`, but that environment variable was being escaped twice before being sent to aegea, creating this issue.

# Tests

* Manual tests