### PR TITLE
Fix issue where phylo tree modal was closing when mouse left browser.

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -21,6 +21,7 @@ import { parseUrlParams } from "~/helpers/url";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import ThresholdFilterTag from "~/components/common/ThresholdFilterTag";
 import FilterTag from "~ui/controls/FilterTag";
+import PhyloTreeCreationModal from "~/components/views/phylo_tree/PhyloTreeCreationModal";
 
 import {
   computeThresholdedTaxons,
@@ -188,6 +189,7 @@ class PipelineSampleReport extends React.Component {
       contigTaxidList: [],
       minContigSize: cachedMinContigSize || DEFAULT_MIN_CONTIG_SIZE,
       hoverRowId: null,
+      phyloTreeModalParams: null,
     };
 
     this.state = {
@@ -822,6 +824,18 @@ class PipelineSampleReport extends React.Component {
     }
   };
 
+  handlePhyloTreeModalOpen = phyloTreeModalParams => {
+    this.setState({
+      phyloTreeModalParams,
+    });
+  };
+
+  handlePhyloTreeModalClose = () => {
+    this.setState({
+      phyloTreeModalParams: null,
+    });
+  };
+
   displayHoverActions = (taxInfo, reportDetails) => {
     const { reportPageParams } = this.props;
     const validTaxId =
@@ -854,10 +868,6 @@ class PipelineSampleReport extends React.Component {
     return (
       <HoverActions
         className="link-tag"
-        admin={parseInt(this.admin)}
-        csrf={this.csrf}
-        projectId={this.projectId}
-        projectName={this.projectName}
         taxId={taxInfo.tax_id}
         taxLevel={taxInfo.tax_level}
         taxName={taxInfo.name}
@@ -887,12 +897,11 @@ class PipelineSampleReport extends React.Component {
           analyticsContext
         )}
         phyloTreeEnabled={phyloTreeEnabled}
-        onPhyloTreeModalOpened={() =>
-          logAnalyticsEvent(
-            "PipelineSampleReport_phylotree-link_clicked",
-            analyticsContext
-          )
-        }
+        onPhyloTreeModalOpened={withAnalytics(
+          this.handlePhyloTreeModalOpen,
+          "PipelineSampleReport_phylotree-link_clicked",
+          analyticsContext
+        )}
         pipelineVersion={reportPageParams.pipeline_version}
       />
     );
@@ -1614,6 +1623,17 @@ class RenderMarkup extends React.Component {
                 <div className="loading-container">
                   <LoadingLabel />
                 </div>
+              )}
+              {parent.state.phyloTreeModalParams && (
+                <PhyloTreeCreationModal
+                  admin={parent.admin}
+                  csrf={parent.csrf}
+                  taxonId={parent.state.phyloTreeModalParams.taxId}
+                  taxonName={parent.state.phyloTreeModalParams.taxName}
+                  projectId={parent.projectId}
+                  projectName={parent.projectName}
+                  onClose={parent.handlePhyloTreeModalClose}
+                />
               )}
             </div>
           </div>

--- a/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
+++ b/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
@@ -3,7 +3,6 @@ import React from "react";
 import cx from "classnames";
 // TODO(mark): Move BasicPopup into /ui.
 import BasicPopup from "~/components/BasicPopup";
-import PhyloTreeCreationModal from "~/components/views/phylo_tree/PhyloTreeCreationModal";
 import BetaLabel from "~/components/ui/labels/BetaLabel";
 import CoverageIcon from "~ui/icons/CoverageIcon";
 import PropTypes from "~/components/utils/propTypes";
@@ -12,17 +11,14 @@ import { pipelineVersionHasCoverageViz } from "~/components/utils/sample";
 import cs from "./hover_actions.scss";
 
 class HoverActions extends React.Component {
-  state = {
-    phyloTreeCreationModalOpen: false,
-  };
-
   handlePhyloModalOpen = () => {
-    this.setState({ phyloTreeCreationModalOpen: true });
-    this.props.onPhyloTreeModalOpened && this.props.onPhyloTreeModalOpened();
-  };
+    const { taxId, taxName, onPhyloTreeModalOpened } = this.props;
 
-  handlePhyloModalClose = () => {
-    this.setState({ phyloTreeCreationModalOpen: false });
+    onPhyloTreeModalOpened &&
+      onPhyloTreeModalOpened({
+        taxId,
+        taxName,
+      });
   };
 
   // Metadata for each of the hover actions.
@@ -154,30 +150,11 @@ class HoverActions extends React.Component {
   };
 
   render() {
-    const {
-      admin,
-      csrf,
-      taxId,
-      taxName,
-      projectId,
-      projectName,
-      className,
-    } = this.props;
+    const { className } = this.props;
 
     return (
       <span className={cx(cs.hoverActions, className)}>
         {this.getHoverActions().map(this.renderHoverAction)}
-        {this.state.phyloTreeCreationModalOpen && (
-          <PhyloTreeCreationModal
-            admin={admin}
-            csrf={csrf}
-            taxonId={taxId}
-            taxonName={taxName}
-            projectId={projectId}
-            projectName={projectName}
-            onClose={this.handlePhyloModalClose}
-          />
-        )}
       </span>
     );
   }
@@ -185,10 +162,6 @@ class HoverActions extends React.Component {
 
 HoverActions.propTypes = {
   className: PropTypes.string,
-  admin: PropTypes.number,
-  csrf: PropTypes.string,
-  projectId: PropTypes.number,
-  projectName: PropTypes.string,
   taxId: PropTypes.number,
   taxLevel: PropTypes.number,
   taxName: PropTypes.string,


### PR DESCRIPTION
# Description

PhyloTreeCreationModal was originally inside `<HoverActions>` so it would unmount whenever hoveractions unmounted (which happened on onMouseOut, which would trigger when the user moved their mouse out of the browser).

Moved the PhyloTreeCreationModal higher up in the component tree so this doesn't happen.

# Tests

* Verified that the bug no longer occurs.
* Verified that modal still behaves correctly.
