### PR TITLE
Fix bug in location dropdown with apply all

### DIFF
--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Input from "~ui/controls/Input";
 import { BareDropdown } from "~ui/controls/dropdowns";
-import { forEach, sumBy, values } from "lodash/fp";
+import { forEach, sumBy, values, clone } from "lodash/fp";
 import cx from "classnames";
 import cs from "./live_search_pop_box.scss";
 
@@ -128,10 +128,15 @@ class LiveSearchPopBox extends React.Component {
   };
 
   handleBlur = currentEvent => {
-    // Call handleResultSelect again to give a chance for warnings to show
-    this.handleResultSelect({
-      currentEvent,
-      result: this.state.currentResult,
+    const result = clone(this.state.currentResult);
+    this.setState({ focus: false, currentResult: "" }, () => {
+      console.log("handleBlur", result);
+      // Call handleResultSelect again to give a chance for warnings to show
+      result &&
+        this.handleResultSelect({
+          currentEvent,
+          result,
+        });
     });
   };
 

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -130,7 +130,6 @@ class LiveSearchPopBox extends React.Component {
   handleBlur = currentEvent => {
     const result = clone(this.state.currentResult);
     this.setState({ focus: false, currentResult: "" }, () => {
-      console.log("handleBlur", result);
       // Call handleResultSelect again to give a chance for warnings to show
       result &&
         this.handleResultSelect({

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -128,15 +128,14 @@ class LiveSearchPopBox extends React.Component {
   };
 
   handleBlur = currentEvent => {
+    const { onResultSelect } = this.props;
     const result = clone(this.state.currentResult);
-    this.setState({ focus: false, currentResult: "" }, () => {
-      // Call handleResultSelect again to give a chance for warnings to show
-      result &&
-        this.handleResultSelect({
-          currentEvent,
-          result,
-        });
-    });
+    this.setState(
+      { focus: false, currentResult: "" },
+      () =>
+        // Call handleResultSelect again to give a chance for warnings to show
+        result && onResultSelect && onResultSelect({ currentEvent, result })
+    );
   };
 
   buildItem = (categoryKey, result, index) => (

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -131,9 +131,10 @@ class LiveSearchPopBox extends React.Component {
     const { onResultSelect } = this.props;
     const result = clone(this.state.currentResult);
     this.setState(
+      // Clear currentResult so that "apply to all" will work
       { focus: false, currentResult: "" },
       () =>
-        // Call handleResultSelect again to give a chance for warnings to show
+        // Call onResultSelect again to give a chance for warnings to show
         result && onResultSelect && onResultSelect({ currentEvent, result })
     );
   };


### PR DESCRIPTION
# Description

This fixes some related bugs discovered by @happyimadesignr  and @oliviabholmes . I had added `currentResult` to the input component state so that the blur handler could validate `currentResult` and produce warnings. However, the "apply to all" function set the input value by a different code path. In consequence, when focusing in and out of an input that had a value "applied" to it, bad things happened. 

The solution is simply to always clear `currentResult` onblur, and not validate when `currentResult` is blank. 

Warnings will only appear in the single input the user is focussed on. Warnings will not appear on other inputs when "apply all" is applied. I think this is consistent with the original intention. 

# Notes

There is another bug I uncovered in testing that is already in prod and probably always has been. If you trigger a warning on a input, then override the value with "apply all" from another input, the warning will *not* go away. 

![image](https://user-images.githubusercontent.com/28797/68247195-22487d80-ffcf-11e9-9fde-d18204c984a4.png)

@MarkAZhang  has proposed me a fix already, which I may add here. 

# Tests

* Upload more than one sample
* Match a location
* Hit apply to all
* Focus in and out of second input
* See value stay the same, no warning