### PR TITLE
Fix metadata input vert align

### DIFF
--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -294,10 +294,6 @@ class MetadataManualInput extends React.Component {
 
           const inputClasses = cx(
             cs.input,
-            // Add extra bottom padding to get inputs to align with the input that has Apply to All under it.
-            column !== this.state.applyToAllCell.column &&
-              sample.name === this.state.applyToAllCell.sampleName &&
-              cs.extraPadding,
             // Add extra width to location inputs for long names.
             column.startsWith("collection_location") && cs.extraWidth
           );

--- a/app/assets/src/components/common/metadata_manual_input.scss
+++ b/app/assets/src/components/common/metadata_manual_input.scss
@@ -32,7 +32,12 @@
   .inputTable {
     margin-bottom: 20px;
 
+    td {
+      vertical-align: top !important;
+    }
+
     .sampleName {
+      padding: $space-m 0; // align vertically with inputs
       font-weight: $font-weight-semibold;
     }
 
@@ -43,10 +48,6 @@
     .input {
       margin: $space-xxs $space-m $space-xxs 0;
       width: 130px;
-
-      &.extraPadding {
-        margin-bottom: 22px;
-      }
 
       &.extraWidth {
         width: 240px;

--- a/app/assets/src/components/common/metadata_manual_input.scss
+++ b/app/assets/src/components/common/metadata_manual_input.scss
@@ -33,7 +33,7 @@
     margin-bottom: 20px;
 
     td {
-      vertical-align: top !important;
+      vertical-align: top !important; // override semantic ui
     }
 
     .sampleName {

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -16,6 +16,7 @@ export const LOCATION_UNRESOLVED_WARNING =
 export const processLocationSelection = (result, isHuman) => {
   let warning = "";
   if (isHuman && get("geo_level", result) === "city") {
+    result = Object.assign({}, result); // make a copy to avoid side effects
     // For human samples, drop the city part of the name and show a warning.
     // NOTE: The backend will redo the geosearch for confirmation and re-apply
     // this restriction.

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -15,7 +15,7 @@ class LiveSearchPopBox extends React.Component {
       results: [],
       value: this.props.initialValue,
       selectedResult: null,
-      currentResult: null, // result set on click
+      currentResult: "", // either string or object
     };
 
     this.lastestTimerId = null;

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -124,11 +124,13 @@ class LiveSearchPopBox extends React.Component {
   };
 
   handleBlur = currentEvent => {
-    // Give a chance for warnings to show
-    this.handleResultSelect({
-      currentEvent: currentEvent,
-      result: this.state.currentResult,
-    });
+    // Call onResultSelect again to give a chance for warnings to show
+    const { onResultSelect } = this.props;
+    onResultSelect &&
+      onResultSelect({
+        currentEvent,
+        result: this.state.currentResult,
+      });
   };
 
   buildItem = (categoryKey, result, index) => (


### PR DESCRIPTION
# Description

See https://jira.czi.team/browse/IDSEQ-1524. 

![image](https://user-images.githubusercontent.com/28797/67995905-2577ee00-fc0a-11e9-89b9-055d1e798ee6.png)


# Notes

* It was hard to tell the origin of the `middle` alignment because of CSS bundling. How can I verify that it is from semantic UI? 

* I had to remove some previous special case CSS from @jshoe 

# Tests

* Open metadata upload
* Check "apply to all" and location warning does not affect vert align