### PR TITLE
[Report Page] Fix tag_pathogens

### DIFF
--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -475,23 +475,20 @@ class PipelineReportService
   end
 
   def tag_pathogens(counts_by_tax_level)
-    counts_by_tax_level[TaxonCount::TAX_LEVEL_SPECIES].each do |_species_tax_id, species_info|
-      pathogen_tags = []
-      TaxonLineage::PRIORITY_PATHOGENS.each do |category, pathogen_list|
-        pathogen_tags |= [category] if pathogen_list.include?(species_info[:name])
-      end
-      best_tag = pathogen_tags[0] # first element is highest-priority element (see PRIORITY_PATHOGENS documentation)
-      species_info['pathogenTag'] = best_tag
-    end
-    counts_by_tax_level[TaxonCount::TAX_LEVEL_GENUS].each do |_genus_tax_id, genus_info|
-      pathogen_tags = []
-      TaxonLineage::PRIORITY_PATHOGENS.each do |category, pathogen_list|
-        pathogen_tags |= [category] if pathogen_list.include?(genus_info[:name])
-      end
-      best_tag = pathogen_tags[0] # first element is highest-priority element (see PRIORITY_PATHOGENS documentation)
-      genus_info['pathogenTag'] = best_tag
-    end
+    get_best_pathogen_tag(counts_by_tax_level[TaxonCount::TAX_LEVEL_SPECIES])
+    get_best_pathogen_tag(counts_by_tax_level[TaxonCount::TAX_LEVEL_GENUS])
     counts_by_tax_level
+  end
+
+  def get_best_pathogen_tag(tax_map)
+    tax_map.each do |_tax_id, tax_info|
+      pathogen_tags = []
+      TaxonLineage::PRIORITY_PATHOGENS.each do |category, pathogen_list|
+        pathogen_tags |= [category] if pathogen_list.include?(tax_info[:name])
+      end
+      best_tag = pathogen_tags[0] # first element is highest-priority element (see PRIORITY_PATHOGENS documentation)
+      tax_info['pathogenTag'] = best_tag
+    end
   end
 
   def report_csv(counts, sorted_genus_tax_ids)


### PR DESCRIPTION
# Description

* The new report page was crashing for certain samples.
  *  `tag_pathogens` was checking the entire lineage of a taxon to see any of the names in the lineage were contained in the pathogen list. However, some tax ids for a given pipeline run are missing a taxon lineage defined for the corresponding taxon lineage version (e.g staging pipeline run 10339, tax id 171), so an error would occur.
  * `tag_pathogens` actually doesn't need to check the entire lineage since only species and genus are displayed, so the lineage check was removed to fix the bug.
* Pathogens on the genus level will now also be labelled appropriately. (Previously, all the species within the genus would be labelled rather than the genus row itself.)

![image](https://user-images.githubusercontent.com/53838890/70106179-c38b1980-15f7-11ea-8af1-d14f56dd4826.png)

# Notes

The TaxonLineage issue is also mentioned in [this doc](https://czi.quip.com/u5ajAc1o5Chq/Report-Page-Optimization).

# Tests

* Verified that new report page doesn't crash/load forever.
* Verified that pathogen labels show up on the genus level as expected.
