### PR TITLE
[Report Page] Adapts taxonomic tree view to report page format changes.

### DIFF
--- a/app/assets/src/components/PipelineSampleReport.jsx
+++ b/app/assets/src/components/PipelineSampleReport.jsx
@@ -785,21 +785,27 @@ class PipelineSampleReport extends React.Component {
   downloadFastaUrl = params => {
     const { taxLevel, taxId } = params;
     const pipelineVersion = this.props.reportPageParams.pipeline_version;
-    location.href = `/samples/${this.sampleId}/fasta/${taxLevel}/${taxId}/NT_or_NR?pipeline_version=${pipelineVersion}`;
+    location.href = `/samples/${
+      this.sampleId
+    }/fasta/${taxLevel}/${taxId}/NT_or_NR?pipeline_version=${pipelineVersion}`;
   };
 
   // download Contig
   downloadContigUrl = params => {
     const { taxId } = params;
     const pipelineVersion = this.props.reportPageParams.pipeline_version;
-    location.href = `/samples/${this.sampleId}/taxid_contigs?taxid=${taxId}&pipeline_version=${pipelineVersion}`;
+    location.href = `/samples/${
+      this.sampleId
+    }/taxid_contigs?taxid=${taxId}&pipeline_version=${pipelineVersion}`;
   };
 
   handleCoverageVizClick = params => {
     const { taxId, taxLevel, taxName, taxCommonName } = params;
     const pipelineVersion = this.props.reportPageParams.pipeline_version;
 
-    const alignmentVizUrl = `/samples/${this.sampleId}/alignment_viz/nt_${taxLevel}_${taxId}?pipeline_version=${pipelineVersion}`;
+    const alignmentVizUrl = `/samples/${
+      this.sampleId
+    }/alignment_viz/nt_${taxLevel}_${taxId}?pipeline_version=${pipelineVersion}`;
 
     const speciesTaxons =
       taxLevel === "genus" ? this.genusToSpeciesMap[taxId] : [];
@@ -1257,7 +1263,11 @@ class PipelineSampleReport extends React.Component {
   };
 
   render() {
-    const filter_stats = `${this.state.rows_passing_filters} rows passing the above filters, out of ${this.state.rows_total} total rows.`;
+    const filter_stats = `${
+      this.state.rows_passing_filters
+    } rows passing the above filters, out of ${
+      this.state.rows_total
+    } total rows.`;
 
     let truncation_stats =
       this.report_details && this.report_details.pipeline_info.truncated
@@ -1272,7 +1282,9 @@ class PipelineSampleReport extends React.Component {
       subsampled_reads &&
       subsampled_reads <
         this.report_details.pipeline_info.adjusted_remaining_reads
-        ? `Report values are computed from ${subsampled_reads} reads subsampled randomly from the ${this.report_details.pipeline_info.adjusted_remaining_reads} reads passing host and quality filters.`
+        ? `Report values are computed from ${subsampled_reads} reads subsampled randomly from the ${
+            this.report_details.pipeline_info.adjusted_remaining_reads
+          } reads passing host and quality filters.`
         : "";
     const disable_filter = this.anyFilterSet() ? (
       <span
@@ -1459,7 +1471,7 @@ class RenderMarkup extends React.Component {
           taxa={parent.state.selected_taxons}
           topTaxa={parent.state.topScoringTaxa}
           sample={parent.report_details.sample_info}
-          metric={parent.state.treeMetric}
+          metric={parent.state.treeMetric || "aggregatescore"}
           nameType={parent.props.nameType}
           backgroundData={parent.state.backgroundData}
           onTaxonClick={parent.props.onTaxonClick}

--- a/app/assets/src/components/views/SampleViewV2/ReportFilters.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportFilters.jsx
@@ -222,7 +222,7 @@ class ReportFilters extends React.Component {
             <div className={cs.filterListElement}>
               <MetricPicker
                 options={TREE_METRICS}
-                value={selected.metric}
+                value={selected.metric || TREE_METRICS[0].value}
                 onChange={value =>
                   this.handleFilterChange({
                     key: "metric",

--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -666,7 +666,7 @@ ReportTable.propTypes = {
   rowHeight: PropTypes.number,
 
   // Needed only for hover actions
-  // Consider adding a callback to that render the hover actions
+  // Consider adding a callback to render the hover actions
   alignVizAvailable: PropTypes.bool.isRequired,
   fastaDownloadEnabled: PropTypes.bool.isRequired,
   onCoverageVizClick: PropTypes.func.isRequired,

--- a/app/assets/src/components/views/SampleViewV2/ReportViewSelector.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportViewSelector.jsx
@@ -4,7 +4,7 @@ import { Menu, Icon, Popup } from "semantic-ui-react";
 
 const ReportViewSelector = ({ view, onViewClick }) => {
   return (
-    <Menu icon floated="right" className={cs.tableTreeSelector}>
+    <Menu icon floated="right">
       <Popup
         trigger={
           <Menu.Item

--- a/app/assets/src/components/views/SampleViewV2/ReportViewSelector.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportViewSelector.jsx
@@ -2,8 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Menu, Icon, Popup } from "semantic-ui-react";
 
-import cs from "./report_view_selector.scss";
-
 const ReportViewSelector = ({ view, onViewClick }) => {
   return (
     <Menu icon floated="right" className={cs.tableTreeSelector}>

--- a/app/assets/src/components/views/SampleViewV2/ReportViewSelector.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportViewSelector.jsx
@@ -12,7 +12,7 @@ const ReportViewSelector = ({ view, onViewClick }) => {
           <Menu.Item
             name="table"
             active={view === "table"}
-            onClick={() => onViewClick({ view: "tree" })}
+            onClick={() => onViewClick({ view: "table" })}
           >
             <Icon name="table" />
           </Menu.Item>

--- a/app/assets/src/components/views/SampleViewV2/ReportViewSelector.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportViewSelector.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Menu, Icon, Popup } from "semantic-ui-react";
+
+import cs from "./report_view_selector.scss";
+
+const ReportViewSelector = ({ view, onViewClick }) => {
+  return (
+    <Menu icon floated="right" className={cs.tableTreeSelector}>
+      <Popup
+        trigger={
+          <Menu.Item
+            name="table"
+            active={view === "table"}
+            onClick={() => onViewClick({ view: "tree" })}
+          >
+            <Icon name="table" />
+          </Menu.Item>
+        }
+        content="Table View"
+        inverted
+      />
+
+      <Popup
+        trigger={
+          <Menu.Item
+            name="tree"
+            active={view === "tree"}
+            onClick={() => onViewClick({ view: "tree" })}
+          >
+            <Icon name="fork" />
+          </Menu.Item>
+        }
+        content={<div>Taxonomic Tree View</div>}
+        inverted
+      />
+    </Menu>
+  );
+};
+
+ReportViewSelector.defaultProps = {
+  view: "table",
+};
+
+ReportViewSelector.propTypes = {
+  view: PropTypes.oneOf(["table", "tree"]),
+  onViewClick: PropTypes.func,
+};
+
+export default ReportViewSelector;

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -853,7 +853,7 @@ export default class SampleViewV2 extends React.Component {
         }),
       },
       () => {
-        this.persistReportOptions();
+        this.updateHistoryAndPersistOptions();
       }
     );
     logAnalyticsEvent("PipelineSampleReport_clear-filters-link_clicked");

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -947,6 +947,7 @@ export default class SampleViewV2 extends React.Component {
   };
 
   handleViewClick = ({ view }) => {
+    logAnalyticsEvent(`PipelineSampleReport_${view}-view-menu_clicked`);
     this.setState({ view }, () => {
       this.updateHistoryAndPersistOptions();
     });

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -81,8 +81,15 @@ export default class SampleViewV2 extends React.Component {
     super(props);
 
     this.urlParser = new UrlQueryParser(URL_FIELDS);
-    const urlState = this.urlParser.parse(location.search);
-    const localState = this.loadState(localStorage, "SampleViewOptions");
+    // remove nested options to be merge separately
+    const {
+      selectedOptions: selectedOptionsFromUrl,
+      ...nonNestedUrlState
+    } = this.urlParser.parse(location.search);
+    const {
+      selectedOptions: selectedOptionsFromLocal,
+      ...nonNestedLocalState
+    } = this.loadState(localStorage, "SampleViewOptions");
 
     this.state = Object.assign(
       {
@@ -105,10 +112,14 @@ export default class SampleViewV2 extends React.Component {
         sidebarVisible: false,
         sidebarTaxonData: null,
         view: "table",
-        selectedOptions: this.defaultSelectedOptions(),
+        selectedOptions: Object.assign(
+          this.defaultSelectedOptions(),
+          selectedOptionsFromLocal,
+          selectedOptionsFromUrl
+        ),
       },
-      localState,
-      urlState
+      nonNestedLocalState,
+      nonNestedUrlState
     );
   }
 

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -33,17 +33,18 @@ import { UserContext } from "~/components/common/UserContext";
 import { AMR_TABLE_FEATURE } from "~/components/utils/features";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import { sampleErrorInfo } from "~/components/utils/sample";
+import AlertIcon from "~ui/icons/AlertIcon";
+import AMRView from "~/components/AMRView";
+import BacteriaIcon from "~ui/icons/BacteriaIcon";
 import DetailsSidebar from "~/components/common/DetailsSidebar";
+import LoadingIcon from "~/components/ui/icons/LoadingIcon";
 import NarrowContainer from "~/components/layout/NarrowContainer";
 import PropTypes from "~/components/utils/propTypes";
 import ReportTable from "./ReportTable";
 import SampleViewHeader from "./SampleViewHeader";
 import Tabs from "~/components/ui/controls/Tabs";
+import TaxonTreeVis from "./views/TaxonTreeVis";
 import UrlQueryParser from "~/components/utils/UrlQueryParser";
-import AMRView from "~/components/AMRView";
-import BacteriaIcon from "~ui/icons/BacteriaIcon";
-import AlertIcon from "~ui/icons/AlertIcon";
-import LoadingIcon from "~/components/ui/icons/LoadingIcon";
 
 import ReportFilters from "./ReportFilters";
 import cs from "./sample_view_v2.scss";
@@ -212,6 +213,7 @@ export default class SampleViewV2 extends React.Component {
     this.setState({
       reportData,
       reportMetadata: rawReportData.metadata,
+
       filteredReportData,
       selectedOptions: Object.assign({}, selectedOptions, {
         background: rawReportData.metadata.backgroundId,
@@ -813,12 +815,27 @@ export default class SampleViewV2 extends React.Component {
               </span>
             )}
           </div>
-          <div className={cs.reportTable}>
-            <ReportTable
-              data={filteredReportData}
-              onTaxonNameClick={this.handleTaxonClick}
-            />
-          </div>
+          {view == "tree" && (
+            <div>
+              <TaxonTreeVis
+                taxa={filteredReportData}
+                topTaxa={topScoringTaxa}
+                sample={sample}
+                metric={selectedOptions.metric}
+                nameType={selectedOptions.nameType}
+                backgroundData={selectedOptions.background}
+                onTaxonClick={this.handleTaxonClick}
+              />
+            </div>
+          )}
+          {view == "table" && (
+            <div className={cs.reportTable}>
+              <ReportTable
+                data={filteredReportData}
+                onTaxonNameClick={this.handleTaxonClick}
+              />
+            </div>
+          )}
         </div>
       );
     } else {

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -48,13 +48,13 @@ import NarrowContainer from "~/components/layout/NarrowContainer";
 import PropTypes from "~/components/utils/propTypes";
 import SampleViewHeader from "./SampleViewHeader";
 import Tabs from "~/components/ui/controls/Tabs";
-import TaxonTreeVis from "~/components/views/TaxonTreeVis";
 import UrlQueryParser from "~/components/utils/UrlQueryParser";
 
 import { TREE_METRICS } from "./constants";
 import ReportViewSelector from "./ReportViewSelector";
 import ReportFilters from "./ReportFilters";
 import ReportTable from "./ReportTable";
+import TaxonTreeVis from "./TaxonTreeVis";
 import cs from "./sample_view_v2.scss";
 
 const mapValuesWithKey = mapValues.convert({ cap: false });
@@ -106,7 +106,6 @@ export default class SampleViewV2 extends React.Component {
       localState,
       urlState
     );
-    console.log(this.state);
   }
 
   componentDidMount = () => {
@@ -476,13 +475,6 @@ export default class SampleViewV2 extends React.Component {
     if (urlQuery) {
       urlQuery = `?${urlQuery}`;
     }
-    console.log({
-      urlState,
-      localState,
-      URL_FIELDS,
-      state: this.state,
-      urlQuery,
-    });
     history.replaceState(urlState, `SampleView`, `${urlQuery}`);
 
     localStorage.setItem("SampleViewOptions", JSON.stringify(localState));
@@ -490,9 +482,7 @@ export default class SampleViewV2 extends React.Component {
 
   handleOptionChanged = ({ key, value }) => {
     const { selectedOptions } = this.state;
-    console.log("option changed", key, value);
     if (deepEqual(selectedOptions[key], value)) {
-      console.log("returned", selectedOptions[key], value);
       return;
     }
 
@@ -933,7 +923,6 @@ export default class SampleViewV2 extends React.Component {
   };
 
   handleViewClick = ({ view }) => {
-    console.log("view changed?", view);
     this.setState({ view }, () => {
       this.updateHistoryAndPersistOptions();
     });
@@ -983,31 +972,29 @@ export default class SampleViewV2 extends React.Component {
               />
             </div>
           </div>
-          <div className={cs.reportTable}>
-            <ReportTable
-              alignVizAvailable={
-                !!(reportMetadata && reportMetadata.alignVizAvailable)
-              }
-              data={filteredReportData}
-              onCoverageVizClick={this.handleCoverageVizClick}
-              onTaxonNameClick={this.handleTaxonClick}
-              fastaDownloadEnabled={
-                !!(reportMetadata && reportMetadata.hasByteRanges)
-              }
-              phyloTreeAllowed={sample ? sample.editable : false}
-              pipelineVersion={pipelineRun && pipelineRun.pipeline_version}
-              projectId={project && project.id}
-              projectName={project && project.name}
-              sampleId={sample && sample.id}
-            />
-          </div>
+          {view == "table" && (
+            <div className={cs.reportTable}>
+              <ReportTable
+                alignVizAvailable={
+                  !!(reportMetadata && reportMetadata.alignVizAvailable)
+                }
+                data={filteredReportData}
+                onCoverageVizClick={this.handleCoverageVizClick}
+                onTaxonNameClick={this.handleTaxonClick}
+                fastaDownloadEnabled={
+                  !!(reportMetadata && reportMetadata.hasByteRanges)
+                }
+                phyloTreeAllowed={sample ? sample.editable : false}
+                pipelineVersion={pipelineRun && pipelineRun.pipeline_version}
+                projectId={project && project.id}
+                projectName={project && project.name}
+                sampleId={sample && sample.id}
+              />
+            </div>
+          )}
           {view == "tree" && (
             <div>
               <TaxonTreeVis
-                backgroundData={find(
-                  { id: selectedOptions.background },
-                  backgrounds
-                )}
                 lineage={lineageData}
                 metric={selectedOptions.metric}
                 nameType={selectedOptions.nameType}

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -935,7 +935,7 @@ export default class SampleViewV2 extends React.Component {
   handleViewClick = ({ view }) => {
     console.log("view changed?", view);
     this.setState({ view }, () => {
-      this.persistReportOptions();
+      this.updateHistoryAndPersistOptions();
     });
   };
 

--- a/app/assets/src/components/views/SampleViewV2/sample_view_v2.scss
+++ b/app/assets/src/components/views/SampleViewV2/sample_view_v2.scss
@@ -29,22 +29,31 @@
     flex: 1 0 auto;
   }
 
-  .statsRow {
-    @include font-body-xxs;
+  .reportHeader {
+    display: flex;
 
-    color: $medium-grey;
+    .statsRow {
+      @include font-body-xxs;
 
-    .reportInfoMsg {
-      &:not(:first-child) {
-        margin-left: $space-xs;
+      color: $medium-grey;
+      flex: 1 0 auto;
+
+      .reportInfoMsg {
+        &:not(:first-child) {
+          margin-left: $space-xs;
+        }
+      }
+
+      .clearAllFilters {
+        margin-left: $space-s;
+        font-weight: $font-weight-semibold;
+        white-space: nowrap;
+        cursor: pointer;
       }
     }
 
-    .clearAllFilters {
-      margin-left: $space-s;
-      font-weight: $font-weight-semibold;
-      white-space: nowrap;
-      cursor: pointer;
+    .reportViewSelector {
+      flex: 0 0 auto;
     }
   }
 }

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -51,23 +51,21 @@ class TaxonTreeVis extends React.Component {
   }
 
   componentDidMount() {
-    this.treeVis = new TidyTree(
-      this.treeContainer,
-      this.createTree(this.taxa),
-      {
-        attribute: this.metric,
-        useCommonName: this.isCommonNameActive(),
-        onNodeHover: this.handleNodeHover,
-        onNodeLabelClick: this.handleNodeLabelClick,
-        onCreatedTree: this.fillNodeValues,
-        tooltipContainer: this.treeTooltip,
-        onCollapsedStateChange: withAnalytics(
-          this.persistCollapsedInUrl,
-          "TaxonTreeVis_node-collapsed-state_changed"
-        ),
-        collapsed: this.getCollapsedInUrl() || new Set(),
-      }
-    );
+    const tree = this.createTree(this.taxa);
+    console.log("Tree format: ", tree);
+    this.treeVis = new TidyTree(this.treeContainer, tree, {
+      attribute: this.metric,
+      useCommonName: this.isCommonNameActive(),
+      onNodeHover: this.handleNodeHover,
+      onNodeLabelClick: this.handleNodeLabelClick,
+      onCreatedTree: this.fillNodeValues,
+      tooltipContainer: this.treeTooltip,
+      onCollapsedStateChange: withAnalytics(
+        this.persistCollapsedInUrl,
+        "TaxonTreeVis_node-collapsed-state_changed"
+      ),
+      collapsed: this.getCollapsedInUrl() || new Set(),
+    });
     this.treeVis.update();
   }
 

--- a/app/assets/src/components/views/TaxonTreeVis.jsx
+++ b/app/assets/src/components/views/TaxonTreeVis.jsx
@@ -300,7 +300,7 @@ class TaxonTreeVis extends React.Component {
       taxId: nodeData.taxId,
       parentId: parentId,
       scientificName: nodeData.name,
-      lineageRank: "genus",
+      lineageRank: nodeData.taxLevel,
       commonName: nodeData.common_name,
       highlight: nodeData.highlighted,
       values: {
@@ -325,6 +325,9 @@ class TaxonTreeVis extends React.Component {
 
       genusData.filteredSpecies.forEach(speciesData => {
         const speciesLineage = lineage[genusData.taxId] || {};
+        if (speciesData.name === "Hubei mosquito virus 2") {
+          console.log(speciesData.name, speciesData);
+        }
         nodes.push(
           formatNode({
             nodeData: speciesData,
@@ -403,6 +406,7 @@ class TaxonTreeVis extends React.Component {
   }
 
   renderPathogenLabels() {
+    console.log("rendering pathogens", this.taxa);
     return this.taxa.filter(taxon => taxon.pathogenTag).map(taxon => (
       <div
         className={`node-overlay node-overlay__${taxon.tax_id}`}
@@ -422,7 +426,9 @@ class TaxonTreeVis extends React.Component {
             this.treeContainer = container;
           }}
         >
-          <div className="pathogen-labels">{this.renderPathogenLabels()}</div>
+          {this.tree && (
+            <div className="pathogen-labels">{this.renderPathogenLabels()}</div>
+          )}
         </div>
         <div
           className="taxon-tree-vis__tooltip"

--- a/app/assets/src/components/visualizations/TidyTree.js
+++ b/app/assets/src/components/visualizations/TidyTree.js
@@ -228,10 +228,12 @@ export default class TidyTree {
   expandCollapsedWithFewChildrenOrNoName(node) {
     if (!node) return;
 
+    // keep expanding nodes with children that have either (a) few children or (b) no name
     if (
-      !(node.data || {}).name ||
-      (node.collapsedChildren &&
-        node.collapsedChildren.length <= this.options.minNonCollapsableChildren)
+      node.collapsedChildren &&
+      (node.collapsedChildren.length <=
+        this.options.minNonCollapsableChildren ||
+        !(node.data || {}).name)
     ) {
       node.children = (node.children || []).concat(node.collapsedChildren);
       node.collapsedChildren = null;
@@ -521,15 +523,14 @@ export default class TidyTree {
       .select(".clickable")
       .on("click", d => this.toggleCollapseNode(d));
 
-    nodeUpdate
-      .select("circle")
-      .attr(
-        "r",
-        d =>
-          d.data.scientificName || this.hasChildren(d) || d.isAggregated
-            ? nodeScale(d.data.values[this.options.attribute])
-            : 0
-      );
+    nodeUpdate.select("circle").attr(
+      "r",
+      // hide nodes (except root) that do not have name (typically ranks not assigned)
+      d =>
+        !d.parent || d.data.scientificName || this.hasHiddenChildren(d)
+          ? nodeScale(d.data.values[this.options.attribute])
+          : 0
+    );
 
     nodeUpdate.select("path.cross").attr("d", d => {
       let r = nodeScale(d.data.values[this.options.attribute]) * 0.9;

--- a/app/assets/src/components/visualizations/TidyTree.js
+++ b/app/assets/src/components/visualizations/TidyTree.js
@@ -85,11 +85,27 @@ export default class TidyTree {
   }
 
   setTree(nodes) {
+    console.log("nodes", nodes);
     let stratifier = stratify()
       .id(node => node.id)
       .parentId(node => node.parentId);
 
+    // const a = nodes.filter(node => node.id === "_" || node.parentId === "_");
+    // a.forEach(node => {
+    //   if (node.parentId === a[0].id) {
+    //     console.log("vvv HERE vvv");
+    //     console.log("vvv HERE vvv");
+    //     console.log("vvv HERE vvv");
+    //   }
+    //   console.log(`id=${node.id}   parent=${node.parentId}`);
+    //   if (node.parentId === a[0].id) {
+    //     console.log("^^^ HERE ^^^");
+    //     console.log("^^^ HERE ^^^");
+    //     console.log("^^^ HERE ^^^");
+    //   }
+    // })
     this.root = stratifier(nodes);
+    console.log(this.root);
     this.options.onCreatedTree && this.options.onCreatedTree(this.root);
     this.sortAndScaleTree();
 
@@ -119,6 +135,11 @@ export default class TidyTree {
         a.data.values[this.options.attribute]
     );
 
+    console.log(
+      "computing range",
+      this.root,
+      this.root.data.values[this.options.attribute]
+    );
     this.range = [
       Math.min(
         ...this.root.leaves().map(l => l.data.values[this.options.attribute])
@@ -323,6 +344,12 @@ export default class TidyTree {
       this.initialize();
     }
 
+    if (!this.options.attribute) {
+      // eslint-disable-next-line no-console
+      console.error("TidyTree: Option 'attribute' is not defined.");
+      return;
+    }
+
     // adjust dimensions
     let width = this.options.minWidth;
     let height = Math.max(
@@ -342,6 +369,8 @@ export default class TidyTree {
       .attr("height", height + this.margins.top + this.margins.bottom);
 
     d3Tree().size([height, width])(this.root);
+    console.log("attribute", this.options.attribute);
+    console.log("range", this.range);
 
     source = source || this.root;
 
@@ -482,13 +511,16 @@ export default class TidyTree {
         d => (this.hasVisibleChildren(d) ? "baseline" : "middle")
       )
       .style("font-size", d => fontScale(d.data.values[this.options.attribute]))
-      .attr(
-        "dy",
-        d =>
-          this.hasVisibleChildren(d)
-            ? -4 - 1.3 * nodeScale(d.data.values[this.options.attribute])
-            : 0
-      )
+      .attr("dy", d => {
+        // console.log({
+        //   d,
+        //   attribute: this.options.attribute,
+        //   v: d.data.values[this.options.attribute],
+        //   sc: nodeScale(d.data.values[this.options.attribute])});
+        return this.hasVisibleChildren(d)
+          ? -4 - 1.3 * nodeScale(d.data.values[this.options.attribute])
+          : 0;
+      })
       .attr(
         "x",
         d =>

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -496,7 +496,9 @@ class PipelineReportService
         end
       end
       best_tag = pathogen_tags[0] # first element is highest-priority element (see PRIORITY_PATHOGENS documentation)
-      species_info['pathogenTag'] = best_tag
+      if best_tag
+        species_info['pathogenTag'] = best_tag
+      end
     end
     counts_by_tax_level
   end

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -496,7 +496,7 @@ class PipelineReportService
       end
       best_tag = pathogen_tags[0] # first element is highest-priority element (see PRIORITY_PATHOGENS documentation)
       if best_tag
-        species_info['pathogenTag'] = best_tag
+        tax_info['pathogenTag'] = best_tag
       end
     end
   end


### PR DESCRIPTION
# Description

* Create a new version of TaxonTreeVis that format changes.
* New report type (table/tree) selector component
* UI adjustments: 
	- hide uncategorized nodes
	- show non-specific data as in the report

# Notes

* The file: `app/assets/src/components/views/SampleViewV2/TaxonTreeVis.jsx` should be compared against `app/assets/src/components/views/TaxonTreeVis.jsx`. 
	- It made sense for the refactor to make this view a component of SampleViewV2
	- The previous file is going to be deprecated and removed upon release of the new report page

# Tests

* Interact with the page to check: 
	- information showing in the correct levels and matching the report table
	- collapse/expand behavior
	- on hover nodes behavior
	- on click taxon behavior
	- pathogen tags
	- highlighted branches match report