### PR TITLE
Add feature flag for biohub s3 upload.

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -137,7 +137,7 @@ class SampleUploadFlow extends React.Component {
           basespaceClientId={this.props.basespaceClientId}
           basespaceOauthRedirectUri={this.props.basespaceOauthRedirectUri}
           admin={this.props.admin}
-          biohubUser={this.props.biohubUser}
+          biohubS3UploadEnabled={this.props.biohubS3UploadEnabled}
         />
         {this.state.samples && (
           <UploadMetadataStep
@@ -199,7 +199,7 @@ SampleUploadFlow.propTypes = {
   csrf: PropTypes.string,
   hostGenomes: PropTypes.arrayOf(PropTypes.HostGenome),
   admin: PropTypes.bool,
-  biohubUser: PropTypes.bool,
+  biohubS3UploadEnabled: PropTypes.bool,
   basespaceClientId: PropTypes.string.isRequired,
   basespaceOauthRedirectUri: PropTypes.string.isRequired,
 };

--- a/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadSampleStep.jsx
@@ -175,13 +175,13 @@ class UploadSampleStep extends React.Component {
   //*** Tab-related functions ***
 
   getUploadTabs = () => {
-    const { admin, biohubUser } = this.props;
+    const { admin, biohubS3UploadEnabled } = this.props;
     return compact([
       {
         value: LOCAL_UPLOAD,
         label: LOCAL_UPLOAD_LABEL,
       },
-      (admin || biohubUser) && {
+      (admin || biohubS3UploadEnabled) && {
         value: REMOTE_UPLOAD,
         label: REMOTE_UPLOAD_LABEL,
       },
@@ -805,7 +805,7 @@ UploadSampleStep.propTypes = {
   onDirty: PropTypes.func.isRequired,
   visible: PropTypes.bool,
   admin: PropTypes.bool,
-  biohubUser: PropTypes.bool,
+  biohubS3UploadEnabled: PropTypes.bool,
   basespaceClientId: PropTypes.string.isRequired,
   basespaceOauthRedirectUri: PropTypes.string.isRequired,
 };

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,7 +92,7 @@ class User < ApplicationRecord
 
     # Don't allow any non-Biohub users to upload from czbiohub buckets
     if CZBIOHUB_BUCKET_PREFIXES.any? { |prefix| user_bucket.downcase.starts_with?(prefix) }
-      unless biohub_user?
+      unless biohub_s3_upload_enabled?
         return false
       end
     end
@@ -103,6 +103,10 @@ class User < ApplicationRecord
   # This method is for tracking purposes only, not security.
   def biohub_user?
     ["czbiohub.org", "ucsf.edu"].include?(email.split("@").last)
+  end
+
+  def biohub_s3_upload_enabled?
+    biohub_user? || allowed_feature_list.include?("biohub_s3_upload_enabled") || admin?
   end
 
   # This method is for tracking purposes only, not security.

--- a/app/views/samples/upload.html.erb
+++ b/app/views/samples/upload.html.erb
@@ -4,7 +4,7 @@
       csrf: '<%= form_authenticity_token %>',
       hostGenomes: JSON.parse('<%= raw escape_json(@host_genomes) %>'),
       admin: JSON.parse('<%= raw escape_json(current_user.admin) %>'),
-      biohubUser: JSON.parse('<%= raw escape_json(current_user.biohub_user?) %>'),
+      biohubS3UploadEnabled: JSON.parse('<%= raw escape_json(current_user.biohub_s3_upload_enabled?) %>'),
       basespaceClientId: '<%= @basespace_client_id %>',
       basespaceOauthRedirectUri: '<%= @basespace_oauth_redirect_uri %>',
     }, 'upload_page', JSON.parse('<%= raw escape_json(request_context) %>'))


### PR DESCRIPTION
# Description

Add a way to temporarily give a non-biohub user the ability to upload from a biohub s3 bucket.
This was needed for our GCE grantees that were visiting Biohub. Their samples were uploaded to a biohub s3 bucket, and there wasn't a way to upload from s3 with their accounts.

# Tests
Verified that the feature flag works as expected.
