### PR TITLE
Fix issue where Apply All doesn't update warnings in location input.

### DIFF
--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -35,10 +35,17 @@ export const processLocationSelection = (result, isHuman) => {
     }
 
     warning = LOCATION_PRIVACY_WARNING;
-  } else if (!result || !result.geo_level) {
-    warning = LOCATION_UNRESOLVED_WARNING;
+  } else {
+    warning = getLocationWarning(result);
   }
   return { result, warning };
+};
+
+export const getLocationWarning = result => {
+  if (!result || !result.geo_level) {
+    return LOCATION_UNRESOLVED_WARNING;
+  }
+  return "";
 };
 
 // An input box that fetches and shows geosearch suggestions for user input of locations.


### PR DESCRIPTION
# Description

Previously, when you click Apply All, the warnings don't update. This fixes that.

# Notes

Here's a particular edge case:

Start with two plain text fields.
![Screen Shot 2019-11-05 at 4 51 49 PM](https://user-images.githubusercontent.com/837004/68258865-f20fd780-ffec-11e9-9c5e-e865e9b2ac89.png)

Change one of them to a location that needs to be changed to county/district level. (the `warnedValue` code in the PR is to ensure that at this step, the warning displays)
![Screen Shot 2019-11-05 at 4 52 00 PM](https://user-images.githubusercontent.com/837004/68258909-19ff3b00-ffed-11e9-9829-ed6ee95a13b9.png)


Click Apply to All. The other warning disappears. The warning for the current input stays.
![Screen Shot 2019-11-05 at 4 52 03 PM](https://user-images.githubusercontent.com/837004/68258914-1d92c200-ffed-11e9-8c38-ad44ce63021a.png)



# Tests

* Verified that `<MetadataCSVLocationsMenu>` (when you upload a CSV and it shows you how it resolved the locations) still works properly.
* If user clicks Apply to All, it should apply the value to all.
* If the value is location option, should remove all warnings.
* If the value is plain text, should show warnings for all.

