### PR TITLE
Change export_users_auth0 rake tool to use environment variables

### DIFF
--- a/lib/tasks/export_users_auth0.rake
+++ b/lib/tasks/export_users_auth0.rake
@@ -44,7 +44,7 @@ task 'export_users_auth0' => :environment do |_t, _args|
     exit 2
   end
 
-  eua = ExportUsersAuth0.new()
+  eua = ExportUsersAuth0.new
 
   if options[:export_all]
     eua.export_all_users
@@ -69,7 +69,7 @@ class ExportUsersAuth0
   attr_reader :auth0_domain, :auth0_api_bearer_token
   AUTH0_DB_CONNECTION_NAME = "idseq-legacy-users"
 
-  def initialize()
+  def initialize
     # Fetch auth0 management keys
     unless AUTH0_KEYS.all? { |k| ENV[k].present? }
       puts "!!! ERROR: missing environment variables #{AUTH0_KEYS}"


### PR DESCRIPTION
# Description

`export_users_auth0` is a tool created to export legacy users that needs to be executed manually on the AWS environment where do you want to export your users from, since it needs to connect to the database.

Those web instances however have a restricted access to SSM parameters, and the auth0 keys required to run this tool are stored in different parameters.

For this reason, `export_users_auth0` is being changed to work with environment variables instead of reading them directly from AWS SSM Parameters.
