### PR TITLE
Fix issue where pressing spacebar on search dropdown closes dropdown.

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -12,7 +12,7 @@
 // redundant with props.items.customNode and props.children.
 import React from "react";
 import cx from "classnames";
-import { omit, zip, filter, map, nth, sortBy } from "lodash/fp";
+import { identity, omit, zip, filter, map, nth, sortBy } from "lodash/fp";
 import { forbidExtraProps } from "airbnb-prop-types";
 import { Dropdown as BaseDropdown } from "semantic-ui-react";
 import Input from "~ui/controls/Input";
@@ -224,11 +224,17 @@ class BareDropdown extends React.Component {
       );
     }
 
+    // When search is enabled, we need to tell semantic-ui that we are in search mode.
+    // Otherwise, pressing spacebar will cause the dropdown to close.
+    // See https://github.com/Semantic-Org/Semantic-UI-React/issues/3768
+    // This causes other issues. Specifically, now when you click on the trigger or any items,
+    // the dropdown no longer closes at all. You have to click outside the dropdown.
     return (
       <BaseDropdown
         {...baseDropdownProps}
         className={dropdownClassName}
         onBlur={e => e.stopPropagation()}
+        search={search ? identity : undefined}
       >
         {menu}
       </BaseDropdown>

--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -60,6 +60,12 @@
     }
   }
 
+  // Since we have our own custom search input,
+  // hide the semantic-ui search input.
+  :global(.search) {
+    display: none;
+  }
+
   .item {
     cursor: pointer;
 


### PR DESCRIPTION
# Description

This fixes the immediate issue (which seems quite serious) but introduces other annoying issues. Specifically, now when you click on the trigger or any items, the dropdown no longer closes at all. You have to click outside the dropdown.

I think the underlying issue is that we've implemented a lot of custom behavior around the semantic ui component, which semantic ui doesn't know about. The long-term solution might be to either write our own component, or adopt semantic-ui's behavior instead of our custom behavior.
