### PR TITLE
[IDSEQ-1643] Fix bug for cross-region S3 uploads

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -161,7 +161,7 @@ module SamplesHelper
     begin
       # We set S3_GLOBAL_ENDPOINT to enable cross-region listing in this case.
       # By default S3::Client sets a regional endpoint such as
-      # s3.us-west-2.amazonaws.com and errors if you use a bucket in a different
+      # s3.us-west-2.amazonaws.com and errs if you use a bucket in a different
       # region.
       s3_client_local = Aws::S3::Client.new(endpoint: S3_GLOBAL_ENDPOINT)
       entries = s3_client_local.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -161,8 +161,8 @@ module SamplesHelper
     begin
       # We set S3_GLOBAL_ENDPOINT to enable cross-region listing in this case.
       # By default S3::Client sets a regional endpoint such as
-      # s3.us-west-2.amazonaws.com and errs if you use a bucket in a different
-      # region.
+      # s3.us-west-2.amazonaws.com (from the config) and errs if you use a
+      # bucket in a different region.
       s3_client_local = Aws::S3::Client.new(endpoint: S3_GLOBAL_ENDPOINT)
       entries = s3_client_local.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
       # ignore illumina Undetermined FASTQ files (ex: "Undetermined_AAA_R1_001.fastq.gz")

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -159,9 +159,11 @@ module SamplesHelper
     s3_prefix = parsed_uri.path.sub(%r{^/(.*?)/?$}, '\1/')
 
     begin
-      puts "foobar 11:30am"
+      # We set S3_GLOBAL_ENDPOINT to enable cross-region listing in this case.
+      # By default S3::Client sets a regional endpoint such as
+      # s3.us-west-2.amazonaws.com and errors if you use a bucket in a different
+      # region.
       s3_client_local = Aws::S3::Client.new(endpoint: S3_GLOBAL_ENDPOINT)
-      puts "END"
       entries = s3_client_local.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
       # ignore illumina Undetermined FASTQ files (ex: "Undetermined_AAA_R1_001.fastq.gz")
       entries = entries.reject { |line| line.include? "Undetermined" }

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -6,6 +6,12 @@ module SamplesHelper
   include PipelineOutputsHelper
   include ErrorHelper
 
+  # We set S3_GLOBAL_ENDPOINT to enable cross-region listing in
+  # parsed_samples_for_s3_path. By default S3::Client sets a regional endpoint
+  # such as s3.us-west-2.amazonaws.com (from the config) and errs if you use a
+  # bucket in a different region.
+  S3_CLIENT = Aws::S3::Client.new(endpoint: S3_GLOBAL_ENDPOINT)
+
   def generate_sample_list_csv(formatted_samples)
     attributes = %w[sample_name uploader upload_date overall_job_status runtime_seconds
                     total_reads nonhost_reads nonhost_reads_percent total_ercc_reads subsampled_fraction
@@ -159,12 +165,7 @@ module SamplesHelper
     s3_prefix = parsed_uri.path.sub(%r{^/(.*?)/?$}, '\1/')
 
     begin
-      # We set S3_GLOBAL_ENDPOINT to enable cross-region listing in this case.
-      # By default S3::Client sets a regional endpoint such as
-      # s3.us-west-2.amazonaws.com (from the config) and errs if you use a
-      # bucket in a different region.
-      s3_client_local = Aws::S3::Client.new(endpoint: S3_GLOBAL_ENDPOINT)
-      entries = s3_client_local.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
+      entries = S3_CLIENT.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
       # ignore illumina Undetermined FASTQ files (ex: "Undetermined_AAA_R1_001.fastq.gz")
       entries = entries.reject { |line| line.include? "Undetermined" }
     rescue Aws::S3::Errors::ServiceError => e # Covers all S3 access errors (AccessDenied/NoSuchBucket/AllAccessDisabled)

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -161,6 +161,9 @@ module SamplesHelper
     s3_prefix = parsed_uri.path.sub(%r{^/(.*?)/?$}, '\1/')
 
     begin
+      puts "foobar 11:30am"
+      puts S3_CLIENT.get_bucket_location(bucket: s3_bucket_name)
+      puts "END"
       entries = S3_CLIENT.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
       # ignore illumina Undetermined FASTQ files (ex: "Undetermined_AAA_R1_001.fastq.gz")
       entries = entries.reject { |line| line.include? "Undetermined" }

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -6,8 +6,6 @@ module SamplesHelper
   include PipelineOutputsHelper
   include ErrorHelper
 
-  S3_CLIENT = Aws::S3::Client.new
-
   def generate_sample_list_csv(formatted_samples)
     attributes = %w[sample_name uploader upload_date overall_job_status runtime_seconds
                     total_reads nonhost_reads nonhost_reads_percent total_ercc_reads subsampled_fraction
@@ -162,9 +160,9 @@ module SamplesHelper
 
     begin
       puts "foobar 11:30am"
-      puts S3_CLIENT.get_bucket_location(bucket: s3_bucket_name)
+      s3_client_local = Aws::S3::Client.new(endpoint: S3_GLOBAL_ENDPOINT)
       puts "END"
-      entries = S3_CLIENT.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
+      entries = s3_client_local.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
       # ignore illumina Undetermined FASTQ files (ex: "Undetermined_AAA_R1_001.fastq.gz")
       entries = entries.reject { |line| line.include? "Undetermined" }
     rescue Aws::S3::Errors::ServiceError => e # Covers all S3 access errors (AccessDenied/NoSuchBucket/AllAccessDisabled)

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -10,7 +10,7 @@ module SamplesHelper
   # parsed_samples_for_s3_path. By default S3::Client sets a regional endpoint
   # such as s3.us-west-2.amazonaws.com (from the config) and errs if you use a
   # bucket in a different region.
-  S3_CLIENT = Aws::S3::Client.new(endpoint: S3_GLOBAL_ENDPOINT)
+  S3_CLIENT_LOCAL = Aws::S3::Client.new(endpoint: S3_GLOBAL_ENDPOINT)
 
   def generate_sample_list_csv(formatted_samples)
     attributes = %w[sample_name uploader upload_date overall_job_status runtime_seconds
@@ -165,7 +165,7 @@ module SamplesHelper
     s3_prefix = parsed_uri.path.sub(%r{^/(.*?)/?$}, '\1/')
 
     begin
-      entries = S3_CLIENT.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
+      entries = S3_CLIENT_LOCAL.list_objects_v2(bucket: s3_bucket_name, prefix: s3_prefix).contents.map(&:key)
       # ignore illumina Undetermined FASTQ files (ex: "Undetermined_AAA_R1_001.fastq.gz")
       entries = entries.reject { |line| line.include? "Undetermined" }
     rescue Aws::S3::Errors::ServiceError => e # Covers all S3 access errors (AccessDenied/NoSuchBucket/AllAccessDisabled)

--- a/config/initializers/s3_presigner.rb
+++ b/config/initializers/s3_presigner.rb
@@ -2,3 +2,4 @@ S3_CLIENT = Aws::S3::Client.new
 S3_PRESIGNER = Aws::S3::Presigner.new(client: S3_CLIENT) # auth from the env
 SAMPLES_BUCKET_NAME = ENV['SAMPLES_BUCKET_NAME']
 SAMPLE_DOWNLOAD_EXPIRATION = 3600 # seconds
+S3_GLOBAL_ENDPOINT = "https://s3.amazonaws.com"

--- a/config/initializers/s3_presigner.rb
+++ b/config/initializers/s3_presigner.rb
@@ -2,4 +2,4 @@ S3_CLIENT = Aws::S3::Client.new
 S3_PRESIGNER = Aws::S3::Presigner.new(client: S3_CLIENT) # auth from the env
 SAMPLES_BUCKET_NAME = ENV['SAMPLES_BUCKET_NAME']
 SAMPLE_DOWNLOAD_EXPIRATION = 3600 # seconds
-S3_GLOBAL_ENDPOINT = "https://s3.amazonaws.com"
+S3_GLOBAL_ENDPOINT = "https://s3.amazonaws.com".freeze


### PR DESCRIPTION
### Description
- This is just to address the cross-region copying issue from last week. See JIRA for details.
- Using the S3 "global" non-regional specific endpoint means that AWS will resolve the region itself.

### Notes
- This was the most elegant solution I could find. My original proposal was to use `GetBucketLocation` but apparently it is only for the bucket owner (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html). I also found suggestions to use head bucket but got 301 redirects / couldn't figure out how to get the region info from that (https://github.com/aws/aws-sdk-ruby/issues/796).
- This was the only use of S3_CLIENT that I found necessary to change, and it was the only one changed in the previous PR (#2538).
- Why not set this global endpoint all the time? AWS recommends against it "Please configure the proper region to avoid multiple unnecessary redirects and signing attempts". And for most other requests we're in our own buckets in our known region.

### Tests
- Testing with the reported user URL.

#### Before:
![Screen Shot 2019-10-29 at 2 59 37 PM](https://user-images.githubusercontent.com/5652739/67895204-4a3f6900-fb17-11e9-8a60-c4b9b05d36b6.png)

#### After:
![Screen Shot 2019-10-29 at 3 02 12 PM](https://user-images.githubusercontent.com/5652739/67895214-4f9cb380-fb17-11e9-81b9-698bc63ff13d.png)

#### Ran samples end-to-end locally and it works: 
<img width="1088" alt="Screen Shot 2019-10-30 at 12 53 59 PM" src="https://user-images.githubusercontent.com/5652739/67895228-54f9fe00-fb17-11e9-9d5b-69c19cbcf898.png">