### PR TITLE
Fix issue with pipeline_version url param.

### DIFF
--- a/app/assets/src/helpers/url.js
+++ b/app/assets/src/helpers/url.js
@@ -26,10 +26,16 @@ export const parseUrlParams = () => {
     arrayFormat: "bracket",
   });
   for (var key in urlParams) {
-    try {
-      urlParams[key] = JSON.parse(urlParams[key]);
-    } catch (e) {
-      // pass
+    // Don't parse pipeline_version even though it looks like a number.
+    // 3.10 is different from 3.1
+    // TODO(mark): Switch to using UrlQueryParser instead.
+    if (key !== "pipeline_version") {
+      try {
+        // This parses booleans and numbers.
+        urlParams[key] = JSON.parse(urlParams[key]);
+      } catch (e) {
+        // pass
+      }
     }
   }
   return urlParams;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12966,11 +12966,12 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.1.0.tgz",
-      "integrity": "sha512-pNB/Gr8SA8ff8KpUFM36o/WFAlthgaThka5bV19AD9PNTH20Pwq5Zxodif2YyHwrctp6SkL4GqlOot0qR/wGaw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.9.0.tgz",
+      "integrity": "sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==",
       "requires": {
         "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
     },
@@ -15332,6 +15333,11 @@
       "requires": {
         "through": "2"
       }
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
     "split-string": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "number-abbreviate": "^2.0.0",
     "papaparse": "^4.6.2",
     "prop-types": "^15.6.0",
-    "query-string": "^6.1.0",
+    "query-string": "^6.9.0",
     "rc-slider": "^8.7.1",
     "react": "^16.10.2",
     "react-autocomplete": "^1.7.2",


### PR DESCRIPTION
Also update query-string package.

# Description

This fixes an issue where if you are looking at a report with pipeline_version=3.10, on refresh the pipeline_version becomes 3.1, because the value was being parsed as an integer.

To do this, we had to update the query-string package because the "parseNumbers" option wasn't added until a later version.

# Notes

Also updated the UrlQueryParser to not parse booleans and numbers by default. In the previous implementation, numbers and booleans were automatically parsed.

# Tests

* Verified that sample report url params still work.
* Verified that data discovery url params still work.
