### PR TITLE
Fix secondary sign-in link

### DIFF
--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -182,7 +182,7 @@ class Landing extends React.Component {
           <div className="form-title">Learn more about IDseq</div>
           {this.props.browserInfo.supported && (
             <div className="form-description">
-              Already have an account? <a href="/users/sign_in">Sign in.</a>
+              Already have an account? <a href="/auth0/login">Sign in.</a>
             </div>
           )}
         </div>


### PR DESCRIPTION
### Description
- Secondary sign-in link was broken on the interest form. Thanks Greg for flagging!

![Screen Shot 2019-12-03 at 1 38 39 PM](https://user-images.githubusercontent.com/5652739/70092230-aa23a680-15d2-11ea-8067-e935f5ccbd96.png)

### Tests
- Link works now.