### PR TITLE
Split out 3rd party JS and CSS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,5 +2,5 @@
 // should contain idseq-written JS and the second file should contain JS from
 // node_modules.
 
-//= require main.bundle.min.js
 //= require vendors~main.bundle.min.js
+//= require main.bundle.min.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,6 @@
+// This file needs to be in sync with webpack.config.prod.js. The first file
+// should contain idseq-written JS and the second file should contain JS from
+// node_modules.
+
 //= require bundle.min
+//= require 1.bundle.min

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,5 +2,5 @@
 // should contain idseq-written JS and the second file should contain JS from
 // node_modules.
 
-//= require bundle.min
-//= require 1.bundle.min
+//= require main.bundle.min.js
+//= require vendors~main.bundle.min.js

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,5 +2,5 @@
 // should contain idseq-written CSS and the second file should contain CSS from
 // node_modules.
 
-//= require bundle.min
-//= require 1.bundle.min
+//= require main.bundle.min.css
+//= require vendors~main.bundle.min.css

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,6 +1,6 @@
 // This file needs to be in sync with webpack.config.prod.js. The first file
 // should contain idseq-written CSS and the second file should contain CSS from
-// node_modules.
+// node_modules. The order of requires is important!
 
-//= require main.bundle.min.css
 //= require vendors~main.bundle.min.css
+//= require main.bundle.min.css

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,1 +1,6 @@
+// This file needs to be in sync with webpack.config.prod.js. The first file
+// should contain idseq-written CSS and the second file should contain CSS from
+// node_modules.
+
 //= require bundle.min
+//= require 1.bundle.min

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -8,7 +8,7 @@ const config = {
   entry: `${path.resolve(__dirname, "app/assets/src/")}/index.jsx`,
   output: {
     path: path.resolve(__dirname, "app/assets/"),
-    filename: "dist/bundle.min.js",
+    filename: "dist/[name].bundle.min.js",
   },
   resolve: {
     extensions: [".js", ".jsx"],
@@ -21,7 +21,7 @@ const config = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "dist/bundle.min.css",
+      filename: "dist/[name].bundle.min.css",
     }),
   ],
   devtool: "source-map",

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -6,14 +6,22 @@ module.exports = merge(commonConfig, {
   devtool: "source-map",
   mode: "production",
   optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          chunks: "all",
+        },
+      },
+    },
     minimizer: [
       new UglifyJsPlugin({
         uglifyOptions: {
-          mangle: false
+          mangle: false,
         },
         parallel: true,
-        sourceMap: true
-      })
-    ]
-  }
+        sourceMap: true,
+      }),
+    ],
+  },
 });

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -8,9 +8,11 @@ module.exports = merge(commonConfig, {
   optimization: {
     splitChunks: {
       cacheGroups: {
+        default: false, // disable default cache group
         vendors: {
           test: /[\\/]node_modules[\\/]/,
           chunks: "all",
+          enforce: true, // always create a chunk
         },
       },
     },


### PR DESCRIPTION
# Description

This splits out 3rd party node_modules js and css for better cache hits rates, both for the client and for the cloudfront CDN. 

The new files loaded are:

![image](https://user-images.githubusercontent.com/28797/70103719-c3d3e680-15f0-11ea-8e2d-85437c1202ac.png)

![image](https://user-images.githubusercontent.com/28797/70103721-c5051380-15f0-11ea-9fd4-0aa94198675c.png)


# Notes

* See https://webpack.js.org/guides/code-splitting/

* resulting files
```
main.bundle.min.css
main.bundle.min.css.map
main.bundle.min.js
main.bundle.min.js.map
vendors~main.bundle.min.css
vendors~main.bundle.min.css.map
vendors~main.bundle.min.js
vendors~main.bundle.min.js.map
```

* There is another level of optimization we could do with code splitting where we only load assets on pages where needed. 

* And there is yet another level of optimization we could do with code splitting where we could split into the optimal number of files for http download. 

# Tests

webpack --config webpack.config.prod.js --verbose

see JS files generated add up to the same total size as before, 6.4 MB

load localhost, see site load normally