### PR TITLE
Enable mangling in webpack

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -19,7 +19,9 @@ module.exports = merge(commonConfig, {
     minimizer: [
       new UglifyJsPlugin({
         uglifyOptions: {
-          mangle: false,
+          mangle: true,
+          // We need this option for rails react_component.
+          keep_fnames: true,
         },
         parallel: true,
         sourceMap: true,


### PR DESCRIPTION
# Description

On suggestion from @tfrcarvalho , I enabled JS mangling to reduce file size. The change results in a 25% reduction (before gzipping), 5-10% after gzipping.

```
# before
-rw-r--r--  1 gdingle  staff   2.0M Dec  4 10:48 main.bundle.min.js
-rw-r--r--  1 gdingle  staff   414K Dec  4 12:31 main.bundle.min.js.gz
-rw-r--r--  1 gdingle  staff   4.4M Dec  4 10:48 vendors~main.bundle.min.js
-rw-r--r--  1 gdingle  staff   1.1M Dec  4 12:31 vendors~main.bundle.min.js.gz


# after
-rw-r--r--  1 gdingle  staff   1.5M Dec  4 12:25 main.bundle.min.js
-rw-r--r--  1 gdingle  staff   368K Dec  4 12:25 main.bundle.min.js.gz
-rw-r--r--  1 gdingle  staff   3.4M Dec  4 12:25 vendors~main.bundle.min.js
-rw-r--r--  1 gdingle  staff   962K Dec  4 12:25 vendors~main.bundle.min.js.gz
``` 

# Notes

* We may want to turn this on in dev also

# Tests

delete all local files in `/dist`
load site, see error
run webpack
load site, see normal