### PR TITLE
[Release fix] IDSEQ-1693 - Remove premature aegea job termination code from pipeline monitor

### DIFF
--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -170,7 +170,6 @@ class PipelineRunStage < ApplicationRecord
         _job_status, self.job_log_id, _job_hash, self.job_description = job_info(job_id, id)
         save
       end
-      terminate_job
       return
     end
     # The job appears to be in progress.  Check to make sure it hasn't been killed in AWS.   But not too frequently.
@@ -199,10 +198,6 @@ class PipelineRunStage < ApplicationRecord
       return
     end
     run_job # this saves
-  end
-
-  def terminate_job
-    _stdout, _stderr, _status = Open3.capture3("aegea", "batch", "terminate", job_id.to_s)
   end
 
   def log_url


### PR DESCRIPTION
# Description

Pipeline monitor terminates aegea jobs once it finds a success file. This is causing issues with aegea since it cannot run until completion, and it is leaving behind unused EBS volumes.

Remove the code that terminates the instances prematurely.

# Tests

* Manual tests to be executed in staging