### PR TITLE
Add remaining fargate-style download tasks.

### DIFF
--- a/app/assets/src/components/utils/propTypes.js
+++ b/app/assets/src/components/utils/propTypes.js
@@ -105,6 +105,25 @@ const Location = PropTypes.shape({
 
 const SampleUploadType = PropTypes.oneOf(["basespace", "local", "remote"]);
 
+// Bulk download types
+const DownloadType = PropTypes.shape({
+  type: PropTypes.string,
+  display_name: PropTypes.string,
+  description: PropTypes.string,
+  category: PropTypes.string,
+  fields: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.string,
+      display_name: PropTypes.string,
+    })
+  ),
+});
+
+const DownloadTypeParam = PropTypes.shape({
+  displayName: PropTypes.string,
+  value: PropTypes.string,
+});
+
 export default {
   ReportDetails,
   Taxon,
@@ -118,5 +137,7 @@ export default {
   HostGenome,
   Location,
   SampleUploadType,
+  DownloadType,
+  DownloadTypeParam,
   ...PropTypes,
 };

--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -10,8 +10,28 @@ import ChooseStep from "./ChooseStep";
 import ReviewStep from "./ReviewStep";
 
 const assembleSelectedDownload = memoize(
-  (selectedDownloadTypeName, allSelectedFields, sampleIds) => {
-    const fields = get(selectedDownloadTypeName, allSelectedFields);
+  (
+    selectedDownloadTypeName,
+    allSelectedFields,
+    allSelectedFieldsDisplay,
+    sampleIds
+  ) => {
+    const fieldValues = get(selectedDownloadTypeName, allSelectedFields);
+    const fieldDisplayNames = get(
+      selectedDownloadTypeName,
+      allSelectedFieldsDisplay
+    );
+
+    const fields = {};
+    if (fieldValues) {
+      for (let [fieldName, fieldValue] of Object.entries(fieldValues)) {
+        fields[fieldName] = {
+          value: fieldValue,
+          // Use the display name for the value if it exists. Otherwise, use the value.
+          displayName: fieldDisplayNames[fieldName] || fieldValue,
+        };
+      }
+    }
 
     return {
       downloadType: selectedDownloadTypeName,
@@ -27,6 +47,13 @@ class BulkDownloadModal extends React.Component {
     // We save the fields for ALL download types.
     // If the user clicks between different download types, all their selections are saved.
     selectedFields: {},
+    // For each selected field, we also save a human-readable "display name" for that field.
+    // While the user is in the choose step, we store a field's value and display name separately.
+    // This is to be compatible with <Dropdowns>, which only accept a string or number as the value
+    // (as opposed to an object).
+    // However, after the selected download is "assembled", both the value and display name for each field are stored
+    // are stored in the params. This is also how the bulk download is stored in the database.
+    selectedFieldsDisplay: {},
     selectedDownloadTypeName: null,
     currentStep: "choose",
   };
@@ -50,23 +77,28 @@ class BulkDownloadModal extends React.Component {
     }
   }
 
-  onSelectDownloadType = selectedDownloadTypeName => {
+  handleSelectDownloadType = selectedDownloadTypeName => {
     this.setState({
       selectedDownloadTypeName,
     });
   };
 
-  onFieldSelect = (downloadType, fieldType, value) => {
+  handleFieldSelect = (downloadType, fieldType, value, displayName) => {
     this.setState({
       selectedFields: set(
         [downloadType, fieldType],
         value,
         this.state.selectedFields
       ),
+      selectedFieldsDisplay: set(
+        [downloadType, fieldType],
+        displayName,
+        this.state.selectedFieldsDisplay
+      ),
     });
   };
 
-  onChooseStepContinue = () => {
+  handleChooseStepContinue = () => {
     this.setState({ currentStep: "review" });
   };
   handleBackClick = () => {
@@ -80,6 +112,7 @@ class BulkDownloadModal extends React.Component {
       bulkDownloadTypes,
       selectedDownloadTypeName,
       selectedFields,
+      selectedFieldsDisplay,
     } = this.state;
 
     if (currentStep === "choose") {
@@ -87,10 +120,10 @@ class BulkDownloadModal extends React.Component {
         <ChooseStep
           downloadTypes={bulkDownloadTypes}
           selectedDownloadTypeName={selectedDownloadTypeName}
-          onSelect={this.onSelectDownloadType}
+          onSelect={this.handleSelectDownloadType}
           selectedFields={selectedFields}
-          onFieldSelect={this.onFieldSelect}
-          onContinue={this.onChooseStepContinue}
+          onFieldSelect={this.handleFieldSelect}
+          onContinue={this.handleChooseStepContinue}
         />
       );
     }
@@ -99,6 +132,7 @@ class BulkDownloadModal extends React.Component {
       const selectedDownload = assembleSelectedDownload(
         selectedDownloadTypeName,
         selectedFields,
+        selectedFieldsDisplay,
         selectedSampleIds
       );
 

--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -52,7 +52,7 @@ class BulkDownloadModal extends React.Component {
     // This is to be compatible with <Dropdowns>, which only accept a string or number as the value
     // (as opposed to an object).
     // However, after the selected download is "assembled", both the value and display name for each field are stored
-    // are stored in the params. This is also how the bulk download is stored in the database.
+    // in the params. This is also how the bulk download is stored in the database.
     selectedFieldsDisplay: {},
     selectedDownloadTypeName: null,
     currentStep: "choose",

--- a/app/assets/src/components/views/bulk_download/BulkDownloadSummary.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadSummary.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import PropTypes from "prop-types";
+import PropTypes from "~/components/utils/propTypes";
 import { get, find } from "lodash/fp";
 import cx from "classnames";
 
@@ -14,7 +14,7 @@ class BulkDownloadSummary extends React.Component {
     return (
       <div className={cs.param} key={param}>
         <div className={cs.name}>{fieldDisplayName}</div>
-        <div className={cs.value}>{value}</div>
+        <div className={cs.value}>{value.displayName}</div>
       </div>
     );
   };
@@ -34,8 +34,8 @@ class BulkDownloadSummary extends React.Component {
         </div>
         {downloadSummary.params && (
           <div className={cs.params}>
-            {Object.entries(downloadSummary.params).map(([key, value]) =>
-              this.renderDownloadParam(key, value)
+            {Object.entries(downloadSummary.params).map(([key, param]) =>
+              this.renderDownloadParam(key, param)
             )}
           </div>
         )}
@@ -47,18 +47,10 @@ class BulkDownloadSummary extends React.Component {
 BulkDownloadSummary.propTypes = {
   className: PropTypes.string,
   downloadSummary: PropTypes.shape({
-    params: PropTypes.object,
+    params: PropTypes.objectOf(PropTypes.DownloadTypeParam),
     numSamples: PropTypes.number,
   }).isRequired,
-  downloadType: PropTypes.shape({
-    display_name: PropTypes.string,
-    fields: PropTypes.arrayOf(
-      PropTypes.shape({
-        type: PropTypes.string,
-        display_name: PropTypes.string,
-      })
-    ),
-  }).isRequired,
+  downloadType: PropTypes.DownloadType.isRequired,
 };
 
 export default BulkDownloadSummary;

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import PropTypes from "prop-types";
+import PropTypes from "~/components/utils/propTypes";
 import { find, filter, get, some, map, isUndefined } from "lodash/fp";
 import cx from "classnames";
 
@@ -67,8 +67,30 @@ class ChooseStep extends React.Component {
             <Dropdown
               fluid
               options={dropdownOptions}
-              onChange={value =>
-                onFieldSelect(downloadType.type, field.type, value)
+              onChange={(value, displayName) =>
+                onFieldSelect(downloadType.type, field.type, value, displayName)
+              }
+              value={selectedField}
+            />
+          </div>
+        );
+      case "taxon":
+        // TODO(mark): Implement more sophisticated taxon dropdown. This is a placeholder for now.
+        dropdownOptions = [
+          {
+            text: "All Taxon",
+            value: "all",
+          },
+        ];
+
+        return (
+          <div className={cs.field} key={field.type}>
+            <div className={cs.label}>Taxon:</div>
+            <Dropdown
+              fluid
+              options={dropdownOptions}
+              onChange={(value, displayName) =>
+                onFieldSelect(downloadType.type, field.type, value, displayName)
               }
               value={selectedField}
             />
@@ -157,20 +179,7 @@ class ChooseStep extends React.Component {
 }
 
 ChooseStep.propTypes = {
-  downloadTypes: PropTypes.arrayOf(
-    PropTypes.shape({
-      type: PropTypes.string,
-      display_name: PropTypes.string,
-      description: PropTypes.string,
-      category: PropTypes.string,
-      fields: PropTypes.arrayOf(
-        PropTypes.shape({
-          type: PropTypes.string,
-          display_name: PropTypes.string,
-        })
-      ),
-    })
-  ),
+  downloadTypes: PropTypes.arrayOf(PropTypes.DownloadType),
   selectedDownloadTypeName: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   selectedFields: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),

--- a/app/assets/src/components/views/bulk_download/ReviewStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ReviewStep.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import PropTypes from "prop-types";
+import PropTypes from "~/components/utils/propTypes";
 import cx from "classnames";
 
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
@@ -99,21 +99,10 @@ class ReviewStep extends React.Component {
 ReviewStep.propTypes = {
   selectedDownload: PropTypes.shape({
     downloadType: PropTypes.string.isRequired,
-    fields: PropTypes.object,
+    fields: PropTypes.objectOf(PropTypes.DownloadTypeParam),
     sampleIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   }).isRequired,
-  downloadType: PropTypes.shape({
-    type: PropTypes.string,
-    display_name: PropTypes.string,
-    description: PropTypes.string,
-    category: PropTypes.string,
-    fields: PropTypes.arrayOf(
-      PropTypes.shape({
-        type: PropTypes.string,
-        display_name: PropTypes.string,
-      })
-    ),
-  }),
+  downloadType: PropTypes.DownloadType,
   onBackClick: PropTypes.func.isRequired,
 };
 

--- a/app/assets/src/components/views/bulk_download/choose_step.scss
+++ b/app/assets/src/components/views/bulk_download/choose_step.scss
@@ -52,6 +52,11 @@
     margin-top: 4px;
   }
 
+  .content {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
   .name {
     @include font-header-xs;
   }
@@ -64,9 +69,15 @@
 
 .fields {
   margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
 
   .field {
-    width: calc(50% - 20px);
+    width: calc(50% - 10px);
+
+    &:nth-child(odd) {
+      margin-right: 20px;
+    }
 
     .label {
       @include font-body-xs;

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -42,12 +42,29 @@ module BulkDownloadTypesHelper
       display_name: "Reads (Non-host)",
       description: "Reads with host data subtracted",
       category: "raw",
+      fields: [
+        {
+          display_name: "Taxa",
+          type: "taxon",
+        },
+        {
+          display_name: "File Format",
+          type: "file_format",
+          options: [".fasta", ".fastq"],
+        },
+      ],
     },
     {
       type: "contigs_non_host",
       display_name: "Contigs (Non-host)",
       description: "Contigs with host data subtracted",
       category: "raw",
+      fields: [
+        {
+          display_name: "Taxa",
+          type: "taxon",
+        },
+      ],
     },
     {
       type: "unmapped_reads",

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -1,19 +1,29 @@
 module BulkDownloadTypesHelper
+  SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE = "sample_overview".freeze
+  SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE = "sample_taxon_report".freeze
+  COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE = "combined_sample_taxon_results".freeze
+  CONTIG_SUMMARY_REPORT_BULK_DOWNLOAD_TYPE = "contig_summary_report".freeze
+  HOST_GENE_COUNTS_BULK_DOWNLOAD_TYPE = "host_gene_counts".freeze
+  READS_NON_HOST_BULK_DOWNLOAD_TYPE = "reads_non_host".freeze
+  CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE = "contigs_non_host".freeze
+  UNMAPPED_READS_BULK_DOWNLOAD_TYPE = "unmapped_reads".freeze
+  ORIGINAL_INPUT_FILE_BULK_DOWNLOAD_TYPE = "original_input_file".freeze
+
   BULK_DOWNLOAD_TYPES = [
     {
-      type: "sample_overview",
+      type: SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE,
       display_name: "Sample Overviews",
       description: "Sample metadata and QC metrics",
       category: "report",
     },
     {
-      type: "sample_taxon_report",
+      type: SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE,
       display_name: "Sample Taxon Reports",
       description: "Metrics (e.g. total reads, rPM) and metadata for each taxon identified in the sample",
       category: "report",
     },
     {
-      type: "combined_sample_taxon_results",
+      type: COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE,
       display_name: "Combined Sample Taxon Results",
       description: "The value of a particular metric (e.g. total reads, rPM) for all taxons in all selected samples, in a single data table",
       category: "report",
@@ -26,19 +36,19 @@ module BulkDownloadTypesHelper
       ],
     },
     {
-      type: "contig_summary_report",
+      type: CONTIG_SUMMARY_REPORT_BULK_DOWNLOAD_TYPE,
       display_name: "Contig Summary Reports",
       description: "Contig metadata and QC metrics",
       category: "report",
     },
     {
-      type: "host_gene_counts",
+      type: HOST_GENE_COUNTS_BULK_DOWNLOAD_TYPE,
       display_name: "Host Gene Counts",
       description: "Host gene count outputs from STAR",
       category: "report",
     },
     {
-      type: "reads_non_host",
+      type: READS_NON_HOST_BULK_DOWNLOAD_TYPE,
       display_name: "Reads (Non-host)",
       description: "Reads with host data subtracted",
       category: "raw",
@@ -55,7 +65,7 @@ module BulkDownloadTypesHelper
       ],
     },
     {
-      type: "contigs_non_host",
+      type: CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE,
       display_name: "Contigs (Non-host)",
       description: "Contigs with host data subtracted",
       category: "raw",
@@ -67,13 +77,13 @@ module BulkDownloadTypesHelper
       ],
     },
     {
-      type: "unmapped_reads",
+      type: UNMAPPED_READS_BULK_DOWNLOAD_TYPE,
       display_name: "Unmapped Reads",
       description: "Reads that didn’t map to any taxa",
       category: "raw",
     },
     {
-      type: "original_input_file",
+      type: ORIGINAL_INPUT_FILE_BULK_DOWNLOAD_TYPE,
       display_name: "Original Input Files",
       description: "Original files you submitted to IDseq",
       category: "raw",

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -14,6 +14,7 @@ class BulkDownload < ApplicationRecord
   OUTPUT_DOWNLOAD_EXPIRATION = 86_400 # seconds
 
   before_save :convert_params_to_json
+  after_find :set_params
 
   attr_accessor :params
 
@@ -24,6 +25,12 @@ class BulkDownload < ApplicationRecord
     # Convert params to JSON right before saving.
     if params
       self.params_json = params.to_json
+    end
+  end
+
+  def set_params
+    if params_json
+      self.params = JSON.parse(params_json)
     end
   end
 
@@ -150,36 +157,92 @@ class BulkDownload < ApplicationRecord
     end
   end
 
+  def get_param_value(key)
+    params[key]["value"]
+  end
+
+  # cleaned_project_names is a map from project id to cleaned project name
+  def get_output_file_prefix(sample, cleaned_project_names)
+    "#{sample.name}__" \
+      "#{cleaned_project_names[sample.project_id]}_#{sample.project_id}__"
+  end
+
   def bulk_download_ecs_task_command
+    samples = Sample.where(id: pipeline_runs.map(&:sample_id))
+    projects = Project.where(id: samples.pluck(:project_id))
+
+    # Compute cleaned project name once instead of once per sample.
+    cleaned_project_names = {}
+    projects.each do |project|
+      cleaned_project_names[project.id] = project.cleaned_project_name
+    end
+
+    download_src_urls = nil
+    download_tar_names = nil
+
     if download_type == "original_input_file"
-      samples = Sample.where(id: pipeline_runs.map(&:sample_id))
-                      .includes(:input_files)
+      samples = samples.includes(:input_files)
 
-      download_src_urls = samples.map do |sample|
-        sample.input_files.map { |input_file| "s3://#{ENV['SAMPLES_BUCKET_NAME']}/#{input_file.file_path}" }
-      end.flatten
+      download_src_urls = samples.map(&:input_file_s3_paths).flatten
 
-      projects = Project.where(id: samples.pluck(:project_id))
-
-      # Compute cleaned project name once instead of once per sample.
-      cleaned_project_names = {}
-      projects.each do |project|
-        cleaned_project_names[project.id] = project.cleaned_project_name
-      end
-
-      # We use the sample name in the output file names (instead of the original file name)
+      # We use the sample name in the output file names (instead of the original input file names)
       # because the sample name is what's visible to the user.
       # Also, there might be duplicates between the original file names.
       download_tar_names = samples.map do |sample|
         # We assume that the first input file is R1 and the second input file is R2. This is the convention that the pipeline follows.
         sample.input_files.map.with_index do |input_file, input_file_index|
           # Include the project id because the cleaned project names might have duplicates as well.
-          "#{input_file.sample.name}__" \
-            "#{cleaned_project_names[sample.project.id]}_#{sample.project.id}__" \
+          "#{get_output_file_prefix(sample, cleaned_project_names)}" \
             "original_R#{input_file_index + 1}.#{input_file.file_type}"
         end
       end.flatten
+    end
 
+    if download_type == "unmapped_reads"
+      download_src_urls = pipeline_runs.map(&:unidentified_fasta_s3_path)
+
+      download_tar_names = samples.map do |sample|
+        "#{get_output_file_prefix(sample, cleaned_project_names)}" \
+          "unmapped.fasta"
+      end
+    end
+
+    if download_type == "reads_non_host" && get_param_value("file_format") == ".fasta"
+      download_src_urls = pipeline_runs.map(&:annotated_fasta_s3_path)
+
+      download_tar_names = samples.map do |sample|
+        "#{get_output_file_prefix(sample, cleaned_project_names)}" \
+          "reads_nonhost_all.fasta"
+      end
+    end
+
+    if download_type == "reads_non_host" && get_param_value("file_format") == ".fastq"
+      pipeline_runs_with_assocs = pipeline_runs.includes(sample: [:input_files])
+
+      download_src_urls = pipeline_runs_with_assocs.map(&:nonhost_fastq_s3_paths).flatten
+
+      download_tar_names = pipeline_runs_with_assocs.map do |pipeline_run|
+        sample = pipeline_run.sample
+        file_ext = sample.fasta_input? ? 'fasta' : 'fastq'
+        # We assume that the first input file is R1 and the second input file is R2. This is the convention that the pipeline follows.
+        sample.input_files.map.with_index do |_input_file, input_file_index|
+          # Include the project id because the cleaned project names might have duplicates as well.
+          "#{get_output_file_prefix(sample, cleaned_project_names)}" \
+            "reads_nonhost_all_R#{input_file_index + 1}.#{file_ext}"
+        end
+      end.flatten
+    end
+
+    if download_type == "contigs_non_host"
+      download_src_urls = pipeline_runs.map(&:contigs_fasta_s3_path)
+
+      download_tar_names = samples.map do |sample|
+        "#{get_output_file_prefix(sample, cleaned_project_names)}" \
+            "contigs_nonhost_all.fasta"
+      end
+    end
+
+    if !download_src_urls.nil? && !download_tar_names.nil?
       return s3_tar_writer_command(
         download_src_urls,
         download_tar_names,

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -57,6 +57,7 @@ class PipelineRun < ApplicationRecord
   STATS_JSON_NAME = "stats.json".freeze
   INPUT_VALIDATION_NAME = "validate_input_summary.json".freeze
   INVALID_STEP_NAME = "invalid_step_input.json".freeze
+  NONHOST_FASTQ_OUTPUT_NAME = 'taxid_annot.fasta'.freeze
   ERCC_OUTPUT_NAME = 'reads_per_gene.star.tab'.freeze
   AMR_DRUG_SUMMARY_RESULTS = 'amr_summary_results.csv'.freeze
   AMR_FULL_RESULTS_NAME = 'amr_processed_results.csv'.freeze
@@ -407,6 +408,20 @@ class PipelineRun < ApplicationRecord
     return "#{postprocess_output_s3_path}/#{DAG_ANNOTATED_FASTA_BASENAME}" if pipeline_version_at_least_2(pipeline_version)
 
     multihit? ? "#{alignment_output_s3_path}/#{MULTIHIT_FASTA_BASENAME}" : "#{alignment_output_s3_path}/#{HIT_FASTA_BASENAME}"
+  end
+
+  def nonhost_fastq_s3_paths
+    input_file_ext = sample.fasta_input? ? 'fasta' : 'fastq'
+
+    files = [
+      "#{postprocess_output_s3_path}/nonhost_R1.#{input_file_ext}",
+    ]
+
+    if sample.input_files.length == 2
+      files << "#{postprocess_output_s3_path}/nonhost_R2.#{input_file_ext}"
+    end
+
+    files
   end
 
   def unidentified_fasta_s3_path

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -459,7 +459,7 @@ class Sample < ApplicationRecord
   end
 
   def sample_input_s3_path
-    "s3://#{SAMPLES_BUCKET_NAME}/#{sample_path}/fastqs"
+    "s3://#{ENV['SAMPLES_BUCKET_NAME']}/#{sample_path}/fastqs"
   end
 
   def filter_host_flag
@@ -471,7 +471,7 @@ class Sample < ApplicationRecord
   end
 
   def sample_output_s3_path
-    "s3://#{SAMPLES_BUCKET_NAME}/#{sample_path}/results"
+    "s3://#{ENV['SAMPLES_BUCKET_NAME']}/#{sample_path}/results"
   end
 
   def sample_alignment_output_s3_path
@@ -494,14 +494,14 @@ class Sample < ApplicationRecord
   end
 
   def sample_postprocess_s3_path
-    "s3://#{SAMPLES_BUCKET_NAME}/#{sample_path}/postprocess"
+    "s3://#{ENV['SAMPLES_BUCKET_NAME']}/#{sample_path}/postprocess"
   end
 
   # This is for the "Experimental" pipeline run stage and path where results
   # for this stage are outputted. Currently, Antimicrobial Resistance
   # outputs are in this path.
   def sample_expt_s3_path
-    "s3://#{SAMPLES_BUCKET_NAME}/#{sample_path}/expt"
+    "s3://#{ENV['SAMPLES_BUCKET_NAME']}/#{sample_path}/expt"
   end
 
   def host_genome_name
@@ -916,5 +916,9 @@ class Sample < ApplicationRecord
   # error messages.
   def status_url
     UrlUtil.absolute_base_url + "/samples/#{id}/pipeline_runs"
+  end
+
+  def input_file_s3_paths
+    input_files.map { |input_file| "s3://#{ENV['SAMPLES_BUCKET_NAME']}/#{input_file.file_path}" }
   end
 end

--- a/spec/factories/bulk_downloads.rb
+++ b/spec/factories/bulk_downloads.rb
@@ -2,5 +2,11 @@ FactoryBot.define do
   factory :bulk_download do
     download_type { "sample_overview" }
     status { "waiting" }
+
+    before :create do |bulk_download, options|
+      if options.params
+        bulk_download.params_json = options.params.to_json
+      end
+    end
   end
 end

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -79,7 +79,7 @@ describe BulkDownload, type: :model do
     end
 
     it "returns the correct task command for original_input_file download type" do
-      @bulk_download = create(:bulk_download, user: @joe, download_type: "original_input_file", pipeline_run_ids: [
+      @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::ORIGINAL_INPUT_FILE_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ])
@@ -113,7 +113,7 @@ describe BulkDownload, type: :model do
     end
 
     it "returns the correct task command for unmapped_reads download type" do
-      @bulk_download = create(:bulk_download, user: @joe, download_type: "unmapped_reads", pipeline_run_ids: [
+      @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::UNMAPPED_READS_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ])
@@ -144,7 +144,7 @@ describe BulkDownload, type: :model do
     end
 
     it "returns the correct task command for reads_non_host download type with fasta file format" do
-      @bulk_download = create(:bulk_download, user: @joe, download_type: "reads_non_host", pipeline_run_ids: [
+      @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ], params: {
@@ -180,7 +180,7 @@ describe BulkDownload, type: :model do
     end
 
     it "returns the correct task command for reads_non_host download type with fastq file format" do
-      @bulk_download = create(:bulk_download, user: @joe, download_type: "reads_non_host", pipeline_run_ids: [
+      @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ], params: {
@@ -219,7 +219,7 @@ describe BulkDownload, type: :model do
     end
 
     it "returns the correct task command for contigs_non_host download type with fasta file format" do
-      @bulk_download = create(:bulk_download, user: @joe, download_type: "contigs_non_host", pipeline_run_ids: [
+      @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ])


### PR DESCRIPTION
# Description

* Add unmapped reads, reads-non-host and contigs-non-host.
* Also modify how params are stored in the back-end. Previously, we stored just `key: value`. Now we store `key: {value, displayName}` for each field. See notes below.

# Notes
Regarding the param format:

The reason for storing both the value and the displayName is 1) the value can be something like a background id, which is not human-readable. We can either resolve the displayName for each value every time we fetch it, or just store the displayName with the value. 2) It's possible that, for example, the background corresponding to the background id is modified or removed in the future. If we then try to resolve the displayName for the value (e.g. background id), we won't be able to get it, and the user will no longer be able to know what the background name had been for their bulk download. It seems to be better to just freeze the displayName at the time the bulk download was generated. (the downside to this approach is that the displayName won't automatically update if the background is renamed, but this seems fine. We do also have the value stored if the user asks us)

Also, the reads-non-host and contigs-non-host download types aren't finished. Still need to handle the per-taxon case, which will be handled with Resque.

# Tests
* Unit tests for each download type.
* Verified for each download type that the generated files were correct, by downloading and manually inspecting. Verified that the files match what the user get when they download the files individually from the sample report page. Did this for both a single-read and a paired-read sample.
