### PR TITLE
Add contigs summary report bulk download.

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -919,7 +919,7 @@ class SamplesController < ApplicationController
 
   def contigs_summary
     pr = select_pipeline_run(@sample, params[:pipeline_version])
-    local_file = pr.generate_contig_mapping_table
+    local_file = pr.generate_contig_mapping_table_file
 
     @contigs_summary = File.read(local_file)
     send_data @contigs_summary, filename: @sample.name + '_contigs_summary.csv'

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -279,19 +279,28 @@ class BulkDownload < ApplicationRecord
     # The last time since we updated the progress.
     last_progress_time = Time.now.to_f
 
-    if download_type == BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE
-      samples = Sample.where(id: pipeline_runs.pluck(:sample_id))
-      projects = Project.where(id: samples.pluck(:project_id))
+    samples = Sample.where(id: pipeline_runs.pluck(:sample_id))
+    projects = Project.where(id: samples.pluck(:project_id))
 
-      # Compute cleaned project name once instead of once per sample.
-      cleaned_project_names = {}
-      projects.each do |project|
-        cleaned_project_names[project.id] = project.cleaned_project_name
-      end
+    # Compute cleaned project name once instead of once per sample.
+    cleaned_project_names = {}
+    projects.each do |project|
+      cleaned_project_names[project.id] = project.cleaned_project_name
+    end
 
-      pipeline_runs.includes(sample: [:project]).map.with_index do |pipeline_run, index|
-        begin
-          Rails.logger.info("Processing pipeline run #{pipeline_run.id} (#{index + 1} of #{pipeline_runs.length})...")
+    # Bulk-include data for performance based on the download type.
+    pipeline_runs_with_includes = if download_type == BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE
+                                    pipeline_runs.includes(sample: [:project])
+                                  elsif download_type == BulkDownloadTypesHelper::CONTIG_SUMMARY_REPORT_BULK_DOWNLOAD_TYPE
+                                    pipeline_runs.includes(:contigs, :sample)
+                                  else
+                                    pipeline_runs
+                                  end
+
+    pipeline_runs_with_includes.map.with_index do |pipeline_run, index|
+      begin
+        Rails.logger.info("Processing pipeline run #{pipeline_run.id} (#{index + 1} of #{pipeline_runs.length})...")
+        if download_type == BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE
           tax_details = ReportHelper.taxonomy_details(pipeline_run.id, get_param_value("background"), TaxonScoringModel::DEFAULT_MODEL_NAME, ReportHelper::DEFAULT_SORT_PARAM)
           report_csv = ReportHelper.generate_report_csv(tax_details)
           s3_tar_writer.add_file_with_data(
@@ -299,21 +308,28 @@ class BulkDownload < ApplicationRecord
               "taxon_report.csv",
             report_csv
           )
-        rescue
-          failed_sample_ids << pipeline_run.sample.id
+        elsif download_type == BulkDownloadTypesHelper::CONTIG_SUMMARY_REPORT_BULK_DOWNLOAD_TYPE
+          contig_mapping_table_csv = pipeline_run.generate_contig_mapping_table_csv
+          s3_tar_writer.add_file_with_data(
+            "#{get_output_file_prefix(pipeline_run.sample, cleaned_project_names)}" \
+              "contig_summary_report.csv",
+            contig_mapping_table_csv
+          )
         end
-
-        if Time.now.to_f - last_progress_time > progress_update_delay
-          progress = (index + 1).to_f / pipeline_runs.length
-          update(progress: progress)
-          Rails.logger.info(format("Updated progress. %3.1f complete.", progress))
-        end
+      rescue
+        failed_sample_ids << pipeline_run.sample.id
       end
 
-      unless failed_sample_ids.empty?
-        LogUtil.log_err_and_airbrake("BulkDownloadFailedSamplesError(id #{id}): The following samples failed to process: #{failed_sample_ids}")
-        update(error_message: BulkDownloadsHelper::FAILED_SAMPLES_ERROR_TEMPLATE % failed_sample_ids.length)
+      if Time.now.to_f - last_progress_time > progress_update_delay
+        progress = (index + 1).to_f / pipeline_runs.length
+        update(progress: progress)
+        Rails.logger.info(format("Updated progress. %3.1f complete.", progress))
       end
+    end
+
+    unless failed_sample_ids.empty?
+      LogUtil.log_err_and_airbrake("BulkDownloadFailedSamplesError(id #{id}): The following samples failed to process: #{failed_sample_ids}")
+      update(error_message: BulkDownloadsHelper::FAILED_SAMPLES_ERROR_TEMPLATE % failed_sample_ids.length)
     end
   end
 

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -463,33 +463,44 @@ class PipelineRun < ApplicationRecord
     output
   end
 
-  def generate_contig_mapping_table
+  # buffer can be a file or an array.
+  def write_contig_mapping_table_csv(buffer)
+    nt_m8_map = get_m8_mapping(CONTIG_NT_TOP_M8)
+    nr_m8_map = get_m8_mapping(CONTIG_NR_TOP_M8)
+    header_row = ['contig_name', 'read_count', 'contig_length', 'contig_coverage']
+    header_row += TaxonLineage.names_a.map { |name| "NT.#{name}" }
+    header_row += M8_FIELDS_TO_EXTRACT.map { |idx| "NT.#{M8_FIELDS[idx]}" }
+    header_row += TaxonLineage.names_a.map { |name| "NR.#{name}" }
+    header_row += M8_FIELDS_TO_EXTRACT.map { |idx| "NR.#{M8_FIELDS[idx]}" }
+    buffer << header_row
+    contigs.each do |c|
+      nt_m8 = nt_m8_map[c.name] || []
+      nr_m8 = nr_m8_map[c.name] || []
+      lineage = JSON.parse(c.lineage_json || "{}")
+      row = [c.name, c.read_count]
+      cfs = c.name.split("_")
+      row += [cfs[3], cfs[5]]
+      row += (lineage['NT'] || TaxonLineage.null_array)
+      row += M8_FIELDS_TO_EXTRACT.map { |idx| nt_m8[idx] }
+      row += (lineage['NR'] || TaxonLineage.null_array)
+      row += M8_FIELDS_TO_EXTRACT.map { |idx| nr_m8[idx] }
+      buffer << row
+    end
+  end
+
+  def generate_contig_mapping_table_csv
+    CSVSafe.generate(headers: true) do |csv|
+      write_contig_mapping_table_csv(csv)
+    end
+  end
+
+  def generate_contig_mapping_table_file
     # generate a csv file for contig mapping based on lineage_json and top m8
     local_file_name = "#{LOCAL_JSON_PATH}/#{CONTIG_MAPPING_NAME}#{id}"
     Open3.capture3("mkdir -p #{File.dirname(local_file_name)}")
     # s3_file_name = contigs_summary_s3_path # TODO(yf): might turn back for s3 generation later
-    nt_m8_map = get_m8_mapping(CONTIG_NT_TOP_M8)
-    nr_m8_map = get_m8_mapping(CONTIG_NR_TOP_M8)
     CSVSafe.open(local_file_name, 'w') do |writer|
-      header_row = ['contig_name', 'read_count', 'contig_length', 'contig_coverage']
-      header_row += TaxonLineage.names_a.map { |name| "NT.#{name}" }
-      header_row += M8_FIELDS_TO_EXTRACT.map { |idx| "NT.#{M8_FIELDS[idx]}" }
-      header_row += TaxonLineage.names_a.map { |name| "NR.#{name}" }
-      header_row += M8_FIELDS_TO_EXTRACT.map { |idx| "NR.#{M8_FIELDS[idx]}" }
-      writer << header_row
-      contigs.each do |c|
-        nt_m8 = nt_m8_map[c.name] || []
-        nr_m8 = nr_m8_map[c.name] || []
-        lineage = JSON.parse(c.lineage_json || "{}")
-        row = [c.name, c.read_count]
-        cfs = c.name.split("_")
-        row += [cfs[3], cfs[5]]
-        row += (lineage['NT'] || TaxonLineage.null_array)
-        row += M8_FIELDS_TO_EXTRACT.map { |idx| nt_m8[idx] }
-        row += (lineage['NR'] || TaxonLineage.null_array)
-        row += M8_FIELDS_TO_EXTRACT.map { |idx| nr_m8[idx] }
-        writer << row
-      end
+      write_contig_mapping_table_csv(writer)
     end
     # Open3.capture3("aws s3 cp #{local_file_name} #{s3_file_name}")
     local_file_name


### PR DESCRIPTION
# Description

Add new download type.
Refactor existing download method to reuse code.

# Tests

* Verify that new download type works properly for multiple downloads without extraneous sql queries (in the screenshot, there are no per-pipeline-run queries as each pipeline run processes):

![Screen Shot 2019-11-08 at 11 45 43 AM](https://user-images.githubusercontent.com/837004/68506000-7648a180-021d-11ea-932a-d285a4c78598.png)

* Wrote rspec model test.
* Verify that old download still works.
* Verify that a sample with no contigs assembled will generate an empty file with just the csv headers. (which is the current behavior)
