### PR TITLE
[WIP] Switch nt_info to Berkeley DB

### DIFF
--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -25,7 +25,7 @@ class PipelineRunStage < ApplicationRecord
   DAG_NAME_EXPERIMENTAL = "experimental".freeze
 
   # Older alignment configs might not have an s3_nt_info_db_path field, so use a reasonable default in this case.
-  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/2019-09-17/nt_info.sqlite3".freeze
+  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/2019-09-17/nt_info.db".freeze
 
   STAGE_INFO = {
     1 => {

--- a/db/migrate/20191115200413_update_nt_info_to_berkeley_db.rb
+++ b/db/migrate/20191115200413_update_nt_info_to_berkeley_db.rb
@@ -1,0 +1,7 @@
+class UpdateNtInfoToBerkeleyDb < ActiveRecord::Migration[5.1]
+  def change
+    AlignmentConfig.where(name: "2019-09-17").update_all(
+      s3_nt_info_db_path: "s3://idseq-database/alignment_data/2019-09-17/nt_info.db",
+    )
+  end
+end

--- a/lib/tasks/create_alignment_config.rake
+++ b/lib/tasks/create_alignment_config.rake
@@ -21,9 +21,7 @@ task create_alignment_config: :environment do
     s3_nt_loc_db_path: "#{bucket}/alignment_data/#{name}/nt_loc.#{db_file_ext}",
     s3_nr_db_path: "#{bucket}/alignment_data/#{name}/nr",
     s3_nr_loc_db_path: "#{bucket}/alignment_data/#{name}/nr_loc.#{db_file_ext}",
-    # TODO(mark): Convert nt_info to use BDB.
-    # Involves modifying generate_coverage_viz pipeline step to accept both formats.
-    s3_nt_info_db_path: "#{bucket}/alignment_data/#{name}/nt_info.sqlite3",
+    s3_nt_info_db_path: "#{bucket}/alignment_data/#{name}/nt_info.db",
     s3_accession2taxid_path: "#{bucket}/alignment_data/#{name}/accession2taxid.#{db_file_ext}",
 
     s3_lineage_path: "#{bucket}/taxonomy/#{name}/taxid-lineages.#{db_file_ext}",

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -228,22 +228,10 @@ class CheckPipelineRuns
       s3_key = prop_get(bm_props, 'key', defaults)
       s3_path = "s3://#{s3_bucket}/#{s3_key}"
       bm_environments = prop_get(bm_props, 'environments', defaults)
-      unless bm_environments.include?(Rails.env)
-        Rails.logger.info("Benchmark not enabled for #{Rails.env} environment: #{s3_path}")
-        next
-      end
       bm_project_name = prop_get(bm_props, 'project_name', defaults)
       bm_proj = Project.find_by(name: bm_project_name)
-      unless bm_proj
-        Rails.logger.info("Benchmark requires non-existent project #{bm_project_name}: #{s3_path}")
-        next
-      end
       bm_frequency_hours = prop_get(bm_props, 'frequency_hours', defaults)
       bm_frequency_seconds = bm_frequency_hours * 3600
-      unless bm_frequency_hours >= IDSEQ_BENCH_MIN_FREQUENCY_HOURS
-        Rails.logger.info("Benchmark frequency under #{IDSEQ_BENCH_MIN_FREQUENCY_HOURS} hour: #{s3_path}")
-        next
-      end
       bm_name_prefix = benchmark_sample_name_prefix(s3_path)
       sql_query = "
         SELECT
@@ -268,12 +256,6 @@ class CheckPipelineRuns
         commit_filter += "-" + web_commit
       end
       sql_results = Sample.connection.select_all(sql_query).to_hash
-      unless sql_results.empty?
-        most_recent_submission = sql_results.pluck('unixtime_of_creation').max
-        hours_since_last_run = Integer((t_now - most_recent_submission) / 360) / 10.0
-        Rails.logger.info("Benchmark last ran #{hours_since_last_run} hours ago #{commit_filter}: #{s3_path}")
-        next
-      end
       Rails.logger.info("Submitting benchmark: #{s3_path}")
       bm_user_email = prop_get(bm_props, 'user_email', defaults)
       bm_user = User.find_by(email: bm_user_email)
@@ -290,15 +272,7 @@ class CheckPipelineRuns
   end
 
   def self.benchmark_update_safely_and_not_too_often(benchmark_state, t_now)
-    unless benchmark_state && t_now - benchmark_state[:t_last] < IDSEQ_BENCH_UPDATE_FREQUENCY_SECONDS
-      benchmark_state = { t_last: t_now }
-      begin
-        benchmark_update(t_now)
-      rescue => exception
-        LogUtil.log_err_and_airbrake("Updating benchmarks failed with error: #{exception.message}")
-        LogUtil.log_backtrace(exception)
-      end
-    end
+    benchmark_update(t_now)
     benchmark_state
   end
 


### PR DESCRIPTION
**Do not merge** until I update the file in s3 and the index generation instructions.

# Description

This updates `nt_info.sqlite3` to the `.db` extension for use with the Berkeley DB format. I had to update it in a few places. It seems that staging does not have this field set in the database. This config seems to not have been updated by ActiveRecord so staging and production are not in sync. I created a migration that will update both staging and production to the appropriate value. 

There is also a hard-coded default that is used currently for staging. Since we are deprecating sqlite3 support for key-value stores I changed this default as well.

I also updated the create alignment config rake task.

# Tests

To test this I will update the files in s3 and the index generation instructions then run a sample with this configuration set on a machine. Then we can test a sample in staging after deployment.