### PR TITLE
Add CORS accept header for Cloudfront

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,9 @@ gem 'csv-safe', '~> 1.2'
 # For accessing Auth0 management APIs
 gem 'auth0'
 
+# For Access-Control-Allow-Origin and Cloudfront
+gem "rack-cors"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'bundler-audit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -972,6 +972,8 @@ GEM
     quantile (0.2.1)
     raabro (1.1.6)
     rack (2.0.7)
+    rack-cors (1.1.0)
+      rack (>= 2.0.0)
     rack-host-redirect (1.3.0)
       rack
     rack-mini-profiler (1.0.2)
@@ -1214,6 +1216,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 0.1.2)
   prometheus-client (= 0.7.1)
   puma (~> 3.7)
+  rack-cors
   rack-host-redirect
   rack-mini-profiler
   rails (~> 5.1.5)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [IDseq](https://idseq.net/) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/chanzuckerberg/idseq-web/blob/master/LICENSE) [![Build Status](https://travis-ci.org/chanzuckerberg/idseq-web.svg?branch=master)](https://travis-ci.org/chanzuckerberg/idseq-web) ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 
-![logo](https://assets.idseq.net/Logo_Black.png)
+![logo](https://assets.idseq.net/assets/Logo_Black.png)
 
 #### Infectious Disease Sequencing Platform
 IDseq is a hypothesis-free global software platform that helps scientists identify pathogens in metagenomic sequencing data.
@@ -15,6 +15,6 @@ Check out our repositories:
 - [idseq-web](https://github.com/chanzuckerberg/idseq-web) - Frontend portal (here)
 - [idseq-dag](https://github.com/chanzuckerberg/idseq-dag) - Bioinformatics pipeline and workflow engine
 - [idseq-cli](https://github.com/chanzuckerberg/idseq-cli) - Command line upload interface
-- [idseq-bench](https://github.com/chanzuckerberg/idseq-bench) - Pipeline benchmarking tools 
+- [idseq-bench](https://github.com/chanzuckerberg/idseq-bench) - Pipeline benchmarking tools
 
 Check out our [user wiki](https://github.com/chanzuckerberg/idseq-web/wiki) for getting started as a user. Check out our [dev wiki](https://github.com/chanzuckerberg/idseq-web/wiki/Developer-info) to get started as a developer.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,8 +71,15 @@ Rails.application.configure do
   config.action_controller.asset_host = proc { |source|
     "http://localhost:8080" if source =~ /wp_bundle\.js$/i
   }
-  # Uncomment this line to test cloudfront CDN. Must be running staging branch.
+  # Uncomment this line to test cloudfront CDN. Must be running staging branch,
+  # so that filename hashes match.
   # config.action_controller.asset_host = 'assets.staging.idseq.net'
+
+  # Custom config for idseq to enable CORS headers by environment. See rack_cors.rb.
+  config.allowed_cors_origins = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+  ]
 
   ActiveRecordQueryTrace.enabled = true
 

--- a/config/environments/prod.rb
+++ b/config/environments/prod.rb
@@ -83,6 +83,13 @@ Rails.application.configure do
 
   # We configure IDseq to use cloudfront CDN when available.
   config.action_controller.asset_host = ENV['CLOUDFRONT_ENDPOINT'] || 'idseq.net'
+  # Custom config for idseq to enable CORS headers by environment. See rack_cors.rb.
+  config.allowed_cors_origins = [
+    "https://idseq.net",
+    "https://www.idseq.net",
+    "https://assets.idseq.net",
+  ]
+
   config.middleware.use Rack::HostRedirect, 'www.idseq.net' => 'idseq.net'
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -82,6 +82,13 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # We configure IDseq to use cloudfront CDN when available.
   config.action_controller.asset_host = ENV['CLOUDFRONT_ENDPOINT'] || 'staging.idseq.net'
+  # Custom config for idseq to enable CORS headers by environment. See rack_cors.rb.
+  config.allowed_cors_origins = [
+    "https://idseq.net",
+    "https://www.idseq.net",
+    "https://assets.idseq.net",
+  ]
+
   config.middleware.use Rack::HostRedirect, 'www.staging.idseq.net' => 'staging.idseq.net'
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -84,9 +84,9 @@ Rails.application.configure do
   config.action_controller.asset_host = ENV['CLOUDFRONT_ENDPOINT'] || 'staging.idseq.net'
   # Custom config for idseq to enable CORS headers by environment. See rack_cors.rb.
   config.allowed_cors_origins = [
-    "https://idseq.net",
-    "https://www.idseq.net",
-    "https://assets.idseq.net",
+    "https://staging.idseq.net",
+    "https://www.staging.idseq.net",
+    "https://assets.staging.idseq.net",
   ]
 
   config.middleware.use Rack::HostRedirect, 'www.staging.idseq.net' => 'staging.idseq.net'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,5 +47,11 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Custom config for idseq to enable CORS headers by environment. See rack_cors.rb.
+  config.allowed_cors_origins = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+  ]
+
   config.middleware.use ResqueMiddleware
 end

--- a/config/initializers/rack_cors.rb
+++ b/config/initializers/rack_cors.rb
@@ -7,9 +7,10 @@ if defined? Rack::Cors
       origins [
         # SERVER_DOMAIN should be set to the current env root web address
         # such as https://staging.idseq.net/
-        ENV["SERVER_DOMAIN"] || "",
+        ENV["SERVER_DOMAIN"],
+        *Rails.application.config.allowed_cors_origins
         # All other domains should be added in env config files such as prod.rb.
-      ] + (Rails.application.config.allowed_cors_origins || [])
+      ].compact
       resource '/assets/*'
     end
   end

--- a/config/initializers/rack_cors.rb
+++ b/config/initializers/rack_cors.rb
@@ -1,0 +1,25 @@
+## Configure Rack CORS Middleware, so that CloudFront can serve our assets.
+## See https://github.com/cyu/rack-cors
+## And see https://stackoverflow.com/a/36585871
+if defined? Rack::Cors
+  Rails.configuration.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins [
+        # SERVER_DOMAIN should be set to the current env root web address
+        # such as https://staging.idseq.net/
+        ENV["SERVER_DOMAIN"] || "",
+        # Add all expected origins to be safe
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "https://idseq.net",
+        "https://www.idseq.net",
+        "https://staging.idseq.net",
+        "https://www.staging.idseq.net",
+        # Add CloudFront domains
+        "https://assets.idseq.net",
+        "https://assets.staging.idseq.net",
+      ]
+      resource '/assets/*'
+    end
+  end
+end

--- a/config/initializers/rack_cors.rb
+++ b/config/initializers/rack_cors.rb
@@ -8,17 +8,8 @@ if defined? Rack::Cors
         # SERVER_DOMAIN should be set to the current env root web address
         # such as https://staging.idseq.net/
         ENV["SERVER_DOMAIN"] || "",
-        # Add all expected origins to be safe
-        "http://localhost:3000",
-        "http://127.0.0.1:3000",
-        "https://idseq.net",
-        "https://www.idseq.net",
-        "https://staging.idseq.net",
-        "https://www.staging.idseq.net",
-        # Add CloudFront domains
-        "https://assets.idseq.net",
-        "https://assets.staging.idseq.net",
-      ]
+        # All other domains should be added in env config files such as prod.rb.
+      ] + (Rails.application.config.allowed_cors_origins || [])
       resource '/assets/*'
     end
   end


### PR DESCRIPTION
# Description

After considerable debugging, @davidrissato and I determined that Cloudfront was asking for font files with a different origin, so our rails server blocked the requests by default CORS policy. This PR adds a whitelist through the gem `rack-cors`. 

![image](https://user-images.githubusercontent.com/28797/69470465-a9c21a80-0d4b-11ea-84e7-27caa11411f2.png)


# Tests

* open localhost
* see accept origin header in responses of current domain