### PR TITLE
[Release fix] - IDSEQ-1669 - [bug] Phylogenetic trees error message shows wrong bounaries

### DIFF
--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -420,7 +420,7 @@ class PhyloTreeCreation extends React.Component {
       return (
         <Notification type="error" displayStyle="flat">
           Phylogenetic Tree creation must have between{" "}
-          {PhyloTreeChecks.MIN_SAMPLES} and {PhyloTreeChecks.MIN_SAMPLES}{" "}
+          {PhyloTreeChecks.MIN_SAMPLES} and {PhyloTreeChecks.MAX_SAMPLES}{" "}
           samples.
         </Notification>
       );


### PR DESCRIPTION
# Description

Fix an issue in the Phylogenetic trees error message showing the wrong upper limit.

It is displaying:

`Phylogenetic Tree creation must have between 4 and 4 samples`

instead of 

`Phylogenetic Tree creation must have between 4 and 100 samples`
