### PR TITLE
Add taxon with reads dropdown for bulk downloads.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -349,6 +349,15 @@ const getSamplesLocations = ({ domain, filters, projectId, search }) =>
 const getSamplePipelineResults = id =>
   get(`/samples/${id}/results_folder.json`);
 
+// Get autocomplete suggestions for "taxon that have reads" for a set of samples.
+const getTaxonWithReadsSuggestions = (query, sampleIds) =>
+  get("/samples/taxon_with_reads_suggestions.json", {
+    params: {
+      query,
+      sampleIds,
+    },
+  });
+
 export {
   bulkImportRemoteSamples,
   bulkUploadRemoteSamples,
@@ -390,4 +399,5 @@ export {
   validateSampleFiles,
   validateSampleNames,
   getBackgrounds,
+  getTaxonWithReadsSuggestions,
 };

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -349,9 +349,9 @@ const getSamplesLocations = ({ domain, filters, projectId, search }) =>
 const getSamplePipelineResults = id =>
   get(`/samples/${id}/results_folder.json`);
 
-// Get autocomplete suggestions for "taxon that have reads" for a set of samples.
-const getTaxonWithReadsSuggestions = (query, sampleIds) =>
-  get("/samples/taxon_with_reads_suggestions.json", {
+// Get autocomplete suggestions for "taxa that have reads" for a set of samples.
+const getTaxaWithReadsSuggestions = (query, sampleIds) =>
+  get("/samples/taxa_with_reads_suggestions.json", {
     params: {
       query,
       sampleIds,
@@ -399,5 +399,5 @@ export {
   validateSampleFiles,
   validateSampleNames,
   getBackgrounds,
-  getTaxonWithReadsSuggestions,
+  getTaxaWithReadsSuggestions,
 };

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -144,6 +144,9 @@ class BareDropdown extends React.Component {
       menuClassName,
       disableAutocomplete,
       trigger,
+      optionsHeader,
+      showNoResultsMessage,
+      loadingSearchOptions,
       ...otherProps
     } = this.props;
 
@@ -240,9 +243,17 @@ class BareDropdown extends React.Component {
             />
           </div>
         )}
+        {optionsHeader && (
+          <div className={cs.optionsHeader}>{optionsHeader}</div>
+        )}
         <BaseDropdown.Menu scrolling className={cs.innerMenu}>
           {filteredItems}
         </BaseDropdown.Menu>
+        {filteredItems.length === 0 &&
+          showNoResultsMessage &&
+          !loadingSearchOptions && (
+            <div className={cs.noResultsMessage}>No results found.</div>
+          )}
       </BaseDropdown.Menu>
     );
 
@@ -294,6 +305,8 @@ BareDropdown.propTypes = forbidExtraProps({
   hideArrow: PropTypes.bool,
   smallArrow: PropTypes.bool,
   menuLabel: PropTypes.string,
+  // Optional header that displays between the search box and the options.
+  optionsHeader: PropTypes.node,
   // whether the dropdown should close when you click on the menu. Useful for custom dropdown menus.
   closeOnClick: PropTypes.bool,
   search: PropTypes.bool,
@@ -303,6 +316,11 @@ BareDropdown.propTypes = forbidExtraProps({
   // If search is true, but you want to customize behavior of search function, e.g. async search,
   // you should provide your own handler
   onFilterChange: PropTypes.func,
+  showNoResultsMessage: PropTypes.bool,
+  // Don't show the no results message if search options are still loading.
+  // TODO(mark): Visually indicate that search options are loading even if
+  // there are old search results to display.
+  loadingSearchOptions: PropTypes.bool,
 
   // Custom props for rendering options
   options: PropTypes.arrayOf(

--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -146,7 +146,7 @@ class BareDropdown extends React.Component {
       trigger,
       optionsHeader,
       showNoResultsMessage,
-      loadingSearchOptions,
+      isLoadingSearchOptions,
       ...otherProps
     } = this.props;
 
@@ -251,7 +251,7 @@ class BareDropdown extends React.Component {
         </BaseDropdown.Menu>
         {filteredItems.length === 0 &&
           showNoResultsMessage &&
-          !loadingSearchOptions && (
+          !isLoadingSearchOptions && (
             <div className={cs.noResultsMessage}>No results found.</div>
           )}
       </BaseDropdown.Menu>
@@ -317,10 +317,10 @@ BareDropdown.propTypes = forbidExtraProps({
   // you should provide your own handler
   onFilterChange: PropTypes.func,
   showNoResultsMessage: PropTypes.bool,
-  // Don't show the no results message if search options are still loading.
+  // Don't show the no results message if search options are currently loading.
   // TODO(mark): Visually indicate that search options are loading even if
   // there are old search results to display.
-  loadingSearchOptions: PropTypes.bool,
+  isLoadingSearchOptions: PropTypes.bool,
 
   // Custom props for rendering options
   options: PropTypes.arrayOf(

--- a/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
@@ -88,7 +88,7 @@ class Dropdown extends React.Component {
         onFilterChange={this.props.onFilterChange}
         optionsHeader={this.props.optionsHeader}
         showNoResultsMessage={this.props.showNoResultsMessage}
-        loadingSearchOptions={this.props.loadingSearchOptions}
+        isLoadingSearchOptions={this.props.isLoadingSearchOptions}
       />
     );
   }
@@ -131,7 +131,7 @@ Dropdown.propTypes = {
   // Don't show the no results message if search options are still loading.
   // TODO(mark): Visually indicate that search options are loading even if
   // there are old search results to display.
-  loadingSearchOptions: PropTypes.bool,
+  isLoadingSearchOptions: PropTypes.bool,
 };
 
 export default Dropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/Dropdown.jsx
@@ -85,6 +85,10 @@ class Dropdown extends React.Component {
         withinModal={this.props.withinModal}
         items={this.props.items}
         itemSearchStrings={this.props.itemSearchStrings}
+        onFilterChange={this.props.onFilterChange}
+        optionsHeader={this.props.optionsHeader}
+        showNoResultsMessage={this.props.showNoResultsMessage}
+        loadingSearchOptions={this.props.loadingSearchOptions}
       />
     );
   }
@@ -117,9 +121,17 @@ Dropdown.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   search: PropTypes.bool,
   menuLabel: PropTypes.string,
+  // Optional header that displays between the search box and the options.
+  optionsHeader: PropTypes.node,
   usePortal: PropTypes.bool,
   direction: PropTypes.oneOf(["left", "right"]),
   withinModal: PropTypes.bool,
+  onFilterChange: PropTypes.func,
+  showNoResultsMessage: PropTypes.bool,
+  // Don't show the no results message if search options are still loading.
+  // TODO(mark): Visually indicate that search options are loading even if
+  // there are old search results to display.
+  loadingSearchOptions: PropTypes.bool,
 };
 
 export default Dropdown;

--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -1,5 +1,6 @@
 @import "~styles/themes/colors";
 @import "~styles/themes/elements";
+@import "~styles/themes/typography";
 
 :global(.ui):global(.dropdown).bareDropdown,
 .portalDropdown {
@@ -122,6 +123,12 @@
 
   .dropdownMenu {
     padding: 6px 0;
+  }
+
+  .noResultsMessage {
+    @include font-body-xxs-crop;
+    padding: $space-xxs $space-m;
+    color: $medium-grey;
   }
 
   .innerMenu {

--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -4,7 +4,6 @@ import { find, get, set } from "lodash/fp";
 import memoize from "memoize-one";
 
 import { getBulkDownloadTypes } from "~/api/bulk_downloads";
-import { getBackgrounds } from "~/api";
 import Modal from "~ui/containers/Modal";
 
 import ChooseStep from "./ChooseStep";
@@ -57,7 +56,6 @@ class BulkDownloadModal extends React.Component {
     selectedFieldsDisplay: {},
     selectedDownloadTypeName: null,
     currentStep: "choose",
-    fieldOptions: {},
   };
 
   componentDidMount() {
@@ -73,11 +71,6 @@ class BulkDownloadModal extends React.Component {
         selectedFields: {},
       });
     }
-
-    // When the modal is opened, fetch options for the bulk download fields.
-    if (!prevProps.open && this.props.open) {
-      this.fetchBackgrounds();
-    }
   }
 
   async fetchDownloadTypes() {
@@ -86,22 +79,6 @@ class BulkDownloadModal extends React.Component {
     this.setState({
       bulkDownloadTypes,
     });
-  }
-
-  // TODO(mark): Set a reasonable default background based on the samples and the user's preferences.
-  async fetchBackgrounds() {
-    if (this.state.fieldOptions.backgrounds) {
-      return;
-    }
-
-    const backgrounds = await getBackgrounds();
-
-    // Since multiple async functions might set fieldOptions, we use the function form
-    // of setState to prevent race conditions.
-    this.setState(prevState => ({
-      ...prevState,
-      fieldOptions: set("backgrounds", backgrounds, prevState.fieldOptions),
-    }));
   }
 
   handleSelectDownloadType = selectedDownloadTypeName => {
@@ -140,7 +117,6 @@ class BulkDownloadModal extends React.Component {
       selectedDownloadTypeName,
       selectedFields,
       selectedFieldsDisplay,
-      fieldOptions,
     } = this.state;
 
     if (currentStep === "choose") {
@@ -152,7 +128,7 @@ class BulkDownloadModal extends React.Component {
           selectedFields={selectedFields}
           onFieldSelect={this.handleFieldSelect}
           onContinue={this.handleChooseStepContinue}
-          fieldOptions={fieldOptions}
+          selectedSampleIds={selectedSampleIds}
         />
       );
     }

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -16,7 +16,7 @@ import memoize from "memoize-one";
 import Dropdown from "~ui/controls/dropdowns/Dropdown";
 import LoadingMessage from "~/components/common/LoadingMessage";
 import RadioButton from "~ui/controls/RadioButton";
-import { getBackgrounds, getTaxonWithReadsSuggestions } from "~/api";
+import { getBackgrounds, getTaxaWithReadsSuggestions } from "~/api";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 
 import cs from "./choose_step.scss";
@@ -26,11 +26,11 @@ const AUTOCOMPLETE_DEBOUNCE_DELAY = 200;
 class ChooseStep extends React.Component {
   state = {
     backgroundOptions: null,
-    taxonWithReadsOptions: null,
-    loadingTaxonWithReadsOptions: false,
+    taxaWithReadsOptions: null,
+    isLoadingTaxaWithReadsOptionsOptions: false,
   };
 
-  _lastTaxonWithReadsQuery = "";
+  _lastTaxaWithReadsQuery = "";
 
   componentDidMount() {
     this.fetchBackgrounds();
@@ -88,36 +88,36 @@ class ChooseStep extends React.Component {
     return true;
   };
 
-  handleTaxonWithReadsSelectFilterChange = query => {
+  handleTaxaWithReadsSelectFilterChange = query => {
     this.setState({
-      loadingTaxonWithReadsOptions: true,
+      isLoadingTaxaWithReadsOptionsOptions: true,
     });
 
-    this.loadTaxonWithReadsOptionsForQuery(query);
+    this.loadTaxaWithReadsOptionsForQuery(query);
   };
 
   // Debounce this function, so it only runs after the user has not typed for a delay.
-  loadTaxonWithReadsOptionsForQuery = debounce(
+  loadTaxaWithReadsOptionsForQuery = debounce(
     AUTOCOMPLETE_DEBOUNCE_DELAY,
     async query => {
-      this._lastTaxonWithReadsQuery = query;
+      this._lastTaxaWithReadsQuery = query;
       const { selectedSampleIds } = this.props;
 
-      const searchResults = await getTaxonWithReadsSuggestions(
+      const searchResults = await getTaxaWithReadsSuggestions(
         query,
         Array.from(selectedSampleIds)
       );
 
       // If the query has since changed, discard the response.
-      if (query != this._lastTaxonWithReadsQuery) {
+      if (query != this._lastTaxaWithReadsQuery) {
         return;
       }
 
-      const taxonWithReadsOptions = searchResults.map(result => ({
+      const taxaWithReadsOptions = searchResults.map(result => ({
         value: result.taxid,
         text: result.title,
         customNode: (
-          <div className={cs.taxonWithReadsOption}>
+          <div className={cs.taxaWithReadsOption}>
             <div className={cs.taxonName}>{result.title}</div>
             <div className={cs.fill} />
             <div className={cs.sampleCount}>{result.sample_count}</div>
@@ -128,13 +128,13 @@ class ChooseStep extends React.Component {
       }));
 
       this.setState({
-        taxonWithReadsOptions,
-        loadingTaxonWithReadsOptions: false,
+        taxaWithReadsOptions,
+        isLoadingTaxaWithReadsOptionsOptions: false,
       });
     }
   );
 
-  sortTaxonWithReadsOptions = memoize(options =>
+  sortTaxaWithReadsOptions = memoize(options =>
     orderBy(["sampleCount", "text"], ["desc", "asc"], options)
   );
 
@@ -142,8 +142,8 @@ class ChooseStep extends React.Component {
     const { selectedFields, onFieldSelect, selectedSampleIds } = this.props;
     const {
       backgroundOptions,
-      taxonWithReadsOptions,
-      loadingTaxonWithReadsOptions,
+      taxaWithReadsOptions,
+      isLoadingTaxaWithReadsOptionsOptions,
     } = this.state;
 
     const selectedField = get([downloadType.type, field.type], selectedFields);
@@ -156,7 +156,7 @@ class ChooseStep extends React.Component {
     let search = false;
     let onFilterChange = null;
     let showNoResultsMessage = false;
-    let loadingSearchOptions = false;
+    let isLoadingSearchOptions = false;
 
     // Set different props for the dropdown depending on the field type.
     switch (field.type) {
@@ -168,13 +168,13 @@ class ChooseStep extends React.Component {
 
         placeholder = "Select file format";
         break;
-      case "taxon_with_reads":
+      case "taxa_with_reads":
         dropdownOptions = [
           {
             text: "All Taxon",
             value: "all",
             customNode: (
-              <div className={cs.taxonWithReadsOption}>
+              <div className={cs.taxaWithReadsOption}>
                 <div className={cs.taxonName}>All taxon</div>
                 <div className={cs.fill} />
                 <div className={cs.sampleCount}>{selectedSampleIds.size}</div>
@@ -183,19 +183,19 @@ class ChooseStep extends React.Component {
           },
           // Note: BareDropdown with search prioritizes prefix matches, so the final ordering of options
           // might not be the one provided here.
-          ...(this.sortTaxonWithReadsOptions(taxonWithReadsOptions) || []),
+          ...(this.sortTaxaWithReadsOptions(taxaWithReadsOptions) || []),
         ];
 
         placeholder = "Select taxa";
         menuLabel = "Select taxa";
         showNoResultsMessage = true;
         search = true;
-        onFilterChange = this.handleTaxonWithReadsSelectFilterChange;
-        className = cs.taxonWithReadsDropdown;
-        loadingSearchOptions = loadingTaxonWithReadsOptions;
+        onFilterChange = this.handleTaxaWithReadsSelectFilterChange;
+        className = cs.taxaWithReadsDropdown;
+        isLoadingSearchOptions = isLoadingTaxaWithReadsOptionsOptions;
 
         optionsHeader = (
-          <div className={cs.taxonWithReadsOptionsHeader}>
+          <div className={cs.taxaWithReadsOptionsHeader}>
             <div className={cs.header}>Taxa</div>
             <div className={cs.fill} />
             <div className={cs.header}>Samples</div>
@@ -232,7 +232,7 @@ class ChooseStep extends React.Component {
           search={search}
           onFilterChange={onFilterChange}
           showNoResultsMessage={showNoResultsMessage}
-          loadingSearchOptions={loadingSearchOptions}
+          isLoadingSearchOptions={isLoadingSearchOptions}
         />
       </div>
     );

--- a/app/assets/src/components/views/bulk_download/choose_step.scss
+++ b/app/assets/src/components/views/bulk_download/choose_step.scss
@@ -1,5 +1,6 @@
 @import "~styles/themes/typography";
 @import "~styles/themes/colors";
+@import "~styles/themes/elements";
 
 .chooseStep {
   height: calc(85vh - 80px);
@@ -32,6 +33,48 @@
 
     .title {
       @include font-label-s;
+      color: $medium-grey;
+    }
+  }
+}
+
+.taxonWithReadsDropdown {
+  width: 300px;
+
+  .taxonWithReadsOptionsHeader {
+    display: flex;
+    padding: $space-s $space-m;
+
+    .header {
+      @include font-header-xs-crop;
+      color: $dark-grey;
+    }
+
+    .fill {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+  }
+
+  .taxonWithReadsOption {
+    display: flex;
+    padding: $space-s $space-m;
+
+    .taxonName {
+      @include font-body-xxs-crop;
+      flex-shrink: 1;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    .fill {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+
+    .sampleCount {
+      @include font-body-xxs-crop;
       color: $medium-grey;
     }
   }

--- a/app/assets/src/components/views/bulk_download/choose_step.scss
+++ b/app/assets/src/components/views/bulk_download/choose_step.scss
@@ -38,10 +38,10 @@
   }
 }
 
-.taxonWithReadsDropdown {
+.taxaWithReadsDropdown {
   width: 300px;
 
-  .taxonWithReadsOptionsHeader {
+  .taxaWithReadsOptionsHeader {
     display: flex;
     padding: $space-s $space-m;
 
@@ -56,7 +56,7 @@
     }
   }
 
-  .taxonWithReadsOption {
+  .taxaWithReadsOption {
     display: flex;
     padding: $space-s $space-m;
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -4,6 +4,7 @@ class SamplesController < ApplicationController
   include ErrorHelper
   include LocationHelper
   include PipelineOutputsHelper
+  include PipelineRunsHelper
   include ReportHelper
   include SamplesHelper
 
@@ -27,7 +28,7 @@ class SamplesController < ApplicationController
 
   OTHER_ACTIONS = [:create, :bulk_new, :bulk_upload, :bulk_upload_with_metadata, :bulk_import, :new, :index, :index_v2, :details,
                    :dimensions, :all, :show_sample_names, :cli_user_instructions, :metadata_fields, :samples_going_public,
-                   :search_suggestions, :stats, :upload, :validate_sample_files,].freeze
+                   :search_suggestions, :stats, :upload, :validate_sample_files, :taxon_with_reads_suggestions,].freeze
   OWNER_ACTIONS = [:raw_results_folder].freeze
   TOKEN_AUTH_ACTIONS = [:create, :update, :bulk_upload, :bulk_upload_with_metadata].freeze
 
@@ -1256,6 +1257,29 @@ class SamplesController < ApplicationController
     render json: {
       error: "There was an error fetching the coverage viz data file.",
     }
+  end
+
+  # GET /samples/taxon_with_reads_suggestions
+  # Get taxon search suggestions, where taxon are restricted to the provided sample ids.
+  # Also include, for each taxon, the number of samples that contain the taxon.
+  def taxon_with_reads_suggestions
+    sample_ids = (params[:sampleIds] || []).map(&:to_i)
+    query = params[:query]
+    samples = current_power.viewable_samples.where(id: sample_ids)
+
+    # User should not be querying for unviewable samples.
+    if samples.length != sample_ids.length
+      LogUtil.log_err_and_airbrake("Get taxons with reads error: Unauthorized access of samples")
+      render json: {
+        error: "There was an error fetching the taxons with reads for samples.",
+      }, status: :unauthorized
+      return
+    end
+
+    taxon_list = taxon_search(query, ["species", "genus"], samples: samples)
+    taxon_list = augment_taxon_list_with_sample_count(taxon_list, samples)
+
+    render json: taxon_list
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -28,7 +28,7 @@ class SamplesController < ApplicationController
 
   OTHER_ACTIONS = [:create, :bulk_new, :bulk_upload, :bulk_upload_with_metadata, :bulk_import, :new, :index, :index_v2, :details,
                    :dimensions, :all, :show_sample_names, :cli_user_instructions, :metadata_fields, :samples_going_public,
-                   :search_suggestions, :stats, :upload, :validate_sample_files, :taxon_with_reads_suggestions,].freeze
+                   :search_suggestions, :stats, :upload, :validate_sample_files, :taxa_with_reads_suggestions,].freeze
   OWNER_ACTIONS = [:raw_results_folder].freeze
   TOKEN_AUTH_ACTIONS = [:create, :update, :bulk_upload, :bulk_upload_with_metadata].freeze
 
@@ -1259,19 +1259,19 @@ class SamplesController < ApplicationController
     }
   end
 
-  # GET /samples/taxon_with_reads_suggestions
-  # Get taxon search suggestions, where taxon are restricted to the provided sample ids.
+  # GET /samples/taxa_with_reads_suggestions
+  # Get taxon search suggestions, where taxa are restricted to the provided sample ids.
   # Also include, for each taxon, the number of samples that contain the taxon.
-  def taxon_with_reads_suggestions
+  def taxa_with_reads_suggestions
     sample_ids = (params[:sampleIds] || []).map(&:to_i)
     query = params[:query]
     samples = current_power.viewable_samples.where(id: sample_ids)
 
     # User should not be querying for unviewable samples.
     if samples.length != sample_ids.length
-      LogUtil.log_err_and_airbrake("Get taxons with reads error: Unauthorized access of samples")
+      LogUtil.log_err_and_airbrake("Get taxa with reads error: Unauthorized access of samples")
       render json: {
-        error: "There was an error fetching the taxons with reads for samples.",
+        error: "There was an error fetching the taxa with reads for samples.",
       }, status: :unauthorized
       return
     end

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -70,7 +70,7 @@ module BulkDownloadTypesHelper
       fields: [
         {
           display_name: "Taxa",
-          type: "taxon_with_reads",
+          type: "taxa_with_reads",
         },
         {
           display_name: "File Format",
@@ -88,7 +88,7 @@ module BulkDownloadTypesHelper
       fields: [
         {
           display_name: "Taxa",
-          type: "taxon_with_contigs",
+          type: "taxa_with_contigs",
         },
       ],
       execution_type: VARIABLE_EXECUTION_TYPE,

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -70,7 +70,7 @@ module BulkDownloadTypesHelper
       fields: [
         {
           display_name: "Taxa",
-          type: "taxon",
+          type: "taxon_with_reads",
         },
         {
           display_name: "File Format",
@@ -88,7 +88,7 @@ module BulkDownloadTypesHelper
       fields: [
         {
           display_name: "Taxa",
-          type: "taxon",
+          type: "taxon_with_contigs",
         },
       ],
       execution_type: VARIABLE_EXECUTION_TYPE,

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -4,6 +4,7 @@ require 'aws-sdk-s3'
 
 module SamplesHelper
   include PipelineOutputsHelper
+  include PipelineRunsHelper
   include ErrorHelper
 
   # We set S3_GLOBAL_ENDPOINT to enable cross-region listing in
@@ -604,6 +605,23 @@ module SamplesHelper
         .includes(:metadata_field)
         .group(metadata_field.validated_field)
     end
+  end
+
+  # For each taxon, count how many samples have taxon counts for that taxon.
+  # Add these counts to the taxon objects.
+  def augment_taxon_list_with_sample_count(taxon_list, samples)
+    tax_ids = taxon_list.map { |taxon| taxon["taxid"] }
+    pipeline_run_ids = get_succeeded_pipeline_runs_for_samples(samples).pluck(:id)
+    counts_by_taxid = TaxonCount
+                      .where(tax_id: tax_ids, pipeline_run_id: pipeline_run_ids)
+                      .group(:tax_id)
+                      .select("tax_id, COUNT(DISTINCT pipeline_run_id) as sample_count")
+                      .map { |r| [r.tax_id, r.sample_count] }
+                      .to_h
+    taxon_list.each do |taxon|
+      taxon["sample_count"] = counts_by_taxid[taxon["taxid"]]
+    end
+    taxon_list
   end
 
   private

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -337,7 +337,7 @@ class BulkDownload < ApplicationRecord
     end
 
     if [BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, BulkDownloadTypesHelper:: CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE].include?(download_type)
-      return get_param_value("taxon_with_reads") == "all" ? BulkDownloadTypesHelper::ECS_EXECUTION_TYPE : BulkDownloadTypesHelper::RESQUE_EXECUTION_TYPE
+      return get_param_value("taxa_with_reads") == "all" ? BulkDownloadTypesHelper::ECS_EXECUTION_TYPE : BulkDownloadTypesHelper::RESQUE_EXECUTION_TYPE
     end
 
     # Should never happen

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -337,7 +337,7 @@ class BulkDownload < ApplicationRecord
     end
 
     if [BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, BulkDownloadTypesHelper:: CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE].include?(download_type)
-      return get_param_value("taxon") == "all" ? BulkDownloadTypesHelper::ECS_EXECUTION_TYPE : BulkDownloadTypesHelper::RESQUE_EXECUTION_TYPE
+      return get_param_value("taxon_with_reads") == "all" ? BulkDownloadTypesHelper::ECS_EXECUTION_TYPE : BulkDownloadTypesHelper::RESQUE_EXECUTION_TYPE
     end
 
     # Should never happen

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
     get :coverage_viz_summary, on: :member
     get :coverage_viz_data, on: :member
     get :show_v2, on: :member
-    get :taxon_with_reads_suggestions, on: :collection
+    get :taxa_with_reads_suggestions, on: :collection
   end
 
   get 'samples/:id/fasta/:tax_level/:taxid/:hit_type', to: 'samples#show_taxid_fasta'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
     get :coverage_viz_summary, on: :member
     get :coverage_viz_data, on: :member
     get :show_v2, on: :member
+    get :taxon_with_reads_suggestions, on: :collection
   end
 
   get 'samples/:id/fasta/:tax_level/:taxid/:hit_type', to: 'samples#show_taxid_fasta'

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SamplesController, type: :controller do
       end
     end
 
-    describe "GET #taxon_with_reads_suggestions" do
+    describe "GET #taxa_with_reads_suggestions" do
       before do
         @project = create(:project, users: [@joe])
         @sample_one = create(:sample, project: @project, name: "Test Sample One",
@@ -62,7 +62,7 @@ RSpec.describe SamplesController, type: :controller do
                                                                   },
                                                                 ])
 
-        get :taxon_with_reads_suggestions, params: { format: "json", sampleIds: [@sample_one.id, @sample_two.id, @sample_three.id], query: mock_query }
+        get :taxa_with_reads_suggestions, params: { format: "json", sampleIds: [@sample_one.id, @sample_two.id, @sample_three.id], query: mock_query }
 
         expect(response).to have_http_status :success
 
@@ -95,7 +95,7 @@ RSpec.describe SamplesController, type: :controller do
         create(:taxon_count, tax_id: 100, pipeline_run_id: @sample_two.first_pipeline_run.id)
         create(:taxon_count, tax_id: 100, pipeline_run_id: @sample_three.first_pipeline_run.id)
 
-        get :taxon_with_reads_suggestions, params: { format: "json", sampleIds: [@sample_one.id, sample_admin.id], query: "MOCK_QUERY" }
+        get :taxa_with_reads_suggestions, params: { format: "json", sampleIds: [@sample_one.id, sample_admin.id], query: "MOCK_QUERY" }
 
         expect(response).to have_http_status :unauthorized
       end

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -24,6 +24,82 @@ RSpec.describe SamplesController, type: :controller do
         expect(response).to have_http_status :success
       end
     end
+
+    describe "GET #taxon_with_reads_suggestions" do
+      before do
+        @project = create(:project, users: [@joe])
+        @sample_one = create(:sample, project: @project, name: "Test Sample One",
+                                      pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+        @sample_two = create(:sample, project: @project, name: "Test Sample Two",
+                                      pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+        @sample_three = create(:sample, project: @project, name: "Test Sample Three",
+                                        pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+      end
+
+      it "should return taxon list with correct sample counts" do
+        create(:taxon_count, tax_id: 100, pipeline_run_id: @sample_one.first_pipeline_run.id)
+        create(:taxon_count, tax_id: 100, pipeline_run_id: @sample_two.first_pipeline_run.id)
+        create(:taxon_count, tax_id: 100, pipeline_run_id: @sample_three.first_pipeline_run.id)
+        create(:taxon_count, tax_id: 200, pipeline_run_id: @sample_one.first_pipeline_run.id)
+        create(:taxon_count, tax_id: 200, pipeline_run_id: @sample_two.first_pipeline_run.id)
+        create(:taxon_count, tax_id: 300, pipeline_run_id: @sample_one.first_pipeline_run.id)
+
+        mock_query = "MOCK_QUERY"
+
+        expect(controller).to receive(:taxon_search).with(mock_query, ["species", "genus"], any_args).exactly(1).times
+                                                    .and_return([
+                                                                  {
+                                                                    "taxid" => 100,
+                                                                    "name" => "Mock Taxa 100",
+                                                                  },
+                                                                  {
+                                                                    "taxid" => 200,
+                                                                    "name" => "Mock Taxa 200",
+                                                                  },
+                                                                  {
+                                                                    "taxid" => 300,
+                                                                    "name" => "Mock Taxa 300",
+                                                                  },
+                                                                ])
+
+        get :taxon_with_reads_suggestions, params: { format: "json", sampleIds: [@sample_one.id, @sample_two.id, @sample_three.id], query: mock_query }
+
+        expect(response).to have_http_status :success
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to include_json([
+                                                {
+                                                  "taxid" => 100,
+                                                  "name" => "Mock Taxa 100",
+                                                  "sample_count" => 3,
+                                                },
+                                                {
+                                                  "taxid" => 200,
+                                                  "name" => "Mock Taxa 200",
+                                                  "sample_count" => 2,
+                                                },
+                                                {
+                                                  "taxid" => 300,
+                                                  "name" => "Mock Taxa 300",
+                                                  "sample_count" => 1,
+                                                },
+                                              ])
+      end
+
+      it "should return unauthorized if user doesn't have access to sample" do
+        project_admin = create(:project, users: [@admin])
+        sample_admin = create(:sample, project: project_admin, name: "Test Sample Admin",
+                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+
+        create(:taxon_count, tax_id: 100, pipeline_run_id: @sample_one.first_pipeline_run.id)
+        create(:taxon_count, tax_id: 100, pipeline_run_id: @sample_two.first_pipeline_run.id)
+        create(:taxon_count, tax_id: 100, pipeline_run_id: @sample_three.first_pipeline_run.id)
+
+        get :taxon_with_reads_suggestions, params: { format: "json", sampleIds: [@sample_one.id, sample_admin.id], query: "MOCK_QUERY" }
+
+        expect(response).to have_http_status :unauthorized
+      end
+    end
   end
 
   context "User with report_v2 flag" do


### PR DESCRIPTION
# Description

This adds a `taxon_with_reads_suggestions` endpoint that uses the existing elasticsearch-backed `taxon_search` and also adds a front-end dropdown that allows users to search for taxons that have reads (in the bulk download modal).

![Screen Shot 2019-11-06 at 2 07 53 PM](https://user-images.githubusercontent.com/837004/68342165-dcf38100-009e-11ea-86d6-943526141a61.png)

Refactored the bulk download render options method to remove duplicate code.

# Notes
Added some additional search-related props to dropdown.

One prop adds the header directly above the search results (Taxa/Samples)
Another prop shows a "no results" message if we aren't still loading results and there are no results.

Note that "no results found" only appears after the search response comes back. We could also show a loading indicator, but that seems out of scope of this PR.
![Nov-06-2019 14-07-58](https://user-images.githubusercontent.com/837004/68342178-e381f880-009e-11ea-8c75-e6ae666ff328.gif)

The search querying is debounced (will only fire after the user hasn't typed for 200ms), and handles race conditions from response ordering. 

This doesn't cover the back-end implementation for this bulk download type. (dividing into smaller PRs)

# Tests

* Added controller tests.
* Verified that data discovery taxon search is unaffected by changes.
* Verified that component behaves as expected.
* Verified that other dropdowns in bulk download modal still work as expected.