### PR TITLE
Enable/redirect users with report_v2 flag to new report page

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
@@ -92,6 +92,15 @@ export default function SampleViewHeader({
             }}
           />
         </div>
+        {/* Temporary link to legacy view of report page.
+        TODO: Remove when v2 of report page is enabled for everyone. */}
+        {sample && (
+          <span className={cs.legacyLink}>
+            <a href={`/samples/${sample.id}/legacy`}>
+              | View legacy report page.
+            </a>
+          </span>
+        )}
         <ViewHeader.Pretitle
           breadcrumbLink={project && `/home?project_id=${project.id}`}
         >

--- a/app/assets/src/components/views/SampleViewV2/sample_view_header.scss
+++ b/app/assets/src/components/views/SampleViewV2/sample_view_header.scss
@@ -7,6 +7,7 @@
 
   .pipelineInfo {
     @include font-body-xxxs;
+    display: inline-block;
 
     color: $medium-grey;
     margin-top: 14px;
@@ -25,6 +26,15 @@
   .linkToPipelineViz {
     cursor: pointer;
 
+    &:hover {
+      color: $primary-light;
+    }
+  }
+
+  .legacyLink {
+    @include font-body-xxxs;
+    color: $medium-grey;
+    padding-left: 2px;
     &:hover {
       color: $primary-light;
     }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -48,7 +48,7 @@ class SamplesController < ApplicationController
   before_action :check_owner, only: OWNER_ACTIONS
   before_action :check_access
   before_action only: :show_v2 do
-    allowed_feature_required("report_v2", true)
+    allowed_feature_required("report_v2")
   end
   before_action only: :amr do
     allowed_feature_required("AMR")
@@ -688,7 +688,7 @@ class SamplesController < ApplicationController
   # GET /samples/1
   # GET /samples/1.json
   def show
-    if !params[:legacy] && (current_user.admin? || current_user.allowed_feature_list.include?("report_v2"))
+    if !params[:legacy] && current_user.allowed_feature_list.include?("report_v2")
       show_v2
     else
       @pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -20,7 +20,7 @@ class SamplesController < ApplicationController
   ##########################################
 
   # Read action meant for single samples with set_sample before_action
-  READ_ACTIONS = [:show, :show_v2, :report_v2, :report_info, :report_csv, :report_csv_v2, :assembly, :show_taxid_fasta, :nonhost_fasta, :unidentified_fasta,
+  READ_ACTIONS = [:show, :show_v2, :report_v2, :legacy, :report_info, :report_csv, :report_csv_v2, :assembly, :show_taxid_fasta, :nonhost_fasta, :unidentified_fasta,
                   :contigs_fasta, :contigs_fasta_by_byteranges, :contigs_sequences_by_byteranges, :contigs_summary,
                   :results_folder, :show_taxid_alignment, :show_taxid_alignment_viz, :metadata, :amr,
                   :contig_taxid_list, :taxid_contigs, :summary_contig_counts, :coverage_viz_summary, :coverage_viz_data,].freeze
@@ -48,7 +48,7 @@ class SamplesController < ApplicationController
   before_action :check_owner, only: OWNER_ACTIONS
   before_action :check_access
   before_action only: :show_v2 do
-    allowed_feature_required("report_v2")
+    allowed_feature_required("report_v2", true)
   end
   before_action only: :amr do
     allowed_feature_required("AMR")
@@ -680,56 +680,65 @@ class SamplesController < ApplicationController
     end
   end
 
+  # GET /samples/1/legacy
+  def legacy
+    redirect_to action: "show", legacy: true
+  end
+
   # GET /samples/1
   # GET /samples/1.json
   def show
-    @pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
-    @amr_counts = nil
-    can_see_amr = (current_user.admin? || current_user.allowed_feature_list.include?("AMR"))
-    if can_see_amr && @pipeline_run
-      amr_state = @pipeline_run.output_states.find_by(output: "amr_counts")
-      if amr_state.present? && amr_state.state == PipelineRun::STATUS_LOADED
-        @amr_counts = @pipeline_run.amr_counts
+    if !params[:legacy] && (current_user.admin? || current_user.allowed_feature_list.include?("report_v2"))
+      show_v2
+    else
+      @pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
+      @amr_counts = nil
+      can_see_amr = (current_user.admin? || current_user.allowed_feature_list.include?("AMR"))
+      if can_see_amr && @pipeline_run
+        amr_state = @pipeline_run.output_states.find_by(output: "amr_counts")
+        if amr_state.present? && amr_state.state == PipelineRun::STATUS_LOADED
+          @amr_counts = @pipeline_run.amr_counts
+        end
       end
+      @pipeline_version = @pipeline_run.report_info_params[:pipeline_version] if @pipeline_run
+      @pipeline_versions = @sample.pipeline_versions
+
+      @pipeline_run_display = curate_pipeline_run_display(@pipeline_run)
+      @sample_status = @pipeline_run ? @pipeline_run.job_status_display : 'Waiting to Start or Receive Files'
+      pipeline_run_id = @pipeline_run ? @pipeline_run.id : nil
+      job_stats_hash = job_stats_get(pipeline_run_id)
+      @summary_stats = job_stats_hash.present? ? get_summary_stats(job_stats_hash, @pipeline_run) : nil
+      @project_info = @sample.project ? @sample.project : nil
+      @project_sample_ids_names = @sample.project ? Hash[current_power.project_samples(@sample.project).map { |s| [s.id, s.name] }] : nil
+      @host_genome = @sample.host_genome ? @sample.host_genome : nil
+      @background_models = current_power.backgrounds.where(ready: 1)
+      @can_edit = current_power.updatable_sample?(@sample)
+      @git_version = ENV['GIT_VERSION'] || ""
+
+      @align_viz = false
+      align_summary_file = @pipeline_run ? "#{@pipeline_run.alignment_viz_output_s3_path}.summary" : nil
+      @align_viz = true if align_summary_file && get_s3_file(align_summary_file)
+
+      background_id = get_background_id(@sample)
+      @report_page_params = { pipeline_version: @pipeline_version, background_id: background_id } if background_id
+      @report_page_params[:scoring_model] = params[:scoring_model] if params[:scoring_model]
+
+      # Check if the report table should actually show
+      if background_id && @pipeline_run && @pipeline_run.report_ready?
+        @report_present = true
+        @report_ts = @pipeline_run.report_info_params[:report_ts]
+        @all_categories = ReportHelper::ALL_CATEGORIES
+        @report_details = ReportHelper.report_details(@pipeline_run, current_user.id)
+        @ercc_comparison = @pipeline_run.compare_ercc_counts
+      end
+
+      viz = last_saved_visualization
+      @saved_param_values = viz ? viz.data : {}
+
+      tags = %W[sample_id:#{@sample.id} user_id:#{current_user.id}]
+      # DEPRECATED. Use log_analytics_event.
+      MetricUtil.put_metric_now("samples.showed", 1, tags)
     end
-    @pipeline_version = @pipeline_run.report_info_params[:pipeline_version] if @pipeline_run
-    @pipeline_versions = @sample.pipeline_versions
-
-    @pipeline_run_display = curate_pipeline_run_display(@pipeline_run)
-    @sample_status = @pipeline_run ? @pipeline_run.job_status_display : 'Waiting to Start or Receive Files'
-    pipeline_run_id = @pipeline_run ? @pipeline_run.id : nil
-    job_stats_hash = job_stats_get(pipeline_run_id)
-    @summary_stats = job_stats_hash.present? ? get_summary_stats(job_stats_hash, @pipeline_run) : nil
-    @project_info = @sample.project ? @sample.project : nil
-    @project_sample_ids_names = @sample.project ? Hash[current_power.project_samples(@sample.project).map { |s| [s.id, s.name] }] : nil
-    @host_genome = @sample.host_genome ? @sample.host_genome : nil
-    @background_models = current_power.backgrounds.where(ready: 1)
-    @can_edit = current_power.updatable_sample?(@sample)
-    @git_version = ENV['GIT_VERSION'] || ""
-
-    @align_viz = false
-    align_summary_file = @pipeline_run ? "#{@pipeline_run.alignment_viz_output_s3_path}.summary" : nil
-    @align_viz = true if align_summary_file && get_s3_file(align_summary_file)
-
-    background_id = get_background_id(@sample)
-    @report_page_params = { pipeline_version: @pipeline_version, background_id: background_id } if background_id
-    @report_page_params[:scoring_model] = params[:scoring_model] if params[:scoring_model]
-
-    # Check if the report table should actually show
-    if background_id && @pipeline_run && @pipeline_run.report_ready?
-      @report_present = true
-      @report_ts = @pipeline_run.report_info_params[:report_ts]
-      @all_categories = ReportHelper::ALL_CATEGORIES
-      @report_details = ReportHelper.report_details(@pipeline_run, current_user.id)
-      @ercc_comparison = @pipeline_run.compare_ercc_counts
-    end
-
-    viz = last_saved_visualization
-    @saved_param_values = viz ? viz.data : {}
-
-    tags = %W[sample_id:#{@sample.id} user_id:#{current_user.id}]
-    # DEPRECATED. Use log_analytics_event.
-    MetricUtil.put_metric_now("samples.showed", 1, tags)
   end
 
   def show_v2

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -101,7 +101,7 @@ module ReportsHelper
 
   def self.fake_genus(tax_id, tax_info)
     fake_genus_info = tax_info.clone
-    fake_genus_info[:name] = "Ad hoc bucket for #{tax_info[:name].downcase}"
+    fake_genus_info[:name] = tax_info[:name] ? "Ad hoc bucket for #{tax_info[:name].downcase}" : "Ad hoc bucket for #{tax_id}"
     fake_genus_id = FAKE_GENUS_BASE - tax_id
     fake_genus_info[:genus_tax_id] = fake_genus_id
     fake_genus_info[:tax_level] = TaxonCount::TAX_LEVEL_GENUS

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
     get :show_v2, on: :member
     get :taxa_with_reads_suggestions, on: :collection
     get :uploaded_by_current_user, on: :collection
+    get :legacy, on: :member
   end
 
   get 'samples/:id/fasta/:tax_level/:taxid/:hit_type', to: 'samples#show_taxid_fasta'

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -192,10 +192,10 @@ RSpec.describe SamplesController, type: :controller do
     end
 
     describe "GET show_v2" do
-      it "can see sample report_v2" do
+      it "redirected to home page" do
         sample = create(:sample, project: @project)
         get :show_v2, params: { id: sample.id }
-        expect(response).to have_http_status :success
+        expect(response).to redirect_to(root_path)
       end
     end
   end

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -154,6 +154,21 @@ RSpec.describe SamplesController, type: :controller do
     end
   end
 
+  context "User without report_v2 flag" do
+    before do
+      sign_in @joe
+      @project = create(:project, users: [@joe])
+    end
+
+    describe "GET show_v2" do
+      it "redirected to home page" do
+        sample = create(:sample, project: @project)
+        get :show_v2, params: { id: sample.id }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
   context "User with report_v2 flag" do
     before do
       sign_in @joe
@@ -177,10 +192,10 @@ RSpec.describe SamplesController, type: :controller do
     end
 
     describe "GET show_v2" do
-      it "redirected to home page" do
+      it "can see sample report_v2" do
         sample = create(:sample, project: @project)
         get :show_v2, params: { id: sample.id }
-        expect(response).to redirect_to(root_path)
+        expect(response).to have_http_status :success
       end
     end
   end


### PR DESCRIPTION
# Description

Automatically redirect users with the `report_v2` feature flag to the new report page when viewing a sample.

There is a link at the top of the page to navigate to the legacy version of the report.
![image](https://user-images.githubusercontent.com/53838890/70096865-ebb94f00-15dc-11ea-8f86-27f850942b6b.png)

Users can also view the old version of the report by adding `/legacy` after the sample id in the url, e.g. `/samples/{sample-id}/legacy`.

# Notes

* Minor bug fix in `reports_helper.rb`: check if species name exists before assigning a name to fake genus.

# Tests

* Verify sample report pages display the new version by default.
* Verify adding `/legacy` will bring users to the old version of the report page.
* Verify users without the `report_v2` flag will still see the old report page by default.
* Verify users without the `report_v2` flag will be redirected to the home page if they attempt to access the new report page directly (`/samples/{sample-id}/show_v2`).
