### PR TITLE
[Release fix] Fix issues with auth0 login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,12 +32,15 @@ class ApplicationController < ActionController::Base
   def sign_in_auth0_token!
     @auth0_token = auth0_decode_auth_token
     if @auth0_token
-      if @auth0_token[:authenticated] && !user_signed_in?
+      if @auth0_token[:authenticated] && (!user_signed_in? || @auth0_token.dig(:auth_payload, :email) != current_user.email)
         auth_payload = @auth0_token[:auth_payload]
         auth_user = User.find_by(email: auth_payload["email"])
         if auth_user.present?
           sign_in auth_user
           return
+        else
+          auth0_logout
+          redirect_to root_path
         end
       end
     end

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -32,6 +32,15 @@ class Auth0Controller < ApplicationController
     )
   end
 
+  def logout
+    auth0_logout
+    redirect_to auth0_signout_url
+  end
+
+  def failure
+    logout
+  end
+
   def background_refresh
     @mode = params["mode"]
     @refresh_values = background_refresh_values

--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -34,6 +34,7 @@ module Auth0Helper
   # (see https://auth0.com/docs/sessions/concepts/session-layers)
   def auth0_remove_application_session
     session.delete(:auth0_credentials)
+    sign_out_all_scopes
   end
 
   # URL used to remove auth0 session from Auth0 Session Layer

--- a/config/initializers/auth0.rb
+++ b/config/initializers/auth0.rb
@@ -10,3 +10,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     }
   )
 end
+
+OmniAuth.config.failure_raise_out_environments = []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,14 @@ Rails.application.routes.draw do
   }
 
   get 'auth/auth0/callback/' => 'auth0#callback'
+  get 'auth/failure/' => 'auth0#failure'
   namespace :auth0 do
     post :request_password_reset
     get :refresh_token
     get :background_refresh
     get :login
+    get :logout
+    get :failure
   end
 
   resources :samples do


### PR DESCRIPTION
# Description

This PR is fixing two issues with auth0 login:
- When auth0 SSO cookie is expired OmniAuth redirects user to failure endpoint, which didn't exist. The failure endpoint now logs out the user and redirect it to the main page.
- If a user tried to authenticate a different user without logging out the previous one, the authentication wouldn't work as expected.

# Tests

* Manual tests
