### PR TITLE
Fix location dropdown focus bug

### DIFF
--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -124,13 +124,11 @@ class LiveSearchPopBox extends React.Component {
   };
 
   handleBlur = currentEvent => {
-    // Call onResultSelect again to give a chance for warnings to show
-    const { onResultSelect } = this.props;
-    onResultSelect &&
-      onResultSelect({
-        currentEvent,
-        result: this.state.currentResult,
-      });
+    // Call handleResultSelect again to give a chance for warnings to show
+    this.handleResultSelect({
+      currentEvent,
+      result: this.state.currentResult,
+    });
   };
 
   buildItem = (categoryKey, result, index) => (


### PR DESCRIPTION
# Description

I introduced this bug in fixing the last bug. We still need the `focus: false` to close the popup. 

# Tests

* select a location in the dropdown
* re-enter the input, see the dropdown again
* click away, see dropdown disappear (before it would not disappear)