### PR TITLE
Add separator between location results and plain text option

### DIFF
--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -94,6 +94,13 @@ class GeoSearchInputBox extends React.Component {
       });
     }
 
+    // TODO (gdingle): Horizontal Line Between Location Results and Plain Text Sections
+
+    // TODO (gdingle):
+    // If there are no results but the Plain Text option, still display dropdown
+    // menu with “No Results” under “Location Results”, as well as the Plain
+    // Text option
+
     // Let users select an unresolved plain text option
     let noMatchName = "Plain Text (No Location Match)";
     categories[noMatchName] = {

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -94,13 +94,6 @@ class GeoSearchInputBox extends React.Component {
       });
     }
 
-    // TODO (gdingle): Horizontal Line Between Location Results and Plain Text Sections
-
-    // TODO (gdingle):
-    // If there are no results but the Plain Text option, still display dropdown
-    // menu with “No Results” under “Location Results”, as well as the Plain
-    // Text option
-
     // Let users select an unresolved plain text option
     let noMatchName = "Plain Text (No Location Match)";
     categories[noMatchName] = {

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -63,8 +63,9 @@ class GeoSearchInputBox extends React.Component {
   // Fetch geosearch results and format into categories for LiveSearchBox
   handleSearchTriggered = async query => {
     let categories = {};
+    let serverSideSuggestions = [];
     try {
-      const serverSideSuggestions = await getGeoSearchSuggestions(query);
+      serverSideSuggestions = await getGeoSearchSuggestions(query);
       // Semantic UI Search expects results as: `{ category: { name: '', results: [{ title: '', description: '' }] }`
       if (serverSideSuggestions.length > 0) {
         const locationsCategory = "Location Results";
@@ -95,7 +96,12 @@ class GeoSearchInputBox extends React.Component {
     }
 
     // Let users select an unresolved plain text option
-    let noMatchName = "Plain Text (No Location Match)";
+    let noMatchName = "";
+    if (serverSideSuggestions.length > 0) {
+      noMatchName = "Use Plain Text (No Location Match)";
+    } else {
+      noMatchName = "No Results (Use Plain Text)";
+    }
     categories[noMatchName] = {
       name: noMatchName,
       results: [{ title: query, name: query }],

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -121,16 +121,12 @@ class LiveSearchPopBox extends React.Component {
   };
 
   handleBlur = currentEvent => {
-    // Give a chance for handleResultSelect to happen. Otherwise, the dropdown
-    // will disappear before the item onClick fires.
-    setTimeout(() => {
-      this.setState({ focus: false });
-      // Give a chance for warnings to show
-      this.handleResultSelect({
-        currentEvent: currentEvent,
-        result: this.state.value,
-      });
-    }, 100);
+    this.setState({ focus: false });
+    // Give a chance for warnings to show
+    this.handleResultSelect({
+      currentEvent: currentEvent,
+      result: this.state.value,
+    });
   };
 
   buildItem = (categoryKey, result, index) => (
@@ -144,7 +140,8 @@ class LiveSearchPopBox extends React.Component {
           )}
         </div>
       }
-      onClick={currentEvent =>
+      onMouseDown={currentEvent =>
+        // use onMouseDown instead of onClick to work with handleBlur
         this.handleResultSelect({ currentEvent, result })
       }
       value={`${categoryKey}-${index}`}

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -14,9 +14,6 @@ class LiveSearchPopBox extends React.Component {
       isLoading: false,
       results: [],
       value: this.props.initialValue,
-      // TODO (gdingle): First result in dropdown menu should be selected by
-      // default. Pressing return should select that result.
-
       selectedResult: null,
     };
 
@@ -34,9 +31,6 @@ class LiveSearchPopBox extends React.Component {
   }
 
   handleKeyDown = keyEvent => {
-    // TODO (gdingle):
-    // User can move through options in menu with the arrow keys
-
     const { onEnter, inputMode } = this.props;
     const { value, selectedResult } = this.state;
 
@@ -191,8 +185,6 @@ class LiveSearchPopBox extends React.Component {
       this.state.focus &&
       this.state.value.trim().length >= this.props.minChars;
 
-    // TODO (gdingle): Dropdown should stay next to the input field and not
-    // float above it when the list gets smaller
     return (
       <BareDropdown
         className={cx(

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -14,6 +14,9 @@ class LiveSearchPopBox extends React.Component {
       isLoading: false,
       results: [],
       value: this.props.initialValue,
+      // TODO (gdingle): First result in dropdown menu should be selected by
+      // default. Pressing return should select that result.
+
       selectedResult: null,
     };
 
@@ -31,6 +34,9 @@ class LiveSearchPopBox extends React.Component {
   }
 
   handleKeyDown = keyEvent => {
+    // TODO (gdingle):
+    // User can move through options in menu with the arrow keys
+
     const { onEnter, inputMode } = this.props;
     const { value, selectedResult } = this.state;
 
@@ -184,6 +190,9 @@ class LiveSearchPopBox extends React.Component {
       this.getResultsLength() &&
       this.state.focus &&
       this.state.value.trim().length >= this.props.minChars;
+
+    // TODO (gdingle): Dropdown should stay next to the input field and not
+    // float above it when the list gets smaller
     return (
       <BareDropdown
         className={cx(

--- a/app/assets/src/components/ui/controls/live_search_pop_box.scss
+++ b/app/assets/src/components/ui/controls/live_search_pop_box.scss
@@ -32,7 +32,7 @@
     margin: 0 14px;
     text-transform: uppercase;
     border-top: 2px solid $lightest-grey;
-    margin-top: $space-s; // 8px
+    margin-top: $space-m;
   }
 
   .category:first-child {

--- a/app/assets/src/components/ui/controls/live_search_pop_box.scss
+++ b/app/assets/src/components/ui/controls/live_search_pop_box.scss
@@ -29,10 +29,10 @@
 
     background-color: transparent;
     color: $light-grey;
-    padding: 0 14px;
+    margin: 0 14px;
     text-transform: uppercase;
     border-top: 2px solid $lightest-grey;
-    margin-top: $space-xs; // 8px
+    margin-top: $space-s; // 8px
   }
 
   .category:first-child {

--- a/app/assets/src/components/ui/controls/live_search_pop_box.scss
+++ b/app/assets/src/components/ui/controls/live_search_pop_box.scss
@@ -1,5 +1,6 @@
 @import "~styles/themes/colors";
 @import "~styles/themes/typography";
+@import "~styles/themes/elements";
 
 .liveSearchPopBox {
   &:not(.rectangular) {
@@ -30,6 +31,12 @@
     color: $light-grey;
     padding: 0 14px;
     text-transform: uppercase;
+    border-top: 2px solid $lightest-grey;
+    margin-top: $space-xs; // 8px
+  }
+
+  .category:first-child {
+    border: none;
   }
 
   .entry {

--- a/app/assets/src/components/ui/controls/live_search_pop_box.scss
+++ b/app/assets/src/components/ui/controls/live_search_pop_box.scss
@@ -29,13 +29,15 @@
 
     background-color: transparent;
     color: $light-grey;
-    margin: 0 14px;
+    margin: $space-m $space-m 0;
+    padding: $space-xxxs 0;
     text-transform: uppercase;
     border-top: 2px solid $lightest-grey;
-    margin-top: $space-m;
   }
 
+  // skip divider line
   .category:first-child {
+    margin-top: 0;
     border: none;
   }
 


### PR DESCRIPTION
# Description

As title. 

![image](https://user-images.githubusercontent.com/28797/67990140-37e62d80-fbf2-11e9-9916-6ac37972a02b.png)

![image](https://user-images.githubusercontent.com/28797/67990143-39aff100-fbf2-11e9-9ef5-74c55d898f88.png)

# Notes

* I matched the CSS style I've saw elsewhere and I increased the margin to make the visual separation obvious. 
* I also changed the message when there are no results, to address https://jira.czi.team/browse/IDSEQ-1516 . It was going to be more work than I had time to add a new type of dropdown item that was non-selectable and different style than the `category` type. 
![image](https://user-images.githubusercontent.com/28797/67910787-54765d00-fb41-11e9-9020-658e386ad39c.png)
* I also took the opportunity to improve a workaround from my last PR. Now we use onMouseDown to get around the onBlur onClick race condition. 


# Tests

* open menu, see line
* type "asdf", see "no results" message