### PR TITLE
Make CSS use fingerprinting hash

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,2 +1,1 @@
-@import url('bundle.min.css');
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800');
+//= require bundle.min

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -8,7 +8,7 @@ const config = {
   entry: `${path.resolve(__dirname, "app/assets/src/")}/index.jsx`,
   output: {
     path: path.resolve(__dirname, "app/assets/"),
-    filename: "dist/bundle.min.js"
+    filename: "dist/bundle.min.js",
   },
   resolve: {
     extensions: [".js", ".jsx"],
@@ -16,13 +16,13 @@ const config = {
       "~": path.resolve(__dirname, "app/assets/src"),
       "~ui": path.resolve(__dirname, "app/assets/src/components/ui"),
       "~utils": path.resolve(__dirname, "app/assets/src/components/utils"),
-      styles: path.resolve(__dirname, "app/assets/src/styles")
-    }
+      styles: path.resolve(__dirname, "app/assets/src/styles"),
+    },
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "dist/bundle.min.css"
-    })
+      filename: "dist/bundle.min.css",
+    }),
   ],
   devtool: "source-map",
   target: "web",
@@ -33,14 +33,14 @@ const config = {
         exclude: new RegExp(
           `/node_modules/(?!(${includedNodeModules.join("|")})/).*/`
         ),
-        loader: "babel-loader"
+        loader: "babel-loader",
       },
       {
         test: /.jsx$/,
         exclude: new RegExp(
           `/node_modules/(?!(${includedNodeModules.join("|")})/).*/`
         ),
-        loader: "babel-loader"
+        loader: "babel-loader",
       },
       {
         // Use CSS modules for new files.
@@ -48,7 +48,7 @@ const config = {
         exclude: [
           path.resolve(__dirname, "node_modules/"),
           path.resolve(__dirname, "app/assets/src/styles"),
-          path.resolve(__dirname, "app/assets/src/loader.scss")
+          path.resolve(__dirname, "app/assets/src/loader.scss"),
         ],
         use: [
           MiniCssExtractPlugin.loader,
@@ -58,17 +58,17 @@ const config = {
               minimize: true,
               sourceMap: true,
               modules: true,
-              localIdentName: "[local]-[hash:base64:5]"
-            }
+              localIdentName: "[local]-[hash:base64:5]",
+            },
           },
           {
             loader: "sass-loader",
             options: {
               minimize: true,
-              sourceMap: true
-            }
-          }
-        ]
+              sourceMap: true,
+            },
+          },
+        ],
       },
       {
         // Sass / Scss loader for legacy files in assets/src/styles.
@@ -76,7 +76,7 @@ const config = {
         include: [
           path.resolve(__dirname, "node_modules/"),
           path.resolve(__dirname, "app/assets/src/styles"),
-          path.resolve(__dirname, "app/assets/src/loader.scss")
+          path.resolve(__dirname, "app/assets/src/loader.scss"),
         ],
         use: [
           MiniCssExtractPlugin.loader,
@@ -84,17 +84,17 @@ const config = {
             loader: "css-loader",
             options: {
               minimize: true,
-              sourceMap: true
-            }
+              sourceMap: true,
+            },
           },
           {
             loader: "sass-loader",
             options: {
               minimize: true,
-              sourceMap: true
-            }
-          }
-        ]
+              sourceMap: true,
+            },
+          },
+        ],
       },
       {
         test: /\.(png|eot|ttf|svg)$/,
@@ -104,9 +104,9 @@ const config = {
           name: "fonts/[name].[ext]",
           mimetype: "application/font-woff",
           publicPath: url => {
-            return `/assets/${url.replace(/fonts/, "")}`;
-          }
-        }
+            return `/assets${url.replace(/fonts/, "")}`;
+          },
+        },
       },
       {
         test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
@@ -116,12 +116,12 @@ const config = {
           name: "fonts/[name].[ext]",
           mimetype: "application/font-woff",
           publicPath: url => {
-            return `/assets/${url.replace(/fonts/, "")}`;
-          }
-        }
-      }
-    ]
-  }
+            return `/assets${url.replace(/fonts/, "")}`;
+          },
+        },
+      },
+    ],
+  },
 };
 
 module.exports = config;


### PR DESCRIPTION
# Description

To invalidate the new cloudfront cache, we want to use rails fingerprinting of static assets on both CSS and JS (already working). 

# Notes

* see https://guides.rubyonrails.org/asset_pipeline.html#what-is-fingerprinting-and-why-should-i-care-questionmark
* I also fixed a double slash // issue with font assets 

# Tests

* try locally with `  config.assets.debug = true`

* see hash in CSS filename

* see site load normally