### PR TITLE
Only check close condition in PortalDropdown if dropdown is open.

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/PortalDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/PortalDropdown.jsx
@@ -59,6 +59,7 @@ class PortalDropdown extends React.Component {
 
   handleOutClick = () => {
     if (
+      !this.state.open &&
       !(this._triggerRef && this._triggerRef.contains(event.target)) &&
       !(this._menuRef && this._menuRef.contains(event.target))
     ) {


### PR DESCRIPTION
# Description

Tiny change that should help metadata rendering (https://jira.czi.team/browse/IDSEQ-1708) and is good in general.

Only run the expensive `contains` check if the portal dropdown is actually open.