### PR TITLE
[Release fix] Add helpful error message on legacy password reset link

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,36 +1,44 @@
 <div class="outer-container">
-  <h2>Set your password</h2>
-
-  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :put}) do |f| %>
-    <%= f.hidden_field :reset_password_token %>
-
-    <div class="field new-pass-field">
-      <%= f.label :password, "New password" %><br/>
-      <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em><br/>
-      <% end %>
-      <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+  <% if get_app_config(AppConfig::USE_AUTH0_FOR_NEW_USERS) == "1" %>
+    <h2>Link Expired</h2>
+    <br/>
+    <div>
+      Sorry, this link has expired. Please click <a href="/auth0/login" target="_blank" rel="noopener noreferrer" class="terms-link">here</a> and go to "Forgot Password" to request a new link.
     </div>
+  <% else %>
+    <h2>Set your password</h2>
 
-    <div class="field">
-      <%= f.label :password_confirmation, "Confirm new password" %><br/>
-      <%= f.password_field :password_confirmation, autocomplete: "off" %>
-    </div>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :put}) do |f| %>
+      <%= f.hidden_field :reset_password_token %>
 
-    <div class="terms">
-      By registering for IDseq, you agree to our
-      <a href="https://idseq.net/terms" target="_blank" rel="noopener noreferrer" class="terms-link">
-        Terms
-      </a> and
-      <a href="https://idseq.net/privacy" target="_blank" rel="noopener noreferrer" class="terms-link">
-        Data Privacy Notice.
-      </a>
-    </div>
+      <div class="field new-pass-field">
+        <%= f.label :password, "New password" %><br/>
+        <% if @minimum_password_length %>
+          <em>(<%= @minimum_password_length %> characters minimum)</em><br/>
+        <% end %>
+        <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+      </div>
 
-    <%= devise_error_messages! %>
+      <div class="field">
+        <%= f.label :password_confirmation, "Confirm new password" %><br/>
+        <%= f.password_field :password_confirmation, autocomplete: "off" %>
+      </div>
 
-    <div class="submit-btn">
-      <%= f.submit "Register", class: "ui primary button idseq-ui" %>
-    </div>
+      <div class="terms">
+        By registering for IDseq, you agree to our
+        <a href="https://idseq.net/terms" target="_blank" rel="noopener noreferrer" class="terms-link">
+          Terms
+        </a> and
+        <a href="https://idseq.net/privacy" target="_blank" rel="noopener noreferrer" class="terms-link">
+          Data Privacy Notice.
+        </a>
+      </div>
+
+      <%= devise_error_messages! %>
+
+      <div class="submit-btn">
+        <%= f.submit "Register", class: "ui primary button idseq-ui" %>
+      </div>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
### Description
- Add a helpful error message in case users try to open an old "reset password" email from pre-Auth0-migration in the post-Auth0-migration state.
- For example, if we added users last week and they don't open the welcome reset email until next week, they'll run into trouble trying to set up a password on Devise that doesn't get synced to Auth0.

### Notes
- It's not ideal to have the conditional logic in the `.erb` template but I couldn't find where to override the Devise `passwords/edit` endpoint since that's not a controller we wrote ourselves.

### Tests
- Flipped `AppConfig::USE_AUTH0_FOR_NEW_USERS` on-and-off and saw the right reset screen.

![Screen Shot 2019-11-25 at 2 27 40 PM](https://user-images.githubusercontent.com/5652739/69583993-fe0a0c00-0f90-11ea-81ff-aeb2c1f383bc.png)