### PR TITLE
Use TaxonLineage instead of TaxonCount for taxon lookup.

### DIFF
--- a/app/helpers/bulk_downloads_helper.rb
+++ b/app/helpers/bulk_downloads_helper.rb
@@ -15,7 +15,7 @@ module BulkDownloadsHelper
   UNKNOWN_EXECUTION_TYPE = "Could not find execution type for bulk download".freeze
   BULK_DOWNLOAD_GENERATION_FAILED = "Could not generate bulk download".freeze
   READS_NON_HOST_TAXID_EXPECTED = "Expected taxid for reads non-host bulk download".freeze
-  READS_NON_HOST_TAXON_COUNT_EXPECTED_TEMPLATE = "Unexpected error. Could not find taxon count for taxid %s".freeze
+  READS_NON_HOST_TAXON_LINEAGE_EXPECTED_TEMPLATE = "Unexpected error. Could not find valid taxon lineage for taxid %s".freeze
 
   # Check that all pipeline runs have succeeded for the provided samples
   # and return the pipeline run ids.

--- a/app/models/alignment_config.rb
+++ b/app/models/alignment_config.rb
@@ -2,4 +2,12 @@ class AlignmentConfig < ApplicationRecord
   # configuration for alignment database for pipelines
   DEFAULT_NAME = ENV["ALIGNMENT_CONFIG_DEFAULT_NAME"]
   has_many :pipeline_runs, dependent: :restrict_with_exception
+
+  # Get the max lineage version from a set of alignment config ids.
+  def self.max_lineage_version(alignment_config_ids)
+    AlignmentConfig
+      .select("lineage_version")
+      .where(id: alignment_config_ids)
+      .maximum(:lineage_version)
+  end
 end

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -170,6 +170,12 @@ class TaxonLineage < ApplicationRecord
     level_str
   end
 
+  def self.versioned_lineages(tax_ids, lineage_version)
+    TaxonLineage
+      .where(taxid: tax_ids)
+      .where('? BETWEEN version_start AND version_end', lineage_version)
+  end
+
   def self.fetch_lineage_by_taxid(tax_map, pipeline_run_id)
     t0 = Time.now.to_f
     # Get list of tax_ids to look up in TaxonLineage rows. Include family_taxids.
@@ -193,9 +199,7 @@ class TaxonLineage < ApplicationRecord
       class_common_name order_common_name family_common_name genus_common_name
       species_common_name kingdom_taxid kingdom_name kingdom_common_name tax_name
     ]
-    lineage_by_taxid = TaxonLineage
-                       .where(taxid: tax_ids)
-                       .where('? BETWEEN version_start AND version_end', lineage_version)
+    lineage_by_taxid = versioned_lineages(tax_ids, lineage_version)
                        .pluck(*required_columns)
                        .map { |r| [r[0], required_columns.zip(r).to_h] }
                        .to_h

--- a/spec/factories/taxon_lineage.rb
+++ b/spec/factories/taxon_lineage.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :taxon_lineage do
     sequence(:tax_name) { |n| "taxon-#{n}" }
     sequence(:taxid) { |n| n }
+    sequence(:started_at) { |n| Time.zone.local(2000 - n, 1, 1) }
+    sequence(:ended_at) { |n| Time.zone.local(3000 + n, 1, 1) }
 
     factory :species do
       sequence(:tax_name) { |n| "species-#{n}" }

--- a/spec/models/alignment_config_spec.rb
+++ b/spec/models/alignment_config_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe AlignmentConfig, type: :model do
+  context "#max_lineage_version" do
+    let(:taxid) { 100 }
+    before do
+      @alignment_config_one = create(:alignment_config, lineage_version: 2)
+      @alignment_config_two = create(:alignment_config, lineage_version: 2)
+      @alignment_config_three = create(:alignment_config, lineage_version: 3)
+    end
+
+    it "returns the correct lineage_version" do
+      max_lineage_version = AlignmentConfig.max_lineage_version([@alignment_config_one.id, @alignment_config_two.id, @alignment_config_three.id])
+      expect(max_lineage_version).to eq(3)
+    end
+  end
+end

--- a/spec/models/taxon_lineage_spec.rb
+++ b/spec/models/taxon_lineage_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe TaxonLineage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "#versioned_lineages" do
+    let(:taxid) { 100 }
+    before do
+      @taxon_lineage_one = create(:taxon_lineage, taxid: taxid, version_start: 2, version_end: 4)
+      @taxon_lineage_two = create(:taxon_lineage, taxid: taxid, version_start: 5, version_end: 7)
+    end
+
+    it "fetches the correct lineage" do
+      taxon_lineages = TaxonLineage.versioned_lineages(taxid, 5)
+      expect(taxon_lineages.length).to eq(1)
+      expect(taxon_lineages[0].id).to eq(@taxon_lineage_two.id)
+    end
+
+    it "returns empty relation if no match" do
+      taxon_lineages = TaxonLineage.versioned_lineages(taxid, 10)
+      expect(taxon_lineages.length).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
As discussed, use TaxonLineage instead of TaxonCount to perform a taxid => tax_name lookup.

Refactored methods slightly and added tests for new methods.

# Tests
Verified that the report_details are the same.
Verified that the reads non-host bulk download behaves as before.
Verified that the bulk download doesn't have any one-query-per-sample situations.