### PR TITLE
Manually close BareDropdown when search is enabled.

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx
@@ -143,6 +143,7 @@ class MultipleDropdown extends React.Component {
         items={renderedMenuItems}
         itemSearchStrings={searchStrings}
         onOpen={this.handleOpen}
+        closeOnClick={false}
       />
     );
   }
@@ -166,6 +167,7 @@ MultipleDropdown.propTypes = {
   trigger: PropTypes.node,
   value: PropTypes.array,
   className: PropTypes.string,
+  search: PropTypes.bool,
 };
 
 export default MultipleDropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/MultipleNestedDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/MultipleNestedDropdown.jsx
@@ -253,6 +253,9 @@ class MultipleNestedDropdown extends React.Component {
         "rounded",
         "onChange",
         "options",
+        // This component needs to implement the itemSearchStrings prop before search will work.
+        // Manually disable the search prop for now.
+        "search",
       ],
       this.props
     );
@@ -265,6 +268,7 @@ class MultipleNestedDropdown extends React.Component {
         {...otherProps}
         trigger={this.renderLabel()}
         items={this.renderItems()}
+        closeOnClick={false}
       />
     );
   }

--- a/app/assets/src/components/views/playgrounds/PlaygroundControls.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundControls.jsx
@@ -265,6 +265,7 @@ class PlaygroundControls extends React.Component {
                 key={0}
                 fluid
                 rounded
+                search
                 options={this.dropdownOptions}
                 label="Options"
                 onChange={() =>
@@ -285,7 +286,7 @@ class PlaygroundControls extends React.Component {
             ]}
           />
           <ComponentCard
-            title="Multiple Tree Dropdown"
+            title="Multiple Nested Dropdown"
             width={4}
             components={[
               <MultipleNestedDropdown
@@ -293,7 +294,7 @@ class PlaygroundControls extends React.Component {
                 fluid
                 rounded
                 options={this.dropdownOptions}
-                label="Options: "
+                label="Options"
                 onChange={(a, b) => {
                   this.setState({ event: "MultipleDropdown:Change" });
                 }}


### PR DESCRIPTION
# Description

This is a follow-up to PR #2714.

To fix the previous bug, we passed the "search" prop to semantic-ui so it wouldn't close the dropdown when Spacebar is pressed.
This causes two other issues: when search is true, the dropdown no longer closes when the user clicks on the trigger element or selects an option.
In this PR, we fix that by manually calling the `close` function in the semantic ui Dropdown in these two cases.

For selecting an option, we implement this by closing the menu when any part of it is clicked (including selecting an option). However, some elements do not want this behavior, such as ThresholdFilterDropdown and MinContigSizeFilter.

MultipleDropdown, which is used extensively in Data Discovery, also doesn't want the menu to close when it is clicked, so that the user can select multiple options. We pass `closeOnClick={false}` for these two components, and verify that these dropdowns behave correctly with search (by adding search functionality to a component in the Playground).

![Screen Shot 2019-11-04 at 9 38 59 PM](https://user-images.githubusercontent.com/837004/68181542-9d1c8480-ff4c-11e9-9c18-51ac494742a4.png)


# Notes
These solutions are kind of hacky, in that it is manually overriding behavior in semantic-ui. If we continue to run into more issues like this, we should think about a better long-term solution.

MultipleDropdown was actually behaving correctly even with `closeOnClick={true}`. This turned out to be because click events were getting `stopPropagated()` in `<CheckboxItem>`, so they weren't reaching the menu click handler. I temporarily removed this stopPropagation and verified that MultipleDropdown was no longer behaving correctly. Applying `closeOnClick={false}` then fixed the problem as expected.

Also disable the search prop in MultipleNestedDropdown, because it's not going to work until `itemSearchStrings` is implemented. Added a comment.

# Tests
Manually tested that the ProjectSelect now closes when trigger or option is clicked.
Manually verify that ThresholdDropdown and MinContigSizeFilter don't close when you click on them. (since they use closeOnClick)
Manually verify that MultipleDropdown with search enabled doesn't close when you select options.