### PR TITLE
Adapt old sample report tests to new report service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,8 +113,8 @@ end
 
 group :test do
   gem 'rspec-json_expectations'
-  gem 'webmock', '~> 3.6'
   gem 'resque_spec'
+  gem 'webmock', '~> 3.6'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -114,6 +114,7 @@ end
 group :test do
   gem 'rspec-json_expectations'
   gem 'webmock', '~> 3.6'
+  gem 'resque_spec'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -112,8 +112,8 @@ group :development do
 end
 
 group :test do
-  gem 'rspec-json_expectations'
   gem 'resque_spec'
+  gem 'rspec-json_expectations'
   gem 'webmock', '~> 3.6'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1029,6 +1029,11 @@ GEM
       redis (>= 3.3, < 5)
       resque (~> 1.26)
       rufus-scheduler (~> 3.2)
+    resque_spec (0.18.1)
+      resque (>= 1.26.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+      rspec-mocks (>= 3.0.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -1194,6 +1199,7 @@ DEPENDENCIES
   resque (>= 1.27.4)
   resque-lock
   resque-scheduler (>= 4.3.1)
+  resque_spec
   rspec-json_expectations
   rspec-rails (>= 3.7.2)
   rubocop (= 0.49.1)

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -257,9 +257,15 @@ class PipelineReportService
   def compute_aggregate_scores(species_counts, genus_counts)
     species_counts.each do |tax_id, species|
       genus = genus_counts[species[:genus_tax_id]]
-      # Workaround placeholder for bad data (species NR is present in TaxonSummary but genus NR isn't)
+      # Workaround placeholder for bad data (e.g. species counts present in TaxonSummary but genus counts aren't)
       genus_nt_zscore = genus[:nt].present? ? genus[:nt][:z_score] : 100
       genus_nr_zscore = genus[:nr].present? ? genus[:nr][:z_score] : 100
+      if species[:nt].present? && genus[:nt].blank?
+        Rails.logger.warn("NT data present for species #{tax_id} but missing for genus #{species[:genus_tax_id]}.")
+      end
+      if species[:nr].present? && genus[:nr].blank?
+        Rails.logger.warn("NR data present for species #{tax_id} but missing for genus #{species[:genus_tax_id]}.")
+      end
 
       species[:agg_score] = (species[:nt].present? ? genus_nt_zscore.abs * species[:nt][:z_score] * species[:nt][:rpm] : 0) \
         + (species[:nr].present? ? genus_nr_zscore.abs * species[:nr][:z_score] * species[:nr][:rpm] : 0)

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -48,14 +48,12 @@ class PipelineReportService
     taxon_counts_and_summaries = fetch_taxon_counts(@pipeline_run_id, @background_id)
     @timer.split("fetch_taxon_counts_and_summaries")
 
-    missing_taxons = fetch_missing_taxons(@pipeline_run_id, @background_id)
-    @timer.split("fetch_missing_taxons")
+    taxons_absent_from_sample = fetch_taxons_absent_from_sample(@pipeline_run_id, @background_id)
+    @timer.split("fetch_taxons_absent_from_sample")
 
-    missing_taxon_summaries = []
-    missing_taxons.each do |taxon|
-      missing_taxon_summaries += [zero_metrics(*taxon)]
+    taxons_absent_from_sample.each do |taxon|
+      taxon_counts_and_summaries.concat([zero_metrics(*taxon)])
     end
-    taxon_counts_and_summaries += missing_taxon_summaries
     @timer.split("fill_zero_metrics")
 
     counts_by_tax_level = split_by_tax_level(taxon_counts_and_summaries)
@@ -149,22 +147,23 @@ class PipelineReportService
   end
 
   def zero_metrics(tax_id, tax_level, count_type, mean, stdev)
+    # fill in default zero values for FIELDS_TO_PLUCK
     [
-      tax_id, # tax_id
-      nil, # genus_taxid
-      count_type, # count_type
-      tax_level, # tax_level
-      0, # count
-      0, # percent_identity
-      0, # alignment_length
-      0, # e_value
-      mean, # mean
-      stdev, # stdev
-      nil # name
+      tax_id,
+      nil,
+      count_type,
+      tax_level,
+      0,
+      0,
+      0,
+      0,
+      mean,
+      stdev,
+      nil,
     ]
   end
 
-  def fetch_missing_taxons(_pipeline_run_id, _background_id)
+  def fetch_taxons_absent_from_sample(_pipeline_run_id, _background_id)
     taxons_absent_from_sample = TaxonSummary
                                 .joins(
                                   " LEFT JOIN taxon_counts ON ("\

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -247,6 +247,8 @@ class PipelineReportService
 
   def find_taxa_to_highlight(sorted_genus_tax_ids, counts_by_tax_level)
     ui_config = UiConfig.last
+    return unless ui_config
+
     highlighted_tax_ids = []
 
     meets_highlight_condition = lambda do |counts|

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -171,7 +171,7 @@ class PipelineReportService
   end
 
   def fetch_taxons_absent_from_sample(_pipeline_run_id, _background_id)
-    tax_ids = TaxonCount.select(:tax_id).where(pipeline_run_id: @pipeline_run_id).distinct.pluck(:tax_id)
+    tax_ids = TaxonCount.select(:tax_id).where(pipeline_run_id: @pipeline_run_id).distinct
 
     taxons_absent_from_sample = TaxonSummary
                                 .joins("LEFT OUTER JOIN"\
@@ -258,8 +258,8 @@ class PipelineReportService
     species_counts.each do |tax_id, species|
       genus = genus_counts[species[:genus_tax_id]]
       # Workaround placeholder for bad data (e.g. species counts present in TaxonSummary but genus counts aren't)
-      # TODO: investigate why a count type appearing in species is missing in its genus. It's possible the data is
-      # only missing in local/staging and is present on prod.
+      # TODO: investigate why a count type appearing in species is missing in its genus.
+      # JIRA: https://jira.czi.team/browse/IDSEQ-1807
       genus_nt_zscore = genus[:nt].present? ? genus[:nt][:z_score] : 100
       genus_nr_zscore = genus[:nr].present? ? genus[:nr][:z_score] : 100
       if species[:nt].present? && genus[:nt].blank?

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -574,12 +574,12 @@ RSpec.describe ProjectsController, type: :controller do
             expected_projects = []
             create(:project, users: [@user])
             create(:project, :with_sample, users: [@user])
-            klebsiella_tax_id = 2
+            KLEBSIELLA_TAX_ID = 2
             create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsormidium", nt: 10, tax_id: 1 }], job_status: "CHECKED" }] }])
-            create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 0, tax_id: klebsiella_tax_id }], job_status: "CHECKED" }] }])
-            expected_projects << create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 10, tax_id: klebsiella_tax_id }], job_status: "CHECKED" }] }])
+            create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 0, tax_id: KLEBSIELLA_TAX_ID }], job_status: "CHECKED" }] }])
+            expected_projects << create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 10, tax_id: KLEBSIELLA_TAX_ID }], job_status: "CHECKED" }] }])
 
-            get :index, params: { format: "json", domain: domain, taxon: klebsiella_tax_id }
+            get :index, params: { format: "json", domain: domain, taxon: KLEBSIELLA_TAX_ID }
 
             json_response = JSON.parse(response.body)
             expect(json_response["projects"].count).to eq(expected_projects.count)

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -574,11 +574,11 @@ RSpec.describe ProjectsController, type: :controller do
             expected_projects = []
             create(:project, users: [@user])
             create(:project, :with_sample, users: [@user])
-            create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsormidium", nt: 10 }], job_status: "CHECKED" }] }])
-            create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 0 }], job_status: "CHECKED" }] }])
-            expected_projects << create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 10 }], job_status: "CHECKED" }] }])
+            create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsormidium", nt: 10, tax_id: 1 }], job_status: "CHECKED" }] }])
+            create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 0, tax_id: 2 }], job_status: "CHECKED" }] }])
+            expected_projects << create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 10, tax_id: 2 }], job_status: "CHECKED" }] }])
 
-            get :index, params: { format: "json", domain: domain, taxon: TaxonLineage.find_by(tax_name: "klebsiella").id }
+            get :index, params: { format: "json", domain: domain, taxon: TaxonLineage.find_by(tax_name: "klebsiella").taxid }
 
             json_response = JSON.parse(response.body)
             expect(json_response["projects"].count).to eq(expected_projects.count)

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -574,11 +574,12 @@ RSpec.describe ProjectsController, type: :controller do
             expected_projects = []
             create(:project, users: [@user])
             create(:project, :with_sample, users: [@user])
+            klebsiella_tax_id = 2
             create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsormidium", nt: 10, tax_id: 1 }], job_status: "CHECKED" }] }])
-            create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 0, tax_id: 2 }], job_status: "CHECKED" }] }])
-            expected_projects << create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 10, tax_id: 2 }], job_status: "CHECKED" }] }])
+            create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 0, tax_id: klebsiella_tax_id }], job_status: "CHECKED" }] }])
+            expected_projects << create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 10, tax_id: klebsiella_tax_id }], job_status: "CHECKED" }] }])
 
-            get :index, params: { format: "json", domain: domain, taxon: TaxonLineage.find_by(tax_name: "klebsiella").taxid }
+            get :index, params: { format: "json", domain: domain, taxon: klebsiella_tax_id }
 
             json_response = JSON.parse(response.body)
             expect(json_response["projects"].count).to eq(expected_projects.count)

--- a/spec/factories/backgrounds.rb
+++ b/spec/factories/backgrounds.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :background do
+    sequence(:name) { |n| "Background #{n}" }
+    pipeline_run_ids { [] }
+    ready { 1 }
+
+    transient do
+      taxon_summaries_data { [] }
+    end
+
+    before :create do |background, options|
+      options.taxon_summaries_data.each do |taxon_summary_data|
+        create(:taxon_summary, background: background, **taxon_summary_data)
+      end
+    end
+  end
+end

--- a/spec/factories/taxon_counts.rb
+++ b/spec/factories/taxon_counts.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
       # The taxon name for the taxon count entry.
       # Will be loaded or created using species (taxon_lineages) factory.
       taxon_name { nil }
+      tax_id { nil }
       # NT or NR counts. NT will be used if defined. Otherwise, will use NR value.
       # Count type will be filled automaticlaly.
       nt { nil }
@@ -12,12 +13,12 @@ FactoryBot.define do
 
     initialize_with do
       if taxon_name
-        taxon_lineage = TaxonLineage.find_by(tax_name: taxon_name)
+        taxon_lineage = TaxonLineage.find_by(tax_name: taxon_name, taxid: tax_id)
         unless taxon_lineage
-          taxon_lineage = create(:species, tax_name: taxon_name)
+          taxon_lineage = create(:species, tax_name: taxon_name, taxid: tax_id)
         end
         # Unable to edit the original hash for some reason
-        new(**attributes.dup.merge(tax_id: taxon_lineage.id,
+        new(**attributes.dup.merge(tax_id: taxon_lineage.taxid,
                                    name: taxon_lineage.name))
       else
         new(attributes)

--- a/spec/factories/taxon_counts.rb
+++ b/spec/factories/taxon_counts.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
       # The taxon name for the taxon count entry.
       # Will be loaded or created using species (taxon_lineages) factory.
       taxon_name { nil }
-      tax_id { nil }
       # NT or NR counts. NT will be used if defined. Otherwise, will use NR value.
       # Count type will be filled automaticlaly.
       nt { nil }
@@ -13,7 +12,7 @@ FactoryBot.define do
 
     initialize_with do
       if taxon_name
-        taxon_lineage = TaxonLineage.find_by(tax_name: taxon_name, taxid: tax_id)
+        taxon_lineage = TaxonLineage.find_by(tax_name: taxon_name)
         unless taxon_lineage
           taxon_lineage = create(:species, tax_name: taxon_name, taxid: tax_id)
         end

--- a/spec/factories/taxon_summaries.rb
+++ b/spec/factories/taxon_summaries.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :taxon_summary do
+    sequence(:tax_id) { |n| n }
+    count_type { "NT" }
+    tax_level { 1 }
+  end
+end

--- a/spec/services/pipeline_report_service_spec.rb
+++ b/spec/services/pipeline_report_service_spec.rb
@@ -1,0 +1,261 @@
+require 'rails_helper'
+require 'json'
+require 'pp'
+
+RSpec.describe PipelineReportService, type: :service do
+  context "converted report test for species taxid 573" do
+    before do
+      @pipeline_run = create(:pipeline_run,
+                             sample: create(:sample, project: create(:project)),
+                             total_reads: 1122,
+                             adjusted_remaining_reads: 316,
+                             subsample: 1_000_000,
+                             taxon_counts_data: [{
+                               tax_id: 573,
+                               tax_level: 1,
+                               taxon_name: "Klebsiella pneumoniae",
+                               nt: 209,
+                               percent_identity: 99.6995,
+                               alignment_length: 149.402,
+                               e_value: -89.5641,
+                               genus_taxid: 570,
+                               superkingdom_taxid: 2,
+                             }, {
+                               tax_id: 573,
+                               tax_level: 1,
+                               taxon_name: "Klebsiella pneumoniae",
+                               nr: 69,
+                               percent_identity: 97.8565,
+                               alignment_length: 46.3623,
+                               e_value: -16.9101,
+                               genus_taxid: 570,
+                               superkingdom_taxid: 2,
+                             }, {
+                               tax_id: 570,
+                               tax_level: 2,
+                               nt: 217,
+                               taxon_name: "Klebsiella",
+                               percent_identity: 99.7014,
+                               alignment_length: 149.424,
+                               e_value: -89.5822,
+                               genus_taxid: 570,
+                               superkingdom_taxid: 2,
+                             }, {
+                               tax_id: 570,
+                               tax_level: 2,
+                               nr: 87,
+                               taxon_name: "Klebsiella",
+                               percent_identity: 97.9598,
+                               alignment_length: 46.4253,
+                               e_value: -16.9874,
+                               genus_taxid: 570,
+                               superkingdom_taxid: 2,
+                             },])
+
+      @background = create(:background,
+                           pipeline_run_ids: [
+                             create(:pipeline_run,
+                                    sample: create(:sample, project: create(:project))).id,
+                             create(:pipeline_run,
+                                    sample: create(:sample, project: create(:project))).id,
+                           ],
+                           taxon_summaries_data: [{
+                             tax_id: 573,
+                             count_type: "NR",
+                             tax_level: 1,
+                             mean: 29.9171,
+                             stdev: 236.332,
+                           }, {
+                             tax_id: 573,
+                             count_type: "NT",
+                             tax_level: 1,
+                             mean: 9.35068,
+                             stdev: 26.4471,
+                           }, {
+                             tax_id: 570,
+                             count_type: "NR",
+                             tax_level: 2,
+                             mean: 35.0207,
+                             stdev: 238.639,
+                           }, {
+                             tax_id: 570,
+                             count_type: "NT",
+                             tax_level: 2,
+                             mean: 18.3311,
+                             stdev: 64.2056,
+                           },])
+
+      @report = PipelineReportService.call(@pipeline_run.id, @background.id)
+    end
+
+    it "should get correct species values" do
+      species_result = {
+        "genus_tax_id" => 570,
+        "name" => "Klebsiella pneumoniae",
+        "nt" => {
+          "count" => 209,
+          "rpm" => 186_274.50980392157, # previously rounded to 186_274.509
+          "z_score" => 99.0,
+        },
+        "nr" => {
+          "count" => 69,
+          "rpm" => 61_497.326203208555, # previously rounded to 61_497.326
+          "z_score" => 99.0,
+        },
+        "agg_score" => 2_428_411_764.7058825, # previously rounded to 2_428_411_754.8
+      }
+
+      expect(JSON.parse(@report)["counts"]["1"]["573"]).to include_json(species_result)
+    end
+
+    it "should get correct genus values" do
+      genus_result = {
+        "genus_tax_id" => 570,
+        "nt" => {
+          "count" => 217.0,
+          "rpm" => 193_404.63458110517, # previously rounded to 193_404.634
+          "z_score" => 99.0,
+          "e_value" => 89.5822,
+        },
+        "nr" => {
+          "count" => 87.0,
+          "rpm" => 77_540.10695187165, # previously rounded to 77_540.106
+          "z_score" => 99.0,
+          "e_value" => 16.9874,
+        },
+        "agg_score" => 2_428_411_764.7058825, # previously rounded to  2_428_411_754.8
+      }
+
+      expect(JSON.parse(@report)["counts"]["2"]["570"]).to include_json(genus_result)
+    end
+  end
+
+  context "converted report test for species taxid 1313" do
+    before do
+      @pipeline_run = create(:pipeline_run,
+                             sample: create(:sample, project: create(:project)),
+                             total_reads: 1122,
+                             adjusted_remaining_reads: 316,
+                             subsample: 1_000_000,
+                             taxon_counts_data: [{
+                               tax_id: 1313,
+                               tax_level: 1,
+                               taxon_name: "Streptococcus pneumoniae",
+                               nr: 2,
+                               percent_identity: 96.9,
+                               alignment_length: 32.0,
+                               e_value: -9.3,
+                               genus_taxid: 1301,
+                               superkingdom_taxid: 2,
+                             }, {
+                               tax_id: 1301,
+                               tax_level: 2,
+                               nr: 2,
+                               taxon_name: "Streptococcus",
+                               percent_identity: 96.9,
+                               alignment_length: 32.0,
+                               e_value: -9.3,
+                               genus_taxid: 1301,
+                               superkingdom_taxid: 2,
+                             }, {
+                               tax_id: 1301,
+                               tax_level: 2,
+                               nt: 4,
+                               taxon_name: "Streptococcus",
+                               percent_identity: 95.65,
+                               alignment_length: 149.75,
+                               e_value: -81.478,
+                               genus_taxid: 1301,
+                               superkingdom_taxid: 2,
+                             }, {
+                               tax_id: 28_037,
+                               tax_level: 1,
+                               nt: 4,
+                               name: "Streptococcus mitis",
+                               percent_identity: 95.65,
+                               alignment_length: 149.75,
+                               e_value: -81.478,
+                               genus_taxid: 1301,
+                               superkingdom_taxid: 2,
+                             },])
+
+      @background = create(:background,
+                           pipeline_run_ids: [
+                             create(:pipeline_run,
+                                    sample: create(:sample, project: create(:project))).id,
+                             create(:pipeline_run,
+                                    sample: create(:sample, project: create(:project))).id,
+                           ],
+                           taxon_summaries_data: [{
+                             tax_id: 1313,
+                             count_type: "NR",
+                             tax_level: 1,
+                             mean: 81.3845,
+                             stdev: 404.076,
+                           }, {
+                             tax_id: 1313,
+                             count_type: "NT",
+                             tax_level: 1,
+                             mean: 81.6257,
+                             stdev: 442.207,
+                           }, {
+                             tax_id: 1301,
+                             count_type: "NR",
+                             tax_level: 2,
+                             mean: 201.318,
+                             stdev: 942.975,
+                           }, {
+                             tax_id: 1301,
+                             count_type: "NT",
+                             tax_level: 2,
+                             mean: 290.481,
+                             stdev: 1482.97,
+                           },])
+
+      @report = PipelineReportService.call(@pipeline_run.id, @background.id)
+    end
+
+    it "should get correct species values" do
+      species_result = {
+        "genus_tax_id" => 1301,
+        "name" => "Streptococcus pneumoniae",
+        "nt" => {
+          "count" => 0,
+          "rpm" => 0,
+          "z_score" => -100,
+          "e_value" => 0,
+        },
+        "nr" => {
+          "count" => 2,
+          "rpm" => 1782.5311942959001, # previously rounded to 1782.531
+          "z_score" => 4.209967170274651, # previously rounded to 4.2099668
+          "e_value" => 9.3,
+        },
+        "agg_score" => 12_583.634591815486 # previously rounded to 12_583.63
+      }
+
+      expect(JSON.parse(@report)["counts"]["1"]["1313"]).to include_json(species_result)
+    end
+
+    it "should get correct genus values" do
+      genus_result = {
+        "genus_tax_id" => 1301,
+        "nt" => {
+          "count" => 4.0,
+          "rpm" => 3565.0623885918003, # previously rounded to 3565.062
+          "z_score" => 2.208123824886411, # previously rounded to 2.2081236
+          "e_value" => 81.478,
+        },
+        "nr" => {
+          "count" => 2.0,
+          "rpm" => 1782.5311942959001, # previously rounded to 1782.531
+          "z_score" => 1.6768346926439197, # previously rounded to 1.6768345
+          "e_value" => 9.3,
+        },
+        "agg_score" => 73_603.777,
+      }
+
+      expect(JSON.parse(@report)["counts"]["2"]["1301"]).to include_json(genus_result)
+    end
+  end
+end

--- a/spec/services/pipeline_report_service_spec.rb
+++ b/spec/services/pipeline_report_service_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe PipelineReportService, type: :service do
                                tax_id: 28_037,
                                tax_level: 1,
                                nt: 4,
-                               name: "Streptococcus mitis",
+                               taxon_name: "Streptococcus mitis",
                                percent_identity: 95.65,
                                alignment_length: 149.75,
                                e_value: -81.478,
@@ -210,6 +210,18 @@ RSpec.describe PipelineReportService, type: :service do
                              tax_level: 2,
                              mean: 290.481,
                              stdev: 1482.97,
+                           }, {
+                             tax_id: 28_037,
+                             count_type: "NR",
+                             tax_level: 1,
+                             mean: 25.6849,
+                             stdev: 139.526,
+                           }, {
+                             tax_id: 28_037,
+                             count_type: "NT",
+                             tax_level: 1,
+                             mean: 65.9058,
+                             stdev: 374.243,
                            },])
 
       @report = PipelineReportService.call(@pipeline_run.id, @background.id)
@@ -252,7 +264,7 @@ RSpec.describe PipelineReportService, type: :service do
           "z_score" => 1.6768346926439197, # previously rounded to 1.6768345
           "e_value" => 9.3,
         },
-        "agg_score" => 73_603.777,
+        "agg_score" => 73_603.80226971892 # previously rounded to 73_603.777
       }
 
       expect(JSON.parse(@report)["counts"]["2"]["1301"]).to include_json(genus_result)

--- a/spec/services/pipeline_report_service_spec.rb
+++ b/spec/services/pipeline_report_service_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 require 'json'
-require 'pp'
 
 RSpec.describe PipelineReportService, type: :service do
   context "converted report test for species taxid 573" do

--- a/spec/services/pipeline_report_service_spec.rb
+++ b/spec/services/pipeline_report_service_spec.rb
@@ -5,6 +5,8 @@ require 'pp'
 RSpec.describe PipelineReportService, type: :service do
   context "converted report test for species taxid 573" do
     before do
+      ResqueSpec.reset!
+
       @pipeline_run = create(:pipeline_run,
                              sample: create(:sample, project: create(:project)),
                              total_reads: 1122,


### PR DESCRIPTION
# Description

Converts [this test](https://github.com/chanzuckerberg/idseq-web/blob/master/test/controllers/samples_controller_test.rb#L110) into rspec and tests the new report service.

The test is split up into two:

1. species taxid 573 with genus taxid 570

- species NT and NR are both present in both the sample and the background model

2. species taxid 1313 and species taxid 28037, both from genus taxid 1310

- species 1313 NT and NR are present in the background model, but the sample only has NR
- species 28037 NT and NR are present in the background model, but the sample only has NT


# Notes

**Bugs addressed** (more details [here](https://czi.quip.com/u5ajAc1o5Chq/Report-Page-Optimization#bCHACAP4x4C)):
* Return the correct z-score when the taxon is missing in the sample (-100 if it's present in the background model, 0 if it's also missing in the background model.)
* If the species has NT/NR values but the genus is missing them, then use 100 as a placeholder for the genus z-score when calculating aggregate score.
  * The genus z-score will be displayed as 0 on the frontend.
  * [Logging](https://github.com/chanzuckerberg/idseq-web/pull/2746/files#diff-fe537067be5407d2c7c9e3a14329237cR263) has been added for these occurrences.

The new report service rounds values differently, so some of the expected values are not directly carried over from the old tests. The modified values in `pipeline_report_service_spec` are commented with what the old test previously expected.

The TaxonCounts factory was changed to pass `tax_id` as an input to TaxonLineage rather than always having the value be sequentially generated. `projects_controller_spec` had one test case slightly modified to account for this change.