### PR TITLE
Filter by tax level in heatmap SQL

### DIFF
--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -67,7 +67,8 @@ module HeatmapHelper
       num_results,
       min_reads,
       sort_by,
-      threshold_filters
+      threshold_filters,
+      species_selected
     )
 
     details = top_taxons_details(
@@ -161,7 +162,8 @@ module HeatmapHelper
     num_results = 1_000_000,
     min_reads = MINIMUM_READ_THRESHOLD,
     sort_by = DEFAULT_TAXON_SORT_PARAM,
-    threshold_filters = []
+    threshold_filters = [],
+    species_selected = true
   )
     categories_map = ReportHelper::CATEGORIES_TAXID_BY_NAME
     categories_clause = ""
@@ -181,6 +183,8 @@ module HeatmapHelper
     elsif include_phage && categories.blank?
       phage_clause = " AND is_phage = 1"
     end
+
+    tax_level = species_selected ? TaxonCount::TAX_LEVEL_SPECIES : TaxonCount::TAX_LEVEL_GENUS
 
     # fraction_subsampled was introduced 2018-03-30. For prior runs, we assume
     # fraction_subsampled = 1.0.
@@ -228,6 +232,7 @@ module HeatmapHelper
       AND count >= #{min_reads}
       -- We need both types of counts for threshold filters
       AND taxon_counts.count_type IN ('NT', 'NR')
+      AND taxon_counts.tax_level = #{tax_level}
       #{categories_clause}
       #{read_specificity_clause}
       #{phage_clause}"


### PR DESCRIPTION
# Description

This is a small optimization that came out of https://github.com/chanzuckerberg/idseq-web/pull/2676 . Only one tax level is shown per heatmap so we should filter early in SQL. 

# Tests

`rails t`

check test heatmap looks same before and after