### PR TITLE
Reduce complexity in LiveSearchPopBox.

### DIFF
--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -43,24 +43,6 @@ export const processLocationSelection = (result, isHuman) => {
 
 // An input box that fetches and shows geosearch suggestions for user input of locations.
 class GeoSearchInputBox extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      value: props.value,
-    };
-  }
-
-  static getDerivedStateFromProps(props, state) {
-    if (props.value !== state.prevPropsValue) {
-      return {
-        value: props.value,
-        prevPropsValue: props.value,
-      };
-    }
-    return null;
-  }
-
   // Fetch geosearch results and format into categories for LiveSearchBox
   handleSearchTriggered = async query => {
     let categories = {};
@@ -110,21 +92,11 @@ class GeoSearchInputBox extends React.Component {
     return categories;
   };
 
-  handleSearchChange = value => {
-    // Let the inner search box change on edit
-    this.setState({ value }, () => {
-      // Handle the case when they clear the box and hit done/submit without pressing enter
-      if (value === "") this.handleResultSelected({ result: value });
-    });
-  };
-
   handleResultSelected = ({ result }) => {
     const { onResultSelect } = this.props;
 
     // Wrap plain text submission
     if (isString(result) && result !== "") result = { name: result };
-
-    this.setState({ value: result });
 
     logAnalyticsEvent("GeoSearchInputBox_result_selected", {
       selected: result.name,
@@ -136,8 +108,7 @@ class GeoSearchInputBox extends React.Component {
   };
 
   render() {
-    const { className, inputClassName } = this.props;
-    const { value } = this.state;
+    const { className, inputClassName, value } = this.props;
 
     return (
       <LiveSearchPopBox
@@ -145,7 +116,6 @@ class GeoSearchInputBox extends React.Component {
         inputClassName={inputClassName}
         inputMode
         onResultSelect={this.handleResultSelected}
-        onSearchChange={this.handleSearchChange}
         onSearchTriggered={this.handleSearchTriggered}
         placeholder="Enter a city, region, or country"
         rectangular

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Input from "~ui/controls/Input";
 import { BareDropdown } from "~ui/controls/dropdowns";
-import { forEach, sumBy, values, clone } from "lodash/fp";
+import { forEach, sumBy, values } from "lodash/fp";
 import cx from "classnames";
 import cs from "./live_search_pop_box.scss";
 
@@ -13,19 +13,20 @@ class LiveSearchPopBox extends React.Component {
     this.state = {
       isLoading: false,
       results: [],
-      value: this.props.initialValue,
-      selectedResult: null,
-      currentResult: "", // either string or object
+      // the current value of the search input
+      inputValue: this.props.initialValue,
     };
 
     this.lastestTimerId = null;
   }
 
   static getDerivedStateFromProps(props, state) {
-    if (props.value !== state.prevPropsValue) {
+    // If the value has changed, reset the input value.
+    // Store the prevValue to detect whether the value has changed.
+    if (props.value !== state.prevValue) {
       return {
-        value: props.value,
-        prevPropsValue: props.value,
+        prevValue: props.value,
+        inputValue: props.value,
       };
     }
     return null;
@@ -33,35 +34,38 @@ class LiveSearchPopBox extends React.Component {
 
   handleKeyDown = keyEvent => {
     const { onEnter, inputMode } = this.props;
-    const { value, selectedResult } = this.state;
+    const { inputValue } = this.state;
 
+    // Pressing enter selects what they currently typed.
     if (keyEvent.key === "Enter") {
-      if (inputMode && !selectedResult) {
-        // In input mode, if they didn't select anything, count it as submitting what they entered.
-        this.handleResultSelect({ currentEvent: keyEvent, result: value });
+      if (inputMode) {
+        this.handleResultSelect({ result: inputValue });
       }
-      onEnter && onEnter({ current: keyEvent, value });
+      onEnter && onEnter({ current: keyEvent, value: inputValue });
     }
   };
 
   handleResultSelect = ({ currentEvent, result }) => {
     const { onResultSelect } = this.props;
+    onResultSelect && onResultSelect({ currentEvent, result });
+    this.closeDropdown();
+  };
+
+  closeDropdown = () => {
     this.setState({
       isLoading: false,
-      currentResult: result,
-      focus: false, // close the dropdown
+      focus: false,
     });
-    onResultSelect && onResultSelect({ currentEvent, result });
   };
 
   triggerSearch = async () => {
     const { onSearchTriggered } = this.props;
-    const { value } = this.state;
+    const { inputValue } = this.state;
 
-    this.setState({ isLoading: true, selectedResult: null, focus: true });
+    this.setState({ isLoading: true, focus: true });
 
     const timerId = this.lastestTimerId;
-    const results = await onSearchTriggered(value);
+    const results = await onSearchTriggered(inputValue);
 
     if (timerId === this.lastestTimerId) {
       this.setState({
@@ -74,10 +78,7 @@ class LiveSearchPopBox extends React.Component {
   handleSearchChange = value => {
     const { delayTriggerSearch, minChars, onSearchChange } = this.props;
     this.setState({
-      value,
-      // Set the currentResult to the plain text value so that if the user
-      // focuses out of the input, the value will be saved.
-      currentResult: value,
+      inputValue: value,
     });
     onSearchChange && onSearchChange(value);
     // check minimum requirements for value
@@ -86,21 +87,13 @@ class LiveSearchPopBox extends React.Component {
       if (this.lastestTimerId) {
         clearTimeout(this.lastestTimerId);
       }
-      this.lastestTimerId = setTimeout(
-        this.triggerSearch,
-        delayTriggerSearch,
-        value
-      );
+      this.lastestTimerId = setTimeout(this.triggerSearch, delayTriggerSearch);
     }
-  };
-
-  handleSelectionChange = (e, { result }) => {
-    this.setState({ selectedResult: result });
   };
 
   renderSearchBox = () => {
     const { placeholder, rectangular, inputClassName } = this.props;
-    const { isLoading, value } = this.state;
+    const { isLoading, inputValue } = this.state;
 
     return (
       <div onFocus={this.handleFocus} onBlur={this.handleBlur}>
@@ -116,7 +109,7 @@ class LiveSearchPopBox extends React.Component {
           placeholder={placeholder}
           onChange={this.handleSearchChange}
           onKeyPress={this.handleKeyDown}
-          value={value}
+          value={inputValue}
           disableAutocomplete={true}
         />
       </div>
@@ -127,16 +120,18 @@ class LiveSearchPopBox extends React.Component {
     this.setState({ focus: true }); // open the dropdown
   };
 
-  handleBlur = currentEvent => {
-    const { onResultSelect } = this.props;
-    const result = clone(this.state.currentResult);
-    this.setState(
-      // Clear currentResult so that "apply to all" will work
-      { focus: false, currentResult: "" },
-      () =>
-        // Call onResultSelect again to give a chance for warnings to show
-        result && onResultSelect && onResultSelect({ currentEvent, result })
-    );
+  // If a user selects an option, handleResultSelect will run and update this.props.value before this function runs.
+  // So inputValue will equal this.props.value when this function runs and onResultSelect will not be called, which is correct.
+  handleBlur = () => {
+    const { onResultSelect, value } = this.props;
+    const { inputValue } = this.state;
+
+    // If the user has changed the input without selecting an option, select what they currently typed as plain-text.
+    if (onResultSelect && inputValue !== value) {
+      onResultSelect({ result: inputValue });
+    }
+
+    this.closeDropdown();
   };
 
   buildItem = (categoryKey, result, index) => (
@@ -190,7 +185,7 @@ class LiveSearchPopBox extends React.Component {
     const shouldOpen =
       this.getResultsLength() &&
       this.state.focus &&
-      this.state.value.trim().length >= this.props.minChars;
+      this.state.inputValue.trim().length >= this.props.minChars;
 
     return (
       <BareDropdown


### PR DESCRIPTION
# Description

This is a refactor to make some of the logic in LiveSearchPopBox less confusing.

The primary source of confusion was that multiple variables were storing the same thing. `currentResult` and `value` were both storing what the user was typing, but being used in different ways. `currentResult` was also being modified in unintuitive ways, and was being used to overwrite the value on blur, which resulted in some special-case code that was hard to understand.

The component is also tricky because there are multiple ways to interact with it. The user can press enter, blur, or select an element. Furthermore, the user can click "Apply to All" to change the value of the element without interacting with it at all.

This refactor elements `currentResult` and `value` and replaces it with a single variable `inputValue` which stores the string that is currently being displayed in the input (a variable that is easy to understand). When the input is blurred, the `inputValue` is compared with `this.props.value`. If they are different, this means the user has typed something and then blurred without selecting, so we call `onResultSelect`.

# Notes

* Also removed some dead code.
* Also removed some instances where `value` was being stored in the state unnecessarily. Changed it to just use `props.value`.
* This does NOT solve the "warning" issue, where if you click Apply to All on a value, the warnings don't update. That will be in a follow-up PR.

# Tests
Tested the following:
* When the user blurs without clicking, it sets the currently typed text as plain text and shows a warning.
* If user presses enter while typing, it does the same.
* If user selects a location option, it should not show a warning.
* If user clicks Apply to All, it should apply the value to all.
* Focusing and blurring without typing should never change the value. (even after Apply to All)
* If the user deletes the text in the input, and then blurs (or clicks Continue directly), the UI should correctly register that the input is empty.
* If the user submits samples after Apply to All, pressing enter, etc, the samples are uploaded with the correct location metadata (whether it is plain-text or location object), and display properly in the map.
