### PR TITLE
Add host gene counts download type.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -358,6 +358,16 @@ const getTaxaWithReadsSuggestions = (query, sampleIds) =>
     },
   });
 
+const uploadedByCurrentUser = async sampleIds => {
+  const response = await get("samples/uploaded_by_current_user", {
+    params: {
+      sampleIds,
+    },
+  });
+
+  return response.uploaded_by_current_user;
+};
+
 export {
   bulkImportRemoteSamples,
   bulkUploadRemoteSamples,
@@ -400,4 +410,5 @@ export {
   validateSampleNames,
   getBackgrounds,
   getTaxaWithReadsSuggestions,
+  uploadedByCurrentUser,
 };

--- a/app/assets/src/components/ui/controls/RadioButton.jsx
+++ b/app/assets/src/components/ui/controls/RadioButton.jsx
@@ -10,9 +10,10 @@ class RadioButton extends React.Component {
         className={cx(
           cs.radioButton,
           this.props.className,
-          this.props.selected && cs.selected
+          this.props.selected && cs.selected,
+          this.props.disabled && cs.disabled
         )}
-        onClick={this.props.onClick}
+        onClick={this.props.disabled ? undefined : this.props.onClick}
       >
         <div className={cs.inner} />
       </div>
@@ -22,6 +23,7 @@ class RadioButton extends React.Component {
 
 RadioButton.propTypes = {
   selected: PropTypes.bool,
+  disabled: PropTypes.bool,
   onClick: PropTypes.func,
   className: PropTypes.string,
 };

--- a/app/assets/src/components/ui/controls/radio_button.scss
+++ b/app/assets/src/components/ui/controls/radio_button.scss
@@ -32,4 +32,15 @@
       }
     }
   }
+
+  &.disabled {
+    cursor: default;
+    border: 1px solid $light-grey;
+
+    &:hover {
+      .inner {
+        background-color: transparent;
+      }
+    }
+  }
 }

--- a/app/assets/src/components/views/bulk_download/choose_step.scss
+++ b/app/assets/src/components/views/bulk_download/choose_step.scss
@@ -90,6 +90,19 @@
     background-color: $off-white;
   }
 
+  &.disabled {
+    cursor: default;
+
+    &:hover {
+      background-color: white;
+    }
+
+    .name,
+    .description {
+      color: $light-grey;
+    }
+  }
+
   .radioButton {
     margin-right: 10px;
     margin-top: 4px;

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -28,7 +28,7 @@ class SamplesController < ApplicationController
 
   OTHER_ACTIONS = [:create, :bulk_new, :bulk_upload, :bulk_upload_with_metadata, :bulk_import, :new, :index, :index_v2, :details,
                    :dimensions, :all, :show_sample_names, :cli_user_instructions, :metadata_fields, :samples_going_public,
-                   :search_suggestions, :stats, :upload, :validate_sample_files, :taxa_with_reads_suggestions,].freeze
+                   :search_suggestions, :stats, :upload, :validate_sample_files, :taxa_with_reads_suggestions, :uploaded_by_current_user,].freeze
   OWNER_ACTIONS = [:raw_results_folder].freeze
   TOKEN_AUTH_ACTIONS = [:create, :update, :bulk_upload, :bulk_upload_with_metadata].freeze
 
@@ -1280,6 +1280,17 @@ class SamplesController < ApplicationController
     taxon_list = augment_taxon_list_with_sample_count(taxon_list, samples)
 
     render json: taxon_list
+  end
+
+  # GET /samples/uploaded_by_current_user
+  # Return whether all sampleIds were uploaded by the current user.
+  def uploaded_by_current_user
+    sample_ids = (params[:sampleIds] || []).map(&:to_i)
+    samples = Sample.where(user: current_user, id: sample_ids)
+
+    render json: {
+      uploaded_by_current_user: sample_ids.length == samples.length,
+    }
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -60,7 +60,7 @@ module BulkDownloadTypesHelper
       display_name: "Host Gene Counts",
       description: "Host gene count outputs from STAR",
       category: "report",
-      execution_type: RESQUE_EXECUTION_TYPE,
+      execution_type: ECS_EXECUTION_TYPE,
     },
     {
       type: READS_NON_HOST_BULK_DOWNLOAD_TYPE,

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -249,6 +249,15 @@ class BulkDownload < ApplicationRecord
       end
     end
 
+    if download_type == BulkDownloadTypesHelper::HOST_GENE_COUNTS_BULK_DOWNLOAD_TYPE
+      download_src_urls = pipeline_runs.map(&:host_gene_count_s3_path)
+
+      download_tar_names = samples.map do |sample|
+        "#{get_output_file_prefix(sample, cleaned_project_names)}" \
+          "reads_per_gene.star.tab"
+      end
+    end
+
     if !download_src_urls.nil? && !download_tar_names.nil?
       return s3_tar_writer_command(
         download_src_urls,

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -64,6 +64,7 @@ class PipelineRun < ApplicationRecord
   TAXID_BYTERANGE_JSON_NAME = 'taxid_locations_combined.json'.freeze
   REFINED_TAXON_COUNTS_JSON_NAME = 'assembly/refined_taxon_counts.json'.freeze
   REFINED_TAXID_BYTERANGE_JSON_NAME = 'assembly/refined_taxid_locations_combined.json'.freeze
+  READS_PER_GENE_STAR_TAB_NAME = 'reads_per_gene.star.tab'.freeze
 
   ASSEMBLY_PREFIX = 'assembly/refined_'.freeze
   ASSEMBLED_CONTIGS_NAME = 'assembly/contigs.fasta'.freeze
@@ -408,6 +409,10 @@ class PipelineRun < ApplicationRecord
     return "#{postprocess_output_s3_path}/#{DAG_ANNOTATED_FASTA_BASENAME}" if pipeline_version_at_least_2(pipeline_version)
 
     multihit? ? "#{alignment_output_s3_path}/#{MULTIHIT_FASTA_BASENAME}" : "#{alignment_output_s3_path}/#{HIT_FASTA_BASENAME}"
+  end
+
+  def host_gene_count_s3_path
+    return "#{host_filter_output_s3_path}/#{READS_PER_GENE_STAR_TAB_NAME}"
   end
 
   def nonhost_fastq_s3_paths

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     get :coverage_viz_data, on: :member
     get :show_v2, on: :member
     get :taxa_with_reads_suggestions, on: :collection
+    get :uploaded_by_current_user, on: :collection
   end
 
   get 'samples/:id/fasta/:tax_level/:taxid/:hit_type', to: 'samples#show_taxid_fasta'

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -102,6 +102,28 @@ RSpec.describe SamplesController, type: :controller do
     end
   end
 
+  describe "GET #uploaded_by_current_user" do
+    before do
+      @project = create(:project, users: [@joe, @admin])
+      @sample_one = create(:sample, project: @project, name: "Test Sample One", user: @joe)
+      @sample_two = create(:sample, project: @project, name: "Test Sample Two", user: @joe)
+      @sample_three = create(:sample, project: @project, name: "Test Sample Three", user: @admin)
+      sign_in @joe
+    end
+
+    it "should return true if all samples were uploaded by user" do
+      get :uploaded_by_current_user, params: { sampleIds: [@sample_one.id, @sample_two.id] }
+      json_response = JSON.parse(response.body)
+      expect(json_response).to include_json(uploaded_by_current_user: true)
+    end
+
+    it "should return false if some samples were not uploaded by user, even if user belongs to the sample's project" do
+      get :uploaded_by_current_user, params: { sampleIds: [@sample_one.id, @sample_two.id, @sample_three.id] }
+      json_response = JSON.parse(response.body)
+      expect(json_response).to include_json(uploaded_by_current_user: false)
+    end
+  end
+
   context "User with report_v2 flag" do
     before do
       sign_in @joe


### PR DESCRIPTION
# Description

Add host gene counts download type.

Also add `uploaded_by_current_user` endpoint that returns whether the queried sampleIds were all uploaded by the current user. This is used to determine whether the host gene counts download type should be disabled.

Disabled state:
![Screen Shot 2019-11-07 at 12 27 50 AM](https://user-images.githubusercontent.com/837004/68372835-7d28c480-00f6-11ea-9037-54d700d97bd8.png)

With hover tooltip:
![Screen Shot 2019-11-07 at 12 37 30 AM](https://user-images.githubusercontent.com/837004/68373010-ce38b880-00f6-11ea-9428-683dc588292d.png)

# Tests

* Verified that download works as expected.
* Verified that download is disabled as expected.
* Wrote tests for controller endpoints.

