### PR TITLE
IDSEQ-1785 - Implement background sliding session refresh

### DIFF
--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -118,6 +118,7 @@ class Header extends React.Component {
             // Initialize the toast container - can be done anywhere (has absolute positioning)
           }
           <ToastContainer />
+          <iframe style={{ display: "none" }} src="/auth0/background_refresh" />
         </div>
       )
     );

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -118,7 +118,10 @@ class Header extends React.Component {
             // Initialize the toast container - can be done anywhere (has absolute positioning)
           }
           <ToastContainer />
-          <iframe style={{ display: "none" }} src="/auth0/background_refresh" />
+          <iframe
+            className={cs.backgroundRefreshFrame}
+            src="/auth0/background_refresh"
+          />
         </div>
       )
     );

--- a/app/assets/src/components/common/header.scss
+++ b/app/assets/src/components/common/header.scss
@@ -71,3 +71,7 @@
 .notificationLink {
   text-decoration: underline;
 }
+
+.backgroundRefreshFrame {
+  display: none;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,7 +51,7 @@ class ApplicationController < ActionController::Base
           # we want to redirect user to auth0 login page in silent mode
           # if the user still have a valid SSO token in the auth0 session
           # the sliding session will be refreshed
-          redirect_to(auth0_login_url(true))
+          redirect_to "/auth0/refresh_token?mode=expired"
         end
         format.json { render json: { errors: ['Not Authenticated'] }, status: :unauthorized }
       end

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -5,17 +5,48 @@ class Auth0Controller < ApplicationController
 
   include Auth0Helper
 
+  SUPPORTED_MODES = Set[
+    "background_refresh", # Background token refresh in a hidden iframe
+    "login", # Invoked during login callback
+    "expired", # Invoked when the token in the application session is expired / invalid
+    "reset_password", # Invoked after reseting password operation
+  ].freeze
+
   def refresh_token
-    redirect_to auth0_login_url(true)
+    @mode = filter_value(params["mode"], SUPPORTED_MODES)
+    render :refresh_token, layout: false
+  end
+
+  def background_refresh
+    @mode = params["mode"]
+    @refresh_values = background_refresh_values
+    render :background_refresh, layout: false
   end
 
   def callback
     # Store the user token that came from Auth0 and the IdP
     # Auth0Helper#auth0_session
-    self.auth0_session = request.env['omniauth.auth'].credentials.id_token
+    self.auth0_session = request.env['omniauth.auth']&.credentials.to_h
 
-    # Redirect to the URL you want after successful auth
-    redirect_to home_path
+    if auth0_session.nil?
+      redirect_to auth0_signout_url
+    else
+      # https://github.com/omniauth/omniauth-oauth2/issues/31#issuecomment-23806447
+      mode = filter_value(request.env['omniauth.params']['mode'], SUPPORTED_MODES)
+
+      @auth0_token = auth0_decode_auth_token
+
+      case mode
+      when "background_refresh"
+        redirect_to action: :background_refresh
+      when "login", "expired"
+        redirect_to home_path
+      when "reset_password"
+        redirect_to root_path
+      else
+        redirect_to root_path
+      end
+    end
   end
 
   def remove_auth0_session
@@ -40,5 +71,40 @@ class Auth0Controller < ApplicationController
       # Old login page
       redirect_to new_user_session_path
     end
+  end
+
+  private
+
+  def filter_value(value, set_of_values)
+    value if set_of_values.include?(value)
+  end
+
+  def background_refresh_values
+    @auth0_token = auth0_decode_auth_token
+    if @auth0_token && @auth0_token[:auth_payload]
+      exp = @auth0_token[:auth_payload]["exp"]
+      iat = @auth0_token[:auth_payload]["iat"] || (exp - 15.minutes.in_seconds)
+      lifespan = exp - iat
+      expires_in = exp - Time.now.to_i
+      should_refresh_in = expires_in - (lifespan * 0.2).to_i
+      should_refresh = should_refresh_in < 0
+      expired = expires_in <= 0
+    else
+      lifespan = 0
+      should_refresh = true
+      expired = true
+    end
+    {
+      active: auth0_session.present?,
+      exp: exp || 0,
+      iat: iat || 0,
+      lifespan: lifespan,
+      expires_in: expires_in || 0,
+      should_refresh_in: should_refresh_in || 0,
+      should_refresh: should_refresh,
+      expired: expired,
+      refresh_endpoint: "/auth0/refresh_token?mode=background_refresh",
+      reload_wait_seconds: [lifespan / 2, (15.minutes / 1.second)].min,
+    }
   end
 end

--- a/app/views/auth0/background_refresh.html.erb
+++ b/app/views/auth0/background_refresh.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <pre><%=@refresh_values.to_yaml%></pre>
+  <% if @refresh_values[:active] %>
+    <script language="javascript">(function () {
+      var rv = <%=raw @refresh_values.to_json%>;
+      var reload_wait_ms = rv.reload_wait_seconds * 1000;
+      if (rv.should_refresh) {
+        var now = new Date().getTime();
+        var last = localStorage.getItem("background_refresh_last") || 0;
+        var elapsed = Math.abs(now - last);
+        if (elapsed > 30000) {
+          /* <%# Avoid simultaneous calls if multiple tabs are open %> */
+          localStorage.setItem("background_refresh_last", now);
+          location.href = rv.refresh_endpoint;
+          return;
+        }
+      }
+      setTimeout(function () { location.reload(true) }, reload_wait_ms);
+    })();</script>
+  <% end %>
+</html>

--- a/app/views/auth0/background_refresh.html.erb
+++ b/app/views/auth0/background_refresh.html.erb
@@ -7,12 +7,20 @@
       var reload_wait_ms = rv.reload_wait_seconds * 1000;
       if (rv.should_refresh) {
         var now = new Date().getTime();
+        var uid = Math.random().toString();
         var last = localStorage.getItem("background_refresh_last") || 0;
         var elapsed = Math.abs(now - last);
-        if (elapsed > 30000) {
+        if (elapsed > 60000) {
           /* <%# Avoid simultaneous calls if multiple tabs are open %> */
           localStorage.setItem("background_refresh_last", now);
-          location.href = rv.refresh_endpoint;
+          localStorage.setItem("background_refresh_uid", uid);
+          setTimeout( function () {
+            if (localStorage.getItem("background_refresh_uid") == uid) {
+              location.href = rv.refresh_endpoint;
+            } else {
+              setTimeout(function () { location.reload(true) }, reload_wait_ms);
+            }
+          }, 1000);
           return;
         }
       }

--- a/app/views/auth0/refresh_token.html.erb
+++ b/app/views/auth0/refresh_token.html.erb
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <form id="refresh_form" action="/auth/auth0?<%= {mode: @mode}.to_query %>" method="POST">
+    <input id="refresh_input" type="hidden" name="<%= request_forgery_protection_token %>" value="<%=form_authenticity_token%>">
+  </form>
+  <script>document.getElementById("refresh_form").submit();</script>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,12 @@ Rails.application.routes.draw do
     registrations: 'registrations',
   }
 
-  get 'auth/auth0/callback' => 'auth0#callback'
-  post 'auth0/request_password_reset' => 'auth0#request_password_reset'
-  get 'auth0/refresh_token' => 'auth0#refresh_token'
+  get 'auth/auth0/callback/' => 'auth0#callback'
+  namespace :auth0 do
+    post :request_password_reset
+    get :refresh_token
+    get :background_refresh
+  end
 
   resources :samples do
     put :reupload_source, on: :member


### PR DESCRIPTION
# Description

Auth0 sliding sessions feature require you to fetch the authorization endpoint to refresh a bearer token and keep a user session alive.

We want to silently refresh bearer tokens in the background to keep the user session alive, specially during file uploads.

# Notes

There is an extra bit of complexity involved in this PR to prevent multiple tabs from refreshing the token at once.

# Tests

* Manual tests using both strategies.
