### PR TITLE
IDSEQ-1669 - [bug] Phylogenetic trees error message shows wrong boundaries

### DIFF
--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -420,7 +420,7 @@ class PhyloTreeCreation extends React.Component {
       return (
         <Notification type="error" displayStyle="flat">
           Phylogenetic Tree creation must have between{" "}
-          {PhyloTreeChecks.MIN_SAMPLES} and {PhyloTreeChecks.MIN_SAMPLES}{" "}
+          {PhyloTreeChecks.MIN_SAMPLES} and {PhyloTreeChecks.MAX_SAMPLES}{" "}
           samples.
         </Notification>
       );


### PR DESCRIPTION
# Description

The error message is showing incorrect upper limit. It is displaying:

`Phylogenetic Tree creation must have between 4 and 4`

instead of 

`Phylogenetic Tree creation must have between 4 and 100`
