### PR TITLE
Only remove idseq-dag results dir; keep references

### DIFF
--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -130,7 +130,7 @@ module PipelineRunsHelper
 
   def install_pipeline(commit_or_branch)
     "pip install --upgrade git+git://github.com/chanzuckerberg/s3mi.git; " \
-    "cd /mnt; rm -rf *; df -h; " \
+    "cd /mnt; rm -rf idseq/results; df -h; " \
     "git clone https://github.com/chanzuckerberg/idseq-dag.git; " \
     "cd idseq-dag; " \
     "git checkout #{Shellwords.escape(commit_or_branch)}; " \


### PR DESCRIPTION
This unblocks pending reference management changes in idseq-dag.

# Description

*The intended change, motivation and consequences.*

# Notes

*Optional observations, comments or explanations.*

# Tests

This will be tested on staging in concert with corresponding idseq-dag changes.