### PR TITLE
Change default number of taxa in heatmap

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -40,7 +40,7 @@ const SORT_TAXA_OPTIONS = [
   { text: "Cluster", value: "cluster" },
 ];
 const TAXONS_PER_SAMPLE_RANGE = {
-  min: 0,
+  min: 1,
   max: 100,
 };
 const SPECIFICITY_OPTIONS = [
@@ -66,6 +66,8 @@ class SamplesHeatmapView extends React.Component {
 
     this.initOnBeforeUnload(props.savedParamValues);
 
+    // IMPORTANT NOTE: These default values should be kept in sync with the
+    // backend defaults in HeatmapHelper for sanity.
     this.state = {
       selectedOptions: {
         metric: this.getSelectedMetric(),
@@ -80,7 +82,9 @@ class SamplesHeatmapView extends React.Component {
         taxaSortType: this.urlParams.taxaSortType || "cluster",
         thresholdFilters: this.urlParams.thresholdFilters || [],
         dataScaleIdx: parseAndCheckInt(this.urlParams.dataScaleIdx, 0),
-        taxonsPerSample: parseAndCheckInt(this.urlParams.taxonsPerSample, 30),
+        // Based on the trade-off between performance and information quantity, we
+        // decided on 10 as the best default number of taxons to show per sample.
+        taxonsPerSample: parseAndCheckInt(this.urlParams.taxonsPerSample, 10),
         readSpecificity: parseAndCheckInt(this.urlParams.readSpecificity, 1),
       },
       loading: false,

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -3,7 +3,9 @@
 # See selectedOptions in SamplesHeatmapView for client-side defaults, and
 # heatmap action in VisualizationsController.
 module HeatmapHelper
-  DEFAULT_MAX_NUM_TAXONS = 30
+  # Based on the trade-off between performance and information quantity, we
+  # decided on 10 as the best default number of taxons to show per sample.
+  DEFAULT_MAX_NUM_TAXONS = 10
   DEFAULT_TAXON_SORT_PARAM = 'highest_nt_rpm'.freeze
   READ_SPECIFICITY = true
   MINIMUM_READ_THRESHOLD = 5


### PR DESCRIPTION
# Description

Following team discussion, we decided to lower this value. 

![image](https://user-images.githubusercontent.com/28797/69199093-de379b80-0aeb-11ea-98bc-09c2607c5b59.png)

# Tests

Open a new heatmap, see slider at value 10 instead of 30