### PR TITLE
[Release fix] Alter contig taxid migration to include indices and use bulk mode.

### DIFF
--- a/db/migrate/20191126004333_add_species_tax_id_to_contigs.rb
+++ b/db/migrate/20191126004333_add_species_tax_id_to_contigs.rb
@@ -2,9 +2,12 @@ class AddSpeciesTaxIdToContigs < ActiveRecord::Migration[5.1]
   def change
     # Do NOT add a default value.
     # Adding a default value can cause the migration to take a long time, because each row must be modified.
-    add_column :contigs, :species_taxid_nt, :integer
-    add_column :contigs, :species_taxid_nr, :integer
-    add_column :contigs, :genus_taxid_nt, :integer
-    add_column :contigs, :genus_taxid_nr, :integer
+    change_table :contigs, bulk: true do |t|
+      t.integer :species_taxid_nt, :species_taxid_nr, :genus_taxid_nt, :genus_taxid_nr
+      t.index ["pipeline_run_id", "species_taxid_nt"]
+      t.index ["pipeline_run_id", "species_taxid_nr"]
+      t.index ["pipeline_run_id", "genus_taxid_nt"]
+      t.index ["pipeline_run_id", "genus_taxid_nr"]
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -116,8 +116,12 @@ ActiveRecord::Schema.define(version: 20_191_126_004_333) do
     t.integer "species_taxid_nr"
     t.integer "genus_taxid_nt"
     t.integer "genus_taxid_nr"
+    t.index ["pipeline_run_id", "genus_taxid_nr"], name: "index_contigs_on_pipeline_run_id_and_genus_taxid_nr"
+    t.index ["pipeline_run_id", "genus_taxid_nt"], name: "index_contigs_on_pipeline_run_id_and_genus_taxid_nt"
     t.index ["pipeline_run_id", "name"], name: "index_contigs_on_pipeline_run_id_and_name", unique: true
     t.index ["pipeline_run_id", "read_count"], name: "index_contigs_on_pipeline_run_id_and_read_count"
+    t.index ["pipeline_run_id", "species_taxid_nr"], name: "index_contigs_on_pipeline_run_id_and_species_taxid_nr"
+    t.index ["pipeline_run_id", "species_taxid_nt"], name: "index_contigs_on_pipeline_run_id_and_species_taxid_nt"
   end
 
   create_table "ercc_counts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
# Description

The original migration did not use bulk mode and did not include indices.

# Notes

Tested the impact of indices on the migration time on staging:
* Without bulk mode, it was around 800s.
* With bulk mode, it was 210s.
* With bulk mode plus indices, it was 230s.

This migration has been successfully applied on staging (via a rollback and re-migration).

Planning to apply this migration in prod in isolation via a hot fix before the rest of the staging release rolls out, as the migration may cause downtime. 