### PR TITLE
Revert monitor parallelism change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,6 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "parallel", "~> 1.14"
 # HTTP library with a simpler, better designed API than the native Net::HTTP
 gem 'http'
 gem "omniauth-auth0", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1204,7 +1204,6 @@ DEPENDENCIES
   nokogiri
   omniauth-auth0 (~> 2.2)
   omniauth-rails_csrf_protection (~> 0.1.2)
-  parallel (~> 1.14)
   prometheus-client (= 0.7.1)
   puma (~> 3.7)
   rack-host-redirect

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -1,5 +1,6 @@
 # Jos to check the status of pipeline runs
 require 'English'
+require 'thread/pool'
 require 'json'
 
 # Benchmark status will not be updated faster than this.


### PR DESCRIPTION
# Description

Reverts the changes to parallelism that I made. 
- Removes the `parallel` gem (though it is still a dependency of rubocop)
- Returns the sharded approach to parallelism

I am keeping some of the error message handling and logging I added.

# Tests

To test this I started the application locally and ensured that the benchmarks were being properly run.
