### PR TITLE
IDSEQ-1574 - Fix csrf tokens in auth0 and add preliminary sliding sessions support

### DIFF
--- a/app/assets/src/components/utils/links.js
+++ b/app/assets/src/components/utils/links.js
@@ -47,13 +47,13 @@ const postToUrlWithCSRF = (url, params) => {
   const form = document.createElement("form");
   form.setAttribute("method", "POST");
   form.setAttribute("action", url);
-  const input = document.createElement("input");
   const csrf = document.getElementsByName("csrf-token")[0].content;
   params = params || {};
   for (const [key, value] of Object.entries({
     authenticity_token: csrf,
     ...params,
   })) {
+    const input = document.createElement("input");
     input.setAttribute("type", "HIDDEN");
     input.setAttribute("name", key);
     input.setAttribute("value", value);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,8 +25,8 @@ class ApplicationController < ActionController::Base
     redirect_to root_path unless current_user && current_user.admin?
   end
 
-  # This method checks if auth0 token is present and sets the current user,
-  # or redirects to the homepage in case the token is not valid.
+  # This method checks if auth0 token is present and valid
+  # and then sets the current user,
   # This method allows auth0 authentication to work simultaneously
   # with legacy devise database mode.
   def sign_in_auth0_token!
@@ -40,11 +40,23 @@ class ApplicationController < ActionController::Base
           return
         end
       end
+    end
+  end
+
+  def authenticate_user!
+    if @auth0_token && !@auth0_token[:authenticated]
       # redirect user if auth0 token is invalid or expired
       respond_to do |format|
-        format.html { redirect_to(auth0_signout_url) }
+        format.html do
+          # we want to redirect user to auth0 login page in silent mode
+          # if the user still have a valid SSO token in the auth0 session
+          # the sliding session will be refreshed
+          redirect_to(auth0_login_url(true))
+        end
         format.json { render json: { errors: ['Not Authenticated'] }, status: :unauthorized }
       end
+    else
+      super
     end
   end
 

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class Auth0Controller < ApplicationController
-  skip_before_action :authenticate_user!, :verify_authenticity_token
+  skip_before_action :authenticate_user!, :verify_authenticity_token, :sign_in_auth0_token!
 
   include Auth0Helper
+
+  def refresh_token
+    redirect_to auth0_login_url(true)
+  end
 
   def callback
     # Store the user token that came from Auth0 and the IdP

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < Devise::SessionsController
 
   include Auth0Helper
 
-  skip_before_action :verify_authenticity_token, only: [:destroy]
+  skip_before_action :verify_authenticity_token, :authenticate_user!, only: [:destroy]
 
   # Skip devise verify_signed_out_user when logging out an auth0 session
   # https://stackoverflow.com/questions/26241357/overriding-devise-sessionscontroller-destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   get 'auth/auth0/callback' => 'auth0#callback'
   post 'auth0/request_password_reset' => 'auth0#request_password_reset'
+  get 'auth0/refresh_token' => 'auth0#refresh_token'
 
   resources :samples do
     put :reupload_source, on: :member


### PR DESCRIPTION
# Description

Fix an issue with csrf tokens in auth0 and add preliminary support to sliding sessions in auth0.

# Notes

Known caveats:
- When current auth0 token expires, idseq will refresh tokens in auth0 and users get redirected to "My data". This behavior will be fixed in a future PR.

# Tests

* Manual tests both strategies (devise and auth0)