### PR TITLE
Fetch unmapped reads count from assembly

### DIFF
--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -250,4 +250,9 @@ module PipelineRunsHelper
 
     return valid_pipeline_runs
   end
+
+  def aws_s3_read_json(path)
+    raw = Syscall.run("aws", "s3", "cp", path, "-")
+    JSON.parse(raw)
+  end
 end

--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -250,9 +250,4 @@ module PipelineRunsHelper
 
     return valid_pipeline_runs
   end
-
-  def aws_s3_read_json(path)
-    raw = Syscall.run("aws", "s3", "cp", path, "-")
-    JSON.parse(raw)
-  end
 end

--- a/app/lib/syscall.rb
+++ b/app/lib/syscall.rb
@@ -47,6 +47,12 @@ class Syscall
     run("aws", "s3", "cp", source_s3_path, destination_s3_path)
   end
 
+  # See also S3Util::s3_select_json
+  def self.s3_read_json(path)
+    raw = s3_cp(path, "-")
+    JSON.parse(raw)
+  end
+
   def self.pipe(*cmd)
     err_read, err_write = IO.pipe
 

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -45,6 +45,7 @@ class PipelineRun < ApplicationRecord
   SORTED_TAXID_ANNOTATED_FASTA_FAMILY_NR = 'taxid_annot_sorted_family_nr.fasta'.freeze
 
   DAG_ANNOTATED_FASTA_BASENAME = 'taxid_annot.fasta'.freeze
+  DAG_ANNOTATED_COUNT_BASENAME = 'annotated_out.count'.freeze
   DAG_UNIDENTIFIED_FASTA_BASENAME = 'unidentified.fa'.freeze
   UNIDENTIFIED_FASTA_BASENAME = 'unidentified.fasta'.freeze
   MULTIHIT_FASTA_BASENAME = 'accessions.rapsearch2.gsnapl.fasta'.freeze
@@ -397,15 +398,15 @@ class PipelineRun < ApplicationRecord
   end
 
   def contigs_fasta_s3_path
-    return "#{postprocess_output_s3_path}/#{ASSEMBLED_CONTIGS_NAME}" if pipeline_version_has_assembly(pipeline_version)
+    return "#{postprocess_output_s3_path}/#{ASSEMBLED_CONTIGS_NAME}" if supports_assembly?
   end
 
   def contigs_summary_s3_path
-    return "#{postprocess_output_s3_path}/#{CONTIG_MAPPING_NAME}" if pipeline_version_has_assembly(pipeline_version)
+    return "#{postprocess_output_s3_path}/#{CONTIG_MAPPING_NAME}" if supports_assembly?
   end
 
   def annotated_fasta_s3_path
-    return "#{postprocess_output_s3_path}/#{ASSEMBLY_PREFIX}#{DAG_ANNOTATED_FASTA_BASENAME}" if pipeline_version_has_assembly(pipeline_version)
+    return "#{postprocess_output_s3_path}/#{ASSEMBLY_PREFIX}#{DAG_ANNOTATED_FASTA_BASENAME}" if supports_assembly?
     return "#{postprocess_output_s3_path}/#{DAG_ANNOTATED_FASTA_BASENAME}" if pipeline_version_at_least_2(pipeline_version)
 
     multihit? ? "#{alignment_output_s3_path}/#{MULTIHIT_FASTA_BASENAME}" : "#{alignment_output_s3_path}/#{HIT_FASTA_BASENAME}"
@@ -429,8 +430,9 @@ class PipelineRun < ApplicationRecord
     files
   end
 
+  # Unidentified is also referred to as "unmapped"
   def unidentified_fasta_s3_path
-    return "#{postprocess_output_s3_path}/#{ASSEMBLY_PREFIX}#{DAG_UNIDENTIFIED_FASTA_BASENAME}" if pipeline_version_has_assembly(pipeline_version)
+    return "#{postprocess_output_s3_path}/#{ASSEMBLY_PREFIX}#{DAG_UNIDENTIFIED_FASTA_BASENAME}" if supports_assembly?
     return "#{output_s3_path_with_version}/#{DAG_UNIDENTIFIED_FASTA_BASENAME}" if pipeline_version_at_least_2(pipeline_version)
     "#{alignment_output_s3_path}/#{UNIDENTIFIED_FASTA_BASENAME}"
   end
@@ -786,7 +788,7 @@ class PipelineRun < ApplicationRecord
     begin
       # TODO:  Make this less expensive while jobs are running, perhaps by doing it only sometimes, then again at end.
       # TODO:  S3 is a middleman between these two functions;  load_stats shouldn't wait for S3
-      compile_stats_file
+      compile_stats_file!
       load_stats_file
       load_chunk_stats
     rescue
@@ -958,20 +960,40 @@ class PipelineRun < ApplicationRecord
     save
   end
 
-  def compile_stats_file
+  # Generate stats.json from all *.count files in results dir. Example:
+  # [
+  #   {
+  #     "reads_after": 8262,
+  #     "task": "unidentified_fasta"
+  #   },
+  #   {
+  #     "reads_after": 8558,
+  #     "task": "bowtie2_out"
+  #   },
+  #   ...
+  #   {
+  #     "total_reads": 10000
+  #   },
+  #   {
+  #     "fraction_subsampled": 1.0
+  #   },
+  #   {
+  #     "adjusted_remaining_reads": 8558
+  #   }
+  # ]
+  #
+  # IMPORTANT NOTE: This method ALSO sets attributes of pipeline run instance.
+  def compile_stats_file!
     res_folder = output_s3_path_with_version
     stdout, _stderr, status = Open3.capture3("aws s3 ls #{res_folder}/ | grep count$")
     unless status.exitstatus.zero?
       return
     end
 
-    # Compile all counts
-    # Ex: [{"total_reads": 1122}, {"task": "star_out", "reads_after": 832}... {"adjusted_remaining_reads": 474}]
     all_counts = []
     stdout.split("\n").each do |line|
       fname = line.split(" ")[3] # Last col in line
-      raw = Syscall.run("aws", "s3", "cp", "#{res_folder}/#{fname}", "-")
-      contents = JSON.parse(raw)
+      contents = aws_s3_read_json("#{res_folder}/#{fname}")
       # Ex: {"gsnap_filter_out": 194}
       contents.each do |key, count|
         all_counts << { task: key, reads_after: count }
@@ -1019,10 +1041,7 @@ class PipelineRun < ApplicationRecord
     end
 
     # Load unidentified reads
-    unidentified = all_counts.detect { |entry| entry.value?("unidentified_fasta") }
-    if unidentified
-      self.unmapped_reads = unidentified[:reads_after]
-    end
+    self.unmapped_reads = load_unmapped_reads(all_counts) || unmapped_reads
 
     # Write JSON to a file
     tmp = Tempfile.new
@@ -1036,6 +1055,28 @@ class PipelineRun < ApplicationRecord
     end
 
     save
+  end
+
+  # Fetch the unmapped reads count from alignment stage then refined counts from
+  # assembly stage, as each becomes available. Prior to Dec 2019, the count was
+  # only fetched from alignment.
+  def load_unmapped_reads(all_counts)
+    unmapped_reads = nil
+    unidentified = all_counts.detect { |entry| entry.value?("unidentified_fasta") }
+    if unidentified
+      unmapped_reads = unidentified[:reads_after]
+
+      if supports_assembly?
+        # see idseq_dag/steps/generate_annotated_fasta.py
+        refined_annotated_out = aws_s3_read_json(
+          "#{postprocess_output_s3_path}/#{ASSEMBLY_PREFIX}#{DAG_ANNOTATED_COUNT_BASENAME}"
+        )
+        if refined_annotated_out.present?
+          unmapped_reads = refined_annotated_out["unidentified_fasta"]
+        end
+      end
+    end
+    unmapped_reads
   end
 
   def local_json_path
@@ -1278,7 +1319,7 @@ class PipelineRun < ApplicationRecord
 
   def s3_paths_for_taxon_byteranges
     file_prefix = ''
-    file_prefix = ASSEMBLY_PREFIX if pipeline_version_has_assembly(pipeline_version)
+    file_prefix = ASSEMBLY_PREFIX if supports_assembly?
     # by tax_level and hit_type
     { TaxonCount::TAX_LEVEL_SPECIES => {
       'NT' => "#{postprocess_output_s3_path}/#{file_prefix}#{SORTED_TAXID_ANNOTATED_FASTA}",
@@ -1512,5 +1553,9 @@ class PipelineRun < ApplicationRecord
 
   def alignment_db
     alignment_config.name
+  end
+
+  private def supports_assembly?
+    pipeline_version_has_assembly(pipeline_version)
   end
 end

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -15,8 +15,8 @@ class PipelineRunStage < ApplicationRecord
   # Stage names
   HOST_FILTERING_STAGE_NAME = 'Host Filtering'.freeze
   ALIGNMENT_STAGE_NAME = 'GSNAPL/RAPSEARCH alignment'.freeze
-  POSTPROCESS_STAGE_NAME = 'Post Processing'.freeze
-  EXPT_STAGE_NAME = "Experimental".freeze
+  POSTPROCESS_STAGE_NAME = 'Post Processing'.freeze # also known as "assembly"
+  EXPT_STAGE_NAME = "Experimental".freeze # Not actually experimental anymore!
 
   # Dag Json names
   DAG_NAME_HOST_FILTER = "host_filter".freeze


### PR DESCRIPTION
# Description

See IDSEQ-1750. As reported by @katrinakalantar : The unmapped reads field currently displays the # of reads that are unmapped after the initial gsnap/rapsearch steps. The sample report table shows metrics including reads that are "mapped" by assembly into a contig. The "unmapped reads" value should represent the number of reads that are totally unmapped at the END of the pipeline.

This PR adds code to fetch the unmapped count after assembly from the existing file `refined_annotated_out.count`. The final count should be set by the pipeline monitor after all stages have finished.

# Notes

* The count ultimately comes from the lines of the `unidentified_fasta` file. 
```
# idseq_dag/steps/generate_annotated_fasta.py
self.counts_dict["unidentified_fasta"] = count.reads_in_group([self.output_files_local()[1]])
```

* One confusing thing I found was in the pipeline output files was that `additional_files_to_upload` appear to all go into root pipeline run dir, not with other files of the same steps in `/assembly`. Seems like a poor design. 

* The reason why the `stats.json` file exists is a mystery to me. Why not use the database? In fact, it appears we do both. We store the same data in `job_stats_attributes`. There is also a comment by @boris-dimitrov : `# TODO:  S3 is a middleman between these two functions;  load_stats shouldn't wait for S3`

* I refactored a bunch of lines to use `supports_assembly?`

# Tests

I couldn't think of a good way to run automated tests on this so I ran manual tests in the console. 

I will also check the values in staging of the benchmark run after alignment then again after assembly. 

```
pr = PipelineRun.where(
  "sample_id < 12640 AND unmapped_reads > 0 AND pipeline_version > 3.1 AND assembled = 1"
).last
pr.unmapped_reads # 21

# test that reads_after is returned when file does not exist
pr.fetch_unmapped_reads([
  {
    "reads_after": 8262,
    "task": "unidentified_fasta"
  }
]) # 8262

# test that remote file count is returned
pr.fetch_unmapped_reads([
  {
    "reads_after": 8262,
    "task": "unidentified_fasta"
  }
], 
"s3://idseq-samples-prod/samples/744/34488/postprocess/3.13/refined_annotated_out.count"
) # 15812

```