### PR TITLE
Add sample taxon report bulk download type.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -308,6 +308,11 @@ const createBackground = ({ description, name, sampleIds }) =>
     sample_ids: sampleIds,
   });
 
+const getBackgrounds = async () => {
+  const response = await get("/backgrounds.json");
+  return response.backgrounds;
+};
+
 const getCoverageVizSummary = sampleId =>
   get(`/samples/${sampleId}/coverage_viz_summary`);
 
@@ -384,4 +389,5 @@ export {
   validatePhyloTreeName,
   validateSampleFiles,
   validateSampleNames,
+  getBackgrounds,
 };

--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -4,6 +4,7 @@ import { find, get, set } from "lodash/fp";
 import memoize from "memoize-one";
 
 import { getBulkDownloadTypes } from "~/api/bulk_downloads";
+import { getBackgrounds } from "~/api";
 import Modal from "~ui/containers/Modal";
 
 import ChooseStep from "./ChooseStep";
@@ -56,17 +57,14 @@ class BulkDownloadModal extends React.Component {
     selectedFieldsDisplay: {},
     selectedDownloadTypeName: null,
     currentStep: "choose",
+    fieldOptions: {},
   };
 
-  async componentDidMount() {
-    const bulkDownloadTypes = await getBulkDownloadTypes();
-
-    this.setState({
-      bulkDownloadTypes,
-    });
+  componentDidMount() {
+    this.fetchDownloadTypes();
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     // If the user has just closed the modal, reset it.
     if (prevProps.open && !this.props.open) {
       this.setState({
@@ -75,6 +73,35 @@ class BulkDownloadModal extends React.Component {
         selectedFields: {},
       });
     }
+
+    // When the modal is opened, fetch options for the bulk download fields.
+    if (!prevProps.open && this.props.open) {
+      this.fetchBackgrounds();
+    }
+  }
+
+  async fetchDownloadTypes() {
+    const bulkDownloadTypes = await getBulkDownloadTypes();
+
+    this.setState({
+      bulkDownloadTypes,
+    });
+  }
+
+  // TODO(mark): Set a reasonable default background based on the samples and the user's preferences.
+  async fetchBackgrounds() {
+    if (this.state.fieldOptions.backgrounds) {
+      return;
+    }
+
+    const backgrounds = await getBackgrounds();
+
+    // Since multiple async functions might set fieldOptions, we use the function form
+    // of setState to prevent race conditions.
+    this.setState(prevState => ({
+      ...prevState,
+      fieldOptions: set("backgrounds", backgrounds, prevState.fieldOptions),
+    }));
   }
 
   handleSelectDownloadType = selectedDownloadTypeName => {
@@ -113,6 +140,7 @@ class BulkDownloadModal extends React.Component {
       selectedDownloadTypeName,
       selectedFields,
       selectedFieldsDisplay,
+      fieldOptions,
     } = this.state;
 
     if (currentStep === "choose") {
@@ -124,6 +152,7 @@ class BulkDownloadModal extends React.Component {
           selectedFields={selectedFields}
           onFieldSelect={this.handleFieldSelect}
           onContinue={this.handleChooseStepContinue}
+          fieldOptions={fieldOptions}
         />
       );
     }

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -52,7 +52,8 @@ class ChooseStep extends React.Component {
   renderOption = (downloadType, field) => {
     const { selectedFields, onFieldSelect, fieldOptions } = this.props;
     const selectedField = get([downloadType.type, field.type], selectedFields);
-    let dropdownOptions, loadingOptions;
+    let dropdownOptions = [];
+    let loadingOptions = false;
 
     switch (field.type) {
       case "file_format":

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -50,9 +50,9 @@ class ChooseStep extends React.Component {
   };
 
   renderOption = (downloadType, field) => {
-    const { selectedFields, onFieldSelect } = this.props;
+    const { selectedFields, onFieldSelect, fieldOptions } = this.props;
     const selectedField = get([downloadType.type, field.type], selectedFields);
-    let dropdownOptions;
+    let dropdownOptions, loadingOptions;
 
     switch (field.type) {
       case "file_format":
@@ -63,7 +63,7 @@ class ChooseStep extends React.Component {
 
         return (
           <div className={cs.field} key={field.type}>
-            <div className={cs.label}>File Format:</div>
+            <div className={cs.label}>{field.display_name}:</div>
             <Dropdown
               fluid
               options={dropdownOptions}
@@ -85,10 +85,36 @@ class ChooseStep extends React.Component {
 
         return (
           <div className={cs.field} key={field.type}>
-            <div className={cs.label}>Taxon:</div>
+            <div className={cs.label}>{field.display_name}:</div>
             <Dropdown
               fluid
               options={dropdownOptions}
+              onChange={(value, displayName) =>
+                onFieldSelect(downloadType.type, field.type, value, displayName)
+              }
+              value={selectedField}
+            />
+          </div>
+        );
+      // TODO(mark): Consolidate this with the above fields once the set of fields is stable.
+      case "background":
+        if (fieldOptions.backgrounds) {
+          dropdownOptions = fieldOptions.backgrounds.map(background => ({
+            text: background.name,
+            value: background.id,
+          }));
+        } else {
+          loadingOptions = true;
+        }
+
+        return (
+          <div className={cs.field} key={field.type}>
+            <div className={cs.label}>{field.display_name}:</div>
+            <Dropdown
+              fluid
+              disabled={loadingOptions}
+              placeholder={loadingOptions && "Loading..."}
+              options={dropdownOptions || []}
               onChange={(value, displayName) =>
                 onFieldSelect(downloadType.type, field.type, value, displayName)
               }
@@ -185,6 +211,7 @@ ChooseStep.propTypes = {
   selectedFields: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
   onFieldSelect: PropTypes.func.isRequired,
   onContinue: PropTypes.func.isRequired,
+  fieldOptions: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.any)),
 };
 
 export default ChooseStep;

--- a/app/controllers/backgrounds_controller.rb
+++ b/app/controllers/backgrounds_controller.rb
@@ -2,13 +2,18 @@ class BackgroundsController < ApplicationController
   include BackgroundsHelper
   before_action :login_required
   before_action :no_demo_user
-  before_action :admin_required, except: [:create, :show_taxon_dist]
+  before_action :admin_required, except: [:create, :show_taxon_dist, :index]
   before_action :set_background, only: [:show, :edit, :update, :destroy, :show_taxon_dist]
 
   # GET /backgrounds
   # GET /backgrounds.json
   def index
-    @backgrounds = Background.all
+    @backgrounds = current_power.backgrounds
+
+    respond_to do |format|
+      format.html { render :index }
+      format.json { render json: { backgrounds: @backgrounds } }
+    end
   end
 
   # GET /backgrounds/1

--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -33,7 +33,7 @@ class BulkDownloadsController < ApplicationController
     rescue => e
       # Throw an error if any sample doesn't have a valid pipeline run.
       # The user should never see this error, because the validation step should catch any issues.
-      Rails.logger.error(e)
+      LogUtil.log_backtrace(e)
       LogUtil.log_err_and_airbrake("BulkDownloadsFailedEvent: Unexpected issue creating bulk download: #{e}")
       render json: { error: e }, status: :unprocessable_entity
       return
@@ -54,7 +54,7 @@ class BulkDownloadsController < ApplicationController
       rescue => e
         # If the kickoff failed, set to error.
         bulk_download.update(status: BulkDownload::STATUS_ERROR)
-        Rails.logger.error(e)
+        LogUtil.log_backtrace(e)
         LogUtil.log_err_and_airbrake("BulkDownloadsKickoffError: Unexpected issue kicking off bulk download: #{e}")
         render json: {
           error: BulkDownloadsHelper::KICKOFF_FAILURE_HUMAN_READABLE,

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -9,20 +9,24 @@ module BulkDownloadTypesHelper
   UNMAPPED_READS_BULK_DOWNLOAD_TYPE = "unmapped_reads".freeze
   ORIGINAL_INPUT_FILE_BULK_DOWNLOAD_TYPE = "original_input_file".freeze
 
+  RESQUE_EXECUTION_TYPE = "resque".freeze
+  VARIABLE_EXECUTION_TYPE = "variable".freeze
+  ECS_EXECUTION_TYPE = "ecs".freeze
+
   BULK_DOWNLOAD_TYPES = [
     {
       type: SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE,
       display_name: "Sample Overviews",
       description: "Sample metadata and QC metrics",
       category: "report",
-      execution_type: "resque",
+      execution_type: RESQUE_EXECUTION_TYPE,
     },
     {
       type: SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE,
       display_name: "Sample Taxon Reports",
       description: "Metrics (e.g. total reads, rPM) and metadata for each taxon identified in the sample",
       category: "report",
-      execution_type: "resque",
+      execution_type: RESQUE_EXECUTION_TYPE,
       fields: [
         {
           display_name: "Background",
@@ -42,21 +46,21 @@ module BulkDownloadTypesHelper
           options: [".csv", ".biom"],
         },
       ],
-      execution_type: "resque",
+      execution_type: RESQUE_EXECUTION_TYPE,
     },
     {
       type: CONTIG_SUMMARY_REPORT_BULK_DOWNLOAD_TYPE,
       display_name: "Contig Summary Reports",
       description: "Contig metadata and QC metrics",
       category: "report",
-      execution_type: "resque",
+      execution_type: RESQUE_EXECUTION_TYPE,
     },
     {
       type: HOST_GENE_COUNTS_BULK_DOWNLOAD_TYPE,
       display_name: "Host Gene Counts",
       description: "Host gene count outputs from STAR",
       category: "report",
-      execution_type: "resque",
+      execution_type: RESQUE_EXECUTION_TYPE,
     },
     {
       type: READS_NON_HOST_BULK_DOWNLOAD_TYPE,
@@ -74,7 +78,7 @@ module BulkDownloadTypesHelper
           options: [".fasta", ".fastq"],
         },
       ],
-      execution_type: "variable",
+      execution_type: VARIABLE_EXECUTION_TYPE,
     },
     {
       type: CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE,
@@ -87,21 +91,21 @@ module BulkDownloadTypesHelper
           type: "taxon",
         },
       ],
-      execution_type: "variable",
+      execution_type: VARIABLE_EXECUTION_TYPE,
     },
     {
       type: UNMAPPED_READS_BULK_DOWNLOAD_TYPE,
       display_name: "Unmapped Reads",
       description: "Reads that didn’t map to any taxa",
       category: "raw",
-      execution_type: "ecs",
+      execution_type: ECS_EXECUTION_TYPE,
     },
     {
       type: ORIGINAL_INPUT_FILE_BULK_DOWNLOAD_TYPE,
       display_name: "Original Input Files",
       description: "Original files you submitted to IDseq",
       category: "raw",
-      execution_type: "ecs",
+      execution_type: ECS_EXECUTION_TYPE,
     },
   ].freeze
 

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -15,12 +15,20 @@ module BulkDownloadTypesHelper
       display_name: "Sample Overviews",
       description: "Sample metadata and QC metrics",
       category: "report",
+      execution_type: "resque",
     },
     {
       type: SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE,
       display_name: "Sample Taxon Reports",
       description: "Metrics (e.g. total reads, rPM) and metadata for each taxon identified in the sample",
       category: "report",
+      execution_type: "resque",
+      fields: [
+        {
+          display_name: "Background",
+          type: "background",
+        },
+      ],
     },
     {
       type: COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE,
@@ -34,18 +42,21 @@ module BulkDownloadTypesHelper
           options: [".csv", ".biom"],
         },
       ],
+      execution_type: "resque",
     },
     {
       type: CONTIG_SUMMARY_REPORT_BULK_DOWNLOAD_TYPE,
       display_name: "Contig Summary Reports",
       description: "Contig metadata and QC metrics",
       category: "report",
+      execution_type: "resque",
     },
     {
       type: HOST_GENE_COUNTS_BULK_DOWNLOAD_TYPE,
       display_name: "Host Gene Counts",
       description: "Host gene count outputs from STAR",
       category: "report",
+      execution_type: "resque",
     },
     {
       type: READS_NON_HOST_BULK_DOWNLOAD_TYPE,
@@ -63,6 +74,7 @@ module BulkDownloadTypesHelper
           options: [".fasta", ".fastq"],
         },
       ],
+      execution_type: "variable",
     },
     {
       type: CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE,
@@ -75,23 +87,38 @@ module BulkDownloadTypesHelper
           type: "taxon",
         },
       ],
+      execution_type: "variable",
     },
     {
       type: UNMAPPED_READS_BULK_DOWNLOAD_TYPE,
       display_name: "Unmapped Reads",
       description: "Reads that didn’t map to any taxa",
       category: "raw",
+      execution_type: "ecs",
     },
     {
       type: ORIGINAL_INPUT_FILE_BULK_DOWNLOAD_TYPE,
       display_name: "Original Input Files",
       description: "Original files you submitted to IDseq",
       category: "raw",
+      execution_type: "ecs",
     },
   ].freeze
 
-  # A hash of type => display_name.
-  BULK_DOWNLOAD_TYPE_TO_DISPLAY_NAME = Hash[
-    BULK_DOWNLOAD_TYPES.pluck(:type).zip(BULK_DOWNLOAD_TYPES.pluck(:display_name))
+  # A hash of type name => type object
+  BULK_DOWNLOAD_TYPE_NAME_TO_DATA = Hash[
+    BULK_DOWNLOAD_TYPES.pluck(:type).zip(BULK_DOWNLOAD_TYPES)
   ]
+
+  def self.bulk_download_types
+    BULK_DOWNLOAD_TYPES
+  end
+
+  def self.bulk_download_type(type_name)
+    BULK_DOWNLOAD_TYPE_NAME_TO_DATA[type_name]
+  end
+
+  def self.bulk_download_type_display_name(type_name)
+    BULK_DOWNLOAD_TYPE_NAME_TO_DATA[type_name][:display_name]
+  end
 end

--- a/app/helpers/bulk_downloads_helper.rb
+++ b/app/helpers/bulk_downloads_helper.rb
@@ -11,7 +11,9 @@ module BulkDownloadsHelper
   KICKOFF_FAILURE_HUMAN_READABLE = "Could not kick off bulk download. Please contact us for help.".freeze
   PRESIGNED_URL_GENERATION_ERROR = "Could not generate a presigned url.".freeze
   SUCCESS_URL_REQUIRED = "Success url required for bulk download.".freeze
-  FAILED_SRC_URL_ERROR_TEMPLATE = "%s samples could not be processed. Please contact us for help.".freeze
+  FAILED_SAMPLES_ERROR_TEMPLATE = "%s samples could not be processed. Please contact us for help.".freeze
+  UNKNOWN_EXECUTION_TYPE = "Could not find execution type for bulk download".freeze
+  BULK_DOWNLOAD_GENERATION_FAILED = "Could not generate bulk download".freeze
 
   # Check that all pipeline runs have succeeded for the provided samples
   # and return the pipeline run ids.
@@ -37,7 +39,7 @@ module BulkDownloadsHelper
   def format_bulk_download(bulk_download, with_pipeline_runs = false)
     formatted_bulk_download = bulk_download.as_json(except: [:access_token])
     formatted_bulk_download[:num_samples] = bulk_download.pipeline_runs.length
-    formatted_bulk_download[:download_name] = BulkDownloadTypesHelper::BULK_DOWNLOAD_TYPE_TO_DISPLAY_NAME[bulk_download.download_type]
+    formatted_bulk_download[:download_name] = BulkDownloadTypesHelper.bulk_download_type_display_name(bulk_download.download_type)
     unless bulk_download.params_json.nil?
       formatted_bulk_download[:params] = JSON.parse(bulk_download.params_json)
     end

--- a/app/jobs/generate_bulk_download.rb
+++ b/app/jobs/generate_bulk_download.rb
@@ -5,8 +5,8 @@ class GenerateBulkDownload
     Rails.logger.info("Start generating bulk download #{bulk_download_id}")
     BulkDownload.find(bulk_download_id).generate_download_file
   rescue => e
-    failure_message = "Bulk download generation failed for id #{bulk_download_id}"
-    Rails.logger.error(e)
+    failure_message = "Bulk download generation failed for id #{bulk_download_id}: #{e}"
+    LogUtil.log_backtrace(e)
     LogUtil.log_err_and_airbrake(failure_message)
   end
 end

--- a/app/jobs/generate_bulk_download.rb
+++ b/app/jobs/generate_bulk_download.rb
@@ -1,0 +1,12 @@
+# Job to generate a bulk download
+class GenerateBulkDownload
+  @queue = :generate_bulk_download
+  def self.perform(bulk_download_id)
+    Rails.logger.info("Start generating bulk download #{bulk_download_id}")
+    BulkDownload.find(bulk_download_id).generate_download_file
+  rescue => e
+    failure_message = "Bulk download generation failed for id #{bulk_download_id}"
+    Rails.logger.error(e)
+    LogUtil.log_err_and_airbrake(failure_message)
+  end
+end

--- a/app/lib/s3_tar_writer.rb
+++ b/app/lib/s3_tar_writer.rb
@@ -1,0 +1,32 @@
+require 'rubygems/package'
+
+class S3TarWriter
+  def initialize(s3_dest_url)
+    @s3_dest_url = s3_dest_url
+  end
+
+  def start_streaming
+    @stdin, _stdout, @wait_thr = Open3.popen2("aws", "s3", "cp", "-", @s3_dest_url)
+    # Set stdin to binary mode, since GzipWriter outputs binary.
+    @stdin.binmode
+    @gz = Zlib::GzipWriter.new(@stdin)
+    @tar = Gem::Package::TarWriter.new(@gz)
+  end
+
+  def add_file_with_data(file_path, data)
+    @tar.add_file_simple(file_path, 0o444, data.length) do |io|
+      io.write(data)
+    end
+  end
+
+  def close
+    @tar.close
+    @gz.close
+    @stdin.close
+  end
+
+  # Waits for the aws s3 cp process to terminate.
+  def process_status
+    @wait_thr.value
+  end
+end

--- a/app/lib/s3_tar_writer.rb
+++ b/app/lib/s3_tar_writer.rb
@@ -3,6 +3,7 @@ require 'rubygems/package'
 class S3TarWriter
   def initialize(s3_dest_url)
     @s3_dest_url = s3_dest_url
+    @total_size_processed = 0
   end
 
   def start_streaming
@@ -14,9 +15,11 @@ class S3TarWriter
   end
 
   def add_file_with_data(file_path, data)
-    @tar.add_file_simple(file_path, 0o444, data.length) do |io|
+    # 600 is the default permission the file will have. Readable/writable by owner only.
+    @tar.add_file_simple(file_path, 0o600, data.length) do |io|
       io.write(data)
     end
+    @total_size_processed += data.length
   end
 
   def close
@@ -29,4 +32,6 @@ class S3TarWriter
   def process_status
     @wait_thr.value
   end
+
+  attr_reader :total_size_processed
 end

--- a/app/lib/string_util.rb
+++ b/app/lib/string_util.rb
@@ -1,0 +1,15 @@
+class StringUtil
+  def self.human_readable_file_size(size, decimal_places: 1)
+    file_unit = ""
+    file_size = size
+
+    ["B", "KiB", "MiB", "GiB", "TiB"].each do |unit|
+      file_unit = unit
+      if file_size < 1024.0
+        break
+      end
+      file_size /= 1024.0
+    end
+    return format("%3.#{decimal_places}f#{file_unit}", file_size)
+  end
+end

--- a/spec/controllers/backgrounds_controller_spec.rb
+++ b/spec/controllers/backgrounds_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe BackgroundsController, type: :controller do
+  create_users
+
+  # Admin specific behavior
+  context "Normal user" do
+    # create_users
+    before do
+      sign_in @joe
+      @project_admin = create(:project, users: [@admin], name: "Project Admin")
+      @sample_admin = create(:sample, project: @project_admin, name: "Sample Admin",
+                                      pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
+      @sample_admin_two = create(:sample, project: @project_admin, name: "Sample Admin 2",
+                                          pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
+
+      @project_joe = create(:project, users: [@joe], name: "Project Joe")
+      @sample_joe = create(:sample, project: @project_joe, name: "Sample Joe",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
+      @sample_joe_two = create(:sample, project: @project_joe, name: "Sample Joe 2",
+                                        pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
+    end
+
+    describe "GET #index" do
+      it "should not see backgrounds that don't belong to them" do
+        create(:background, name: "Background Joe", user: @joe, pipeline_run_ids: [
+                 @sample_joe.first_pipeline_run.id,
+                 @sample_joe_two.first_pipeline_run.id,
+               ])
+        # Normal users should only see backgrounds if they can see all of the samples that are part of the background.
+        create(:background, name: "Background Admin", user: @admin, pipeline_run_ids: [
+                 @sample_admin.first_pipeline_run.id,
+                 @sample_admin_two.first_pipeline_run.id,
+               ])
+        create(:background, name: "Background Mixed", user: @admin, pipeline_run_ids: [
+                 @sample_joe.first_pipeline_run.id,
+                 @sample_admin.first_pipeline_run.id,
+               ])
+        get :index, format: :json
+        expect(response).to have_http_status(200)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response).to include_json(backgrounds: [{
+                                                name: "Background Joe",
+                                              },])
+      end
+    end
+  end
+end

--- a/spec/controllers/bulk_downloads_controller_spec.rb
+++ b/spec/controllers/bulk_downloads_controller_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe BulkDownloadsController, type: :controller do
         expect(response).to have_http_status(200)
 
         expect(BulkDownload.find(@bulk_download_joe.id).status).to eq(BulkDownload::STATUS_SUCCESS)
-        expect(BulkDownload.find(@bulk_download_joe.id).error_message).to eq(BulkDownloadsHelper::FAILED_SRC_URL_ERROR_TEMPLATE % 2)
+        expect(BulkDownload.find(@bulk_download_joe.id).error_message).to eq(BulkDownloadsHelper::FAILED_SAMPLES_ERROR_TEMPLATE % 2)
         expect(BulkDownload.find(@bulk_download_joe.id).access_token).to eq(nil)
       end
     end

--- a/spec/factories/backgrounds.rb
+++ b/spec/factories/backgrounds.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :background do
+  end
+end

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -320,4 +320,227 @@ describe BulkDownload, type: :model do
       expect(@bulk_download.status).to eq(BulkDownload::STATUS_ERROR)
     end
   end
+
+  context "#generate_download_file" do
+    before do
+      @joe = create(:joe)
+      @project = create(:project, users: [@joe], name: "Test Project")
+      @sample_one = create(:sample, project: @project, name: "Test Sample One",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+      @sample_two = create(:sample, project: @project, name: "Test Sample Two",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+    end
+
+    it "correctly generates download file for download type sample_taxon_report" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        download_type: BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE,
+        pipeline_run_ids: [
+          @sample_one.first_pipeline_run.id,
+          @sample_two.first_pipeline_run.id,
+        ]
+      )
+
+      expect(ReportHelper).to receive(:taxonomy_details).exactly(2).times
+      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv")
+      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv_2")
+
+      expect_any_instance_of(S3TarWriter).to receive(:start_streaming)
+      expect_any_instance_of(S3TarWriter).to receive(:add_file_with_data).with(
+        "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv",
+        "mock_report_csv"
+      )
+      expect_any_instance_of(S3TarWriter).to receive(:add_file_with_data).with(
+        "Test Sample Two__project-test_project_#{@project.id}__taxon_report.csv",
+        "mock_report_csv_2"
+      )
+      expect_any_instance_of(S3TarWriter).to receive(:close)
+      expect_any_instance_of(S3TarWriter).to receive(:process_status).and_return(
+        instance_double(Process::Status, exitstatus: 0, success?: true)
+      )
+
+      bulk_download.generate_download_file
+
+      expect(bulk_download.status).to eq(BulkDownload::STATUS_SUCCESS)
+    end
+
+    it "correctly handles individual sample failures" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        download_type: BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE,
+        pipeline_run_ids: [
+          @sample_one.first_pipeline_run.id,
+          @sample_two.first_pipeline_run.id,
+        ]
+      )
+
+      expect(ReportHelper).to receive(:taxonomy_details).exactly(2).times
+      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv")
+      # The second sample raises an error while generating.
+      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_raise("error")
+
+      # The samples that succeeded are still written to the s3 tar file.
+      expect_any_instance_of(S3TarWriter).to receive(:start_streaming)
+      expect_any_instance_of(S3TarWriter).to receive(:add_file_with_data).with(
+        "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv",
+        "mock_report_csv"
+      )
+      expect_any_instance_of(S3TarWriter).to receive(:close)
+      expect_any_instance_of(S3TarWriter).to receive(:process_status).and_return(
+        instance_double(Process::Status, exitstatus: 0, success?: true)
+      )
+
+      bulk_download.generate_download_file
+
+      # The bulk download succeeds and the failed sample is stored in the error message.
+      expect(bulk_download.status).to eq(BulkDownload::STATUS_SUCCESS)
+      expect(bulk_download.error_message).to eq(BulkDownloadsHelper::FAILED_SAMPLES_ERROR_TEMPLATE % 1)
+    end
+
+    it "correctly handles s3 tar file upload error" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        download_type: BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE,
+        pipeline_run_ids: [
+          @sample_one.first_pipeline_run.id,
+          @sample_two.first_pipeline_run.id,
+        ]
+      )
+
+      expect(ReportHelper).to receive(:taxonomy_details).exactly(2).times
+      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv")
+      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv_2")
+
+      # The samples that succeeded are still written to the s3 tar file.
+      expect_any_instance_of(S3TarWriter).to receive(:start_streaming)
+      expect_any_instance_of(S3TarWriter).to receive(:add_file_with_data).with(
+        "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv",
+        "mock_report_csv"
+      )
+      expect_any_instance_of(S3TarWriter).to receive(:add_file_with_data).with(
+        "Test Sample Two__project-test_project_#{@project.id}__taxon_report.csv",
+        "mock_report_csv_2"
+      )
+      expect_any_instance_of(S3TarWriter).to receive(:close)
+      # Mock a failure status for the aws s3 cp process.
+      expect_any_instance_of(S3TarWriter).to receive(:process_status).and_return(
+        instance_double(Process::Status, exitstatus: 99, success?: false)
+      )
+
+      expect do
+        bulk_download.generate_download_file
+      end.to raise_error.with_message(BulkDownloadsHelper::BULK_DOWNLOAD_GENERATION_FAILED)
+
+      expect(bulk_download.status).to eq(BulkDownload::STATUS_ERROR)
+    end
+  end
+
+  context "#execution_type" do
+    before do
+      @joe = create(:joe)
+      @project = create(:project, users: [@joe], name: "Test Project")
+      @sample_one = create(:sample, project: @project, name: "Test Sample One",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+    end
+
+    it "correctly returns the execution type" do
+      expect(BulkDownloadTypesHelper).to receive(:bulk_download_type).with("FOOBAR").and_return(
+        type: "FOOBAR",
+        display_name: "Sample Overviews",
+        description: "Sample metadata and QC metrics",
+        category: "report",
+        execution_type: "resque"
+      )
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        download_type: "FOOBAR",
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id]
+      )
+
+      expect(bulk_download.execution_type).to eq("resque")
+    end
+
+    it "correctly throws error if execution type missing" do
+      expect(BulkDownloadTypesHelper).to receive(:bulk_download_type).with("FOOBAR").and_return(
+        type: "FOOBAR",
+        display_name: "Sample Overviews",
+        description: "Sample metadata and QC metrics",
+        category: "report"
+      )
+
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        download_type: "FOOBAR",
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id]
+      )
+
+      expect do
+        bulk_download.execution_type
+      end.to raise_error.with_message(BulkDownloadsHelper::UNKNOWN_EXECUTION_TYPE)
+    end
+  end
+
+  context "#kickoff_resque_task" do
+    before do
+      @joe = create(:joe)
+      @project = create(:project, users: [@joe], name: "Test Project")
+      @sample_one = create(:sample, project: @project, name: "Test Sample One",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+    end
+
+    it "properly kicks off resque task" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id]
+      )
+
+      expect(Resque).to receive(:enqueue).with(
+        GenerateBulkDownload, bulk_download.id
+      )
+
+      bulk_download.kickoff_resque_task
+    end
+  end
+
+  context "#kickoff" do
+    before do
+      @joe = create(:joe)
+      @project = create(:project, users: [@joe], name: "Test Project")
+      @sample_one = create(:sample, project: @project, name: "Test Sample One",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+    end
+
+    it "properly kicks off ecs task for download with ecs execution type" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id]
+      )
+
+      expect(bulk_download).to receive(:execution_type).exactly(1).times.and_return("ecs")
+      expect(bulk_download).to receive(:bulk_download_ecs_task_command).exactly(1).times.and_return("mock_ecs_command")
+      expect(bulk_download).to receive(:kickoff_ecs_task).exactly(1).times.with("mock_ecs_command")
+
+      bulk_download.kickoff
+    end
+
+    it "properly kicks off resque task for download with resque execution type" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id]
+      )
+
+      expect(bulk_download).to receive(:execution_type).exactly(1).times.and_return("resque")
+      expect(bulk_download).to receive(:kickoff_resque_task).exactly(1).times
+
+      bulk_download.kickoff
+    end
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -72,11 +72,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   # Backgrounds
 
-  test ' background -non admin shouldnt get index' do
-    get backgrounds_url
-    assert_redirected_to root_url
-  end
-
   test ' background -non admin shouldnt get new' do
     get new_background_url
     assert_redirected_to root_url


### PR DESCRIPTION
# Description
* This is the first resque-style bulk download.

* Expose background index endpoint to non-admin so we can show the background options in the download modal.
![Screen Shot 2019-11-01 at 4 48 09 PM](https://user-images.githubusercontent.com/837004/68062398-6a158f00-fcc7-11e9-85f5-d1c8b6e9ec3f.png)

* If backgrounds are loading, dropdown shows a "Loading" message.

![Screen Shot 2019-11-01 at 2 11 38 PM](https://user-images.githubusercontent.com/837004/68062400-6b46bc00-fcc7-11e9-8d2f-920eadf0dcac.png)

* Add "execution_type" field to download types to indicate how to execute the download.
* Refactor BulkDownloadTypeHelper a bit to make it easier to test.
* Add s3_tar_writer class that accepts data and streams it to an s3 tar file, similar to the s3_tar_writer service in idseq-services.

# Tests

* Added model and controller tests.
* Manually verified that previous download types still work, and sample taxon report generates the correct csv (taking the background into account)