### PR TITLE
skip CDHITDUP if sample name contains PLEASE_SKIP_CDHITDUP

### DIFF
--- a/app/lib/dags/host_filter.json.erb
+++ b/app/lib/dags/host_filter.json.erb
@@ -123,7 +123,7 @@
       "class": "PipelineStepRunCDHitDup",
       "module": "idseq_dag.steps.run_cdhitdup",
       "additional_files": {},
-      "additional_attributes": {}
+      "additional_attributes": { "skip_cdhitdup": <%= @attribute_dict[:skip_cdhitdup] %> }
     },
     {
       "in": ["cdhitdup_out"],
@@ -156,7 +156,7 @@
       "additional_attributes": { "max_fragments": <%= @attribute_dict[:max_subsample_frag] %> }
     },
     <% if @host_genome != "human" %>
-    { 
+    {
       "in": ["subsampled_out", "validate_input_out"],
       "out": "star_human_out",
       "class": "PipelineStepRunStarDownstream",
@@ -164,7 +164,7 @@
       "additional_files": { "star_genome": "<%= @attribute_dict[:human_star_genome] %>" },
       "additional_attributes": {}
     },
-    { 
+    {
       "in": ["star_human_out"],
       "out": "bowtie2_human_out",
       "class": "PipelineStepRunBowtie2",

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -247,6 +247,7 @@ class PipelineRunStage < ApplicationRecord
       bowtie2_genome: sample.s3_bowtie2_index_path,
       max_fragments: pipeline_run.max_input_fragments,
       max_subsample_frag: pipeline_run.subsample,
+      skip_cdhitdup: sample.skip_cdhitdup,
     }
     human_host_genome = HostGenome.find_by(name: "Human")
     attribute_dict[:human_star_genome] = human_host_genome.s3_star_index_path

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -468,6 +468,10 @@ class Sample < ApplicationRecord
     !host_genome || host_genome.skip_deutero_filter == 1 ? 1 : 0
   end
 
+  def skip_cdhitdup
+    name.include? "PLEASE_SKIP_CDHITDUP" ? 1 : 0
+  end
+
   def sample_output_s3_path
     "s3://#{SAMPLES_BUCKET_NAME}/#{sample_path}/results"
   end


### PR DESCRIPTION
# Description

Allow users to request skipping CDHITDUP but adding text PLEASE_SKIP_CDHITDUP to the sample name

# Notes

This sets an attribute in the DAG json, which is then noticed by the pipeline, and has the effect of replacing cdhitdup with the identity function, copying inputs unchanged to outputs.

# Tests

Should confirm that in staging the automatically submitted benchmark sample does run with cdhitdup, and that submitting a new sample with appropriate name runs without it.