### PR TITLE
Fix metadata csv location menu empty row bug.

### DIFF
--- a/app/assets/src/components/common/MetadataCSVUpload.jsx
+++ b/app/assets/src/components/common/MetadataCSVUpload.jsx
@@ -61,6 +61,7 @@ class MetadataCSVUpload extends React.Component {
     if (this.props.onDirty) {
       this.props.onDirty();
     }
+
     this.setState({ metadata: csv });
     this.validateCSV(csv);
   };
@@ -112,6 +113,7 @@ class MetadataCSVUpload extends React.Component {
           title={hasMetadata ? "" : "Upload your metadata CSV"}
           onCSV={this.onCSV}
           className={cx(cs.csvUpload, hasMetadata && cs.uploaded)}
+          removeEmptyRows
         />
       </div>
     );


### PR DESCRIPTION
# Description

During a GCE training, we ran into this issue after deleting rows from an Excel file.

If you have a row of ""s in your CSV file, the location metadata csv menu will show some empty rows with no sample names.

Before:
<img width="937" alt="Screen Shot 2019-11-12 at 5 17 07 PM" src="https://user-images.githubusercontent.com/837004/68724777-4aa51e80-0571-11ea-8a82-75c6015e4072.png">

After:

<img width="1033" alt="Screen Shot 2019-11-12 at 5 21 18 PM" src="https://user-images.githubusercontent.com/837004/68724783-4bd64b80-0571-11ea-8615-781578c5e39c.png">

# Notes

The back-end was already handling these properly, but we now filter them out in the front-end as well. Filter them out in MetadataCSVUpload.