### PR TITLE
[IDSEQ-1331] Disable redundant use of UglifyJS to speed up deploys

### DIFF
--- a/config/environments/prod.rb
+++ b/config/environments/prod.rb
@@ -28,9 +28,8 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
-  # config.assets.css_compressor = :sass
+  # Don't add an asset compressor here because we already minimize with webpack.
+  # Check out webpack.config.prod.js.
 
   config.assets.debug = true
   # Suppress logger output for asset requests.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -28,9 +28,8 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
-  # config.assets.css_compressor = :sass
+  # Don't add an asset compressor here because we already minimize with webpack.
+  # Check out webpack.config.prod.js.
 
   config.assets.debug = true
   # Suppress logger output for asset requests.


### PR DESCRIPTION
### Description
- It looks like we have an extra invocation of UglifyJS that we don't need and slows down our containers on deployment (specifically on the first request post-boot up).
- There may be more deploy-related PRs to follow this.

### Notes
- In our Dockerfile we have `npm run build-img`, which calls `webpack --config webpack.config.prod.js` which includes `minimizer` `UglifyJsPlugin` and already generates packed versions of `app/assets/src` files. As discovered before, this uses a lot of memory.
<img width="851" alt="Screen Shot 2019-10-23 at 3 18 19 PM" src="https://user-images.githubusercontent.com/5652739/67442247-cdf7d380-f5b4-11e9-820c-a8250498cd7c.png">

- In staging.rb and prod.rb, we also have `config.assets.js_compressor = Uglifier.new(harmony: true)`, which uses the Uglifier gem (https://github.com/lautis/uglifier) which also uses UglifyJS. This is almost entirely redundant except for trivial files that are in `app/assets` but not in `app/assets/src` (where we do want to keep all the JS code).

- In my testing, I found that `js_compressor` line to be the likely culprit behind very slow first requests. In the asset pipeline docs, there are modes that reference "on the first request the assets are compiled" (https://guides.rubyonrails.org/v4.0.0/asset_pipeline.html) and that seems to be how our Rails app was behaving. Unfortunately I couldn't get the compressor to generate a nice verbose output, which would've been additional evidence.

<img width="1474" alt="Screen Shot 2019-10-23 at 2 18 29 PM" src="https://user-images.githubusercontent.com/5652739/67442157-8ec98280-f5b4-11e9-8b64-24af6ea822e7.png">

- Indeed, trying to run the compilation locally and manually was slow and I ran out of memory.

<img width="1252" alt="Screen Shot 2019-10-23 at 2 45 17 PM" src="https://user-images.githubusercontent.com/5652739/67442161-96892700-f5b4-11e9-95f7-e6657c8f6c80.png">

### Testing
- As in the notes, I'm confident that nothing of value will be lost, if anything.
- Pushed a testing branch to staging with these settings. You can verify that the site still behaves as expected, and the assets served as still very ugly.
<img width="1051" alt="Screen Shot 2019-10-23 at 4 23 13 PM" src="https://user-images.githubusercontent.com/5652739/67442176-a30d7f80-f5b4-11e9-9d67-cd3d049987c7.png">
<img width="952" alt="Screen Shot 2019-10-23 at 4 06 08 PM" src="https://user-images.githubusercontent.com/5652739/67442184-aa348d80-f5b4-11e9-8ad4-860a84f2261b.png">

- Looked through files in Sources and Network tabs in Chrome in staging vs. prod and found that they had the same formatting.
<img width="900" alt="Screen Shot 2019-10-23 at 3 48 26 PM" src="https://user-images.githubusercontent.com/5652739/67442221-b9b3d680-f5b4-11e9-95ce-e06d172b9d35.png">

- I pushed my test branch multiple times and ran `curl -i https://staging.idseq.net` on a loop. Machines came up much faster and no longer saw the lag and timeout. In the ECS logs, service idseq-staging-web deploy logs were as expected.