### PR TITLE
[Bug] entrypoint log entries affecting sql dumps

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -3,14 +3,11 @@ if test -z "$ENVIRONMENT"; then
     # If ENVIRONMENT not set, assume local development
     export ENVIRONMENT=dev
 fi
-echo ENVIRONMENT is set to \"$ENVIRONMENT\"
 
 if [ "$OFFLINE" = "1" ]
 then
-    echo Offline mode detected
     exec bundle exec "$@"
 else
     # Use Chamber to inject secrets via environment variables.
-    echo Chamber will read entries from AWS SSM /idseq-$ENVIRONMENT-web/
     exec chamber exec idseq-$ENVIRONMENT-web -- bundle exec "$@"
 fi


### PR DESCRIPTION
# Description

Log lines in `entrypoint.sh` showing environment names are being redirected to sql dumps when executing `bin/clam`. This is creating invalid files.

I'm removing these log entries that have been added recently.

