### PR TITLE
Migrate new taxid columns in contig table.

### DIFF
--- a/app/jobs/data_migrations/populate_contig_species_taxids.rb
+++ b/app/jobs/data_migrations/populate_contig_species_taxids.rb
@@ -1,0 +1,72 @@
+# WARNING: Since the contigs table is so large, this data migration may take a long time to run.
+BATCH_SIZE = 10_000
+
+class PopulateContigSpeciesTaxids
+  @queue = :data_migration
+  def self.perform
+    start_time = Time.now.to_f
+    missing_species_id = TaxonLineage::MISSING_SPECIES_ID
+    missing_genus_id = TaxonLineage::MISSING_GENUS_ID
+
+    # Just select the columns that we need. In particular, don't select the sequence column, which is very large.
+    # The "lock" specifies that whenever you make a SELECT query,
+    # you get a lock on the selected rows until the end of the current transaction.
+    contigs_to_update = Contig.lock.where(species_taxid_nt: nil).select(:id, :lineage_json)
+
+    total_updated = 0
+    failed_ids = []
+    Rails.logger.info("populate_contig_species_taxids: Starting data migration.")
+
+    # Process the contigs in batches so we don't need to load everything into RAM at once.
+    contigs_to_update.in_batches(of: BATCH_SIZE) do |contigs|
+      # contigs is an ActiveRecord relation. (the rows themselves are not loaded yet)
+
+      # The transaction ensures that row locks are held FOR THIS BATCH ONLY
+      # until the end of the transaction.
+      Contig.transaction do
+        # Load all the contigs in one query.
+        # This loads the rows and acquires the lock.
+        loaded_contigs = contigs.to_a
+
+        loaded_contigs.each do |contig|
+          begin
+            if contig.lineage_json.present?
+              lineage_json = JSON.parse(contig.lineage_json)
+              contig.species_taxid_nt = lineage_json.dig("NT", 0) || missing_species_id
+              contig.species_taxid_nr = lineage_json.dig("NR", 0) || missing_species_id
+              contig.genus_taxid_nt = lineage_json.dig("NT", 1) || missing_genus_id
+              contig.genus_taxid_nr = lineage_json.dig("NR", 1) || missing_genus_id
+            end
+          rescue => e
+            Rails.logger.error(e)
+            failed_ids << contig.id
+          end
+        end
+
+        # Use active-import to update multiple contigs in one query.
+        # Just update the taxid fields.
+        results = Contig.import loaded_contigs, validate: false, on_duplicate_key_update: [:species_taxid_nt, :species_taxid_nr, :genus_taxid_nt, :genus_taxid_nr]
+        results.failed_instances.each do |contig|
+          Rails.logger.error("Contig ID #{contig.id} failed to save. species_taxid_nt #{contig.species_taxid_nt}, species_taxid_nr #{contig.species_taxid_nr}")
+          failed_ids << contig.id
+        end
+
+        total_updated += loaded_contigs.length
+      end
+
+      # Regularly log progress updates.
+      if total_updated % 100_000 == 0
+        Rails.logger.info("populate_contig_species_taxids: #{total_updated} contigs processed...")
+      end
+    end
+
+    unless failed_ids.empty?
+      Rails.logger.info("#{failed_ids.length} failed ids: #{failed_ids}")
+    end
+    Rails.logger.info(format("Updated %d rows in %3.1f seconds", total_updated, (Time.now.to_f - start_time)))
+  rescue => e
+    # Eventually, this data migration may no longer be compatible with the database.
+    Rails.logger.error(e)
+    Rails.logger.error("populate_contig_species_taxids failed. This data migration may be out of date with the db schema. Consider deleting.")
+  end
+end

--- a/app/jobs/data_migrations/populate_contig_species_taxids.rb
+++ b/app/jobs/data_migrations/populate_contig_species_taxids.rb
@@ -1,56 +1,46 @@
 # WARNING: Since the contigs table is so large, this data migration may take a long time to run.
 BATCH_SIZE = 10_000
 
+# This code assumes that no one tries to delete contigs (via deleting samples) during this migration.
+# If a sample is deleted, there is a chance the migration will crash (it depends on how robust active-import is)
 class PopulateContigSpeciesTaxids
   @queue = :data_migration
   def self.perform
     start_time = Time.now.to_f
 
     # Just select the columns that we need. In particular, don't select the sequence column, which is very large.
-    # The "lock" specifies that whenever you make a SELECT query,
-    # you get a lock on the selected rows until the end of the current transaction.
-    contigs_to_update = Contig.lock.where(species_taxid_nt: nil).select(:id, :lineage_json)
+    contigs_to_update = Contig.where(species_taxid_nt: nil, species_taxid_nr: nil).select(:id, :lineage_json)
 
     total_updated = 0
     failed_ids = []
     Rails.logger.info("populate_contig_species_taxids: Starting data migration.")
 
     # Process the contigs in batches so we don't need to load everything into RAM at once.
-    contigs_to_update.in_batches(of: BATCH_SIZE) do |contigs|
-      # contigs is an ActiveRecord relation. (the rows themselves are not loaded yet)
-
-      # The transaction ensures that row locks are held FOR THIS BATCH ONLY
-      # until the end of the transaction.
-      Contig.transaction do
-        # Load all the contigs in one query.
-        # This loads the rows and acquires the lock.
-        loaded_contigs = contigs.to_a
-
-        loaded_contigs.each do |contig|
-          begin
-            if contig.lineage_json.present?
-              lineage_json = JSON.parse(contig.lineage_json)
-              contig.species_taxid_nt = lineage_json.dig("NT", 0) || nil
-              contig.species_taxid_nr = lineage_json.dig("NR", 0) || nil
-              contig.genus_taxid_nt = lineage_json.dig("NT", 1) || nil
-              contig.genus_taxid_nr = lineage_json.dig("NR", 1) || nil
-            end
-          rescue => e
-            Rails.logger.error(e)
-            failed_ids << contig.id
+    contigs_to_update.find_in_batches(batch_size: BATCH_SIZE) do |contigs|
+      contigs.each do |contig|
+        begin
+          if contig.lineage_json.present?
+            lineage_json = JSON.parse(contig.lineage_json)
+            contig.species_taxid_nt = lineage_json.dig("NT", 0) || nil
+            contig.species_taxid_nr = lineage_json.dig("NR", 0) || nil
+            contig.genus_taxid_nt = lineage_json.dig("NT", 1) || nil
+            contig.genus_taxid_nr = lineage_json.dig("NR", 1) || nil
           end
-        end
-
-        # Use active-import to update multiple contigs in one query.
-        # Just update the taxid fields.
-        results = Contig.import(loaded_contigs, validate: false, on_duplicate_key_update: [:species_taxid_nt, :species_taxid_nr, :genus_taxid_nt, :genus_taxid_nr])
-        results.failed_instances.each do |contig|
-          Rails.logger.error("Contig ID #{contig.id} failed to save. species_taxid_nt #{contig.species_taxid_nt}, species_taxid_nr #{contig.species_taxid_nr}")
+        rescue => e
+          Rails.logger.error(e)
           failed_ids << contig.id
         end
-
-        total_updated += loaded_contigs.length
       end
+
+      # Use active-import to update multiple contigs in one query.
+      # Just update the taxid fields.
+      results = Contig.import(contigs, validate: false, on_duplicate_key_update: [:species_taxid_nt, :species_taxid_nr, :genus_taxid_nt, :genus_taxid_nr])
+      results.failed_instances.each do |contig|
+        Rails.logger.error("Contig ID #{contig.id} failed to save. species_taxid_nt #{contig.species_taxid_nt}, species_taxid_nr #{contig.species_taxid_nr}")
+        failed_ids << contig.id
+      end
+
+      total_updated += contigs.length
 
       # Regularly log progress updates.
       if total_updated % 100_000 == 0

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -558,10 +558,10 @@ class PipelineRun < ApplicationRecord
     get_contig_hash = lambda do |header, sequence|
       read_count = contig_stats_json[header] || 0
       lineage_json = get_lineage_json(contig2taxid[header], taxon_lineage_map)
-      species_taxid_nt = lineage_json.dig("NT", 0) || TaxonLineage::MISSING_SPECIES_ID
-      species_taxid_nr = lineage_json.dig("NR", 0) || TaxonLineage::MISSING_SPECIES_ID
-      genus_taxid_nt = lineage_json.dig("NT", 1) || TaxonLineage::MISSING_GENUS_ID
-      genus_taxid_nr = lineage_json.dig("NR", 1) || TaxonLineage::MISSING_GENUS_ID
+      species_taxid_nt = lineage_json.dig("NT", 0) || nil
+      species_taxid_nr = lineage_json.dig("NR", 0) || nil
+      genus_taxid_nt = lineage_json.dig("NT", 1) || nil
+      genus_taxid_nr = lineage_json.dig("NR", 1) || nil
 
       {
         name: header, sequence: sequence, read_count: read_count, lineage_json: lineage_json.to_json,

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -554,16 +554,31 @@ class PipelineRun < ApplicationRecord
     taxon_lineage_map = {}
     TaxonLineage.where(taxid: taxid_list.uniq).order(:id).each { |t| taxon_lineage_map[t.taxid.to_i] = t.to_a }
 
+    # A lambda allows us to access variables in the enclosing scope, such as contig2taxid.
+    get_contig_hash = lambda do |header, sequence|
+      read_count = contig_stats_json[header] || 0
+      lineage_json = get_lineage_json(contig2taxid[header], taxon_lineage_map)
+      species_taxid_nt = lineage_json.dig("NT", 0) || TaxonLineage::MISSING_SPECIES_ID
+      species_taxid_nr = lineage_json.dig("NR", 0) || TaxonLineage::MISSING_SPECIES_ID
+      genus_taxid_nt = lineage_json.dig("NT", 1) || TaxonLineage::MISSING_GENUS_ID
+      genus_taxid_nr = lineage_json.dig("NR", 1) || TaxonLineage::MISSING_GENUS_ID
+
+      {
+        name: header, sequence: sequence, read_count: read_count, lineage_json: lineage_json.to_json,
+        species_taxid_nt: species_taxid_nt, species_taxid_nr: species_taxid_nr,
+        genus_taxid_nt: genus_taxid_nt, genus_taxid_nr: genus_taxid_nr,
+      }
+    end
+
     File.open(contig_fasta, 'r') do |cf|
       line = cf.gets
       header = ''
       sequence = ''
       while line
         if line[0] == '>'
-          read_count = contig_stats_json[header] || 0
-          lineage_json = get_lineage_json(contig2taxid[header], taxon_lineage_map)
-          if read_count >= MIN_CONTIG_SIZE && header != ''
-            contig_array << { name: header, sequence: sequence, read_count: read_count, lineage_json: lineage_json.to_json }
+          contig_hash = get_contig_hash.call(header, sequence)
+          if contig_hash[:read_count] >= MIN_CONTIG_SIZE && header != ''
+            contig_array << contig_hash
           end
           header = line[1..line.size].rstrip
           sequence = ''
@@ -572,10 +587,9 @@ class PipelineRun < ApplicationRecord
         end
         line = cf.gets
       end
-      read_count = contig_stats_json[header] || 0
-      lineage_json = get_lineage_json(contig2taxid[header], taxon_lineage_map)
-      if read_count >= MIN_CONTIG_SIZE
-        contig_array << { name: header, sequence: sequence, read_count: read_count, lineage_json: lineage_json.to_json }
+      contig_hash = get_contig_hash.call(header, sequence)
+      if contig_hash[:read_count] >= MIN_CONTIG_SIZE
+        contig_array << contig_hash
       end
     end
     update(contigs_attributes: contig_array) unless contig_array.empty?


### PR DESCRIPTION
# Description

Add data migration Resque task to populate contig taxid columns.

This data migration will need to be run manually after the deployment with `Resque.enqueue(PopulateContigSpeciesTaxids)`. It should interfere minimally with the service (it acquires a write lock on the current contigs it is modifying, but idseq-web doesn't modify contigs after they are loaded so it should be unaffeted). The data migration may take a while to run and will run in a Resque worker.

Also update the db_load_contig_count code to populate the new columns.

# Notes

This data migration will need to be run manually after the deployment with `Resque.enqueue(PopulateContigSpeciesTaxids)`.

# Tests

* Verifed that Resque task performs correctly. Will need to run this again on staging and verify that it works, and that it doesn't degrade site performance while it's running. If the performance isn't great or it turns out to be buggy, we can always choose not to run the data migration until we push out a fix. (it doesn't happen automatically)
* Verified that db_load_contig_counts loads the contigs properly with the new taxids.
