### PR TITLE
Improve location dropdown behavior

### DIFF
--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -123,7 +123,7 @@ class LiveSearchPopBox extends React.Component {
   handleBlur = _ => {
     // Give a chance for handleResultSelect to happen. Otherwise, the dropdown
     // will disappear before the item onClick fires.
-    setTimeout(() => this.setState({ focus: false }), 10);
+    setTimeout(() => this.setState({ focus: false }), 100);
   };
 
   buildItem = (categoryKey, result, index) => (

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -43,16 +43,11 @@ class LiveSearchPopBox extends React.Component {
     }
   };
 
-  resetComponent = () => {
-    this.setState({
-      isLoading: false,
-      results: [],
-    });
-  };
-
   handleResultSelect = ({ currentEvent, result }) => {
     const { onResultSelect } = this.props;
-    this.resetComponent();
+    this.setState({
+      isLoading: false,
+    });
     onResultSelect && onResultSelect({ currentEvent, result });
   };
 
@@ -99,23 +94,37 @@ class LiveSearchPopBox extends React.Component {
   renderSearchBox = () => {
     const { placeholder, rectangular, inputClassName } = this.props;
     const { isLoading, value } = this.state;
+    // TODO (gdingle): If still processing, display “Loading” in the drop down
+    // menu and show loading indicator instead of magnifying glass icon. (this
+    // should happen immediately so the user knows that things are happening)
+
     return (
-      <Input
-        fluid
-        className={cx(
-          cs.searchInput,
-          rectangular && cs.rectangular,
-          inputClassName
-        )}
-        icon="search"
-        loading={isLoading}
-        placeholder={placeholder}
-        onChange={this.handleSearchChange}
-        onKeyPress={this.handleKeyDown}
-        value={value}
-        disableAutocomplete={true}
-      />
+      <div onFocus={this.handleFocus} onBlur={this.handleBlur}>
+        <Input
+          fluid
+          className={cx(
+            cs.searchInput,
+            rectangular && cs.rectangular,
+            inputClassName
+          )}
+          icon="search"
+          loading={isLoading}
+          placeholder={placeholder}
+          onChange={this.handleSearchChange}
+          onKeyPress={this.handleKeyDown}
+          value={value}
+          disableAutocomplete={true}
+        />
+      </div>
     );
+  };
+
+  handleFocus = _ => {
+    this.setState({ focus: true });
+  };
+
+  handleBlur = _ => {
+    this.setState({ focus: false });
   };
 
   buildItem = (categoryKey, result, index) => (
@@ -165,6 +174,10 @@ class LiveSearchPopBox extends React.Component {
   render() {
     const { className, rectangular } = this.props;
 
+    const shouldOpen =
+      this.getResultsLength() &&
+      this.state.focus &&
+      this.state.value.trim().length >= this.props.minChars;
     return (
       <BareDropdown
         className={cx(
@@ -176,7 +189,7 @@ class LiveSearchPopBox extends React.Component {
         hideArrow
         items={this.renderDropdownItems()}
         onChange={this.handleResultSelect}
-        open={this.getResultsLength() ? null : false}
+        open={shouldOpen ? true : false}
         trigger={this.renderSearchBox()}
         usePortal
         withinModal
@@ -187,7 +200,7 @@ class LiveSearchPopBox extends React.Component {
 }
 
 LiveSearchPopBox.defaultProps = {
-  delayTriggerSearch: 1000,
+  delayTriggerSearch: 200,
   initialValue: "",
   minChars: 2,
   placeholder: "Search",

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -94,9 +94,6 @@ class LiveSearchPopBox extends React.Component {
   renderSearchBox = () => {
     const { placeholder, rectangular, inputClassName } = this.props;
     const { isLoading, value } = this.state;
-    // TODO (gdingle): If still processing, display “Loading” in the drop down
-    // menu and show loading indicator instead of magnifying glass icon. (this
-    // should happen immediately so the user knows that things are happening)
 
     return (
       <div onFocus={this.handleFocus} onBlur={this.handleBlur}>
@@ -124,7 +121,9 @@ class LiveSearchPopBox extends React.Component {
   };
 
   handleBlur = _ => {
-    this.setState({ focus: false });
+    // Give a chance for handleResultSelect to happen. Otherwise, the dropdown
+    // will disappear before the item onClick fires.
+    setTimeout(() => this.setState({ focus: false }), 10);
   };
 
   buildItem = (categoryKey, result, index) => (


### PR DESCRIPTION
# Description

This addresses the first five usability issues of IDSEQ-1512. Essentially, it changes the search input component to open up the dropdown whenever focus is on the input and there are results. 

I also adjusted `delayTriggerSearch` to make the search feel more responsive. 

# Notes

* I hacked a dom event ordering issue. See https://stackoverflow.com/questions/17769005/onclick-and-onblur-ordering-issue . Other solutions welcome. 

# Tests

* Start upload of a sample locally 
* On metadata page...
* click into blank location field, see no menu
* type 3 chars, see menu
* click out of menu, see menu disappear
* click on item in menu, see menu disappear
* tab into menu, see menu appear
* tab out of menu, see menu disappear
* on change of chars, see loading icon appear in 100ms
* enter "asdfasdf", see no plain text (no match) result