### PR TITLE
Fix issue where pipeline tab doesn't respect pipeline version.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -346,8 +346,12 @@ const getSamplesLocations = ({ domain, filters, projectId, search }) =>
     },
   });
 
-const getSamplePipelineResults = id =>
-  get(`/samples/${id}/results_folder.json`);
+const getSamplePipelineResults = (sampleId, pipelineVersion) =>
+  get(`/samples/${sampleId}/results_folder.json`, {
+    params: {
+      pipeline_version: pipelineVersion,
+    },
+  });
 
 // Get autocomplete suggestions for "taxa that have reads" for a set of samples.
 const getTaxaWithReadsSuggestions = (query, sampleIds) =>

--- a/app/assets/src/components/RawResultsFolder.jsx
+++ b/app/assets/src/components/RawResultsFolder.jsx
@@ -1,6 +1,7 @@
 // This legacy component is intended to be developer-facing only.
 // The user-facing component has since evolved to ResultsFolder.jsx.
 import React from "react";
+import PropTypes from "prop-types";
 
 class RawResultsFolder extends React.Component {
   constructor(props, context) {
@@ -41,7 +42,7 @@ class RawResultsFolder extends React.Component {
             <span className="path">/</span>
             <span
               className="back"
-              onClick={this.gotoPath.bind(this, `/samples/${this.filePath[2]}`)}
+              onClick={this.gotoPath.bind(this, this.props.samplePath)}
             >
               {this.sampleName}
             </span>
@@ -87,5 +88,9 @@ class RawResultsFolder extends React.Component {
     );
   }
 }
+
+RawResultsFolder.propTypes = {
+  samplePath: PropTypes.string,
+};
 
 export default RawResultsFolder;

--- a/app/assets/src/components/ResultsFolder.jsx
+++ b/app/assets/src/components/ResultsFolder.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Divider from "./layout/Divider";
 import { openUrl, downloadStringToFile } from "./utils/links";
 
@@ -143,7 +144,7 @@ class ResultsFolder extends React.Component {
             <span className="path">/</span>
             <span
               className="back"
-              onClick={this.gotoPath.bind(this, `/samples/${this.filePath[2]}`)}
+              onClick={this.gotoPath.bind(this, this.props.samplePath)}
             >
               {this.sampleName}
             </span>
@@ -198,5 +199,9 @@ class ResultsFolder extends React.Component {
     );
   }
 }
+
+ResultsFolder.propTypes = {
+  samplePath: PropTypes.string,
+};
 
 export default ResultsFolder;

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -91,8 +91,11 @@ class PipelineTab extends React.Component {
   };
 
   getReadCounts = async () => {
-    const { sampleId } = this.props;
-    const pipelineResults = await getSamplePipelineResults(sampleId);
+    const { sampleId, pipelineRun } = this.props;
+    const pipelineResults = await getSamplePipelineResults(
+      sampleId,
+      pipelineRun && pipelineRun.pipeline_version
+    );
 
     if (pipelineResults && pipelineResults["displayed_data"]) {
       this.setState({

--- a/app/assets/src/components/utils/sample.js
+++ b/app/assets/src/components/utils/sample.js
@@ -77,7 +77,7 @@ export const joinServerError = response => {
 };
 
 export const sampleErrorInfo = (sample, pipelineRun) => {
-  let status, message, linkText, type, link;
+  let status, message, linkText, type, link, pipelineVersionUrlParam;
   switch (
     sample.upload_error || (pipelineRun && pipelineRun.known_user_error)
   ) {
@@ -126,7 +126,11 @@ export const sampleErrorInfo = (sample, pipelineRun) => {
         "Oh no! No matches were identified because there weren't any reads left after host and quality filtering.";
       linkText = "Check where your reads were filtered out.";
       type = "warning";
-      link = `/samples/${sample.id}/results_folder`;
+      pipelineVersionUrlParam =
+        pipelineRun && pipelineRun.pipeline_version
+          ? `?pipeline_version=${pipelineRun.pipeline_version}`
+          : "";
+      link = `/samples/${sample.id}/results_folder${pipelineVersionUrlParam}`;
       break;
     case "BROKEN_PAIRS":
       status = "COMPLETE - ISSUE";

--- a/app/assets/src/components/views/report/utils/download.js
+++ b/app/assets/src/components/views/report/utils/download.js
@@ -61,7 +61,9 @@ const getDownloadLinkInfoMap = (sampleId, pipelineRun) => ({
     newPage: false,
   },
   [RESULTS_FOLDER_LABEL]: {
-    path: `/samples/${sampleId}/results_folder`,
+    path: `/samples/${sampleId}/results_folder?pipeline_version=${
+      pipelineRun.pipeline_version
+    }`,
     newPage: true,
   },
   [PIPELINE_VIZ_LABEL]: {

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1006,15 +1006,23 @@ class SamplesController < ApplicationController
 
   def raw_results_folder
     # See access check in check_owner
-    @file_list = @sample.results_folder_files
+    @file_list = @sample.results_folder_files(params[:pipeline_version])
     @file_path = "#{@sample.sample_path}/results/"
+    pipeline_version_url_param = params[:pipeline_version] ? "?pipeline_version=#{params[:pipeline_version]}" : ""
+    @sample_path = "#{sample_path(@sample)}#{pipeline_version_url_param}"
     render template: "samples/raw_folder"
   end
 
   def results_folder
+    pr = select_pipeline_run(@sample, params[:pipeline_version])
     can_see_stage1_results = (current_user.id == @sample.user_id)
-    @exposed_raw_results_url = can_see_stage1_results ? raw_results_folder_sample_url(@sample) : nil
-    @file_list = @sample.first_pipeline_run ? @sample.first_pipeline_run.outputs_by_step(can_see_stage1_results) : []
+    pipeline_version_url_param = params[:pipeline_version] ? "?pipeline_version=#{params[:pipeline_version]}" : ""
+    @exposed_raw_results_url = can_see_stage1_results ? "#{raw_results_folder_sample_url(@sample)}#{pipeline_version_url_param}" : nil
+    @sample_path = "#{sample_path(@sample)}#{pipeline_version_url_param}"
+    @file_list = []
+    if pr
+      @file_list = pr.outputs_by_step(can_see_stage1_results)
+    end
     @file_path = "#{@sample.sample_path}/results/"
     respond_to do |format|
       format.html do

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1419,7 +1419,7 @@ class PipelineRun < ApplicationRecord
   def outputs_by_step(can_see_stage1_results = false)
     # Get map of s3 path to presigned URL and size.
     filename_to_info = {}
-    sample.results_folder_files.each do |entry|
+    sample.results_folder_files(pipeline_version).each do |entry|
       filename_to_info[entry[:key]] = entry
     end
     # Get read counts

--- a/app/views/samples/folder.html.erb
+++ b/app/views/samples/folder.html.erb
@@ -4,6 +4,7 @@
       filePath: JSON.parse('<%= raw escape_json(@file_path) %>'),
       fileList: JSON.parse('<%= raw escape_json(@file_list) %>'),
       sampleName: '<%= @sample.name %>',
+      samplePath: '<%= @sample_path %>',
       projectName: '<%= @sample.project.name %>',
       rawResultsUrl: '<%= @exposed_raw_results_url %>'
     }, 'ResultsFolder');

--- a/app/views/samples/raw_folder.html.erb
+++ b/app/views/samples/raw_folder.html.erb
@@ -3,6 +3,7 @@
     react_component('RawResultsFolder', {
       filePath: JSON.parse('<%= raw escape_json(@file_path) %>'),
       fileList: JSON.parse('<%= raw escape_json(@file_list) %>'),
+      samplePath: '<%= @sample_path %>',
       sampleName: '<%= @sample.name %>',
       projectName: '<%= @sample.project.name %>'
     }, 'RawResultsFolder');

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -12,15 +12,45 @@ RSpec.describe SamplesController, type: :controller do
     describe "GET raw_results_folder (nonadmin)" do
       it "can see raw results on the user's own samples" do
         project = create(:project, users: [@joe])
-        sample = create(:sample, project: project)
+        sample = create(:sample, project: project, user: @joe)
         get :raw_results_folder, params: { id: sample.id }
-        expect(response).to have_http_status :unauthorized
+        expect(response).to have_http_status :success
       end
 
       it "cannot see raw results on another user's sample" do
         project = create(:project, users: [@joe])
-        sample = create(:sample, project: project, user: @joe)
+        sample = create(:sample, project: project)
         get :raw_results_folder, params: { id: sample.id }
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    describe "GET results_folder (nonadmin)" do
+      it "can see raw results on the user's own samples" do
+        project = create(:project, users: [@joe])
+        sample = create(:sample, project: project, user: @joe)
+        get :results_folder, params: { id: sample.id }
+        expect(response).to have_http_status :success
+      end
+
+      it "can see raw results on the user's own samples with previous pipeline version" do
+        project = create(:project, users: [@joe])
+        sample_one = create(:sample, project: project, name: "Test Sample One", user: @joe,
+                                     pipeline_runs_data: [
+                                       { finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.10" },
+                                       { finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" },
+                                     ])
+        expect_any_instance_of(Sample).to receive(:results_folder_files).with("3.10").exactly(1).times.and_return({})
+
+        get :results_folder, params: { id: sample_one.id, pipeline_version: "3.10" }
+
+        expect(response).to have_http_status :success
+      end
+
+      it "can see raw results on another user's sample (if part of that project)" do
+        project = create(:project, users: [@joe])
+        sample = create(:sample, project: project)
+        get :results_folder, params: { id: sample.id }
         expect(response).to have_http_status :success
       end
     end


### PR DESCRIPTION
# Description

Fixes some issue where the pipeline tab doesn't respond to pipeline version.

The red boxes were regions that previously didn't respond to pipeline version.
![Screen Shot 2019-11-15 at 4 12 09 PM](https://user-images.githubusercontent.com/837004/68984039-07da8500-07c3-11ea-8ec3-9ef02deb47b4.png)

Also on the result folder and raw result folder pages:
![Screen Shot 2019-11-15 at 4 13 27 PM](https://user-images.githubusercontent.com/837004/68984064-1b85eb80-07c3-11ea-9ea9-cb3c1b9bc9eb.png)

![Screen Shot 2019-11-15 at 4 13 49 PM](https://user-images.githubusercontent.com/837004/68984067-1de84580-07c3-11ea-9af6-fdb43a953121.png)

# Tests
* Verified that all affected pages/endpoints now respect pipeline version, and the pipeline_version is propagated properly into various URLs.
* Wrote controller rspec test.
