### PR TITLE
Add explanation to tooltips for grayed out Save and Heatmap buttons

### DIFF
--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -199,6 +199,7 @@ class SamplesView extends React.Component {
         disabled
         icon={heatmapIcon}
         popupText="Heatmap"
+        popupSubtitle="Select at least 2 samples"
       />
     ) : (
       <BareDropdown
@@ -316,6 +317,7 @@ class SamplesView extends React.Component {
         disabled
         icon={saveIcon}
         popupText={"Save a Collection"}
+        popupSubtitle="Select at least 2 samples"
       />
     ) : (
       <CollectionModal

--- a/app/assets/src/components/views/samples/ToolbarIcon.jsx
+++ b/app/assets/src/components/views/samples/ToolbarIcon.jsx
@@ -10,7 +10,14 @@ import cs from "./toolbar_icon.scss";
 
 class ToolbarIcon extends React.Component {
   render() {
-    const { className, popupText, disabled, onClick, icon } = this.props;
+    const {
+      className,
+      popupText,
+      popupSubtitle,
+      disabled,
+      onClick,
+      icon,
+    } = this.props;
 
     const iconWrapper = (
       <div
@@ -28,7 +35,12 @@ class ToolbarIcon extends React.Component {
     return (
       <BasicPopup
         trigger={iconWrapper}
-        content={popupText}
+        content={
+          <div className={cs.popupText}>
+            {popupText}
+            <div className={cs.popupSubtitle}>{popupSubtitle}</div>
+          </div>
+        }
         position="top center"
         basic={false}
       />
@@ -40,6 +52,7 @@ ToolbarIcon.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.node,
   popupText: PropTypes.string,
+  popupSubtitle: PropTypes.string,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
 };

--- a/app/assets/src/components/views/samples/toolbar_icon.scss
+++ b/app/assets/src/components/views/samples/toolbar_icon.scss
@@ -1,4 +1,5 @@
 @import "~styles/themes/colors";
+@import "~styles/themes/typography";
 
 .iconWrapper {
   display: flex;
@@ -24,5 +25,13 @@
     svg {
       fill: $primary-light;
     }
+  }
+}
+
+.popupText {
+  @include font-body-xxs-crop;
+
+  .popupSubtitle {
+    color: $medium-grey;
   }
 }


### PR DESCRIPTION
# Description
Add an explanation of the 2 sample minimum in order to Save a Collection or create a Heatmap. 
(The `Select at least 2 samples` line will not appear if 2+ samples have been selected.)

![image](https://user-images.githubusercontent.com/53838890/67508194-5faf2180-f645-11e9-8370-275e759d354a.png)
![image](https://user-images.githubusercontent.com/53838890/67508213-68075c80-f645-11e9-946a-2ceec5c32266.png)


# Notes

* The tooltip text for ToolbarIcon has also been updated to have 0.3px letter-spacing as requested by Jenn (applied through `font-body-xxs-crop`).
