### PR TITLE
Migrate cleanup functions to the new report service

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -33,15 +33,15 @@ module ReportsHelper
               parent_name = "taxon #{parent_tax_id}"
             end
             tax_info[:name] = "non-#{level_str}-specific reads in #{parent_level} #{parent_name}"
-            Rails.logger.debug("Pipeline run #{pipeline_run_id} contains non-#{level_str}-specific reads in #{parent_level} #{parent_name}")
+            Rails.logger.info("Pipeline run #{pipeline_run_id} contains non-#{level_str}-specific reads in #{parent_level} #{parent_name}")
 
           elsif tax_id == TaxonLineage::BLACKLIST_GENUS_ID
             tax_info[:name] = "all artificial constructs"
-            Rails.logger.debug("Blacklisted genus id appeared in report for pipeline run #{pipeline_run_id}.")
+            Rails.logger.info("Blacklisted genus id appeared in report for pipeline run #{pipeline_run_id}.")
 
           elsif !(TaxonLineage::MISSING_LINEAGE_ID.values.include? tax_id) && tax_id != TaxonLineage::MISSING_SPECIES_ID_ALT
             tax_info[:name] += " #{tax_id}"
-            Rails.logger.debug("Pipeline run #{pipeline_run_id} missing lineage for #{tax_id}.")
+            Rails.logger.info("Pipeline run #{pipeline_run_id} missing lineage for #{tax_id}.")
           end
 
         elsif !tax_info[:name]

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,2 +1,110 @@
 module ReportsHelper
+  # For taxon_count 'species' rows without a corresponding 'genus' rows,
+  # we create a fake singleton genus containing just that species;
+  # the fake genus IDs start here:
+  FAKE_GENUS_BASE = -1_900_000_000
+
+  def self.validate_names!(counts, lineage_by_tax_id)
+    # This makes up suitable names for missing and blacklisted genera and species. Such
+    # made-up names should be lowercase so they are sorted below proper names.
+    missing_names = Set.new
+    missing_parents = {}
+
+    genus_str = TaxonLineage.level_name(TaxonCount::TAX_LEVEL_GENUS)
+    family_str = TaxonLineage.level_name(TaxonCount::TAX_LEVEL_FAMILY)
+
+    # Iterate through both species and genus.
+    counts.each do |tax_level, tax_counts|
+      tax_counts.each do |tax_id, tax_info|
+        level_str = TaxonLineage.level_name(tax_level)
+
+        if tax_id < 0
+          # Usually -1 means accession number did not resolve to species.
+          # TODO: Can we keep the accession numbers to show in these cases?
+          # NOTE: important to be lowercase for sorting below uppercase valid genuses
+          tax_info[:name] = "all taxa with neither family nor genus classification"
+
+          if tax_id < TaxonLineage::INVALID_CALL_BASE_ID
+            parent_str = tax_level == TaxonCount::TAX_LEVEL_SPECIES ? genus_str : family_str
+            parent_tax_id = tax_level == TaxonCount::TAX_LEVEL_SPECIES ? tax_info[genus_tax_id] : convert_neg_taxid(tax_id)
+            parent_name = fetch_parent_name(tax_level, tax_id, tax_info, lineage_by_tax_id)
+            # If no parent (genus/family) name was found, then use the parent id as the name.
+            unless parent_name
+              missing_parents[parent_tax_id] = tax_id
+              parent_name = "taxon #{parent_tax_id}"
+            end
+            tax_info[:name] = "non-#{level_str}-specific reads in #{parent_str} #{parent_name}"
+            MetricUtil.log_analytics_event("non-#{level_str}-specific reads in #{parent_str} #{parent_name}", nil)
+
+          elsif tax_id == TaxonLineage::BLACKLIST_GENUS_ID
+            tax_info[:name] = "all artificial constructs"
+            MetricUtil.log_analytics_event("Blacklisted genus id appeared in report.", nil)
+
+          elsif !(TaxonLineage::MISSING_LINEAGE_ID.values.include? tax_id) && tax_id != TaxonLineage::MISSING_SPECIES_ID_ALT
+            tax_info[:name] += " #{tax_id}"
+            MetricUtil.log_analytics_event("Missing lineage for #{tax_id}.", nil)
+          end
+
+        elsif !tax_info[:name]
+          missing_names.add(tax_id)
+          tax_info[:name] = "unnamed #{level_str} taxon #{tax_id}"
+          MetricUtil.log_analytics_event("No name found for #{level_str} #{tax_id}.", nil)
+        end
+      end
+    end
+
+    Rails.logger.warn "Missing names for taxon ids #{missing_names.to_a}" unless missing_names.empty?
+    Rails.logger.warn "Missing parent for child:  #{missing_parents}" unless missing_parents.empty?
+  end
+
+  def self.convert_neg_taxid(tax_id)
+    thres = TaxonLineage::INVALID_CALL_BASE_ID
+    if tax_id < thres
+      tax_id = -(tax_id % thres).to_i
+    end
+    tax_id
+  end
+
+  def self.fetch_parent_name(tax_level, tax_id, tax_info, lineage_by_tax_id)
+    if tax_level == TaxonCount::TAX_LEVEL_SPECIES
+      parent_name = lineage_by_tax_id[tax_info[:genus_tax_id]]["genus_name"]
+    else
+      # Get the family name through lineage_by_tax_id.
+      # If genus id is undefined, then find taxon lineage by species id instead.
+      lineage_id_by_species = lineage_by_tax_id.keys & tax_info[:children]
+      parent_name = lineage_by_tax_id[tax_id] ? lineage_by_tax_id[tax_id]["family_name"] : lineage_by_tax_id[lineage_id_by_species[0]]["family_name"]
+    end
+    parent_name
+  end
+
+  def self.cleanup_missing_genus_counts!(species_counts, genus_counts)
+    # there should be a genus_pair for every species (even if it is the pseudo
+    # genus id -200);  anything else indicates a bug in data import;
+    # warn and ensure affected data is NOT hidden from view
+    fake_genera = []
+    missing_genera = Set.new
+    taxids_with_missing_genera = Set.new
+    species_counts.each do |tax_id, tax_info|
+      genus_tax_id = tax_info[:genus_tax_id]
+      unless genus_counts[genus_tax_id]
+        taxids_with_missing_genera.add(tax_id)
+        missing_genera.add(genus_tax_id)
+        fake_genera << fake_genus!(tax_id, tax_info)
+      end
+    end
+    Rails.logger.warn "Missing taxon_counts for genus ids #{missing_genera.to_a} corresponding to taxon ids #{taxids_with_missing_genera.to_a}." unless missing_genera.empty?
+    fake_genera.each do |fake_genus_info|
+      genus_counts[fake_genus_info[:genus_tax_id]] = fake_genus_info
+    end
+  end
+
+  def self.fake_genus!(tax_id, tax_info)
+    fake_genus_info = tax_info.clone
+    fake_genus_info[:name] = "Ad hoc bucket for #{tax_info[:name].downcase}"
+    fake_genus_id = FAKE_GENUS_BASE - tax_id
+    fake_genus_info[:genus_tax_id] = fake_genus_id
+    fake_genus_info[:tax_level] = TaxonCount::TAX_LEVEL_GENUS
+    tax_info[:genus_tax_id] = fake_genus_id
+    fake_genus_info
+  end
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -69,7 +69,6 @@ module ReportsHelper
     if tax_level == TaxonCount::TAX_LEVEL_SPECIES
       parent_name = lineage_by_tax_id[tax_info[:genus_tax_id]]["genus_name"]
     else
-      # Get the family name through lineage_by_tax_id.
       # If genus id is undefined, then find taxon lineage by species id instead.
       lineage_id_by_species = lineage_by_tax_id.keys & tax_info[:children]
       parent_name = lineage_by_tax_id[tax_id] ? lineage_by_tax_id[tax_id]["family_name"] : lineage_by_tax_id[lineage_id_by_species[0]]["family_name"]

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -1,5 +1,6 @@
 class PipelineReportService
   include Callable
+  include ReportsHelper
 
   FIELDS_TO_PLUCK = [
     :tax_id,
@@ -76,6 +77,14 @@ class PipelineReportService
     counts_by_tax_level.transform_values! { |counts| hash_by_tax_id_and_count_type(counts) }
     @timer.split("index_by_tax_id_and_count_type")
 
+    # TODO: this cleanup function is carried over from the previous version of the report,
+    # check if this is still necessary?
+    ReportsHelper.cleanup_missing_genus_counts!(
+      counts_by_tax_level[TaxonCount::TAX_LEVEL_SPECIES],
+      counts_by_tax_level[TaxonCount::TAX_LEVEL_GENUS]
+    )
+    @timer.split("cleanup_missing_genus_counts")
+
     merge_contigs(contigs, counts_by_tax_level)
     @timer.split("merge_contigs")
 
@@ -103,6 +112,13 @@ class PipelineReportService
     ]
 
     tax_ids = counts_by_tax_level[TaxonCount::TAX_LEVEL_GENUS].keys
+    # If a species has an undefined genus (id < 0), the TaxonLineage id is based off the
+    # species id rather than genus id, so select those species ids as well.
+    species_with_missing_genus = []
+    counts_by_tax_level[TaxonCount::TAX_LEVEL_SPECIES].each do |tax_id, species|
+      species_with_missing_genus += [tax_id] unless species[:genus_tax_id] >= 0
+    end
+    tax_ids += species_with_missing_genus
 
     lineage_by_tax_id = TaxonLineage
                         .where(taxid: tax_ids)
@@ -110,7 +126,13 @@ class PipelineReportService
                         .pluck(*required_columns)
                         .map { |r| [r[0], required_columns.zip(r).to_h] }
                         .to_h
-    @timer.split("fetch_genus_lineage")
+    @timer.split("fetch_taxon_lineage")
+
+    ReportsHelper.validate_names!(
+      counts_by_tax_level,
+      lineage_by_tax_id
+    )
+    @timer.split("fill_missing_names")
 
     structured_lineage = {}
     encode_taxon_lineage(lineage_by_tax_id, structured_lineage)


### PR DESCRIPTION
# Description

Migrate the [cleanup functions](https://github.com/chanzuckerberg/idseq-web/blob/master/app/lib/report_helper.rb#L507) from the old ReportHelper to use in the new report service.
1) `validate_names`  fills in names for species/genera that are either blacklisted or missing names for various reasons
2) `cleanup_missing_genus_counts` creates a fake genus if a species is lacking one

# Notes

It's unclear if `cleanup_missing_genus_counts` is necessary to migrate over; some more investigation will be necessary to determine if/when a species is missing a genus, and if that can be resolved on the database side.

Logging has been added to `validate_names` to see how frequently each case of a missing name occurs.

# Tests

* Verified that species/genus names are no longer empty in the report.
