### PR TITLE
IDSEQ-1784 - Login counters being incremented on every request when using auth0

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,11 +32,11 @@ class ApplicationController < ActionController::Base
   def sign_in_auth0_token!
     @auth0_token = auth0_decode_auth_token
     if @auth0_token
-      if @auth0_token[:authenticated]
+      if @auth0_token[:authenticated] && !user_signed_in?
         auth_payload = @auth0_token[:auth_payload]
         auth_user = User.find_by(email: auth_payload["email"])
         if auth_user.present?
-          sign_in auth_user, store: false
+          sign_in auth_user
           return
         end
       end

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -52,11 +52,6 @@ class Auth0Controller < ApplicationController
     end
   end
 
-  def remove_auth0_session
-    # Invalidate auth0 session (https://auth0.com/docs/sessions/concepts/session-layers)
-    redirect_to auth0_signout_url
-  end
-
   def request_password_reset
     email = params.dig("user", "email")
     return if email.blank?

--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -33,7 +33,7 @@ module Auth0Helper
   # Remove auth0 session from Application Session Layer
   # (see https://auth0.com/docs/sessions/concepts/session-layers)
   def auth0_remove_application_session
-    reset_session
+    session.delete(:auth0_credentials)
   end
 
   # URL used to remove auth0 session from Auth0 Session Layer

--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -33,7 +33,7 @@ module Auth0Helper
   # Remove auth0 session from Application Session Layer
   # (see https://auth0.com/docs/sessions/concepts/session-layers)
   def auth0_remove_application_session
-    session.delete(:auth0_credentials)
+    reset_session
   end
 
   # URL used to remove auth0 session from Auth0 Session Layer


### PR DESCRIPTION
# Description

This PR makes devise store the authentication state in the user's session to prevent incrementing login counters on every request.

# Tests

* Manual tests using both strategies
