### PR TITLE
[Release Fix] Fix double scrollbar on search dropdown.

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -66,6 +66,15 @@
     display: none;
   }
 
+  // semantic-ui applies max-height when search is true.
+  // We have our max-height on .innerMenu, so override this max-height
+  // to prevent double scrollbars.
+  &:global(.search) {
+    .menu {
+      max-height: none;
+    }
+  }
+
   .item {
     cursor: pointer;
 


### PR DESCRIPTION
# Description

Fix double scrollbar issue.

Before:
<img width="298" alt="Screen Shot 2019-11-04 at 2 41 59 PM" src="https://user-images.githubusercontent.com/837004/68164634-38443880-ff12-11e9-9455-9dc5b88af057.png">

After:
<img width="364" alt="Screen Shot 2019-11-04 at 2 38 12 PM" src="https://user-images.githubusercontent.com/837004/68164635-3a0dfc00-ff12-11e9-8a33-88da2f5cfc5e.png">

# Notes
Just fixing the styling here, which is lower risk.