### PR TITLE
Clean idseq-dag checkout

### DIFF
--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -130,7 +130,7 @@ module PipelineRunsHelper
 
   def install_pipeline(commit_or_branch)
     "pip install --upgrade git+git://github.com/chanzuckerberg/s3mi.git; " \
-    "cd /mnt; rm -rf idseq/results; df -h; " \
+    "cd /mnt; rm -rf idseq-dag idseq/results; df -h; " \
     "git clone https://github.com/chanzuckerberg/idseq-dag.git; " \
     "cd idseq-dag; " \
     "git checkout #{Shellwords.escape(commit_or_branch)}; " \


### PR DESCRIPTION
# Description

The idseq-dag repo is expected to not be checked out already by the script.

