### PR TITLE
[Bug] Disable browser autocomplete of location fields

### DIFF
--- a/app/assets/src/components/ui/controls/Input.jsx
+++ b/app/assets/src/components/ui/controls/Input.jsx
@@ -16,23 +16,22 @@ class Input extends React.Component {
   render() {
     let { className, disableAutocomplete, ...props } = this.props;
     className = "idseq-ui " + className;
-    console.log("value: ", disableAutocomplete);
     return (
       <SemanticInput
-        autoComplete={disableAutocomplete ? "idseq-ui" : null}
         className={className}
-        onChange={this.handleChange}
         {...props}
+        onChange={this.handleChange}
+        autoComplete={disableAutocomplete ? "idseq-ui" : null}
       />
     );
   }
 }
 
 Input.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onChange: PropTypes.func,
   className: PropTypes.string,
   disableAutocomplete: PropTypes.bool,
-  onChange: PropTypes.func,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 export default Input;

--- a/app/assets/src/components/ui/controls/Input.jsx
+++ b/app/assets/src/components/ui/controls/Input.jsx
@@ -14,22 +14,25 @@ class Input extends React.Component {
   };
 
   render() {
-    let { className, ...props } = this.props;
+    let { className, disableAutocomplete, ...props } = this.props;
     className = "idseq-ui " + className;
+    console.log("value: ", disableAutocomplete);
     return (
       <SemanticInput
+        autoComplete={disableAutocomplete ? "idseq-ui" : null}
         className={className}
-        {...props}
         onChange={this.handleChange}
+        {...props}
       />
     );
   }
 }
 
 Input.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  onChange: PropTypes.func,
   className: PropTypes.string,
+  disableAutocomplete: PropTypes.bool,
+  onChange: PropTypes.func,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 export default Input;

--- a/app/assets/src/components/ui/controls/Input.jsx
+++ b/app/assets/src/components/ui/controls/Input.jsx
@@ -21,6 +21,8 @@ class Input extends React.Component {
         className={className}
         {...props}
         onChange={this.handleChange}
+        // Chrome ignores autocomplete="off" on purpose, so use a non-standard
+        // label. See: https://stackoverflow.com/questions/15738259/disabling-chrome-autofill
         autoComplete={disableAutocomplete ? "idseq-ui" : null}
       />
     );

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -113,6 +113,7 @@ class LiveSearchPopBox extends React.Component {
         onChange={this.handleSearchChange}
         onKeyPress={this.handleKeyDown}
         value={value}
+        disableAutocomplete={true}
       />
     );
   };
@@ -179,6 +180,7 @@ class LiveSearchPopBox extends React.Component {
         trigger={this.renderSearchBox()}
         usePortal
         withinModal
+        disableAutocomplete={true}
       />
     );
   }

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -292,6 +292,7 @@ BareDropdown.propTypes = forbidExtraProps({
   open: PropTypes.bool,
   selectOnBlur: PropTypes.bool,
   trigger: PropTypes.node.isRequired,
+  disableAutocomplete: PropTypes.bool,
 });
 
 BareDropdown.defaultProps = {

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -188,12 +188,12 @@ class BareDropdown extends React.Component {
             className={cs.searchContainer}
           >
             <Input
-              disableAutocomplete={disableAutocomplete}
               fluid
               className={cs.searchInput}
               icon="search"
               placeholder="Search"
               onChange={this.handleFilterChange}
+              disableAutocomplete={disableAutocomplete}
             />
           </div>
         )}

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -220,7 +220,6 @@ class BareDropdown extends React.Component {
           trigger={this.props.trigger}
           triggerClassName={className}
           withinModal={this.props.withinModal}
-          disableAutocomplete={disableAutocomplete}
         />
       );
     }

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -126,6 +126,7 @@ class BareDropdown extends React.Component {
       children,
       onFilterChange,
       menuClassName,
+      disableAutocomplete,
       ...otherProps
     } = this.props;
 
@@ -187,6 +188,7 @@ class BareDropdown extends React.Component {
             className={cs.searchContainer}
           >
             <Input
+              disableAutocomplete={disableAutocomplete}
               fluid
               className={cs.searchInput}
               icon="search"
@@ -218,6 +220,7 @@ class BareDropdown extends React.Component {
           trigger={this.props.trigger}
           triggerClassName={className}
           withinModal={this.props.withinModal}
+          disableAutocomplete={disableAutocomplete}
         />
       );
     }
@@ -227,6 +230,7 @@ class BareDropdown extends React.Component {
         {...baseDropdownProps}
         className={dropdownClassName}
         onBlur={e => e.stopPropagation()}
+        disableAutocomplete={disableAutocomplete}
       >
         {menu}
       </BaseDropdown>

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -229,7 +229,6 @@ class BareDropdown extends React.Component {
         {...baseDropdownProps}
         className={dropdownClassName}
         onBlur={e => e.stopPropagation()}
-        disableAutocomplete={disableAutocomplete}
       >
         {menu}
       </BaseDropdown>


### PR DESCRIPTION
### Description
- Quick fix to a bug introduced last sprint.
- We changed the placeholder text of the location box to say "Enter a city, region, or country". Words like 'city' cause Chrome to try to show a suggestions box.
- We don't want this because it could cause user confusion vs. our intended suggestions box, so this disables the browser autocomplete.
- Also useful in other contexts like not showing email suggestions on a different flow (came up before).

### Notes
Before:
![Oct-28-2019 17-31-46](https://user-images.githubusercontent.com/5652739/67728046-f57de000-f9a8-11e9-8b2d-a9c09852cb49.gif)

After:
![Oct-28-2019 17-32-28](https://user-images.githubusercontent.com/5652739/67728053-f9a9fd80-f9a8-11e9-8ee1-8bfb30b8cb2a.gif)

### Tests
- See screenshots / try out the location box in the sample upload flow and other flows.