### PR TITLE
IDSEQ-1693 - [Hotfix] Remove premature aegea job termination code from pipeline monitor

### DIFF
--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -170,7 +170,6 @@ class PipelineRunStage < ApplicationRecord
         _job_status, self.job_log_id, _job_hash, self.job_description = job_info(job_id, id)
         save
       end
-      terminate_job
       return
     end
     # The job appears to be in progress.  Check to make sure it hasn't been killed in AWS.   But not too frequently.


### PR DESCRIPTION
Description
Pipeline monitor terminates aegea jobs once it finds a success file. This is causing issues with aegea since it cannot run until completion, and it is leaving behind unused EBS volumes.
Remove the code that terminates the instances prematurely.

Notes
This change has been applied to prod. This is a PR to keep other branches in sync