### PR TITLE
[Report Page] Add analytics

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -5,7 +5,7 @@ import { getOr, map, orderBy } from "lodash/fp";
 import { Table } from "~/components/visualizations/table";
 import { defaultTableRowRenderer } from "react-virtualized";
 import cx from "classnames";
-import { withAnalytics } from "~/api/analytics";
+import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import TableRenderers from "~/components/views/discovery/TableRenderers";
 import InsightIcon from "~ui/icons/InsightIcon";
 import { getCategoryAdjective } from "~/components/views/report/utils/taxon";
@@ -326,13 +326,29 @@ class ReportTable extends React.Component {
       <div className={cs.stack}>
         <div
           className={cx(cs.stackElement, dbType == "nt" || cs.lowlightValue)}
-          onClick={onClick ? () => onClick[0]("nt") : null}
+          onClick={
+            onClick
+              ? () =>
+                  withAnalytics(
+                    onClick[0]("nt"),
+                    "ReportTable_count-type-nt_clicked"
+                  )
+              : null
+          }
         >
           {cellData ? cellData[0] : "-"}
         </div>
         <div
           className={cx(cs.stackElement, dbType == "nr" || cs.lowlightValue)}
-          onClick={onClick ? () => onClick[1]("nr") : null}
+          onClick={
+            onClick
+              ? () =>
+                  withAnalytics(
+                    onClick[1]("nr"),
+                    "ReportTable_count-type-nr_clicked"
+                  )
+              : null
+          }
         >
           {cellData ? cellData[1] : "-"}
         </div>
@@ -363,6 +379,10 @@ class ReportTable extends React.Component {
     // Uses lodash's orderBy function.
     // It uses a triple sorting key that enables nested sorting of genus and species, while guaranteeing that
     // genus is always on top of its children species
+    logAnalyticsEvent("PipelineSampleReport_column-sort-arrow_clicked", {
+      path,
+      sortDirection,
+    });
     return orderBy(
       [
         // 1st value: value defined by path for the genus (guarantees all genus together)

--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -301,7 +301,7 @@ class ReportTable extends React.Component {
   };
 
   renderNtNrDecimalValues = ({ cellData, decimalPlaces }) => {
-    return this.renderNtNrValues({
+    return this.renderNtNrStack({
       cellData: cellData.map(val =>
         TableRenderers.formatNumberWithCommas(
           Number(val).toFixed(decimalPlaces || 0)
@@ -311,44 +311,40 @@ class ReportTable extends React.Component {
   };
 
   renderNtNrSelector = () => {
-    return this.renderNtNrValues({
+    return this.renderNtNrStack({
       cellData: ["NT", "NR"],
       onClick: [
-        () => this.handleNtNrChange("nt"),
-        () => this.handleNtNrChange("nr"),
+        withAnalytics(
+          () => this.handleNtNrChange("nt"),
+          "ReportTable_count-type_clicked",
+          {
+            countType: "NT",
+          }
+        ),
+        withAnalytics(
+          () => this.handleNtNrChange("nr"),
+          "ReportTable_count-type_clicked",
+          {
+            countType: "NR",
+          }
+        ),
       ],
     });
   };
 
-  renderNtNrValues = ({ cellData, onClick }) => {
+  renderNtNrStack = ({ cellData, onClick }) => {
     const { dbType } = this.state;
     return (
       <div className={cs.stack}>
         <div
           className={cx(cs.stackElement, dbType == "nt" || cs.lowlightValue)}
-          onClick={
-            onClick
-              ? () =>
-                  withAnalytics(
-                    onClick[0]("nt"),
-                    "ReportTable_count-type-nt_clicked"
-                  )
-              : null
-          }
+          onClick={onClick ? () => onClick[0]("nt") : null}
         >
           {cellData ? cellData[0] : "-"}
         </div>
         <div
           className={cx(cs.stackElement, dbType == "nr" || cs.lowlightValue)}
-          onClick={
-            onClick
-              ? () =>
-                  withAnalytics(
-                    onClick[1]("nr"),
-                    "ReportTable_count-type-nr_clicked"
-                  )
-              : null
-          }
+          onClick={onClick ? () => onClick[1]("nr") : null}
         >
           {cellData ? cellData[1] : "-"}
         </div>

--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -342,14 +342,14 @@ class ReportTable extends React.Component {
           () => this.handleNtNrChange("nt"),
           "ReportTable_count-type_clicked",
           {
-            countType: "NT",
+            countType: "nt",
           }
         ),
         withAnalytics(
           () => this.handleNtNrChange("nr"),
           "ReportTable_count-type_clicked",
           {
-            countType: "NR",
+            countType: "nr",
           }
         ),
       ],

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -107,7 +107,8 @@ export default class SampleViewV2 extends React.Component {
     logAnalyticsEvent("PipelineSampleReport_sample_viewed", {
       sampleId: this.props.sampleId,
     });
-    // DEPRECATED: kept for continuity
+    // DEPRECATED: kept temporarily for continuity
+    // TODO (written 12/2/19): remove after v2 of the report page has been active for 3 months.
     logAnalyticsEvent(ANALYTICS_EVENT_NAMES.sampleViewed, {
       sampleId: this.props.sampleId,
     });

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -31,7 +31,11 @@ import {
 import { getAmrData } from "~/api/amr";
 import { UserContext } from "~/components/common/UserContext";
 import { AMR_TABLE_FEATURE } from "~/components/utils/features";
-import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
+import {
+  logAnalyticsEvent,
+  withAnalytics,
+  ANALYTICS_EVENT_NAMES,
+} from "~/api/analytics";
 import { sampleErrorInfo } from "~/components/utils/sample";
 import DetailsSidebar from "~/components/common/DetailsSidebar";
 import NarrowContainer from "~/components/layout/NarrowContainer";
@@ -99,6 +103,14 @@ export default class SampleViewV2 extends React.Component {
     this.fetchSample();
     this.fetchBackgrounds();
     this.fetchSampleReportData();
+
+    logAnalyticsEvent("PipelineSampleReport_sample_viewed", {
+      sampleId: this.props.sampleId,
+    });
+    // DEPRECATED: kept for continuity
+    logAnalyticsEvent(ANALYTICS_EVENT_NAMES.sampleViewed, {
+      sampleId: this.props.sampleId,
+    });
   };
 
   componentDidUpdate() {
@@ -816,7 +828,10 @@ export default class SampleViewV2 extends React.Component {
           <div className={cs.reportTable}>
             <ReportTable
               data={filteredReportData}
-              onTaxonNameClick={this.handleTaxonClick}
+              onTaxonNameClick={withAnalytics(
+                this.handleTaxonClick,
+                "PipelineSampleReport_taxon-sidebar-link_clicked"
+              )}
             />
           </div>
         </div>


### PR DESCRIPTION
# Description

Add back some analytics to the new report page that were missing after the refactor.

# Notes

A second pass should be done to make sure all analytics were carried over once all the features are in. Analytics that are known to be missing since they're dependent on features in pending/future PRs:
* row actions
* switching between table/tree view