### PR TITLE
Enable JS code splitting in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,6 +56,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
+  # NOTE: webpack already pre-processes assets so we don't want to rails to.
   config.assets.debug = true
 
   # Suppress logger output for asset requests.

--- a/config/environments/prod.rb
+++ b/config/environments/prod.rb
@@ -30,7 +30,6 @@ Rails.application.configure do
 
   # Don't add an asset compressor here because we already minimize with webpack.
   # Check out webpack.config.prod.js.
-
   config.assets.debug = true
   # Suppress logger output for asset requests.
   config.assets.quiet = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -30,7 +30,6 @@ Rails.application.configure do
 
   # Don't add an asset compressor here because we already minimize with webpack.
   # Check out webpack.config.prod.js.
-
   config.assets.debug = true
   # Suppress logger output for asset requests.
   config.assets.quiet = true

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 // modules that are not compatible with IE11
 const includedNodeModules = ["query-string", "strict-uri-encode"];
@@ -120,6 +121,29 @@ const config = {
           },
         },
       },
+    ],
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        default: false, // disable default cache group
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          chunks: "all",
+          enforce: true, // always create a chunk
+        },
+      },
+    },
+    minimizer: [
+      new UglifyJsPlugin({
+        uglifyOptions: {
+          mangle: true,
+          // We need this option for rails react_component.
+          keep_fnames: true,
+        },
+        parallel: true,
+        sourceMap: true,
+      }),
     ],
   },
 };

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -4,27 +4,4 @@ const commonConfig = require("./webpack.config.common.js");
 module.exports = merge(commonConfig, {
   devtool: "source-map",
   mode: "production",
-  optimization: {
-    splitChunks: {
-      cacheGroups: {
-        default: false, // disable default cache group
-        vendors: {
-          test: /[\\/]node_modules[\\/]/,
-          chunks: "all",
-          enforce: true, // always create a chunk
-        },
-      },
-    },
-    minimizer: [
-      new UglifyJsPlugin({
-        uglifyOptions: {
-          mangle: true,
-          // We need this option for rails react_component.
-          keep_fnames: true,
-        },
-        parallel: true,
-        sourceMap: true,
-      }),
-    ],
-  },
 });

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,5 +1,4 @@
 const merge = require("webpack-merge");
-const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 const commonConfig = require("./webpack.config.common.js");
 
 module.exports = merge(commonConfig, {


### PR DESCRIPTION
# Description

This moves the prod webpack config into common so it is active in local dev.  The bundle splitting should help. 

# Notes

* Another benefit is the simplicity of more shared config so we will catch any config bugs sooner
* Minification is skipped with cheap source maps. See https://webpack.js.org/plugins/uglifyjs-webpack-plugin/#sourcemap . 

# Tests

delete all assets in `dist`
load site, see error
`npm start`
load site, see it working normally

add a `throw` in code
see that source maps work
![image](https://user-images.githubusercontent.com/28797/70181547-f3d5c500-1696-11ea-80d5-9dc3f1274269.png)
