### PR TITLE
[Report Page] Add alerts for in progress/failed samples

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -817,6 +817,7 @@ export default class SampleViewV2 extends React.Component {
 
   render = () => {
     const {
+      amrData,
       currentTab,
       pipelineRun,
       pipelineRunInfo,

--- a/app/assets/src/components/views/SampleViewV2/sample_view_v2.scss
+++ b/app/assets/src/components/views/SampleViewV2/sample_view_v2.scss
@@ -65,3 +65,85 @@
   height: 2px;
   padding: 30px 0;
 }
+
+.sampleMessage {
+  display: flex;
+  justify-content: center;
+  margin-top: 100px;
+
+  .textContainer {
+    margin-top: $space-xs;
+    margin-right: 18px;
+    width: 330px;
+
+    .reportStatus {
+      display: inline-flex;
+      align-items: center;
+      background-color: $error-lightest;
+      border-radius: 15px;
+      padding: 3px $space-xs;
+
+      .icon {
+        width: 20px;
+      }
+
+      .text {
+        @include font-label-s;
+        margin-left: $space-xs;
+        margin-top: 1px;
+      }
+
+      &.warning {
+        background-color: $warning-bg;
+        color: $warning;
+
+        .icon {
+          fill: $warning;
+        }
+      }
+
+      &.error {
+        background-color: $error-bg;
+        color: $error;
+
+        .icon {
+          fill: $error;
+        }
+      }
+
+      &.inProgress {
+        background-color: $primary-lightest;
+        color: $primary-light;
+
+        .icon {
+          fill: $primary-light;
+          font-size: 20px;
+        }
+      }
+    }
+
+    .message {
+      @include font-header-m;
+      margin-bottom: $space-xs;
+      margin-top: $space-xs;
+      margin-left: 2px;
+    }
+
+    .actionLink {
+      @include font-header-xxs;
+      color: $primary-light !important;
+      margin-top: $space-s;
+      margin-left: 2px;
+
+      .rightArrow {
+        font-size: 8px;
+        margin-left: 3px;
+      }
+    }
+  }
+
+  .bacteriaIcon {
+    width: 105px;
+    height: 128px;
+  }
+}

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -797,17 +797,12 @@ class SamplesController < ApplicationController
       render json: PipelineReportService.call(pipeline_run.id, background_id)
     else
       render json: {
-        pipelineRunInfo: {
+        metadata: {
           pipelineRunStatus: "WAITING",
           jobStatus: "Waiting to Start or Receive Files",
           errorMessage: nil,
           knownUserError: nil,
         },
-        metadata: {},
-        counts: {},
-        lineage: {},
-        sortedGenus: [],
-        highlightedTaxIds: [],
       }
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -792,8 +792,25 @@ class SamplesController < ApplicationController
 
   def report_v2
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
-    background_id = get_background_id(@sample, params[:background])
-    render json: PipelineReportService.call(pipeline_run.id, background_id)
+    if pipeline_run
+      background_id = get_background_id(@sample, params[:background])
+      render json: PipelineReportService.call(pipeline_run.id, background_id)
+    else
+      render json: {
+        pipelineRunInfo: {
+          pipelineRunComplete: false,
+          pipelineRunFailed: false,
+          sampleStatus: "Waiting to Start or Receive Files",
+          errorMessage: nil,
+          knownUserError: nil,
+        },
+        metadata: {},
+        counts: {},
+        lineage: {},
+        sortedGenus: [],
+        highlightedTaxIds: [],
+      }
+    end
   end
 
   def amr

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -798,9 +798,8 @@ class SamplesController < ApplicationController
     else
       render json: {
         pipelineRunInfo: {
-          pipelineRunComplete: false,
-          pipelineRunFailed: false,
-          sampleStatus: "Waiting to Start or Receive Files",
+          pipelineRunStatus: "WAITING",
+          jobStatus: "Waiting to Start or Receive Files",
           errorMessage: nil,
           knownUserError: nil,
         },

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -67,15 +67,10 @@ class PipelineReportService
   end
 
   def generate
-    pipeline_run, pipeline_run_info = get_pipeline_status(@pipeline_run_id)
+    pipeline_run, metadata = get_pipeline_status(@pipeline_run_id)
     if @pipeline_run_id.nil? || !pipeline_run.completed? || pipeline_run.failed?
       return JSON.dump(
-        pipelineRunInfo: pipeline_run_info,
-        metadata: {},
-        counts: {},
-        lineage: {},
-        sortedGenus: [],
-        highlightedTaxIds: []
+        metadata: metadata
       )
     end
 
@@ -180,15 +175,13 @@ class PipelineReportService
     if @csv
       return report_csv(counts_by_tax_level, sorted_genus_tax_ids)
     else
+      metadata = metadata.merge(backgroundId: @background_id,
+                                truncatedReadsCount: pipeline_run.truncated,
+                                adjustedRemainingReadsCount: pipeline_run.adjusted_remaining_reads,
+                                subsampledReadsCount: pipeline_run.subsampled_reads)
       json_dump =
         JSON.dump(
-          pipelineRunInfo: pipeline_run_info,
-          metadata: {
-            backgroundId: @background_id,
-            truncatedReadsCount: pipeline_run.truncated,
-            adjustedRemainingReadsCount: pipeline_run.adjusted_remaining_reads,
-            subsampledReadsCount: pipeline_run.subsampled_reads,
-          }.compact,
+          metadata: metadata.compact,
           counts: counts_by_tax_level,
           lineage: structured_lineage,
           sortedGenus: sorted_genus_tax_ids,

--- a/spec/services/pipeline_report_service_spec.rb
+++ b/spec/services/pipeline_report_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe PipelineReportService, type: :service do
       # have NT and NR reads in both the sample and the background model.
       @pipeline_run = create(:pipeline_run,
                              sample: create(:sample, project: create(:project)),
+                             job_status: "CHECKED",
                              total_reads: 1122,
                              adjusted_remaining_reads: 316,
                              subsample: 1_000_000,
@@ -151,6 +152,7 @@ RSpec.describe PipelineReportService, type: :service do
       # the highest aggregate score of all the species within the genus.
       @pipeline_run = create(:pipeline_run,
                              sample: create(:sample, project: create(:project)),
+                             job_status: "CHECKED",
                              total_reads: 1122,
                              adjusted_remaining_reads: 316,
                              subsample: 1_000_000,
@@ -316,6 +318,7 @@ RSpec.describe PipelineReportService, type: :service do
 
       @pipeline_run = create(:pipeline_run,
                              sample: create(:sample, project: create(:project)),
+                             job_status: "CHECKED",
                              total_reads: 1125,
                              adjusted_remaining_reads: 315,
                              subsample: 1_000_000,


### PR DESCRIPTION
# Description

Add the alerts/statuses for samples that are in progress, failed, or completed with issues to the new report page. Example screenshots of these states below:

![Screen Shot 2019-11-26 at 1 12 55 PM](https://user-images.githubusercontent.com/53838890/69683885-40078080-106b-11ea-860c-259a7fda8a4a.png)
![Screen Shot 2019-11-26 at 1 12 35 PM](https://user-images.githubusercontent.com/53838890/69683882-3d0c9000-106b-11ea-969d-fde62a2d7a19.png)
![Screen Shot 2019-11-26 at 1 51 45 PM](https://user-images.githubusercontent.com/53838890/69683887-4138ad80-106b-11ea-9488-e56fef496181.png)
![Screen Shot 2019-11-26 at 2 54 45 PM](https://user-images.githubusercontent.com/53838890/69683889-4269da80-106b-11ea-9663-89af71554c3c.png)
![Screen Shot 2019-11-26 at 3 26 30 PM](https://user-images.githubusercontent.com/53838890/69683892-44339e00-106b-11ea-9eec-bb8f66f3d94a.png)
![Screen Shot 2019-11-26 at 1 12 46 PM](https://user-images.githubusercontent.com/53838890/69683884-3e3dbd00-106b-11ea-9699-1429634183a8.png)

# Notes

* Most of the `renderSampleMessage` [code](https://github.com/chanzuckerberg/idseq-web/blob/476581d1259c0e8eee4b54e38ae26fda58ee9774/app/assets/src/components/views/SampleView/SampleView.jsx#L305) and [styling](https://github.com/chanzuckerberg/idseq-web/blob/476581d1259c0e8eee4b54e38ae26fda58ee9774/app/assets/src/components/views/SampleView/sample_view.scss#L109) was migrated over from the old version of the report page. The styles were replaced with existing spacing variables where possible.

* Samples in the `waiting` status will occasionally throw the following error... It seems that the `rawReportData` isn't fetched so the `pipelineRunInfo` fails to be populated. The error seems to be intermittent, since it appears/disappears when refreshing. Currently investigating, fix may come in a future PR.
![image](https://user-images.githubusercontent.com/53838890/69762144-39861100-111e-11ea-9713-62d58f7e432e.png)


# Tests

* Verified that samples in various states of in progress, completed, or failed displayed alerts as expected.
* Verified that links in the alerts direct users to the expected page.
