### PR TITLE
[Hot fix] Add taxid columns to contig table with indices and bulk mode.

### DIFF
--- a/db/migrate/20191126004333_add_species_tax_id_to_contigs.rb
+++ b/db/migrate/20191126004333_add_species_tax_id_to_contigs.rb
@@ -1,0 +1,13 @@
+class AddSpeciesTaxIdToContigs < ActiveRecord::Migration[5.1]
+  def change
+    # Do NOT add a default value.
+    # Adding a default value can cause the migration to take a long time, because each row must be modified.
+    change_table :contigs, bulk: true do |t|
+      t.integer :species_taxid_nt, :species_taxid_nr, :genus_taxid_nt, :genus_taxid_nr
+      t.index ["pipeline_run_id", "species_taxid_nt"]
+      t.index ["pipeline_run_id", "species_taxid_nr"]
+      t.index ["pipeline_run_id", "genus_taxid_nt"]
+      t.index ["pipeline_run_id", "genus_taxid_nr"]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_023_235_303) do
+ActiveRecord::Schema.define(version: 20_191_126_004_333) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -112,8 +112,16 @@ ActiveRecord::Schema.define(version: 20_191_023_235_303) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "lineage_json"
+    t.integer "species_taxid_nt"
+    t.integer "species_taxid_nr"
+    t.integer "genus_taxid_nt"
+    t.integer "genus_taxid_nr"
+    t.index ["pipeline_run_id", "genus_taxid_nr"], name: "index_contigs_on_pipeline_run_id_and_genus_taxid_nr"
+    t.index ["pipeline_run_id", "genus_taxid_nt"], name: "index_contigs_on_pipeline_run_id_and_genus_taxid_nt"
     t.index ["pipeline_run_id", "name"], name: "index_contigs_on_pipeline_run_id_and_name", unique: true
     t.index ["pipeline_run_id", "read_count"], name: "index_contigs_on_pipeline_run_id_and_read_count"
+    t.index ["pipeline_run_id", "species_taxid_nr"], name: "index_contigs_on_pipeline_run_id_and_species_taxid_nr"
+    t.index ["pipeline_run_id", "species_taxid_nt"], name: "index_contigs_on_pipeline_run_id_and_species_taxid_nt"
   end
 
   create_table "ercc_counts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
# Description
A hot fix which will allow us to perform a schema migration in prod.
This migration is a part of the upcoming staging release, and we are doing the migration in advance and in isolation so the server downtime is during the holidays.

# Tests
This migration succeeded on staging and took 230s to complete. We estimate a few hours to complete the migration on prod.
