### PR TITLE
Correctly pass direction prop through to BareDropdown.

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -276,7 +276,7 @@ BareDropdown.propTypes = forbidExtraProps({
   // Props directly passed to semantic-ui.
   children: PropTypes.node,
   className: PropTypes.string,
-  direction: PropTypes.string,
+  direction: PropTypes.oneOf(["left", "right"]),
   disabled: PropTypes.bool,
   floating: PropTypes.bool,
   fluid: PropTypes.bool,

--- a/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
@@ -81,6 +81,7 @@ class Dropdown extends React.Component {
         onChange={this.handleOnChange}
         trigger={this.renderTrigger()}
         usePortal={this.props.usePortal}
+        direction={this.props.direction}
         withinModal={this.props.withinModal}
         items={this.props.items}
         itemSearchStrings={this.props.itemSearchStrings}
@@ -117,6 +118,7 @@ Dropdown.propTypes = {
   search: PropTypes.bool,
   menuLabel: PropTypes.string,
   usePortal: PropTypes.bool,
+  direction: PropTypes.oneOf(["left", "right"]),
   withinModal: PropTypes.bool,
 };
 


### PR DESCRIPTION
# Description
Right now, there is no way to specify the direction when using `<Dropdown>` (that prop doesn't get passed to BareDropdown). The direction prop is used by both the normal semantic-ui Dropdown, and also PortalDropdown.

Thanks to Greg for pointing this out.

# Tests
* This should have no visible change. I checked the code base and there isn't `<Dropdown>` that uses direction right now.
* Verified in the controls playground that this change works as intended.

By specifying "direction=left" and manually increasing the width of the dropdown items, we get the expected behavior below.
![Screen Shot 2019-10-30 at 5 56 07 PM](https://user-images.githubusercontent.com/837004/67910060-9e117880-fb3e-11e9-9bf6-ede47a01a198.png)
