### PR TITLE
Fix auth0 alpha sign_in bouncing

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,9 +2,21 @@ class SessionsController < Devise::SessionsController
   respond_to :json
 
   skip_before_action :verify_authenticity_token, only: [:destroy]
-  skip_before_action :verify_signed_out_user, only: [:destroy]
 
   include Auth0Helper
+
+  # This method is invoked by Devise when /users/sign_in is invoked
+  # to authenticate using legacy devise method. In this situation
+  # we need to logout user from auth0 first to prevent it
+  # from being authenticated using both strategies at once
+  def new
+    result = auth0_logout
+    if result[:using_auth0]
+      redirect_to result[:auth0_logout_url]
+    else
+      super
+    end
+  end
 
   def after_sign_out_path_for(resource_name)
     if @auth0_logout_result&.fetch(:using_auth0)

--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -2,20 +2,21 @@ module Auth0Helper
   def auth0_logout
     # Check presence of Auth0Helper#auth0_session
     if auth0_session.present?
-      session.delete(:jwt_id_token)
+      auth0_remove_session
       { using_auth0: true, auth0_logout_url: auth0_signout_url }
     else
       { using_auth0: false }
     end
   end
 
-  def check_auth0_auth_token
+  def auth0_decode_auth_token
     auth_payload, auth_header = auth_token
     if auth_payload.present?
       { authenticated: true, auth_payload: auth_payload, auth_header: auth_header }
     end
   rescue JWT::VerificationError, JWT::DecodeError
-    return { authenticated: false }
+    auth0_remove_session
+    { authenticated: false }
   end
 
   def auth0_session
@@ -29,6 +30,10 @@ module Auth0Helper
   end
 
   protected
+
+  def auth0_remove_session
+    session.delete(:jwt_id_token) if session
+  end
 
   def auth0_signout_url
     domain = ENV["AUTH0_DOMAIN"]


### PR DESCRIPTION
# Description

Fix an issue with auth0 alpha where authentication sign_in screen would bounce when a token is expired

# Notes

Only affects auth0 alpha tests

# Tests

* Manual