### PR TITLE
Add combined sample taxon results bulk download.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -387,6 +387,8 @@ const uploadedByCurrentUser = async sampleIds => {
   return response.uploaded_by_current_user;
 };
 
+const getHeatmapMetrics = () => get("/visualizations/heatmap_metrics.json");
+
 export {
   bulkImportRemoteSamples,
   bulkUploadRemoteSamples,
@@ -399,6 +401,7 @@ export {
   getContigsSequencesByByteranges,
   getCoverageVizData,
   getCoverageVizSummary,
+  getHeatmapMetrics,
   getPhyloTree,
   getProject,
   getProjectDimensions,

--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -136,7 +136,7 @@ class BulkDownloadModal extends React.Component {
           downloadTypes={bulkDownloadTypes}
           selectedDownloadTypeName={selectedDownloadTypeName}
           onSelect={this.handleSelectDownloadType}
-          selectedFields={selectedFields}
+          selectedFields={get(selectedDownloadTypeName, selectedFields)}
           onFieldSelect={this.handleFieldSelect}
           onContinue={this.handleChooseStepContinue}
           selectedSampleIds={selectedSampleIds}

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -172,6 +172,10 @@ class VisualizationsController < ApplicationController
     }
   end
 
+  def heatmap_metrics
+    render json: HeatmapHelper::ALL_METRICS
+  end
+
   def download_heatmap
     @sample_taxons_dict = HeatmapHelper.sample_taxons_dict(
       params,

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -41,9 +41,12 @@ module BulkDownloadTypesHelper
       category: "report",
       fields: [
         {
-          display_name: "File Format",
-          type: "file_format",
-          options: [".csv", ".biom"],
+          display_name: "Metric",
+          type: "metric",
+        },
+        {
+          display_name: "Background",
+          type: "background",
         },
       ],
       execution_type: RESQUE_EXECUTION_TYPE,

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -9,6 +9,7 @@ module HeatmapHelper
   DEFAULT_TAXON_SORT_PARAM = 'highest_nt_rpm'.freeze
   READ_SPECIFICITY = true
   MINIMUM_READ_THRESHOLD = 5
+  DEFAULT_NUM_RESULTS = 1_000_000
   # Note: this is activated from the heatmap page by selecting "Viruses -
   # Phages". The default categories are all BUT phages, though the UI does not
   # indicate this.
@@ -161,7 +162,7 @@ module HeatmapHelper
     categories,
     read_specificity = READ_SPECIFICITY,
     include_phage = INCLUDE_PHAGE,
-    num_results = 1_000_000,
+    num_results = DEFAULT_NUM_RESULTS,
     min_reads = MINIMUM_READ_THRESHOLD,
     sort_by = DEFAULT_TAXON_SORT_PARAM,
     threshold_filters = [],
@@ -201,6 +202,8 @@ module HeatmapHelper
         )),
         #{ReportHelper::ZSCORE_WHEN_ABSENT_FROM_BACKGROUND})"
 
+    pr_id_to_sample_id = HeatmapHelper.get_latest_pipeline_runs_for_samples(samples)
+
     query = "
     SELECT
       pipeline_run_id,
@@ -229,7 +232,7 @@ module HeatmapHelper
       taxon_counts.tax_level  = taxon_summaries.tax_level       AND
       taxon_counts.tax_id     = taxon_summaries.tax_id
     WHERE
-      pipeline_run_id IN (#{HeatmapHelper.latest_pipeline_runs_query(samples).join(', ')})
+      pipeline_run_id IN (#{pr_id_to_sample_id.keys.join(',')})
       AND genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}
       AND count >= #{min_reads}
       -- We need both types of counts for threshold filters
@@ -257,7 +260,11 @@ module HeatmapHelper
         pr = result_hash[pipeline_run_id]["pr"]
       else
         pr = pipeline_runs_by_id[pipeline_run_id]
-        result_hash[pipeline_run_id] = { "pr" => pr, "taxon_counts" => [] }
+        result_hash[pipeline_run_id] = {
+          "pr" => pr,
+          "taxon_counts" => [],
+          "sample_id" => pr_id_to_sample_id[pipeline_run_id],
+        }
       end
       if pr.total_reads
         z_max = ReportHelper::ZSCORE_MAX
@@ -328,6 +335,8 @@ module HeatmapHelper
     parent_ids = parent_ids.to_a
     parent_ids_clause = parent_ids.empty? ? "" : " OR taxon_counts.tax_id in (#{parent_ids.join(',')}) "
 
+    pr_id_to_sample_id = HeatmapHelper.get_latest_pipeline_runs_for_samples(samples)
+
     # Note: subsample_fraction is of type 'float' so adjusted_total_reads is too
     # Note: stdev is never 0
     # Note: connection.select_all is TWICE faster than TaxonCount.select
@@ -363,7 +372,7 @@ module HeatmapHelper
         taxon_counts.tax_level  = taxon_summaries.tax_level       AND
         taxon_counts.tax_id     = taxon_summaries.tax_id
       WHERE
-        pipeline_run_id IN (#{HeatmapHelper.latest_pipeline_runs_query(samples).join(', ')})
+        pipeline_run_id IN (#{pr_id_to_sample_id.keys.join(',')})
         AND taxon_counts.genus_taxid != #{TaxonLineage::BLACKLIST_GENUS_ID}
         AND taxon_counts.count_type IN ('NT', 'NR')
         AND (taxon_counts.tax_id IN (#{taxon_ids.join(',')})
@@ -492,14 +501,17 @@ module HeatmapHelper
 
   # NOTE: This was extracted from a subquery because mysql was not using the
   # the resulting IDs for an indexed query.
-  def self.latest_pipeline_runs_query(samples)
+  # Return a map of pipeline run id to sample id.
+  def self.get_latest_pipeline_runs_for_samples(samples)
     # not the ideal way to get the current pipeline but it is consistent with
     # current logic elsewhere.
     TaxonCount.connection.select_all(
-      "SELECT MAX(id) AS id
+      "SELECT MAX(id) AS id, sample_id
         FROM pipeline_runs
         WHERE sample_id IN (#{samples.pluck(:id).to_set.to_a.join(',')})
         GROUP BY sample_id"
-    ).pluck("id")
+    )
+              .map { |r| [r["id"], r["sample_id"]] }
+              .to_h
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Rails.application.routes.draw do
   get 'phylo_trees/validate_name', to: 'phylo_trees#validate_name'
 
   get 'visualizations/samples_taxons.json', to: 'visualizations#samples_taxons'
+  get 'visualizations/heatmap_metrics.json', to: 'visualizations#heatmap_metrics'
   get 'visualizations/download_heatmap', to: 'visualizations#download_heatmap'
   post 'visualizations/:type/save', to: 'visualizations#save'
   get 'visualizations/:type(/:id)', to: 'visualizations#visualization'

--- a/spec/helpers/bulk_download_helper_spec.rb
+++ b/spec/helpers/bulk_download_helper_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+require "webmock/rspec"
+
+RSpec.describe BulkDownloadsHelper, type: :helper do
+  describe "#generate_combined_sample_taxon_results_csv" do
+    def get_mock_metric_value(sample_id, tax_id, metric)
+      metrics = ["NT.rpm", "NT.zscore", "NT.r", "NR.rpm", "NR.zscore", "NR.r"]
+      metric_index = metrics.index(metric)
+      10_000 * sample_id + 100 * tax_id + metric_index
+    end
+
+    def generate_fetch_taxon_response(mock_samples, tax_ids)
+      response = {}
+
+      mock_samples.each do |sample|
+        taxon_counts = []
+
+        tax_ids.each do |tax_id|
+          taxon_counts << {
+            "count_type" => "NT",
+            "rpm" => get_mock_metric_value(sample.id, tax_id, "NT.rpm"),
+            "r" => get_mock_metric_value(sample.id, tax_id, "NT.r"),
+            "zscore" => get_mock_metric_value(sample.id, tax_id, "NT.zscore"),
+            "tax_id" => tax_id,
+            "tax_level" => TaxonCount::TAX_LEVEL_SPECIES,
+            "name" => "Test Taxon #{tax_id}",
+          }
+          taxon_counts << {
+            "count_type" => "NR",
+            "rpm" => get_mock_metric_value(sample.id, tax_id, "NR.rpm"),
+            "r" => get_mock_metric_value(sample.id, tax_id, "NR.r"),
+            "zscore" => get_mock_metric_value(sample.id, tax_id, "NR.zscore"),
+            "tax_id" => tax_id,
+            "tax_level" => TaxonCount::TAX_LEVEL_SPECIES,
+            "name" => "Test Taxon #{tax_id}",
+          }
+        end
+
+        response[sample.first_pipeline_run.id] = {
+          "sample_id" => sample.id,
+          "pr" => sample.first_pipeline_run,
+          "taxon_counts" => taxon_counts,
+        }
+      end
+
+      response
+    end
+
+    def generate_expected_csv_str(lines)
+      CSVSafe.generate(headers: true) do |csv|
+        lines.each do |line|
+          csv << line
+        end
+      end
+    end
+
+    let(:mock_background_id) { 123 }
+
+    before do
+      @joe = create(:joe)
+      @project = create(:project, users: [@joe])
+      @sample_one = create(:sample, project: @project, name: "Test Sample 1",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
+      @sample_two = create(:sample, project: @project, name: "Test Sample 2",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
+    end
+
+    it "returns correct values in basic case" do
+      samples = Sample.where(id: [@sample_one.id, @sample_two.id])
+      expect(HeatmapHelper).to receive(:fetch_top_taxons).with(
+        samples,
+        mock_background_id,
+        any_args
+      ).exactly(1).times.and_return(generate_fetch_taxon_response(samples, [1, 2, 3]))
+
+      response = BulkDownloadsHelper.generate_combined_sample_taxon_results_csv(
+        samples, mock_background_id, "NT.rpm"
+      )
+
+      expect(response[:csv_str]).to eq(
+        generate_expected_csv_str([
+                                    ["Taxon Name", "Test Sample 1", "Test Sample 2"],
+                                    ["Test Taxon 1", get_mock_metric_value(@sample_one.id, 1, "NT.rpm"), get_mock_metric_value(@sample_two.id, 1, "NT.rpm")],
+                                    ["Test Taxon 2", get_mock_metric_value(@sample_one.id, 2, "NT.rpm"), get_mock_metric_value(@sample_two.id, 2, "NT.rpm")],
+                                    ["Test Taxon 3", get_mock_metric_value(@sample_one.id, 3, "NT.rpm"), get_mock_metric_value(@sample_two.id, 3, "NT.rpm")],
+                                  ])
+      )
+      expect(response[:failed_sample_ids]).to eq([])
+    end
+
+    it "returns correct values in second basic case" do
+      samples = Sample.where(id: [@sample_one.id, @sample_two.id])
+      expect(HeatmapHelper).to receive(:fetch_top_taxons).with(
+        samples,
+        mock_background_id,
+        any_args
+      ).exactly(1).times.and_return(generate_fetch_taxon_response(samples, [4, 5, 6]))
+
+      response = BulkDownloadsHelper.generate_combined_sample_taxon_results_csv(
+        samples, mock_background_id, "NR.zscore"
+      )
+
+      expect(response[:csv_str]).to eq(
+        generate_expected_csv_str([
+                                    ["Taxon Name", "Test Sample 1", "Test Sample 2"],
+                                    ["Test Taxon 4", get_mock_metric_value(@sample_one.id, 4, "NR.zscore"), get_mock_metric_value(@sample_two.id, 4, "NR.zscore")],
+                                    ["Test Taxon 5", get_mock_metric_value(@sample_one.id, 5, "NR.zscore"), get_mock_metric_value(@sample_two.id, 5, "NR.zscore")],
+                                    ["Test Taxon 6", get_mock_metric_value(@sample_one.id, 6, "NR.zscore"), get_mock_metric_value(@sample_two.id, 6, "NR.zscore")],
+                                  ])
+      )
+      expect(response[:failed_sample_ids]).to eq([])
+    end
+
+    it "filters out homo sapiens taxid" do
+      samples = Sample.where(id: [@sample_one.id, @sample_two.id])
+      expect(HeatmapHelper).to receive(:fetch_top_taxons).with(
+        samples,
+        mock_background_id,
+        any_args
+      ).exactly(1).times.and_return(generate_fetch_taxon_response(samples, [4, 5, ReportHelper::HOMO_SAPIEN_TAX_ID]))
+
+      response = BulkDownloadsHelper.generate_combined_sample_taxon_results_csv(
+        samples, mock_background_id, "NR.zscore"
+      )
+
+      expect(response[:csv_str]).to eq(
+        generate_expected_csv_str([
+                                    ["Taxon Name", "Test Sample 1", "Test Sample 2"],
+                                    ["Test Taxon 4", get_mock_metric_value(@sample_one.id, 4, "NR.zscore"), get_mock_metric_value(@sample_two.id, 4, "NR.zscore")],
+                                    ["Test Taxon 5", get_mock_metric_value(@sample_one.id, 5, "NR.zscore"), get_mock_metric_value(@sample_two.id, 5, "NR.zscore")],
+                                  ])
+      )
+      expect(response[:failed_sample_ids]).to eq([])
+    end
+
+    it "returns samples with no results as failed" do
+      samples = Sample.where(id: [@sample_one.id, @sample_two.id])
+      expect(HeatmapHelper).to receive(:fetch_top_taxons).with(
+        samples,
+        mock_background_id,
+        any_args
+      ).exactly(1).times.and_return(generate_fetch_taxon_response([@sample_one], [4, 5, 6])) # don't generate results for sample two.
+
+      response = BulkDownloadsHelper.generate_combined_sample_taxon_results_csv(
+        samples, mock_background_id, "NR.zscore"
+      )
+
+      expect(response[:csv_str]).to eq(
+        generate_expected_csv_str([
+                                    ["Taxon Name", "Test Sample 1"],
+                                    ["Test Taxon 4", get_mock_metric_value(@sample_one.id, 4, "NR.zscore")],
+                                    ["Test Taxon 5", get_mock_metric_value(@sample_one.id, 5, "NR.zscore")],
+                                    ["Test Taxon 6", get_mock_metric_value(@sample_one.id, 6, "NR.zscore")],
+                                  ])
+      )
+      expect(response[:failed_sample_ids]).to eq([@sample_two.id])
+    end
+
+    it "omits 0s as empty string for rpm and r" do
+      samples = Sample.where(id: [@sample_one.id, @sample_two.id])
+
+      mock_fetch_taxon_response = generate_fetch_taxon_response(samples, [4, 5, 6])
+
+      mock_fetch_taxon_response[@sample_one.first_pipeline_run.id]["taxon_counts"][0]["rpm"] = 0 # Set the NT.rpm of taxid 4 to 0.
+      mock_fetch_taxon_response[@sample_one.first_pipeline_run.id]["taxon_counts"][4]["rpm"] = 0 # Set the NT.rpm of taxid 6 to 0.
+
+      expect(HeatmapHelper).to receive(:fetch_top_taxons).with(
+        samples,
+        mock_background_id,
+        any_args
+      ).exactly(1).times.and_return(mock_fetch_taxon_response)
+
+      response = BulkDownloadsHelper.generate_combined_sample_taxon_results_csv(
+        samples, mock_background_id, "NT.rpm"
+      )
+
+      expect(response[:csv_str]).to eq(
+        generate_expected_csv_str([
+                                    ["Taxon Name", "Test Sample 1", "Test Sample 2"],
+                                    ["Test Taxon 5", get_mock_metric_value(@sample_one.id, 5, "NT.rpm"), get_mock_metric_value(@sample_two.id, 5, "NT.rpm")],
+                                    ["Test Taxon 4", nil, get_mock_metric_value(@sample_two.id, 4, "NT.rpm")],
+                                    ["Test Taxon 6", nil, get_mock_metric_value(@sample_two.id, 6, "NT.rpm")],
+                                  ])
+      )
+      expect(response[:failed_sample_ids]).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
# Description

Add download type with UI and back-end code.

<img width="702" alt="Screen Shot 2019-12-04 at 5 13 53 PM" src="https://user-images.githubusercontent.com/837004/70195089-7c655d00-16b9-11ea-81df-9f6b1f077980.png">

The background field only shows up when a zscore metric is selected.

<img width="806" alt="Screen Shot 2019-12-04 at 5 13 58 PM" src="https://user-images.githubusercontent.com/837004/70195090-7d968a00-16b9-11ea-9b1b-d4e1c93c6eff.png">

# Notes
* Generalized code to handle conditional fields in bulk downloads.
* Changed heatmap results slightly to make it easier to link the returned pipeline runs with the provided samples.
* Generates a single .csv file.

# Tests
* Helper and model tests for back-end.
* Verified that bulk download produces expected results.
* Verify that the heatmap still produces the same results as before (since we changed the heatmap code slightly)
* Verify that conditional fields behave as expected, including validation and resetting of fields.