### PR TITLE
Add reads non-host bulk download for single taxa.

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/BareDropdown.jsx
@@ -238,6 +238,7 @@ class BareDropdown extends React.Component {
               className={cs.searchInput}
               icon="search"
               placeholder="Search"
+              value={filterString}
               onChange={this.handleFilterChange}
               disableAutocomplete={disableAutocomplete}
             />

--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { find, get, set } from "lodash/fp";
+import { unset, find, get, set } from "lodash/fp";
 import memoize from "memoize-one";
 
 import { getBulkDownloadTypes } from "~/api/bulk_downloads";
@@ -88,17 +88,25 @@ class BulkDownloadModal extends React.Component {
   };
 
   handleFieldSelect = (downloadType, fieldType, value, displayName) => {
-    this.setState({
-      selectedFields: set(
-        [downloadType, fieldType],
-        value,
-        this.state.selectedFields
-      ),
-      selectedFieldsDisplay: set(
-        [downloadType, fieldType],
-        displayName,
-        this.state.selectedFieldsDisplay
-      ),
+    this.setState(prevState => {
+      const newSelectedFields =
+        value !== undefined
+          ? set([downloadType, fieldType], value, prevState.selectedFields)
+          : unset([downloadType, fieldType], prevState.selectedFields);
+
+      const newSelectedFieldsDisplay =
+        displayName !== undefined
+          ? set(
+              [downloadType, fieldType],
+              displayName,
+              prevState.selectedFieldsDisplay
+            )
+          : unset([downloadType, fieldType], prevState.selectedFieldsDisplay);
+
+      return {
+        selectedFields: newSelectedFields,
+        selectedFieldsDisplay: newSelectedFieldsDisplay,
+      };
     });
   };
 

--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -89,6 +89,9 @@ class BulkDownloadModal extends React.Component {
 
   handleFieldSelect = (downloadType, fieldType, value, displayName) => {
     this.setState(prevState => {
+      // If the value is undefined, delete it from selectedFields.
+      // This allows us to support cases where certain fields are conditionally required;
+      // if the field becomes no longer required, we can unset it.
       const newSelectedFields =
         value !== undefined
           ? set([downloadType, fieldType], value, prevState.selectedFields)

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -9,6 +9,8 @@ import {
   map,
   isUndefined,
   orderBy,
+  isNumber,
+  reject,
 } from "lodash/fp";
 import cx from "classnames";
 import memoize from "memoize-one";
@@ -27,6 +29,8 @@ import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import cs from "./choose_step.scss";
 
 const AUTOCOMPLETE_DEBOUNCE_DELAY = 200;
+// Reads non-host download type has some special cases.
+const READS_NON_HOST_DOWNLOAD_TYPE = "reads_non_host";
 
 class ChooseStep extends React.Component {
   state = {
@@ -67,34 +71,55 @@ class ChooseStep extends React.Component {
     });
   }
 
-  isDownloadValid = () => {
-    const {
-      selectedDownloadTypeName,
-      downloadTypes,
-      selectedFields,
-    } = this.props;
+  getSelectedDownloadType = () => {
+    const { selectedDownloadTypeName, downloadTypes } = this.props;
 
     if (!selectedDownloadTypeName) {
-      return false;
+      return null;
     }
 
-    const downloadType = find(
-      ["type", selectedDownloadTypeName],
-      downloadTypes
-    );
+    return find(["type", selectedDownloadTypeName], downloadTypes);
+  };
+
+  // Get all the fields we need to validate for the selected download type.
+  getRequiredFieldsForSelectedType = () => {
+    const { selectedFields } = this.props;
+    const downloadType = this.getSelectedDownloadType();
+
+    if (!downloadType) return null;
+
+    let requiredFields = downloadType.fields;
+
+    // Don't require file_format field if single taxa selected for reads non-host download type.
+    if (
+      downloadType.type === READS_NON_HOST_DOWNLOAD_TYPE &&
+      isNumber(get([downloadType.type, "taxa_with_reads"], selectedFields))
+    ) {
+      requiredFields = reject(["type", "file_format"], requiredFields);
+    }
+
+    return requiredFields;
+  };
+
+  isDownloadValid = () => {
+    const { selectedFields } = this.props;
+
+    const downloadType = this.getSelectedDownloadType();
 
     if (!downloadType) {
       return false;
     }
 
-    if (downloadType.fields) {
+    const requiredFields = this.getRequiredFieldsForSelectedType();
+
+    if (requiredFields) {
       if (
         some(
           Boolean,
           map(
             field =>
               isUndefined(get([downloadType.type, field.type], selectedFields)),
-            downloadType.fields
+            requiredFields
           )
         )
       ) {
@@ -178,6 +203,20 @@ class ChooseStep extends React.Component {
     // Set different props for the dropdown depending on the field type.
     switch (field.type) {
       case "file_format":
+        if (
+          downloadType.type === READS_NON_HOST_DOWNLOAD_TYPE &&
+          isNumber(get([downloadType.type, "taxa_with_reads"], selectedFields))
+        ) {
+          return (
+            <div className={cs.field} key={field.type}>
+              <div className={cs.label}>{field.display_name}:</div>
+              <div className={cs.forcedOption}>.fasta</div>
+              <div className={cs.info}>
+                Note: Only .fasta is available when selecting one taxa.
+              </div>
+            </div>
+          );
+        }
         dropdownOptions = field.options.map(option => ({
           text: option,
           value: option,
@@ -237,9 +276,23 @@ class ChooseStep extends React.Component {
           disabled={loadingOptions}
           placeholder={loadingOptions ? "Loading..." : placeholder}
           options={dropdownOptions}
-          onChange={(value, displayName) =>
-            onFieldSelect(downloadType.type, field.type, value, displayName)
-          }
+          onChange={(value, displayName) => {
+            onFieldSelect(downloadType.type, field.type, value, displayName);
+
+            // If the user has selected a single taxa, reset the file format field.
+            if (
+              downloadType.type === READS_NON_HOST_DOWNLOAD_TYPE &&
+              field.type === "taxa_with_reads" &&
+              isNumber(value)
+            ) {
+              onFieldSelect(
+                READS_NON_HOST_DOWNLOAD_TYPE,
+                "file_format",
+                undefined,
+                undefined
+              );
+            }
+          }}
           value={selectedField}
           optionsHeader={optionsHeader}
           menuLabel={menuLabel}

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -90,7 +90,7 @@ class ChooseStep extends React.Component {
 
     let requiredFields = downloadType.fields;
 
-    // Don't require file_format field if single taxa selected for reads non-host download type.
+    // Don't require file_format field if a single taxa is selected for reads non-host download type.
     if (
       downloadType.type === READS_NON_HOST_DOWNLOAD_TYPE &&
       isNumber(get([downloadType.type, "taxa_with_reads"], selectedFields))
@@ -212,7 +212,7 @@ class ChooseStep extends React.Component {
               <div className={cs.label}>{field.display_name}:</div>
               <div className={cs.forcedOption}>.fasta</div>
               <div className={cs.info}>
-                Note: Only .fasta is available when selecting one taxa.
+                Note: Only .fasta is available when selecting one taxon.
               </div>
             </div>
           );

--- a/app/assets/src/components/views/bulk_download/choose_step.scss
+++ b/app/assets/src/components/views/bulk_download/choose_step.scss
@@ -139,6 +139,17 @@
       @include font-body-xs;
       margin-bottom: 2px;
     }
+
+    .forcedOption {
+      height: 34px;
+      display: flex;
+      align-items: center;
+    }
+
+    .info {
+      @include font-body-xxs;
+      color: $dark-grey;
+    }
   }
 }
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -876,10 +876,10 @@ class SamplesController < ApplicationController
     return if HUMAN_TAX_IDS.include? params[:taxid].to_i
     pr = select_pipeline_run(@sample, params[:pipeline_version])
     if params[:hit_type] == "NT_or_NR"
-      nt_array = get_taxid_fasta_from_pipeline_run(pr, params[:taxid], params[:tax_level].to_i, 'NT').split(">")
-      nr_array = get_taxid_fasta_from_pipeline_run(pr, params[:taxid], params[:tax_level].to_i, 'NR').split(">")
-      @taxid_fasta = ">" + ((nt_array | nr_array) - ['']).join(">")
-      @taxid_fasta = "Coming soon" if @taxid_fasta == ">" # Temporary fix
+      @taxid_fasta = get_taxid_fasta_from_pipeline_run_combined_nt_nr(pr, params[:taxid], params[:tax_level].to_i)
+      if @taxid_fasta.nil?
+        @taxid_fasta = "Coming soon" # Temporary fix
+      end
     else
       @taxid_fasta = get_taxid_fasta_from_pipeline_run(pr, params[:taxid], params[:tax_level].to_i, params[:hit_type])
     end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -876,12 +876,12 @@ class SamplesController < ApplicationController
     return if HUMAN_TAX_IDS.include? params[:taxid].to_i
     pr = select_pipeline_run(@sample, params[:pipeline_version])
     if params[:hit_type] == "NT_or_NR"
-      @taxid_fasta = get_taxid_fasta_from_pipeline_run_combined_nt_nr(pr, params[:taxid], params[:tax_level].to_i)
+      @taxid_fasta = get_taxon_fasta_from_pipeline_run_combined_nt_nr(pr, params[:taxid], params[:tax_level].to_i)
       if @taxid_fasta.nil?
         @taxid_fasta = "Coming soon" # Temporary fix
       end
     else
-      @taxid_fasta = get_taxid_fasta_from_pipeline_run(pr, params[:taxid], params[:tax_level].to_i, params[:hit_type])
+      @taxid_fasta = get_taxon_fasta_from_pipeline_run(pr, params[:taxid], params[:tax_level].to_i, params[:hit_type])
     end
     send_data @taxid_fasta, filename: @sample.name + '_' + clean_taxid_name(pr, params[:taxid]) + '-hits.fasta'
   end

--- a/app/helpers/bulk_downloads_helper.rb
+++ b/app/helpers/bulk_downloads_helper.rb
@@ -14,6 +14,8 @@ module BulkDownloadsHelper
   FAILED_SAMPLES_ERROR_TEMPLATE = "%s samples could not be processed. Please contact us for help.".freeze
   UNKNOWN_EXECUTION_TYPE = "Could not find execution type for bulk download".freeze
   BULK_DOWNLOAD_GENERATION_FAILED = "Could not generate bulk download".freeze
+  READS_NON_HOST_TAXID_EXPECTED = "Expected taxid for reads non-host bulk download".freeze
+  READS_NON_HOST_TAXON_COUNT_EXPECTED_TEMPLATE = "Unexpected error. Could not find taxon count for taxid %s".freeze
 
   # Check that all pipeline runs have succeeded for the provided samples
   # and return the pipeline run ids.

--- a/app/helpers/pipeline_outputs_helper.rb
+++ b/app/helpers/pipeline_outputs_helper.rb
@@ -140,6 +140,18 @@ module PipelineOutputsHelper
     taxon["#{tax_level}_name"] if taxon
   end
 
+  def get_taxid_fasta_from_pipeline_run_combined_nt_nr(pipeline_run, taxid, tax_level)
+    nt_array = get_taxid_fasta_from_pipeline_run(pipeline_run, taxid, tax_level, 'NT').split(">")
+    nr_array = get_taxid_fasta_from_pipeline_run(pipeline_run, taxid, tax_level, 'NR').split(">")
+    combined_array = ((nt_array | nr_array) - [''])
+
+    if combined_array.empty?
+      return nil
+    end
+
+    return ">" + combined_array.join(">")
+  end
+
   def get_taxid_fasta_from_pipeline_run(pipeline_run, taxid, tax_level, hit_type)
     return '' unless pipeline_run
     uri = pipeline_run.s3_paths_for_taxon_byteranges[tax_level][hit_type]

--- a/app/helpers/pipeline_outputs_helper.rb
+++ b/app/helpers/pipeline_outputs_helper.rb
@@ -140,11 +140,13 @@ module PipelineOutputsHelper
     taxon["#{tax_level}_name"] if taxon
   end
 
-  def get_taxid_fasta_from_pipeline_run_combined_nt_nr(pipeline_run, taxid, tax_level)
-    nt_array = get_taxid_fasta_from_pipeline_run(pipeline_run, taxid, tax_level, 'NT').split(">")
-    nr_array = get_taxid_fasta_from_pipeline_run(pipeline_run, taxid, tax_level, 'NR').split(">")
+  # Get a .fasta string containing all the reads mapped to NT/NR for the provided taxid.
+  def get_taxon_fasta_from_pipeline_run_combined_nt_nr(pipeline_run, taxid, tax_level)
+    nt_array = get_taxon_fasta_from_pipeline_run(pipeline_run, taxid, tax_level, 'NT').split(">")
+    nr_array = get_taxon_fasta_from_pipeline_run(pipeline_run, taxid, tax_level, 'NR').split(">")
     combined_array = ((nt_array | nr_array) - [''])
 
+    # If there are no reads for this taxon, return nil for the fasta contents.
     if combined_array.empty?
       return nil
     end
@@ -152,7 +154,7 @@ module PipelineOutputsHelper
     return ">" + combined_array.join(">")
   end
 
-  def get_taxid_fasta_from_pipeline_run(pipeline_run, taxid, tax_level, hit_type)
+  def get_taxon_fasta_from_pipeline_run(pipeline_run, taxid, tax_level, hit_type)
     return '' unless pipeline_run
     uri = pipeline_run.s3_paths_for_taxon_byteranges[tax_level][hit_type]
     uri_parts = uri.split("/", 4)

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -472,7 +472,7 @@ describe BulkDownload, type: :model do
                                              "displayName" => "Salmonella enterica",
                                            })
 
-      allow_any_instance_of(BulkDownload).to receive(:get_taxid_fasta_from_pipeline_run_combined_nt_nr).and_return("mock_reads_nonhost_fasta")
+      allow_any_instance_of(BulkDownload).to receive(:get_taxon_fasta_from_pipeline_run_combined_nt_nr).and_return("mock_reads_nonhost_fasta")
 
       add_s3_tar_writer_expectations(
         "Test Sample One__project-test_project_#{@project.id}__reads_nonhost_Salmonella enterica.fasta" => "mock_reads_nonhost_fasta",
@@ -496,7 +496,7 @@ describe BulkDownload, type: :model do
                                              "displayName" => "Salmonella enterica",
                                            })
 
-      allow_any_instance_of(BulkDownload).to receive(:get_taxid_fasta_from_pipeline_run_combined_nt_nr).and_return(nil)
+      allow_any_instance_of(BulkDownload).to receive(:get_taxon_fasta_from_pipeline_run_combined_nt_nr).and_return(nil)
 
       add_s3_tar_writer_expectations(
         "Test Sample One__project-test_project_#{@project.id}__reads_nonhost_Salmonella enterica.fasta" => "",
@@ -517,7 +517,7 @@ describe BulkDownload, type: :model do
 
       bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, {})
 
-      allow_any_instance_of(BulkDownload).to receive(:get_taxid_fasta_from_pipeline_run_combined_nt_nr).and_return(nil)
+      allow_any_instance_of(BulkDownload).to receive(:get_taxon_fasta_from_pipeline_run_combined_nt_nr).and_return(nil)
 
       expect do
         bulk_download.generate_download_file
@@ -532,7 +532,7 @@ describe BulkDownload, type: :model do
                                              "displayName" => "Salmonella enterica",
                                            })
 
-      allow_any_instance_of(BulkDownload).to receive(:get_taxid_fasta_from_pipeline_run_combined_nt_nr).and_return(nil)
+      allow_any_instance_of(BulkDownload).to receive(:get_taxon_fasta_from_pipeline_run_combined_nt_nr).and_return(nil)
 
       expect do
         bulk_download.generate_download_file


### PR DESCRIPTION
# Description

When the user selects a single taxa, the file format field changes.

<img width="545" alt="Screen Shot 2019-11-20 at 11 00 40 AM" src="https://user-images.githubusercontent.com/837004/69258582-d3801380-0b8a-11ea-9f2d-5e4c22730fe9.png">

On the review screen, the file format is omitted.

<img width="584" alt="Screen Shot 2019-11-20 at 11 00 48 AM" src="https://user-images.githubusercontent.com/837004/69258642-ed215b00-0b8a-11ea-99fe-6792692f6e69.png">

Compare this to the All Taxon download, where the file format is shown.

<img width="541" alt="Screen Shot 2019-11-20 at 11 43 25 AM" src="https://user-images.githubusercontent.com/837004/69258672-fa3e4a00-0b8a-11ea-952b-46ac2d23df18.png">

<img width="650" alt="Screen Shot 2019-11-20 at 11 00 29 AM" src="https://user-images.githubusercontent.com/837004/69258770-2659cb00-0b8b-11ea-8d4d-b1ee246104b2.png">

# Notes

* Also fixed a bug where when you re-opened the taxa select, it would show an empty search filter string, but the results would still be filtered. We now save the search filter string.

# Tests

* Verified that existing single taxa fasta download still works on sample report page, and produces the same data as before.
* Verified that reads non-host bulk download produces identical data to sample report page download.
* Wrote model rspec tests. (and refactored tests to reduce redundancy)