### PR TITLE
Make taxon lineage versions not nullable

### DIFF
--- a/db/migrate/20191022201643_change_taxon_lineage_columns.rb
+++ b/db/migrate/20191022201643_change_taxon_lineage_columns.rb
@@ -1,6 +1,10 @@
 class ChangeTaxonLineageColumns < ActiveRecord::Migration[5.1]
   def change
-    change_column :taxon_lineages, :version_start, :integer, null: false, limit: 2, default: nil
-    change_column :taxon_lineages, :version_end, :integer, null: false, limit: 2, default: nil
+    change_column :taxon_lineages, :version_start, :integer,
+                  null: false, limit: 2, default: nil,
+                  comment: "The first version for which the taxon is active"
+    change_column :taxon_lineages, :version_end, :integer,
+                  null: false, limit: 2, default: nil,
+                  comment: "The last version for which the taxon is active"
   end
 end

--- a/db/migrate/20191022201643_change_taxon_lineage_columns.rb
+++ b/db/migrate/20191022201643_change_taxon_lineage_columns.rb
@@ -1,6 +1,6 @@
 class ChangeTaxonLineageColumns < ActiveRecord::Migration[5.1]
   def change
-    change_column :taxon_lineages, :version_start, :integer, null: false, limit: 1, default: nil
-    change_column :taxon_lineages, :version_end, :integer, null: false, limit: 1, default: nil
+    change_column :taxon_lineages, :version_start, :integer, null: false, limit: 2, default: nil
+    change_column :taxon_lineages, :version_end, :integer, null: false, limit: 2, default: nil
   end
 end

--- a/db/migrate/20191022201643_change_taxon_lineage_columns.rb
+++ b/db/migrate/20191022201643_change_taxon_lineage_columns.rb
@@ -1,0 +1,6 @@
+class ChangeTaxonLineageColumns < ActiveRecord::Migration[5.1]
+  def change
+    change_column :taxon_lineages, :version_start, :integer, null: false, limit: 1, default: nil
+    change_column :taxon_lineages, :version_end, :integer, null: false, limit: 1, default: nil
+  end
+end

--- a/spec/factories/taxon_lineage.rb
+++ b/spec/factories/taxon_lineage.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
       sequence(:tax_name) { |n| "species-#{n}" }
       species_taxid { taxid }
       species_name { tax_name }
+      version_start { 1 }
+      version_end { 1 }
     end
   end
 end

--- a/test/fixtures/taxon_lineages.yml
+++ b/test/fixtures/taxon_lineages.yml
@@ -1,5 +1,7 @@
 one:
   taxid: 1
+  version_start: 1
+  version_end: 1
 
 kleb_pneumo:
   version_start: 1


### PR DESCRIPTION
# Description

This modifies the SQL schema of `taxon_lineages` to avoid data corruption. 

# Notes

* Today I deleted all existing rows in `taxon_lineages` that contained `NULL` in the two columns
* This change will take a few minutes to execute during deployment but it is push-safe because the old and new versions of the schema work with prod code. 

# Tests

`rails db:migrate`