### PR TITLE
Generate downloadable CSV from the new report service

### DIFF
--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -312,7 +312,9 @@ class SampleView extends React.Component {
       type = "inProgress";
       if (pipelineRun && pipelineRun.version && pipelineRun.version.pipeline) {
         linkText = "View Pipeline Visualization";
-        link = `/samples/${sample.id}/pipeline_viz/${pipelineRun.version.pipeline}`;
+        link = `/samples/${sample.id}/pipeline_viz/${
+          pipelineRun.version.pipeline
+        }`;
       }
     } else {
       // Some kind of error or warning has occurred.
@@ -605,6 +607,7 @@ class SampleView extends React.Component {
                 reportDetails={reportDetails}
                 editable={this.props.canEdit}
                 view={this.state.view}
+                reportVersion={1}
               />
             </ViewHeader.Controls>
           </ViewHeader>

--- a/app/assets/src/components/views/SampleView/SampleView.jsx
+++ b/app/assets/src/components/views/SampleView/SampleView.jsx
@@ -607,7 +607,6 @@ class SampleView extends React.Component {
                 reportDetails={reportDetails}
                 editable={this.props.canEdit}
                 view={this.state.view}
-                reportVersion={1}
               />
             </ViewHeader.Controls>
           </ViewHeader>

--- a/app/assets/src/components/views/SampleView/SampleViewControls.jsx
+++ b/app/assets/src/components/views/SampleView/SampleViewControls.jsx
@@ -14,7 +14,7 @@ import {
 
 class SampleViewControls extends React.Component {
   downloadCSV = () => {
-    const { backgroundId, pipelineRun, sample } = this.props;
+    const { backgroundId, pipelineRun, sample, reportVersion } = this.props;
 
     let resParams = {};
     const stringer = require("querystring");
@@ -27,7 +27,11 @@ class SampleViewControls extends React.Component {
     let v = pipelineRun && pipelineRun.pipeline_version;
     if (v) resParams["pipeline_version"] = v;
 
-    let res = `/samples/${sample.id}/report_csv`;
+    // Need to know what version of the report table we're looking at and request accordingly
+    let res =
+      reportVersion === 1
+        ? `/samples/${sample.id}/report_csv`
+        : `/samples/${sample.id}/report_csv_v2`;
     res += `?${stringer.stringify(resParams)}`;
     location.href = res;
   };
@@ -141,6 +145,7 @@ SampleViewControls.propTypes = {
   pipelineRun: PropTypes.PipelineRun,
   editable: PropTypes.bool,
   view: PropTypes.string,
+  reportVersion: PropTypes.number,
 };
 
 export default SampleViewControls;

--- a/app/assets/src/components/views/SampleView/SampleViewControls.jsx
+++ b/app/assets/src/components/views/SampleView/SampleViewControls.jsx
@@ -14,7 +14,13 @@ import {
 
 class SampleViewControls extends React.Component {
   downloadCSV = () => {
-    const { backgroundId, pipelineRun, sample, reportVersion } = this.props;
+    const {
+      backgroundId,
+      pipelineRun,
+      sample,
+      reportVersion,
+      minContigSize,
+    } = this.props;
 
     let resParams = {};
     const stringer = require("querystring");
@@ -26,6 +32,9 @@ class SampleViewControls extends React.Component {
     // Set the right pipeline version.
     let v = pipelineRun && pipelineRun.pipeline_version;
     if (v) resParams["pipeline_version"] = v;
+
+    // Set the min contig size.
+    if (minContigSize) resParams["min_contig_size"] = minContigSize;
 
     // Need to know what version of the report table we're looking at and request accordingly
     let res =
@@ -146,6 +155,7 @@ SampleViewControls.propTypes = {
   editable: PropTypes.bool,
   view: PropTypes.string,
   reportVersion: PropTypes.number,
+  minContigSize: PropTypes.number,
 };
 
 export default SampleViewControls;

--- a/app/assets/src/components/views/SampleView/SampleViewControls.jsx
+++ b/app/assets/src/components/views/SampleView/SampleViewControls.jsx
@@ -14,13 +14,7 @@ import {
 
 class SampleViewControls extends React.Component {
   downloadCSV = () => {
-    const {
-      backgroundId,
-      pipelineRun,
-      sample,
-      reportVersion,
-      minContigSize,
-    } = this.props;
+    const { backgroundId, pipelineRun, sample, minContigSize } = this.props;
 
     let resParams = {};
     const stringer = require("querystring");
@@ -36,11 +30,7 @@ class SampleViewControls extends React.Component {
     // Set the min contig size.
     if (minContigSize) resParams["min_contig_size"] = minContigSize;
 
-    // Need to know what version of the report table we're looking at and request accordingly
-    let res =
-      reportVersion === 1
-        ? `/samples/${sample.id}/report_csv`
-        : `/samples/${sample.id}/report_csv_v2`;
+    let res = `/samples/${sample.id}/report_csv`;
     res += `?${stringer.stringify(resParams)}`;
     location.href = res;
   };
@@ -154,7 +144,6 @@ SampleViewControls.propTypes = {
   pipelineRun: PropTypes.PipelineRun,
   editable: PropTypes.bool,
   view: PropTypes.string,
-  reportVersion: PropTypes.number,
   minContigSize: PropTypes.number,
 };
 

--- a/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
@@ -158,6 +158,7 @@ export default function SampleViewHeader({
           pipelineRun={pipelineRun}
           editable={editable}
           view={view}
+          reportVersion={2}
         />
       </ViewHeader.Controls>
     </ViewHeader>

--- a/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
@@ -159,7 +159,6 @@ export default function SampleViewHeader({
           pipelineRun={pipelineRun}
           editable={editable}
           view={view}
-          reportVersion={2}
           minContigSize={minContigSize}
         />
       </ViewHeader.Controls>

--- a/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
@@ -28,6 +28,7 @@ export default function SampleViewHeader({
   reportPresent,
   sample,
   view,
+  minContigSize,
 }) {
   const currentUser = useContext(UserContext);
 
@@ -159,6 +160,7 @@ export default function SampleViewHeader({
           editable={editable}
           view={view}
           reportVersion={2}
+          minContigSize={minContigSize}
         />
       </ViewHeader.Controls>
     </ViewHeader>
@@ -182,4 +184,5 @@ SampleViewHeader.propTypes = {
   reportPresent: PropTypes.bool,
   sample: PropTypes.Sample,
   view: PropTypes.string.isRequired,
+  minContigSize: PropTypes.number,
 };

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -603,6 +603,7 @@ export default class SampleViewV2 extends React.Component {
               reportPresent={!!reportData.length}
               sample={sample}
               view={view}
+              minContigSize={selectedOptions.minContigSize}
             />
           </div>
           <div className={cs.tabsContainer}>

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -134,7 +134,7 @@ export default class SampleViewV2 extends React.Component {
     rawReportData.sortedGenus.forEach(genusTaxId => {
       let hasHighlightedChildren = false;
       const childrenSpecies =
-        rawReportData.counts[GENUS_LEVEL_INDEX][genusTaxId].children;
+        rawReportData.counts[GENUS_LEVEL_INDEX][genusTaxId].species_tax_ids;
       const speciesData = childrenSpecies.map(speciesTaxId => {
         const isHighlighted = highlightedTaxIds.has(speciesTaxId);
         hasHighlightedChildren = hasHighlightedChildren || isHighlighted;

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -584,13 +584,20 @@ class SamplesController < ApplicationController
 
   # GET /samples/1/report_csv
   def report_csv
-    @report_csv = report_csv_from_params(@sample, params)
-    send_data @report_csv, filename: @sample.name + '_report.csv'
+    if current_user.allowed_feature?("report_v2")
+      report_csv_v2
+    else
+      @report_csv = report_csv_from_params(@sample, params)
+      send_data @report_csv, filename: @sample.name + '_report.csv'
+    end
   end
 
   # GET /samples/1/report_csv_v2
   def report_csv_v2
-    @report_csv = report_csv_from_params_v2(@sample, params)
+    pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
+    background_id = get_background_id(@sample, params[:background])
+    min_contig_size = params[:min_contig_size]
+    @report_csv = PipelineReportService.call(pipeline_run.id, background_id, true, min_contig_size)
     send_data @report_csv, filename: @sample.name + '_report.csv'
   end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -7,6 +7,7 @@ class SamplesController < ApplicationController
   include PipelineRunsHelper
   include ReportHelper
   include SamplesHelper
+  include ReportsHelper
 
   ########################################
   # Note to developers:
@@ -19,7 +20,7 @@ class SamplesController < ApplicationController
   ##########################################
 
   # Read action meant for single samples with set_sample before_action
-  READ_ACTIONS = [:show, :show_v2, :report_v2, :report_info, :report_csv, :assembly, :show_taxid_fasta, :nonhost_fasta, :unidentified_fasta,
+  READ_ACTIONS = [:show, :show_v2, :report_v2, :report_info, :report_csv, :report_csv_v2, :assembly, :show_taxid_fasta, :nonhost_fasta, :unidentified_fasta,
                   :contigs_fasta, :contigs_fasta_by_byteranges, :contigs_sequences_by_byteranges, :contigs_summary,
                   :results_folder, :show_taxid_alignment, :show_taxid_alignment_viz, :metadata,
                   :contig_taxid_list, :taxid_contigs, :summary_contig_counts, :coverage_viz_summary, :coverage_viz_data,].freeze
@@ -584,6 +585,12 @@ class SamplesController < ApplicationController
   # GET /samples/1/report_csv
   def report_csv
     @report_csv = report_csv_from_params(@sample, params)
+    send_data @report_csv, filename: @sample.name + '_report.csv'
+  end
+
+  # GET /samples/1/report_csv_v2
+  def report_csv_v2
+    @report_csv = report_csv_from_params_v2(@sample, params)
     send_data @report_csv, filename: @sample.name + '_report.csv'
   end
 

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -116,7 +116,7 @@ module ReportsHelper
     pipeline_run_id = pipeline_run ? pipeline_run.id : nil
     return "" if pipeline_run_id.nil? || pipeline_run.total_reads.nil? || pipeline_run.adjusted_remaining_reads.nil?
     # TODO: pass in sort_by to PipelineReportService from params
-    tax_details = JSON.parse(PipelineReportService.call(pipeline_run_id, background_id))
+    tax_details = JSON.parse(PipelineReportService.call(pipeline_run_id, background_id, true, params[:min_contig_size]))
 
     rows = []
     tax_details["sortedGenus"].each do |genus_tax_id|
@@ -127,7 +127,6 @@ module ReportsHelper
       genus_flat_hash[["tax_level"]] = 2
       genus_flat_hash = genus_flat_hash.merge(flat_hash(genus_info))
       rows << genus_flat_hash
-
       genus_info["species_tax_ids"].each do |species_tax_id|
         species_info = tax_details["counts"]["1"][species_tax_id.to_s]
         species_flat_hash = flat_hash(species_info)

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -108,15 +108,4 @@ module ReportsHelper
     tax_info[:genus_tax_id] = fake_genus_id
     fake_genus_info
   end
-
-  def flat_hash(h, f = [], g = {})
-    return g.update(f => h) unless h.is_a? Hash
-    h.each { |k, r| flat_hash(r, f + [k], g) }
-    g
-    # example: turn    { :a => { :b => { :c => 1,
-    #                                    :d => 2 },
-    #                            :e => 3 },
-    #                    :f => 4 }
-    # into    {[:a, :b, :c] => 1, [:a, :b, :d] => 2, [:a, :e] => 3, [:f] => 4}
-  end
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -109,47 +109,6 @@ module ReportsHelper
     fake_genus_info
   end
 
-  def report_csv_from_params_v2(sample, params)
-    background_id = params[:background_id] || sample.default_background_id
-    background_id = background_id.to_i
-    pipeline_run = select_pipeline_run(sample, params[:pipeline_version])
-    pipeline_run_id = pipeline_run ? pipeline_run.id : nil
-    return "" if pipeline_run_id.nil? || pipeline_run.total_reads.nil? || pipeline_run.adjusted_remaining_reads.nil?
-    # TODO: pass in sort_by to PipelineReportService from params
-    tax_details = JSON.parse(PipelineReportService.call(pipeline_run_id, background_id, true, params[:min_contig_size]))
-
-    rows = []
-    tax_details["sortedGenus"].each do |genus_tax_id|
-      genus_info = tax_details["counts"]["2"][genus_tax_id.to_s]
-      # add the hash keys in order for csv generation
-      genus_flat_hash = {}
-      genus_flat_hash[["tax_id"]] = genus_tax_id
-      genus_flat_hash[["tax_level"]] = 2
-      genus_flat_hash = genus_flat_hash.merge(flat_hash(genus_info))
-      rows << genus_flat_hash
-      genus_info["species_tax_ids"].each do |species_tax_id|
-        species_info = tax_details["counts"]["1"][species_tax_id.to_s]
-        species_flat_hash = flat_hash(species_info)
-        species_flat_hash[["tax_id"]] = species_tax_id
-        species_flat_hash[["tax_level"]] = 1
-        rows << species_flat_hash
-      end
-    end
-
-    return generate_report_csv(rows)
-  end
-
-  def generate_report_csv(rows)
-    flat_keys = rows[0].keys
-    attribute_names = flat_keys.map { |k| k.map(&:to_s).join("_") }
-    CSVSafe.generate(headers: true) do |csv|
-      csv << attribute_names
-      rows.each do |tax_info|
-        csv << tax_info.values_at(*flat_keys)
-      end
-    end
-  end
-
   def flat_hash(h, f = [], g = {})
     return g.update(f => h) unless h.is_a? Hash
     h.each { |k, r| flat_hash(r, f + [k], g) }

--- a/app/lib/hash_util.rb
+++ b/app/lib/hash_util.rb
@@ -1,0 +1,12 @@
+class HashUtil
+  # example: turn    { :a => { :b => { :c => 1,
+  #                                    :d => 2 },
+  #                            :e => 3 },
+  #                    :f => 4 }
+  # into    {[:a, :b, :c] => 1, [:a, :b, :d] => 2, [:a, :e] => 3, [:f] => 4}
+  def self.flat_hash(h, f = [], g = {})
+    return g.update(f => h) unless h.is_a? Hash
+    h.each { |k, r| flat_hash(r, f + [k], g) }
+    g
+  end
+end

--- a/app/lib/report_helper.rb
+++ b/app/lib/report_helper.rb
@@ -256,7 +256,7 @@ module ReportHelper
   def self.generate_report_csv(tax_details)
     rows = tax_details[2]
     return if rows.blank?
-    flat_keys = flat_hash(rows[0]).keys
+    flat_keys = HashUtil.flat_hash(rows[0]).keys
     flat_keys_symbols = flat_keys.map { |array_key| array_key.map(&:to_sym) }
     attributes_as_symbols = flat_keys_symbols - IGNORE_IN_DOWNLOAD
     attribute_names = attributes_as_symbols.map { |k| k.map(&:to_s).join("_") }
@@ -264,7 +264,7 @@ module ReportHelper
     CSVSafe.generate(headers: true) do |csv|
       csv << attribute_names
       rows.each do |tax_info|
-        flat_tax_info = flat_hash(tax_info)
+        flat_tax_info = HashUtil.flat_hash(tax_info)
         flat_tax_info_by_symbols = flat_tax_info.map { |k, v| [k.map(&:to_sym), v] }.to_h
         csv << flat_tax_info_by_symbols.values_at(*attributes_as_symbols)
       end
@@ -795,16 +795,5 @@ module ReportHelper
     Rails.logger.info "Agg scoring took #{(t2 - t1).round(2)}s,  #{(t3 - t2).round(2)}s."
 
     [rows_passing_filters, rows_total, rows]
-  end
-
-  def self.flat_hash(h, f = [], g = {})
-    return g.update(f => h) unless h.is_a? Hash
-    h.each { |k, r| flat_hash(r, f + [k], g) }
-    g
-    # example: turn    { :a => { :b => { :c => 1,
-    #                                    :d => 2 },
-    #                            :e => 3 },
-    #                    :f => 4 }
-    # into    {[:a, :b, :c] => 1, [:a, :b, :d] => 2, [:a, :e] => 3, [:f] => 4}
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     get :report_v2, on: :member
     get :report_info, on: :member
     get :report_csv, on: :member
+    get :report_csv_v2, on: :member
     get :bulk_new, on: :collection
     get :bulk_import, on: :collection
     get :upload, on: :collection


### PR DESCRIPTION
# Description

Add the ability to download the new report as a CSV.

# Notes

* This includes a bug fix for species not getting sorted within each genus.

* The generated CSV is always sorted by aggregate score. Left a `TODO` to pass in the `sort_by` parameter; it might take some work to extract from `ReportTable` since sorting is currently done entirely on the frontend.

* The CSV format is slightly different from that of the CSV generated by the old version of the report due to the structure having changed. Most notably, `genus_name`, `family_taxid`, `is_phage` have been removed, and `contig`+`contig_r` columns have been added.

  * **Old column names**
  tax_id, name, common_name, tax_level, species_taxid, genus_taxid, genus_name, family_taxid, category_name, is_phage, NT_r, NT_rpm, NT_zscore, NT_percentidentity, NT_alignmentlength, NT_neglogevalue, aggregatescore, NT_r_pct, NT_rpm_bg, NT_maxzscore, NR_r, NR_rpm, NR_zscore, NR_percentidentity, NR_alignmentlength, NR_neglogevalue, NR_r_pct, NR_rpm_bg, NR_maxzscore

  * **New column names**
  tax_id, tax_level, genus_tax_id, name, common_name, category, nr_count, nr_percent_identity, nr_alignment_length, nr_e_value, nr_bg_mean, nr_bg_stdev, nr_contigs, nr_contig_r, nr_rpm, nr_z_score, nt_count, nt_percent_identity, nt_alignment_length, nt_e_value, nt_bg_mean, nt_bg_stdev, nt_contigs, nt_contig_r, nt_rpm, nt_z_score, max_z_score, agg_score, species_tax_ids

# Tests

* Verified that the `Download Report Table (.csv)` button downloads the correct report.
* Verified that contig and contig_r values in the CSV match the results in the table based on the selected min contig size.
* Verified that the download option on the old report table still works as expected.
