### PR TITLE
[IDSEQ-1017] Use display names in ReviewStep in the upload flow

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -59,22 +59,18 @@ class ReviewStep extends React.Component {
   };
 
   getDataHeaders = () => {
-    const { uploadType } = this.props;
+    const { uploadType, metadata } = this.props;
     const { projectMetadataFields } = this.state;
 
     // Omit sample name, which is the first header.
     let metadataHeaders = without(
       ["Sample Name", "sample_name"],
-      this.props.metadata.headers
+      metadata.headers.map(
+        // Convert to use friendly name.
+        h => projectMetadataFields[h] && projectMetadataFields[h].name
+      )
     );
-    if (projectMetadataFields) {
-      metadataHeaders = metadataHeaders.map(
-        h => (projectMetadataFields[h] ? projectMetadataFields[h].name : h)
-      );
-    }
 
-    console.log("first: ", metadataHeaders);
-    console.log("fields: ", this.state.projectMetadataFields);
     if (uploadType !== "basespace") {
       return ["Sample Name", "Input Files", "Host Genome", ...metadataHeaders];
     } else {
@@ -90,32 +86,21 @@ class ReviewStep extends React.Component {
   };
 
   getDataRows = () => {
-    const { uploadType } = this.props;
+    const { uploadType, metadata } = this.props;
     const { projectMetadataFields } = this.state;
 
-    let metadataBySample = keyBy(
-      row => row["Sample Name"] || row.sample_name,
-      this.props.metadata.rows
-    );
-    if (projectMetadataFields) {
-      console.log("rows: ", this.props.metadata.rows);
-      let newRows = this.props.metadata.rows.map(r => {
-        console.log("r: ", r);
-        let z = mapKeys(k => {
-          console.log("k: ", k);
-          return projectMetadataFields[k] ? projectMetadataFields[k].name : k;
-        }, r);
-        console.log("z: ", z);
-        return z;
-      });
-      console.log("new rows: ", newRows);
-      metadataBySample = keyBy(
-        row => row["Sample Name"] || row.sample_name,
-        newRows
+    const metadataRows = metadata.rows.map(r => {
+      return mapKeys(
+        k => projectMetadataFields[k] && projectMetadataFields[k].name,
+        r
       );
-    }
+    });
 
-    console.log("metadataBySample: ", metadataBySample);
+    const metadataBySample = keyBy(
+      row => row["Sample Name"] || row.sample_name,
+      metadataRows
+    );
+
     const hostGenomesById = keyBy("id", this.props.hostGenomes);
 
     const assembleDataForSample = sample => {

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -38,13 +38,17 @@ class ReviewStep extends React.Component {
     showUploadModal: false,
   };
 
-  async componentDidMount() {
+  componentDidMount() {
+    this.loadProjectMetadataFields();
+  }
+
+  loadProjectMetadataFields = async () => {
     const { project } = this.props;
     const projectMetadataFields = await getProjectMetadataFields(project.id);
     this.setState({
       projectMetadataFields: keyBy("key", projectMetadataFields),
     });
-  }
+  };
 
   uploadSamplesAndMetadata = () => {
     const { onUploadStatusChange } = this.props;

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -58,17 +58,18 @@ class ReviewStep extends React.Component {
     this.setState({});
   };
 
+  getFieldDisplayName = key => {
+    const { projectMetadataFields } = this.state;
+    return projectMetadataFields[key] ? projectMetadataFields[key].name : key;
+  };
+
   getDataHeaders = () => {
     const { uploadType, metadata } = this.props;
-    const { projectMetadataFields } = this.state;
 
     // Omit sample name, which is the first header.
     const metadataHeaders = without(
       ["Sample Name", "sample_name"],
-      metadata.headers.map(
-        // Convert to use friendly names.
-        h => (projectMetadataFields[h] ? projectMetadataFields[h].name : h)
-      )
+      metadata.headers.map(this.getFieldDisplayName)
     );
 
     if (uploadType !== "basespace") {
@@ -87,15 +88,10 @@ class ReviewStep extends React.Component {
 
   getDataRows = () => {
     const { uploadType, metadata } = this.props;
-    const { projectMetadataFields } = this.state;
 
-    // Convert to use friendly names.
-    const metadataRows = metadata.rows.map(r => {
-      return mapKeys(
-        k => (projectMetadataFields[k] ? projectMetadataFields[k].name : k),
-        r
-      );
-    });
+    const metadataRows = metadata.rows.map(r =>
+      mapKeys(this.getFieldDisplayName, r)
+    );
 
     const metadataBySample = keyBy(
       row => row["Sample Name"] || row.sample_name,

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -181,6 +181,23 @@ class ReviewStep extends React.Component {
     return 0;
   };
 
+  renderReviewTable = () => {
+    const { projectMetadataFields } = this.state;
+
+    if (!projectMetadataFields) {
+      return <div className={cs.loadingMsg}>Loading...</div>;
+    } else {
+      return (
+        <DataTable
+          className={cs.metadataTable}
+          columns={this.getDataHeaders()}
+          data={this.getDataRows()}
+          getColumnWidth={this.getColumnWidth}
+        />
+      );
+    }
+  };
+
   render() {
     const { showUploadModal, showLessDescription } = this.state;
 
@@ -303,12 +320,7 @@ class ReviewStep extends React.Component {
               </div>
             </div>
             <div className={cs.tableScrollWrapper}>
-              <DataTable
-                className={cs.metadataTable}
-                columns={this.getDataHeaders()}
-                data={this.getDataRows()}
-                getColumnWidth={this.getColumnWidth}
-              />
+              {this.renderReviewTable()}
             </div>
           </div>
         </div>

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -1,14 +1,14 @@
 import React from "react";
 import cx from "classnames";
 import {
-  get,
-  without,
-  map,
-  keyBy,
   flow,
-  mapValues,
+  get,
+  keyBy,
+  map,
   mapKeys,
+  mapValues,
   omit,
+  without,
 } from "lodash/fp";
 
 import { getProjectMetadataFields } from "~/api/metadata";
@@ -63,11 +63,11 @@ class ReviewStep extends React.Component {
     const { projectMetadataFields } = this.state;
 
     // Omit sample name, which is the first header.
-    let metadataHeaders = without(
+    const metadataHeaders = without(
       ["Sample Name", "sample_name"],
       metadata.headers.map(
-        // Convert to use friendly name.
-        h => projectMetadataFields[h] && projectMetadataFields[h].name
+        // Convert to use friendly names.
+        h => (projectMetadataFields[h] ? projectMetadataFields[h].name : h)
       )
     );
 
@@ -89,9 +89,10 @@ class ReviewStep extends React.Component {
     const { uploadType, metadata } = this.props;
     const { projectMetadataFields } = this.state;
 
+    // Convert to use friendly names.
     const metadataRows = metadata.rows.map(r => {
       return mapKeys(
-        k => projectMetadataFields[k] && projectMetadataFields[k].name,
+        k => (projectMetadataFields[k] ? projectMetadataFields[k].name : k),
         r
       );
     });

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import cx from "classnames";
 import { get, without, map, keyBy, flow, mapValues, omit } from "lodash/fp";
 
+import { getProjectMetadataFields } from "~/api/metadata";
 import DataTable from "~/components/visualizations/table/DataTable";
 import PropTypes from "~/components/utils/propTypes";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
@@ -23,9 +24,18 @@ const processMetadataRows = metadataRows =>
 class ReviewStep extends React.Component {
   state = {
     consentChecked: false,
-    showUploadModal: false,
+    projectMetadataFields: null,
     showLessDescription: true,
+    showUploadModal: false,
   };
+
+  async componentDidMount() {
+    const { project } = this.props;
+    const projectMetadataFields = await getProjectMetadataFields(project.id);
+    this.setState({
+      projectMetadataFields: keyBy("key", projectMetadataFields),
+    });
+  }
 
   uploadSamplesAndMetadata = () => {
     const { onUploadStatusChange } = this.props;
@@ -46,6 +56,7 @@ class ReviewStep extends React.Component {
       ["Sample Name", "sample_name"],
       this.props.metadata.headers
     );
+    console.log("first: ", metadataHeaders);
     if (uploadType !== "basespace") {
       return ["Sample Name", "Input Files", "Host Genome", ...metadataHeaders];
     } else {

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -367,6 +367,11 @@
   .tableScrollWrapper {
     overflow: auto;
     max-height: 450px;
+
+    .loadingMsg {
+      @include font-body-s;
+      margin-top: 10px;
+    }
   }
 
   .sampleName {


### PR DESCRIPTION
### Description
- JIRA: https://jira.czi.team/browse/IDSEQ-1017
- Before, the review step was not using the display names for the metadata column headers (and didn't have that info loaded in the component).

### Notes
- This adds an extra call to `getProjectMetadataFields`, which seemed cheap enough and cleaner to me than the alternative of moving that state onto the lowest common parent `SampleUploadFlow` and managing the state like project changes. This is parallel to `MetadataUpload` which also calls `getProjectMetadataFields` and can be used independently.
- The component hierarchy is: SampleUploadFlow => [UploadMetadataStep => MetadataUpload (calls getProjectMetadataFields), ReviewStep].

### Tests
- Go to /samples/upload, go through the steps, get to the review step, see display names like "Sample Type" instead of "sample_type".

#### Before:
<img width="997" alt="Screen Shot 2019-10-16 at 6 14 58 PM" src="https://user-images.githubusercontent.com/5652739/66970121-207b4200-f041-11e9-93ae-bb938a23e09c.png">

#### After:
<img width="1278" alt="Screen Shot 2019-10-16 at 6 02 17 PM" src="https://user-images.githubusercontent.com/5652739/66970129-28d37d00-f041-11e9-937c-28d02b6344d0.png">