### PR TITLE
Add taxon contig select for selecting taxa for contig bulk download.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -368,6 +368,15 @@ const getTaxaWithReadsSuggestions = (query, sampleIds) =>
     },
   });
 
+// Get autocomplete suggestions for "taxa that have contigs" for a set of samples.
+const getTaxaWithContigsSuggestions = (query, sampleIds) =>
+  get("/samples/taxa_with_contigs_suggestions.json", {
+    params: {
+      query,
+      sampleIds,
+    },
+  });
+
 const uploadedByCurrentUser = async sampleIds => {
   const response = await get("samples/uploaded_by_current_user", {
     params: {
@@ -422,5 +431,6 @@ export {
   validateSampleNames,
   getBackgrounds,
   getTaxaWithReadsSuggestions,
+  getTaxaWithContigsSuggestions,
   uploadedByCurrentUser,
 };

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -26,6 +26,7 @@ import {
 } from "~/api";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 
+import TaxonContigSelect from "./TaxonContigSelect";
 import cs from "./choose_step.scss";
 
 const AUTOCOMPLETE_DEBOUNCE_DELAY = 200;
@@ -101,7 +102,7 @@ class ChooseStep extends React.Component {
     return requiredFields;
   };
 
-  isDownloadValid = () => {
+  isSelectedDownloadValid = () => {
     const { selectedFields } = this.props;
 
     const downloadType = this.getSelectedDownloadType();
@@ -258,6 +259,24 @@ class ChooseStep extends React.Component {
           </div>
         );
         break;
+      case "taxa_with_contigs":
+        return (
+          <div className={cs.field} key={field.type}>
+            <div className={cs.label}>{field.display_name}:</div>
+            <TaxonContigSelect
+              sampleIds={selectedSampleIds}
+              onChange={(value, displayName) => {
+                onFieldSelect(
+                  downloadType.type,
+                  field.type,
+                  value,
+                  displayName
+                );
+              }}
+              value={selectedField}
+            />
+          </div>
+        );
       case "background":
         dropdownOptions = backgroundOptions || [];
         placeholder = backgroundOptions ? "Select background" : "Loading...";
@@ -405,7 +424,7 @@ class ChooseStep extends React.Component {
         </div>
         <div className={cs.footer}>
           <PrimaryButton
-            disabled={!this.isDownloadValid()}
+            disabled={!this.isSelectedDownloadValid()}
             text="Continue"
             onClick={onContinue}
           />

--- a/app/assets/src/components/views/bulk_download/TaxonContigSelect.jsx
+++ b/app/assets/src/components/views/bulk_download/TaxonContigSelect.jsx
@@ -1,0 +1,134 @@
+// Given a set of samples, allows the user to select a taxon that had contigs align to it
+// in at least one of the samples.
+// For each taxon, provides a count of how many of the provided samples had contigs align to that taxon.
+import React from "react";
+import { debounce, orderBy } from "lodash/fp";
+import memoize from "memoize-one";
+
+import { getTaxaWithContigsSuggestions } from "~/api";
+import PropTypes from "~/components/utils/propTypes";
+import Dropdown from "~ui/controls/dropdowns/Dropdown";
+
+import cs from "./taxon_contig_select.scss";
+
+const AUTOCOMPLETE_DEBOUNCE_DELAY = 200;
+
+class TaxonContigSelect extends React.Component {
+  state = {
+    options: null,
+    isLoadingOptions: false,
+  };
+
+  _lastQuery = "";
+
+  handleFilterChange = query => {
+    this.setState({
+      isLoadingOptions: true,
+    });
+
+    this.loadOptionsForQuery(query);
+  };
+
+  // Debounce this function, so it only runs after the user has not typed for a delay.
+  loadOptionsForQuery = debounce(AUTOCOMPLETE_DEBOUNCE_DELAY, async query => {
+    this._lastQuery = query;
+    const { sampleIds } = this.props;
+
+    const searchResults = await getTaxaWithContigsSuggestions(
+      query,
+      Array.from(sampleIds)
+    );
+
+    // If the query has since changed, discard the response.
+    if (query != this._lastQuery) {
+      return;
+    }
+
+    const options = searchResults.map(result => ({
+      value: result.taxid,
+      text: result.title,
+      customNode: (
+        <div className={cs.option}>
+          <div className={cs.taxonName}>{result.title}</div>
+          <div className={cs.fill} />
+          <div className={cs.sampleCount}>{result.sample_count_contigs}</div>
+        </div>
+      ),
+      // Ignored by the dropdown, used for sorting.
+      sampleCount: result.sample_count_contigs,
+    }));
+
+    this.setState({
+      options,
+      isLoadingOptions: false,
+    });
+  });
+
+  sortOptions = memoize(options =>
+    orderBy(["sampleCount", "text"], ["desc", "asc"], options)
+  );
+
+  render() {
+    const { sampleIds, onChange, value, usePortal, withinModal } = this.props;
+    const { options, isLoadingOptions } = this.state;
+
+    const dropdownOptions = [
+      {
+        text: "All Taxon",
+        value: "all",
+        customNode: (
+          <div className={cs.option}>
+            <div className={cs.taxonName}>All taxon</div>
+            <div className={cs.fill} />
+            <div className={cs.sampleCount}>{sampleIds.size}</div>
+          </div>
+        ),
+      },
+      // Note: BareDropdown with search prioritizes prefix matches, so the final ordering of options
+      // might not be the one provided here.
+      ...(this.sortOptions(options) || []),
+    ];
+
+    const optionsHeader = (
+      <div className={cs.optionsHeader}>
+        <div className={cs.header}>Taxa</div>
+        <div className={cs.fill} />
+        <div className={cs.header}>Samples</div>
+      </div>
+    );
+
+    return (
+      <Dropdown
+        fluid
+        placeholder="Select taxa"
+        options={dropdownOptions}
+        onChange={onChange}
+        value={value}
+        optionsHeader={optionsHeader}
+        menuLabel="Select taxa"
+        className={cs.taxaWithContigsDropdown}
+        search
+        onFilterChange={this.handleFilterChange}
+        showNoResultsMessage
+        isLoadingSearchOptions={isLoadingOptions}
+        usePortal={usePortal}
+        withinModal={withinModal}
+      />
+    );
+  }
+}
+
+TaxonContigSelect.propTypes = {
+  sampleIds: PropTypes.instanceOf(Set),
+  onChange: PropTypes.func,
+  value: PropTypes.number, // The currently selected taxid.
+  usePortal: PropTypes.bool,
+  withinModal: PropTypes.bool,
+};
+
+TaxonContigSelect.defaultProps = {
+  usePortal: true,
+  withinModal: true,
+};
+
+export default TaxonContigSelect;

--- a/app/assets/src/components/views/bulk_download/taxon_contig_select.scss
+++ b/app/assets/src/components/views/bulk_download/taxon_contig_select.scss
@@ -1,0 +1,45 @@
+@import "~styles/themes/typography";
+@import "~styles/themes/colors";
+@import "~styles/themes/elements";
+
+.taxaWithContigsDropdown {
+  width: 300px;
+
+  .optionsHeader {
+    display: flex;
+    padding: $space-s $space-m;
+
+    .header {
+      @include font-header-xs-crop;
+      color: $dark-grey;
+    }
+
+    .fill {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+  }
+
+  .option {
+    display: flex;
+    padding: $space-s $space-m;
+
+    .taxonName {
+      @include font-body-xxs-crop;
+      flex-shrink: 1;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    .fill {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+
+    .sampleCount {
+      @include font-body-xxs-crop;
+      color: $medium-grey;
+    }
+  }
+}

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1378,9 +1378,9 @@ class SamplesController < ApplicationController
 
     # User should not be querying for unviewable samples.
     if samples.length != sample_ids.length
-      LogUtil.log_err_and_airbrake("Get taxa with reads error: Unauthorized access of samples")
+      LogUtil.log_err_and_airbrake("Get taxa with contigs error: Unauthorized access of samples")
       render json: {
-        error: "There was an error fetching the taxa with reads for samples.",
+        error: "There was an error fetching the taxa with contigs for samples.",
       }, status: :unauthorized
       return
     end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -29,7 +29,7 @@ class SamplesController < ApplicationController
 
   OTHER_ACTIONS = [:create, :bulk_new, :bulk_upload, :bulk_upload_with_metadata, :bulk_import, :new, :index, :index_v2, :details,
                    :dimensions, :all, :show_sample_names, :cli_user_instructions, :metadata_fields, :samples_going_public,
-                   :search_suggestions, :stats, :upload, :validate_sample_files, :taxa_with_reads_suggestions, :uploaded_by_current_user,].freeze
+                   :search_suggestions, :stats, :upload, :validate_sample_files, :taxa_with_reads_suggestions, :uploaded_by_current_user, :taxa_with_contigs_suggestions,].freeze
   OWNER_ACTIONS = [:raw_results_folder].freeze
   TOKEN_AUTH_ACTIONS = [:create, :update, :bulk_upload, :bulk_upload_with_metadata].freeze
 
@@ -1346,7 +1346,7 @@ class SamplesController < ApplicationController
 
   # GET /samples/taxa_with_reads_suggestions
   # Get taxon search suggestions, where taxa are restricted to the provided sample ids.
-  # Also include, for each taxon, the number of samples that contain the taxon.
+  # Also include, for each taxon, the number of samples that contain reads for the taxon.
   def taxa_with_reads_suggestions
     sample_ids = (params[:sampleIds] || []).map(&:to_i)
     query = params[:query]
@@ -1361,8 +1361,33 @@ class SamplesController < ApplicationController
       return
     end
 
-    taxon_list = taxon_search(query, ["species", "genus"], samples: samples)
+    taxon_list = taxon_search(query, ["species", "genus"])
     taxon_list = augment_taxon_list_with_sample_count(taxon_list, samples)
+    taxon_list = taxon_list.select { |taxon| taxon["sample_count"] > 0 }
+
+    render json: taxon_list
+  end
+
+  # GET /samples/taxa_with_contigs_suggestions
+  # Get taxon search suggestions, where taxa are restricted to the provided sample ids.
+  # Also include, for each taxon, the number of samples that contain contigs for the taxon.
+  def taxa_with_contigs_suggestions
+    sample_ids = (params[:sampleIds] || []).map(&:to_i)
+    query = params[:query]
+    samples = current_power.viewable_samples.where(id: sample_ids)
+
+    # User should not be querying for unviewable samples.
+    if samples.length != sample_ids.length
+      LogUtil.log_err_and_airbrake("Get taxa with reads error: Unauthorized access of samples")
+      render json: {
+        error: "There was an error fetching the taxa with reads for samples.",
+      }, status: :unauthorized
+      return
+    end
+
+    taxon_list = taxon_search(query, ["species", "genus"])
+    taxon_list = augment_taxon_list_with_sample_count_contigs(taxon_list, samples)
+    taxon_list = taxon_list.select { |taxon| taxon["sample_count_contigs"] > 0 }
 
     render json: taxon_list
   end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -11,6 +11,7 @@ class PipelineRun < ApplicationRecord
   accepts_nested_attributes_for :pipeline_run_stages
   has_and_belongs_to_many :backgrounds
   has_and_belongs_to_many :phylo_trees
+  has_and_belongs_to_many :bulk_downloads
 
   has_many :output_states, dependent: :destroy
   has_many :taxon_counts, dependent: :destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
     get :coverage_viz_data, on: :member
     get :show_v2, on: :member
     get :taxa_with_reads_suggestions, on: :collection
+    get :taxa_with_contigs_suggestions, on: :collection
     get :uploaded_by_current_user, on: :collection
     get :legacy, on: :member
   end

--- a/spec/factories/contigs.rb
+++ b/spec/factories/contigs.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :contig do
+  end
+end


### PR DESCRIPTION
# Description

This adds the dropdown for selecting taxa.
![Screen Shot 2019-12-03 at 1 36 58 PM](https://user-images.githubusercontent.com/837004/70092399-1a322c80-15d3-11ea-9d90-3baed753f752.png)

# Notes
* An upcoming refactor will refactor the existing dropdown for selecting taxon for the reads non-host download into its own component. That component is quite similar to this one.

# Tests
* Verified that the select only shows taxon with contigs in the selected samples (as opposed to reads).
* Wrote model and controller tests.
