### PR TITLE
Location dropdown: save plain text value on blur

### DIFF
--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -41,6 +41,10 @@ class LiveSearchPopBox extends React.Component {
         this.handleResultSelect({ currentEvent: keyEvent, result: value });
       }
       onEnter && onEnter({ current: keyEvent, value });
+    } else {
+      // Set the currentResult to the plain text value so that if the user
+      // focuses out of the input, the value will be saved.
+      this.setState({ currentResult: value });
     }
   };
 

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -41,10 +41,6 @@ class LiveSearchPopBox extends React.Component {
         this.handleResultSelect({ currentEvent: keyEvent, result: value });
       }
       onEnter && onEnter({ current: keyEvent, value });
-    } else {
-      // Set the currentResult to the plain text value so that if the user
-      // focuses out of the input, the value will be saved.
-      this.setState({ currentResult: value });
     }
   };
 
@@ -77,8 +73,12 @@ class LiveSearchPopBox extends React.Component {
 
   handleSearchChange = value => {
     const { delayTriggerSearch, minChars, onSearchChange } = this.props;
-
-    this.setState({ value });
+    this.setState({
+      value,
+      // Set the currentResult to the plain text value so that if the user
+      // focuses out of the input, the value will be saved.
+      currentResult: value,
+    });
     onSearchChange && onSearchChange(value);
     // check minimum requirements for value
     const parsedValue = value.trim();


### PR DESCRIPTION
# Description

This changes the behavior to current prod (and more standard) behavior, at the hypothetical price of fewer location matches by users.

# Notes

This reverses the agreed behavior yesterday. 

# Tests

* Select a location match
* press backspace
* tab out of input
* see string remain