### PR TITLE
Heatmap sort taxa

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -420,7 +420,7 @@ class PipelineSampleReport extends React.Component {
           taxon.category_name == "Uncategorized" &&
           parseInt(taxon.tax_id) == -200
         ) {
-          // the 'All taxa without genus classification' taxon
+          // the 'all taxa without genus classification' taxon
           const uncat_taxon = taxon;
           const filtered_children = [];
           i++;

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -218,6 +218,31 @@ export default class SamplesHeatmapControls extends React.Component {
     );
   }
 
+  onSortTaxaChange = order => {
+    if (order === this.props.selectedOptions.taxaSortType) {
+      return;
+    }
+
+    this.props.onSelectedOptionsChange({ taxaSortType: order });
+    logAnalyticsEvent("SamplesHeatmapControls_sort-taxa-select_changed", {
+      taxaSortType: order,
+    });
+  };
+
+  renderSortTaxaSelect() {
+    return (
+      <Dropdown
+        fluid
+        rounded
+        options={this.props.options.taxaSortTypeOptions}
+        value={this.props.selectedOptions.taxaSortType}
+        label="Sort Taxa"
+        onChange={this.onSortTaxaChange}
+        disabled={!this.props.data}
+      />
+    );
+  }
+
   onDataScaleChange = scaleIdx => {
     if (scaleIdx == this.props.selectedOptions.dataScaleIdx) {
       return;
@@ -397,6 +422,7 @@ export default class SamplesHeatmapControls extends React.Component {
           <div className="col s3">{this.renderTaxonLevelSelect()}</div>
           <div className="col s3">{this.renderCategoryFilter()}</div>
           <div className="col s2">{this.renderSortSamplesSelect()}</div>
+          <div className="col s2">{this.renderSortTaxaSelect()}</div>
           <div className="col s2">{this.renderMetricSelect()}</div>
           <div className="col s2">{this.renderBackgroundSelect()}</div>
         </div>
@@ -450,6 +476,12 @@ SamplesHeatmapControls.propTypes = {
         value: PropTypes.string,
       })
     ),
+    taxaSortTypeOptions: PropTypes.arrayOf(
+      PropTypes.shape({
+        text: PropTypes.string,
+        value: PropTypes.string,
+      })
+    ),
     sortTaxaOptions: PropTypes.arrayOf(
       PropTypes.shape({
         text: PropTypes.string,
@@ -483,6 +515,7 @@ SamplesHeatmapControls.propTypes = {
     ),
     readSpecificity: PropTypes.number,
     sampleSortType: PropTypes.string,
+    taxaSortType: PropTypes.string,
     dataScaleIdx: PropTypes.number,
     taxonsPerSample: PropTypes.number,
   }),

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -419,10 +419,10 @@ export default class SamplesHeatmapControls extends React.Component {
       <div className={cs.menu}>
         <Divider />
         <div className={`${cs.filterRow} row`}>
-          <div className="col s3">{this.renderTaxonLevelSelect()}</div>
-          <div className="col s3">{this.renderCategoryFilter()}</div>
-          <div className="col s2">{this.renderSortSamplesSelect()}</div>
+          <div className="col s2">{this.renderTaxonLevelSelect()}</div>
+          <div className="col s2">{this.renderCategoryFilter()}</div>
           <div className="col s2">{this.renderSortTaxaSelect()}</div>
+          <div className="col s2">{this.renderSortSamplesSelect()}</div>
           <div className="col s2">{this.renderMetricSelect()}</div>
           <div className="col s2">{this.renderBackgroundSelect()}</div>
         </div>

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -427,8 +427,8 @@ export default class SamplesHeatmapControls extends React.Component {
           <div className="col s2">{this.renderBackgroundSelect()}</div>
         </div>
         <div className={`${cs.filterRow} row`}>
-          <div className="col s3">{this.renderThresholdFilterSelect()}</div>
-          <div className="col s3">{this.renderSpecificityFilter()}</div>
+          <div className="col s2">{this.renderThresholdFilterSelect()}</div>
+          <div className="col s2">{this.renderSpecificityFilter()}</div>
           <div className="col s2">{this.renderScaleSelect()}</div>
           <div className="col s2">{this.renderTaxonsPerSampleSlider()}</div>
           <div className="col s2">{this.renderLegend()}</div>

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -193,14 +193,14 @@ export default class SamplesHeatmapControls extends React.Component {
     );
   }
 
-  onSortSamplesChange = order => {
-    if (order === this.props.selectedOptions.sampleSortType) {
+  onSortSamplesChange = selectedSortType => {
+    if (selectedSortType === this.props.selectedOptions.sampleSortType) {
       return;
     }
 
-    this.props.onSelectedOptionsChange({ sampleSortType: order });
+    this.props.onSelectedOptionsChange({ sampleSortType: selectedSortType });
     logAnalyticsEvent("SamplesHeatmapControls_sort-samples-select_changed", {
-      sampleSortType: order,
+      sampleSortType: selectedSortType,
     });
   };
 
@@ -218,14 +218,14 @@ export default class SamplesHeatmapControls extends React.Component {
     );
   }
 
-  onSortTaxaChange = order => {
-    if (order === this.props.selectedOptions.taxaSortType) {
+  onSortTaxaChange = selectedSortType => {
+    if (selectedSortType === this.props.selectedOptions.taxaSortType) {
       return;
     }
 
-    this.props.onSelectedOptionsChange({ taxaSortType: order });
+    this.props.onSelectedOptionsChange({ taxaSortType: selectedSortType });
     logAnalyticsEvent("SamplesHeatmapControls_sort-taxa-select_changed", {
-      taxaSortType: order,
+      taxaSortType: selectedSortType,
     });
   };
 

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -77,7 +77,7 @@ class SamplesHeatmapView extends React.Component {
         ),
         species: parseAndCheckInt(this.urlParams.species, 1),
         sampleSortType: this.urlParams.sampleSortType || "cluster",
-        taxaSortType: this.urlParams.sampleSortType || "cluster",
+        taxaSortType: this.urlParams.taxaSortType || "cluster",
         thresholdFilters: this.urlParams.thresholdFilters || [],
         dataScaleIdx: parseAndCheckInt(this.urlParams.dataScaleIdx, 0),
         taxonsPerSample: parseAndCheckInt(this.urlParams.taxonsPerSample, 30),

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -339,6 +339,7 @@ class SamplesHeatmapView extends React.Component {
               parentId:
                 taxon.tax_id === taxon.species_taxid && taxon.genus_taxid,
               phage: !!taxon.is_phage,
+              genusName: taxon.genus_name,
             };
             taxonDetails[taxon.name] = taxonDetails[taxon.tax_id];
           } else {

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -312,6 +312,8 @@ class SamplesHeatmapView extends React.Component {
     let data = {};
     let taxonFilterState = {};
 
+    console.log(rawData, "rawData");
+
     for (let i = 0; i < rawData.length; i++) {
       let sample = rawData[i];
       sampleIds.push(sample.sample_id);

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -312,8 +312,6 @@ class SamplesHeatmapView extends React.Component {
     let data = {};
     let taxonFilterState = {};
 
-    console.log(rawData, "rawData");
-
     for (let i = 0; i < rawData.length; i++) {
       let sample = rawData[i];
       sampleIds.push(sample.sample_id);

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -35,7 +35,7 @@ const SORT_SAMPLES_OPTIONS = [
   { text: "Alphabetical", value: "alpha" },
   { text: "Cluster", value: "cluster" },
 ];
-const TAXA_SAMPLES_OPTIONS = [
+const SORT_TAXA_OPTIONS = [
   { text: "Genus", value: "genus" },
   { text: "Cluster", value: "cluster" },
 ];
@@ -522,7 +522,7 @@ class SamplesHeatmapView extends React.Component {
     // Client side options
     scales: SCALE_OPTIONS,
     sampleSortTypeOptions: SORT_SAMPLES_OPTIONS,
-    taxaSortTypeOptions: TAXA_SAMPLES_OPTIONS,
+    taxaSortTypeOptions: SORT_TAXA_OPTIONS,
     taxonsPerSample: TAXONS_PER_SAMPLE_RANGE,
     specificityOptions: SPECIFICITY_OPTIONS,
   });

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -35,6 +35,10 @@ const SORT_SAMPLES_OPTIONS = [
   { text: "Alphabetical", value: "alpha" },
   { text: "Cluster", value: "cluster" },
 ];
+const TAXA_SAMPLES_OPTIONS = [
+  { text: "Genus", value: "genus" },
+  { text: "Cluster", value: "cluster" },
+];
 const TAXONS_PER_SAMPLE_RANGE = {
   min: 0,
   max: 100,
@@ -73,6 +77,7 @@ class SamplesHeatmapView extends React.Component {
         ),
         species: parseAndCheckInt(this.urlParams.species, 1),
         sampleSortType: this.urlParams.sampleSortType || "cluster",
+        taxaSortType: this.urlParams.sampleSortType || "cluster",
         thresholdFilters: this.urlParams.thresholdFilters || [],
         dataScaleIdx: parseAndCheckInt(this.urlParams.dataScaleIdx, 0),
         taxonsPerSample: parseAndCheckInt(this.urlParams.taxonsPerSample, 30),
@@ -517,12 +522,13 @@ class SamplesHeatmapView extends React.Component {
     // Client side options
     scales: SCALE_OPTIONS,
     sampleSortTypeOptions: SORT_SAMPLES_OPTIONS,
+    taxaSortTypeOptions: TAXA_SAMPLES_OPTIONS,
     taxonsPerSample: TAXONS_PER_SAMPLE_RANGE,
     specificityOptions: SPECIFICITY_OPTIONS,
   });
 
   handleSelectedOptionsChange = newOptions => {
-    const excluding = ["dataScaleIdx", "sampleSortType"];
+    const excluding = ["dataScaleIdx", "sampleSortType", "taxaSortType"];
     const shouldRefetchData = difference(keys(newOptions), excluding).length;
     this.setState(
       {
@@ -597,6 +603,7 @@ class SamplesHeatmapView extends React.Component {
           thresholdFilters={this.state.selectedOptions.thresholdFilters}
           sampleSortType={this.state.selectedOptions.sampleSortType}
           fullScreen={this.state.hideFilters}
+          taxaSortType={this.state.selectedOptions.taxaSortType}
         />
       </ErrorBoundary>
     );

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -27,7 +27,6 @@ class SamplesHeatmapVis extends React.Component {
       addMetadataTrigger: null,
       nodeHoverInfo: null,
       columnMetadataLegend: null,
-      rowLabelLegend: null,
       selectedMetadata: new Set(this.props.defaultMetadata),
       tooltipLocation: null,
       displayControlsBanner: true,
@@ -70,7 +69,6 @@ class SamplesHeatmapVis extends React.Component {
         initialColumnMetadataSortAsc: metadataSortAsc,
         onNodeHover: this.handleNodeHover,
         onMetadataNodeHover: this.handleMetadataNodeHover,
-        onRowLabelHover: this.handleRowLabelHover,
         onNodeHoverMove: this.handleMouseHoverMove,
         onNodeHoverOut: this.handleNodeHoverOut,
         onColumnMetadataSortChange: onMetadataSortChange,
@@ -211,18 +209,6 @@ class SamplesHeatmapVis extends React.Component {
       columnMetadataLegend: currentPair,
     });
     logAnalyticsEvent("SamplesHeatmapVis_metadata-node_hovered", metadata);
-  };
-
-  handleRowLabelHover = label => {
-    this.setState({
-      rowLabelLegend: label.genusName,
-    });
-    console.log(
-      "handleRowLabelHover",
-      this.state.rowLabelLegend,
-      this.state.tooltipLocation
-    );
-    logAnalyticsEvent("SamplesHeatmapVis_row-label_hovered", label);
   };
 
   handleNodeHoverOut = () => {
@@ -413,7 +399,6 @@ class SamplesHeatmapVis extends React.Component {
       tooltipLocation,
       nodeHoverInfo,
       columnMetadataLegend,
-      rowLabelLegend,
       addMetadataTrigger,
       selectedMetadata,
     } = this.state;

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -140,8 +140,14 @@ class SamplesHeatmapVis extends React.Component {
 
   extractTaxonLabels() {
     return this.props.taxonIds.map(id => {
+      const taxon = this.props.taxonDetails[id];
+      const sortKey =
+        taxon.parentId == -200 // MISSING_GENUS_ID
+          ? Number.MAX_SAFE_INTEGER
+          : taxon.parentId;
       return {
-        label: this.props.taxonDetails[id].name,
+        label: taxon.name,
+        sortKey: sortKey + "-" + taxon.name, // tie-break by name
       };
     });
   }

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -214,14 +214,12 @@ class SamplesHeatmapVis extends React.Component {
   };
 
   handleRowLabelHover = label => {
-    const nodeHoverInfo = [label.genusName, <b>{label.genusName}</b>];
-
     this.setState({
-      rowLabelLegend: nodeHoverInfo,
+      rowLabelLegend: label.genusName,
     });
     console.log(
       "handleRowLabelHover",
-      nodeHoverInfo,
+      this.state.rowLabelLegend,
       this.state.tooltipLocation
     );
     logAnalyticsEvent("SamplesHeatmapVis_row-label_hovered", label);
@@ -464,20 +462,6 @@ class SamplesHeatmapVis extends React.Component {
               metadataColors={columnMetadataLegend}
               tooltipLocation={tooltipLocation}
             />
-          )}
-        {rowLabelLegend &&
-          tooltipLocation && (
-            <div
-              className={cx(cs.tooltip, rowLabelLegend && cs.visible)}
-              style={getTooltipStyle(tooltipLocation, {
-                buffer: 20,
-                below: true,
-                // so we can show the tooltip above the cursor if need be
-                height: nodeHoverInfo.nodeHasData ? 300 : 180,
-              })}
-            >
-              <DataTooltip {...rowLabelLegend} />
-            </div>
           )}
         {addMetadataTrigger && (
           <MetadataSelector

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -142,8 +142,6 @@ class SamplesHeatmapVis extends React.Component {
   extractTaxonLabels() {
     return this.props.taxonIds.map(id => {
       const taxon = this.props.taxonDetails[id];
-      // TODO (gdingle): need to get parent genus label
-      console.log(taxon);
       const sortKey =
         taxon.parentId == -200 // MISSING_GENUS_ID
           ? Number.MAX_SAFE_INTEGER
@@ -151,6 +149,7 @@ class SamplesHeatmapVis extends React.Component {
       return {
         label: taxon.name,
         sortKey: sortKey,
+        genusName: taxon.genusName,
       };
     });
   }
@@ -213,15 +212,18 @@ class SamplesHeatmapVis extends React.Component {
     logAnalyticsEvent("SamplesHeatmapVis_metadata-node_hovered", metadata);
   };
 
-  handleRowLabelHover = (label, genusGroup) => {
-    // TODO (gdingle): need to get parent label!!!
-    console.log("handleRowLabelHover", label.label, label.sortKey, genusGroup);
+  handleRowLabelHover = label => {
+    console.log(
+      "handleRowLabelHover",
+      label.label,
+      label.sortKey,
+      label.genusName
+    );
+    // TODO (gdingle): create a hover something
     // this.setState({
     //   columnMetadataLegend: currentPair,
     // });
-    logAnalyticsEvent("SamplesHeatmapVis_row-label_hovered", {
-      // TODO (gdingle):
-    });
+    logAnalyticsEvent("SamplesHeatmapVis_row-label_hovered", label);
   };
 
   handleNodeHoverOut = () => {

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -138,6 +138,7 @@ class SamplesHeatmapVis extends React.Component {
     return this.props.taxonIds.map(id => {
       return {
         label: this.props.taxonDetails[id].name,
+        parentId: this.props.taxonDetails[id].parentId, // used for sorting
       };
     });
   }

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -147,7 +147,7 @@ class SamplesHeatmapVis extends React.Component {
           : taxon.parentId;
       return {
         label: taxon.name,
-        sortKey: sortKey + "-" + taxon.name, // tie-break by name
+        sortKey: sortKey,
       };
     });
   }

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -85,6 +85,7 @@ class SamplesHeatmapVis extends React.Component {
         scaleMin: 0,
         printCaption: this.generateHeatmapCaptions(),
         shouldSortColumns: this.props.sampleSortType === "alpha", // else cluster
+        shouldSortRows: this.props.taxaSortType === "genus", // else cluster
         // Shrink to fit the viewport width
         maxWidth: this.heatmapContainer.offsetWidth,
       }
@@ -116,6 +117,9 @@ class SamplesHeatmapVis extends React.Component {
     if (this.props.sampleSortType !== prevProps.sampleSortType) {
       this.heatmap.updateSortColumns(this.props.sampleSortType === "alpha");
     }
+    if (this.props.taxaSortType !== prevProps.taxaSortType) {
+      this.heatmap.updateSortRows(this.props.taxaSortType === "genus");
+    }
   }
 
   extractSampleLabels() {
@@ -138,6 +142,7 @@ class SamplesHeatmapVis extends React.Component {
     return this.props.taxonIds.map(id => {
       return {
         label: this.props.taxonDetails[id].name,
+        // TODO (gdingle): can we use parentLabel here?
         parentId: this.props.taxonDetails[id].parentId, // used for sorting
       };
     });
@@ -494,6 +499,7 @@ SamplesHeatmapVis.propTypes = {
   thresholdFilters: PropTypes.any,
   sampleSortType: PropTypes.string,
   fullScreen: PropTypes.bool,
+  taxaSortType: PropTypes.string,
 };
 
 export default SamplesHeatmapVis;

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -69,6 +69,7 @@ class SamplesHeatmapVis extends React.Component {
         initialColumnMetadataSortAsc: metadataSortAsc,
         onNodeHover: this.handleNodeHover,
         onMetadataNodeHover: this.handleMetadataNodeHover,
+        onRowLabelHover: this.handleRowLabelHover,
         onNodeHoverMove: this.handleMouseHoverMove,
         onNodeHoverOut: this.handleNodeHoverOut,
         onColumnMetadataSortChange: onMetadataSortChange,
@@ -141,10 +142,12 @@ class SamplesHeatmapVis extends React.Component {
   extractTaxonLabels() {
     return this.props.taxonIds.map(id => {
       const taxon = this.props.taxonDetails[id];
+      // TODO (gdingle): need to get parent genus label
+      console.log(taxon);
       const sortKey =
         taxon.parentId == -200 // MISSING_GENUS_ID
           ? Number.MAX_SAFE_INTEGER
-          : taxon.parentId;
+          : taxon.parentId; // parentId is false when taxon level is genus
       return {
         label: taxon.name,
         sortKey: sortKey,
@@ -208,6 +211,17 @@ class SamplesHeatmapVis extends React.Component {
       columnMetadataLegend: currentPair,
     });
     logAnalyticsEvent("SamplesHeatmapVis_metadata-node_hovered", metadata);
+  };
+
+  handleRowLabelHover = (label, genusGroup) => {
+    // TODO (gdingle): need to get parent label!!!
+    console.log("handleRowLabelHover", label.label, label.sortKey, genusGroup);
+    // this.setState({
+    //   columnMetadataLegend: currentPair,
+    // });
+    logAnalyticsEvent("SamplesHeatmapVis_row-label_hovered", {
+      // TODO (gdingle):
+    });
   };
 
   handleNodeHoverOut = () => {

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -140,11 +140,8 @@ class SamplesHeatmapVis extends React.Component {
 
   extractTaxonLabels() {
     return this.props.taxonIds.map(id => {
-      const name = this.props.taxonDetails[id].name;
       return {
-        // Moves missing to the top in "genus" sort.
-        // See MISSING_GENUS_ID in TaxonLineage.
-        label: id === -200 ? "* " + name : name,
+        label: this.props.taxonDetails[id].name,
       };
     });
   }

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -27,6 +27,7 @@ class SamplesHeatmapVis extends React.Component {
       addMetadataTrigger: null,
       nodeHoverInfo: null,
       columnMetadataLegend: null,
+      rowLabelLegend: null,
       selectedMetadata: new Set(this.props.defaultMetadata),
       tooltipLocation: null,
       displayControlsBanner: true,
@@ -213,16 +214,16 @@ class SamplesHeatmapVis extends React.Component {
   };
 
   handleRowLabelHover = label => {
+    const nodeHoverInfo = [label.genusName, <b>{label.genusName}</b>];
+
+    this.setState({
+      rowLabelLegend: nodeHoverInfo,
+    });
     console.log(
       "handleRowLabelHover",
-      label.label,
-      label.sortKey,
-      label.genusName
+      nodeHoverInfo,
+      this.state.tooltipLocation
     );
-    // TODO (gdingle): create a hover something
-    // this.setState({
-    //   columnMetadataLegend: currentPair,
-    // });
     logAnalyticsEvent("SamplesHeatmapVis_row-label_hovered", label);
   };
 
@@ -414,6 +415,7 @@ class SamplesHeatmapVis extends React.Component {
       tooltipLocation,
       nodeHoverInfo,
       columnMetadataLegend,
+      rowLabelLegend,
       addMetadataTrigger,
       selectedMetadata,
     } = this.state;
@@ -462,6 +464,20 @@ class SamplesHeatmapVis extends React.Component {
               metadataColors={columnMetadataLegend}
               tooltipLocation={tooltipLocation}
             />
+          )}
+        {rowLabelLegend &&
+          tooltipLocation && (
+            <div
+              className={cx(cs.tooltip, rowLabelLegend && cs.visible)}
+              style={getTooltipStyle(tooltipLocation, {
+                buffer: 20,
+                below: true,
+                // so we can show the tooltip above the cursor if need be
+                height: nodeHoverInfo.nodeHasData ? 300 : 180,
+              })}
+            >
+              <DataTooltip {...rowLabelLegend} />
+            </div>
           )}
         {addMetadataTrigger && (
           <MetadataSelector

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -140,10 +140,11 @@ class SamplesHeatmapVis extends React.Component {
 
   extractTaxonLabels() {
     return this.props.taxonIds.map(id => {
+      const name = this.props.taxonDetails[id].name;
       return {
-        label: this.props.taxonDetails[id].name,
-        // TODO (gdingle): can we use parentLabel here?
-        parentId: this.props.taxonDetails[id].parentId, // used for sorting
+        // Moves missing to the top in "genus" sort.
+        // See MISSING_GENUS_ID in TaxonLineage.
+        label: id === -200 ? "* " + name : name,
       };
     });
   }

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -839,6 +839,23 @@ export default class Heatmap {
     this.processData("filter");
   };
 
+  handleRowLabelMouseOver = rowEntered => {
+    if (this.rowClustering) return;
+    this.gRowLabels
+      .selectAll(`.${cs.rowLabel}`)
+      .classed(
+        cs.rowLabelHover,
+        row => row.sortKey && row.sortKey === rowEntered.sortKey
+      );
+  };
+
+  handleRowLabelMouseOut = d => {
+    if (this.rowClustering) return;
+    this.gRowLabels
+      .selectAll(`.${cs.rowLabel}`)
+      .classed(cs.rowLabelHover, false);
+  };
+
   handleColumnMetadataLabelClick(value) {
     const { onColumnMetadataSortChange } = this.options;
     if (this.columnMetadataSortField === value) {
@@ -1007,8 +1024,8 @@ export default class Heatmap {
       .enter()
       .append("g")
       .attr("class", cs.rowLabel)
-      .on("mousein", this.options.onRowLabelMouseIn)
-      .on("mouseout", this.options.onRowLabelMouseOut);
+      .on("mouseover", this.handleRowLabelMouseOver)
+      .on("mouseout", this.handleRowLabelMouseOut);
 
     rowLabelEnter
       .append("rect")
@@ -1032,19 +1049,7 @@ export default class Heatmap {
         d =>
           this.options.onRowLabelClick &&
           this.options.onRowLabelClick(d.label, d3.event)
-      )
-      .on("mouseover", d => {
-        this.options.onRowLabelHover && this.options.onRowLabelHover(d);
-      });
-    // TODO (gdingle):
-    // .on("mouseleave", d => {
-    //   this.options.onColumnMetadataLabelOut &&
-    //     this.options.onColumnMetadataLabelOut(d);
-    // })
-    // .on("mousemove", d => {
-    //   this.options.onColumnMetadataLabelMove &&
-    //     this.options.onColumnMetadataLabelMove(d, d3.event);
-    // });
+      );
 
     rowLabelEnter
       .append("line")
@@ -1067,7 +1072,7 @@ export default class Heatmap {
       .append("text")
       .attr("class", cs.removeIcon)
       .text("X")
-      .attr("transform", `translate(0, ${this.cell.height / 2})`)
+      .attr("transform", `translate(2, ${this.cell.height / 2})`)
       .style("dominant-baseline", "central")
       .on("click", this.removeRow);
 

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -587,7 +587,10 @@ export default class Heatmap {
   }
 
   cluster() {
-    if (this.options.clustering) {
+    // TODO (gdingle): replace shouldSortColumns by shouldSortRows
+    if (this.options.shouldSortColumns) {
+      this.sortRows("asc");
+    } else if (this.options.clustering) {
       this.clusterRows();
     }
 
@@ -607,8 +610,9 @@ export default class Heatmap {
     this.renderColumnMetadata();
 
     if (this.options.clustering) {
-      this.renderRowDendrogram();
-      this.renderColumnDendrogram();
+      // TODO (gdingle): replace with shouldSortRows
+      this.options.shouldSortColumns || this.renderRowDendrogram();
+      this.options.shouldSortColumns || this.renderColumnDendrogram();
     }
 
     this.options.onUpdateFinished && this.options.onUpdateFinished();
@@ -753,6 +757,17 @@ export default class Heatmap {
         label.pos = idx;
       }
     );
+  }
+
+  sortRows(direction) {
+    this.rowClustering = null;
+    orderBy(
+      this.rowLabels,
+      label => label.category + "-" + label.parentId + "-" + label.label, // kingdom then genus then species
+      direction
+    ).forEach((label, idx) => {
+      label.pos = idx;
+    });
   }
 
   range(n) {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -53,7 +53,8 @@ export default class Heatmap {
         zoom: null, // multiplier for zooming in and out
         minHeight: 500,
         clustering: true,
-        shouldSortColumns: true,
+        shouldSortColumns: false,
+        shouldSortRows: false,
         defaultClusterStep: 6,
         maxRowClusterWidth: 100,
         maxColumnClusterHeight: 100,
@@ -156,6 +157,11 @@ export default class Heatmap {
 
   updateSortColumns(shouldSortColumns) {
     this.options.shouldSortColumns = shouldSortColumns;
+    this.processData("cluster");
+  }
+
+  updateSortRows(shouldSortRows) {
+    this.options.shouldSortRows = shouldSortRows;
     this.processData("cluster");
   }
 
@@ -587,8 +593,7 @@ export default class Heatmap {
   }
 
   cluster() {
-    // TODO (gdingle): replace shouldSortColumns by shouldSortRows
-    if (this.options.shouldSortColumns) {
+    if (this.options.shouldSortRows) {
       this.sortRows("asc");
     } else if (this.options.clustering) {
       this.clusterRows();
@@ -610,8 +615,7 @@ export default class Heatmap {
     this.renderColumnMetadata();
 
     if (this.options.clustering) {
-      // TODO (gdingle): replace with shouldSortRows
-      this.options.shouldSortColumns || this.renderRowDendrogram();
+      this.options.shouldSortRows || this.renderRowDendrogram();
       this.options.shouldSortColumns || this.renderColumnDendrogram();
     }
 
@@ -759,10 +763,12 @@ export default class Heatmap {
     );
   }
 
+  // This is hardcoded to sort by lineage
   sortRows(direction) {
     this.rowClustering = null;
     orderBy(
       this.rowLabels,
+      // TODO (gdingle): what about unknown genus?
       label => label.category + "-" + label.parentId + "-" + label.label, // kingdom then genus then species
       direction
     ).forEach((label, idx) => {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -1032,7 +1032,19 @@ export default class Heatmap {
         d =>
           this.options.onRowLabelClick &&
           this.options.onRowLabelClick(d.label, d3.event)
-      );
+      )
+      .on("mouseover", d => {
+        this.options.onRowLabelHover && this.options.onRowLabelHover(d);
+      });
+    // TODO (gdingle):
+    // .on("mouseleave", d => {
+    //   this.options.onColumnMetadataLabelOut &&
+    //     this.options.onColumnMetadataLabelOut(d);
+    // })
+    // .on("mousemove", d => {
+    //   this.options.onColumnMetadataLabelMove &&
+    //     this.options.onColumnMetadataLabelMove(d, d3.event);
+    // });
 
     rowLabelEnter
       .append("line")

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -765,11 +765,20 @@ export default class Heatmap {
 
   sortRows(direction) {
     this.rowClustering = null;
-    orderBy(this.rowLabels, label => label.label, direction).forEach(
-      (label, idx) => {
-        label.pos = idx;
-      }
+
+    this.rowLabels = orderBy(this.rowLabels, label => label.label, direction);
+    this.rowLabels.forEach((label, idx) => {
+      label.pos = idx;
+    });
+
+    this.filteredRowLabels = orderBy(
+      this.filteredRowLabels,
+      label => label.label,
+      direction
     );
+    this.filteredRowLabels.forEach((label, idx) => {
+      label.pos = idx;
+    });
   }
 
   range(n) {
@@ -964,7 +973,8 @@ export default class Heatmap {
 
     let rowLabel = this.gRowLabels
       .selectAll(`.${cs.rowLabel}`)
-      .data(this.filteredRowLabels, d => d.label);
+      .data(this.filteredRowLabels, d => d.label)
+      .order();
 
     rowLabel
       .exit()
@@ -983,6 +993,17 @@ export default class Heatmap {
       .enter()
       .append("g")
       .attr("class", cs.rowLabel)
+      .classed("genusBorder", (label, i, nodes) => {
+        const nextLabel = this.filteredRowLabels[i + 1];
+        // TODO (gdingle): remove
+        console.log(label.label, nextLabel, i);
+        if (nextLabel) {
+          // TODO (gdingle): update to use taxid
+          return label.label.split(" ")[0] !== nextLabel.label.split(" ")[0];
+        } else {
+          return false;
+        }
+      })
       .on("mousein", this.options.onRowLabelMouseIn)
       .on("mouseout", this.options.onRowLabelMouseOut);
 

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -763,17 +763,13 @@ export default class Heatmap {
     );
   }
 
-  // This is hardcoded to sort by lineage
   sortRows(direction) {
     this.rowClustering = null;
-    orderBy(
-      this.rowLabels,
-      // TODO (gdingle): what about unknown genus?
-      label => label.category + "-" + label.parentId + "-" + label.label, // kingdom then genus then species
-      direction
-    ).forEach((label, idx) => {
-      label.pos = idx;
-    });
+    orderBy(this.rowLabels, label => label.label, direction).forEach(
+      (label, idx) => {
+        label.pos = idx;
+      }
+    );
   }
 
   range(n) {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -773,14 +773,19 @@ export default class Heatmap {
     // TODO (gdingle): sort unclassifieds to the bottom always
     this.rowClustering = null;
     this.gRowDendogram.classed(cs.shouldSortRows, true);
-    this.rowLabels = orderBy(this.rowLabels, label => label.label, direction);
+    this.rowLabels = orderBy(
+      this.rowLabels,
+      label => label.sortKey || label.label,
+      direction
+    );
     this.rowLabels.forEach((label, idx) => {
       label.pos = idx;
     });
 
+    // Need to sort this array as well. It is created from rowLabels earlier.
     this.filteredRowLabels = orderBy(
       this.filteredRowLabels,
-      label => label.label,
+      label => label.sortKey || label.label,
       direction
     );
     this.filteredRowLabels.forEach((label, idx) => {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -1040,10 +1040,10 @@ export default class Heatmap {
       .classed(cs.hideGenusBorder, (label, i, nodes) => {
         const nextLabel = this.filteredRowLabels[i + 1];
         if (nextLabel) {
-          // TODO (gdingle): update to use taxid
           return label.label.split(" ")[0] === nextLabel.label.split(" ")[0];
         } else {
-          return false;
+          // hide line at very bottom
+          return true;
         }
       });
 

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -993,17 +993,6 @@ export default class Heatmap {
       .enter()
       .append("g")
       .attr("class", cs.rowLabel)
-      .classed("genusBorder", (label, i, nodes) => {
-        const nextLabel = this.filteredRowLabels[i + 1];
-        // TODO (gdingle): remove
-        console.log(label.label, nextLabel, i);
-        if (nextLabel) {
-          // TODO (gdingle): update to use taxid
-          return label.label.split(" ")[0] !== nextLabel.label.split(" ")[0];
-        } else {
-          return false;
-        }
-      })
       .on("mousein", this.options.onRowLabelMouseIn)
       .on("mouseout", this.options.onRowLabelMouseOut);
 
@@ -1030,6 +1019,27 @@ export default class Heatmap {
           this.options.onRowLabelClick &&
           this.options.onRowLabelClick(d.label, d3.event)
       );
+
+    rowLabelEnter
+      .append("line")
+      .attr("x1", 0)
+      .attr("x2", this.rowLabelsWidth)
+      .attr("y1", this.cell.height)
+      .attr("y2", this.cell.height)
+      // TODO (gdingle): adjust me
+      .style("stroke", "black")
+      .style("stroke-width", 1)
+      .classed(cs.hideGenusBorder, (label, i, nodes) => {
+        const nextLabel = this.filteredRowLabels[i + 1];
+        // TODO (gdingle): remove
+        console.log(label.label, nextLabel, i);
+        if (nextLabel) {
+          // TODO (gdingle): update to use taxid
+          return label.label.split(" ")[0] === nextLabel.label.split(" ")[0];
+        } else {
+          return false;
+        }
+      });
 
     rowLabelEnter
       .append("text")

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -770,7 +770,6 @@ export default class Heatmap {
   }
 
   sortRows(direction) {
-    // TODO (gdingle): sort unclassifieds to the bottom always
     this.rowClustering = null;
     this.gRowDendogram.classed(cs.shouldSortRows, true);
     this.rowLabels = orderBy(
@@ -1045,7 +1044,7 @@ export default class Heatmap {
       .classed(cs.hideGenusBorder, (label, i, nodes) => {
         const nextLabel = this.filteredRowLabels[i + 1];
         if (nextLabel) {
-          return label.label.split(" ")[0] === nextLabel.label.split(" ")[0];
+          return label.sortKey === nextLabel.sortKey;
         } else {
           // hide line at very bottom
           return true;

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -1435,9 +1435,6 @@ export default class Heatmap {
         "transform",
         `rotate(-90) translate(-${height + this.options.spacing},0)`
       );
-      this.gColumnDendogram.classed(cs.hidden, false);
-    } else {
-      this.gColumnDendogram.classed(cs.hidden, true);
     }
   }
 
@@ -1459,9 +1456,6 @@ export default class Heatmap {
         "transform",
         `scale(-1,1) translate(-${this.rowClusterWidth},0)`
       );
-      this.gRowDendogram.classed(cs.hidden, false);
-    } else {
-      this.gRowDendogram.classed(cs.hidden, true);
     }
   }
 

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -287,7 +287,7 @@ export default class Heatmap {
     this.gCells = this.g.append("g").attr("class", cs.cells);
     this.gRowDendogram = this.g
       .append("g")
-      .attr("class", cx(cs.dendogram, "rowDendogram"));
+      .attr("class", cx(cs.dendogram, cs.rowDendogram));
     this.gColumnDendogram = this.g
       .append("g")
       .attr("class", cx(cs.dendogram, "columnDendogram"));
@@ -305,6 +305,7 @@ export default class Heatmap {
       .append("rect")
       .attr("class", "metadataLabelsBackground")
       .style("fill", "white");
+
     this.gColumnMetadata = this.g.append("g").attr("class", cs.columnMetadata);
     this.gCaption = this.g.append("g").attr("class", cs.captionContainer);
   }
@@ -740,6 +741,8 @@ export default class Heatmap {
   }
 
   clusterRows() {
+    this.gRowDendogram.classed(cs.shouldSortRows, false);
+
     let rows = this.getRows();
     this.rowClustering = Cluster.hcluster(rows);
 
@@ -748,6 +751,8 @@ export default class Heatmap {
   }
 
   clusterColumns() {
+    this.gColumnDendogram.classed(cs.shouldSortColumns, false);
+
     let columns = this.getColumns();
     this.columnClustering = Cluster.hcluster(columns);
     this.sortTree(this.columnClustering);
@@ -756,6 +761,7 @@ export default class Heatmap {
 
   sortColumns(direction) {
     this.columnClustering = null;
+    this.gColumnDendogram.classed(cs.shouldSortColumns, true);
     orderBy(this.columnLabels, label => label.label, direction).forEach(
       (label, idx) => {
         label.pos = idx;
@@ -766,7 +772,7 @@ export default class Heatmap {
   sortRows(direction) {
     // TODO (gdingle): sort unclassifieds to the bottom always
     this.rowClustering = null;
-
+    this.gRowDendogram.classed(cs.shouldSortRows, true);
     this.rowLabels = orderBy(this.rowLabels, label => label.label, direction);
     this.rowLabels.forEach((label, idx) => {
       label.pos = idx;

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -764,6 +764,7 @@ export default class Heatmap {
   }
 
   sortRows(direction) {
+    // TODO (gdingle): sort unclassifieds to the bottom always
     this.rowClustering = null;
 
     this.rowLabels = orderBy(this.rowLabels, label => label.label, direction);
@@ -971,6 +972,9 @@ export default class Heatmap {
       nodes.attr("transform", d => `translate(0, ${d.pos * this.cell.height})`);
     };
 
+    // hides genus separators in cluster mode
+    this.gRowLabels.classed(cs.rowClustering, this.rowClustering);
+
     let rowLabel = this.gRowLabels
       .selectAll(`.${cs.rowLabel}`)
       .data(this.filteredRowLabels, d => d.label)
@@ -1030,9 +1034,12 @@ export default class Heatmap {
       .style("stroke", "black")
       .style("stroke-width", 1)
       .classed(cs.hideGenusBorder, (label, i, nodes) => {
+        console.log(this.rowClustering, this.options.shouldSortRows);
+        if (this.rowClustering) {
+          return true;
+        }
+        // TODO (gdingle):  always hide if heatmap in genus mode?
         const nextLabel = this.filteredRowLabels[i + 1];
-        // TODO (gdingle): remove
-        console.log(label.label, nextLabel, i);
         if (nextLabel) {
           // TODO (gdingle): update to use taxid
           return label.label.split(" ")[0] === nextLabel.label.split(" ")[0];

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -850,7 +850,7 @@ export default class Heatmap {
       );
   };
 
-  handleRowLabelMouseOut = d => {
+  handleRowLabelMouseOut = () => {
     if (this.rowClustering) return;
     this.gRowLabels
       .selectAll(`.${cs.rowLabel}`)
@@ -935,9 +935,7 @@ export default class Heatmap {
 
     let cells = this.gCells
       .selectAll(`.${cs.cell}`)
-      .data(this.filteredCells, d => d.id)
-      // TODO (gdingle): need to reorder cells correctly
-      .order();
+      .data(this.filteredCells, d => d.id);
 
     cells
       .exit()

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -263,7 +263,12 @@ export default class Heatmap {
     this.filteredCells = this.cells.filter(
       cell => !this.rowLabels[cell.rowIndex].hidden
     );
-    this.filteredRowLabels = this.rowLabels.filter(row => !row.hidden);
+
+    // Initially sort so that genus seperators are placed correctly
+    this.filteredRowLabels = orderBy(
+      this.rowLabels.filter(row => !row.hidden),
+      label => label.sortKey || label.label
+    );
   }
 
   setupContainers() {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -769,20 +769,21 @@ export default class Heatmap {
     );
   }
 
+  // Re-sorts the rows. The rendered order of rows is determined solely by
+  // the `pos` property of each rowLabel and filteredRowLabel.
   sortRows(direction) {
     this.rowClustering = null;
     this.gRowDendogram.classed(cs.shouldSortRows, true);
-    this.rowLabels = orderBy(
+    orderBy(
       this.rowLabels,
       label => label.sortKey || label.label,
       direction
-    );
-    this.rowLabels.forEach((label, idx) => {
+    ).forEach((label, idx) => {
       label.pos = idx;
     });
 
     // Need to sort this array as well. It is created from rowLabels earlier.
-    this.filteredRowLabels = orderBy(
+    orderBy(
       this.filteredRowLabels,
       label => label.sortKey || label.label,
       direction
@@ -934,7 +935,9 @@ export default class Heatmap {
 
     let cells = this.gCells
       .selectAll(`.${cs.cell}`)
-      .data(this.filteredCells, d => d.id);
+      .data(this.filteredCells, d => d.id)
+      // TODO (gdingle): need to reorder cells correctly
+      .order();
 
     cells
       .exit()

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -1030,15 +1030,8 @@ export default class Heatmap {
       .attr("x2", this.rowLabelsWidth)
       .attr("y1", this.cell.height)
       .attr("y2", this.cell.height)
-      // TODO (gdingle): adjust me
-      .style("stroke", "black")
-      .style("stroke-width", 1)
+      .attr("class", cs.genusBorder)
       .classed(cs.hideGenusBorder, (label, i, nodes) => {
-        console.log(this.rowClustering, this.options.shouldSortRows);
-        if (this.rowClustering) {
-          return true;
-        }
-        // TODO (gdingle):  always hide if heatmap in genus mode?
         const nextLabel = this.filteredRowLabels[i + 1];
         if (nextLabel) {
           // TODO (gdingle): update to use taxid

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -55,6 +55,11 @@
     }
   }
 
+  // hides genus separators in cluster mode
+  .rowLabels.rowClustering line {
+    display: none;
+  }
+
   .hoverTarget {
     fill: transparent;
   }

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -50,13 +50,19 @@
       }
     }
 
+    .genusBorder {
+      color: $light-grey;
+      stroke: black;
+      stroke-width: 1;
+    }
+
     .hideGenusBorder {
       display: none;
     }
   }
 
   // hides genus separators in cluster mode
-  .rowLabels.rowClustering line {
+  .rowLabels.rowClustering .genusBorder {
     display: none;
   }
 

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -29,7 +29,6 @@
     .rowLabel,
     .columnLabel {
       font-size: 12px;
-      cursor: pointer;
 
       .removeIcon {
         visibility: hidden;
@@ -42,10 +41,12 @@
       &:hover {
         text {
           fill: $primary-light;
+          cursor: pointer;
         }
 
         .removeIcon {
           visibility: visible;
+          cursor: pointer;
         }
       }
     }
@@ -57,6 +58,10 @@
 
     .hideGenusBorder {
       display: none;
+    }
+
+    .rowLabelHover rect {
+      fill: $lightest-grey;
     }
   }
 

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -90,11 +90,11 @@
     }
   }
 
-  .rowDendogram.shouldSortRows {
+  .rowDendogram.hidden {
     display: none;
   }
 
-  .columnDendogram.shouldSortColumns {
+  .columnDendogram.hidden {
     display: none;
   }
 

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -90,14 +90,6 @@
     }
   }
 
-  .rowDendogram.hidden {
-    display: none;
-  }
-
-  .columnDendogram.hidden {
-    display: none;
-  }
-
   .columnMetadata {
     pointer-events: bounding-box;
 

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -49,6 +49,10 @@
         }
       }
     }
+
+    .hideGenusBorder {
+      display: none;
+    }
   }
 
   .hoverTarget {

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -51,8 +51,7 @@
     }
 
     .genusBorder {
-      color: $light-grey;
-      stroke: black;
+      stroke: $light-grey;
       stroke-width: 1;
     }
 

--- a/app/assets/src/components/visualizations/heatmap/heatmap.scss
+++ b/app/assets/src/components/visualizations/heatmap/heatmap.scss
@@ -86,6 +86,14 @@
     }
   }
 
+  .rowDendogram.shouldSortRows {
+    display: none;
+  }
+
+  .columnDendogram.shouldSortColumns {
+    display: none;
+  }
+
   .columnMetadata {
     pointer-events: bounding-box;
 

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -352,6 +352,11 @@ module HeatmapHelper
           (0.0 - taxon_counts.e_value),
           #{ReportHelper::DEFAULT_SAMPLE_NEGLOGEVALUE}
         )                                AS  neglogevalue
+
+        # TODO: (gdingle): need to get genus name here... from taxon_lineages?
+        genus_taxid
+
+
       FROM taxon_counts
       LEFT OUTER JOIN taxon_summaries ON
         #{background_id.to_i}   = taxon_summaries.background_id   AND

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -340,6 +340,7 @@ module HeatmapHelper
         taxon_counts.genus_taxid         AS  genus_taxid,
         taxon_counts.family_taxid        AS  family_taxid,
         taxon_counts.name                AS  name,
+        taxon_lineages.genus_name        AS  genus_name,
         taxon_counts.superkingdom_taxid  AS  superkingdom_taxid,
         taxon_counts.is_phage            AS  is_phage,
         taxon_counts.count               AS  r,
@@ -352,12 +353,8 @@ module HeatmapHelper
           (0.0 - taxon_counts.e_value),
           #{ReportHelper::DEFAULT_SAMPLE_NEGLOGEVALUE}
         )                                AS  neglogevalue
-
-        # TODO: (gdingle): need to get genus name here... from taxon_lineages?
-        genus_taxid
-
-
       FROM taxon_counts
+      JOIN taxon_lineages ON taxon_counts.tax_id = taxon_lineages.taxid
       LEFT OUTER JOIN taxon_summaries ON
         #{background_id.to_i}   = taxon_summaries.background_id   AND
         taxon_counts.count_type = taxon_summaries.count_type      AND

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -506,7 +506,8 @@ module ReportHelper
 
   def self.validate_names!(tax_2d)
     # This converts superkingdom_id to category_name and makes up
-    # suitable names for missing and blacklisted genera and species.
+    # suitable names for missing and blacklisted genera and species. Such
+    # made-up names should be lowercase so they are sorted below proper names.
     category = {}
     ALL_CATEGORIES.each do |c|
       category[c['taxid']] = c['name']
@@ -519,7 +520,8 @@ module ReportHelper
       if tax_id < 0
         # Usually -1 means accession number did not resolve to species.
         # TODO: Can we keep the accession numbers to show in these cases?
-        tax_info['name'] = "All taxa with neither family nor genus classification"
+        # NOTE: important to be lowercase for sorting below uppercase valid genuses
+        tax_info['name'] = "all taxa with neither family nor genus classification"
 
         if tax_id < TaxonLineage::INVALID_CALL_BASE_ID && species_or_genus(tax_info['tax_level'])
           parent_id = convert_neg_taxid(tax_id)
@@ -531,15 +533,15 @@ module ReportHelper
             parent_name = "taxon #{parent_id}"
             parent_level = ""
           end
-          tax_info['name'] = "Non-#{level_str}-specific reads in #{parent_level} #{parent_name}"
+          tax_info['name'] = "non-#{level_str}-specific reads in #{parent_level} #{parent_name}"
         elsif tax_id == TaxonLineage::BLACKLIST_GENUS_ID
-          tax_info['name'] = "All artificial constructs"
+          tax_info['name'] = "all artificial constructs"
         elsif !(TaxonLineage::MISSING_LINEAGE_ID.values.include? tax_id) && tax_id != TaxonLineage::MISSING_SPECIES_ID_ALT
           tax_info['name'] += " #{tax_id}"
         end
       elsif !tax_info['name']
         missing_names.add(tax_id)
-        tax_info['name'] = "Unnamed #{level_str} taxon #{tax_id}"
+        tax_info['name'] = "unnamed #{level_str} taxon #{tax_id}"
       end
       category_id = tax_info.delete('superkingdom_taxid')
       tax_info['category_name'] = category[category_id] || 'Uncategorized'

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -36,7 +36,7 @@ module ReportHelper
   METRICS = %w[r rpm zscore percentidentity alignmentlength neglogevalue aggregatescore maxzscore r_pct rpm_bg].freeze
   COUNT_TYPES = %w[NT NR].freeze
   # Note: no underscore in sortable column names. Add to here to protect from data cleaning.
-  PROPERTIES_OF_TAXID = %w[tax_id name common_name tax_level species_taxid genus_taxid family_taxid superkingdom_taxid category_name is_phage].freeze
+  PROPERTIES_OF_TAXID = %w[tax_id name common_name tax_level species_taxid genus_taxid genus_name family_taxid superkingdom_taxid category_name is_phage].freeze
   UNUSED_IN_UI_FIELDS = ['superkingdom_taxid', :sort_key].freeze
 
   # This query takes 1.4 seconds and the results are static, so we hardcoded it

--- a/lib/tasks/export_users_auth0.rake
+++ b/lib/tasks/export_users_auth0.rake
@@ -73,7 +73,7 @@ class ExportUsersAuth0
   private def export_user(user)
     email = user.email
     legacy_user_record = format_legacy_user_record(user)
-    puts ">>> Exporting user #{email} <<<"
+    puts ">> Exporting user #{email} <<"
     result = auth0_api_create_user(legacy_user_record)
 
     if result['error'] && result['response'].fetch_values('statusCode', 'error') == [409, 'Conflict']


### PR DESCRIPTION
# Description

Users have asked for the ability to sort the rows in the heatmap instead of clustering them. This add that ability alongside the new "sort samples" control.

![image](https://user-images.githubusercontent.com/28797/67057632-2e46cb00-f106-11e9-8095-15de912f7dc7.png)

The rows of the same genus are highlighted on hover.

![image](https://user-images.githubusercontent.com/28797/67343265-9a9c4280-f4e9-11e9-923a-e223a3601237.png)

# Notes

* See also https://github.com/chanzuckerberg/idseq-web/pull/2553
* And https://github.com/chanzuckerberg/idseq-web/pull/2676
* I also fixed a small CSS bug where pointer was showing for a non-clickable area

# Tests

Open a variety of heatmaps
See that the default taxa sort is "cluster"
Click on "sort taxa: genus"
See that rows are alphabetical
Try "genus" taxon level, see sorting
See that "All taxa with neither..." is at the bottom

Hover over row, See highlight
Hover off, See highlight disappear
Change to genus level, see no highlights on hover 