### PR TITLE
Add contigs non host single taxon bulk download.

### DIFF
--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -467,7 +467,7 @@ describe BulkDownload, type: :model do
     let(:mock_tax_id) { 28_901 }
     let(:mock_tax_level) { 2 }
 
-    it "correctly generates download file for download type reads_non_host for single taxa" do
+    it "correctly generates download file for download type reads_non_host for single taxon" do
       create_taxon_lineage(mock_tax_id)
 
       bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_reads" => {
@@ -487,7 +487,7 @@ describe BulkDownload, type: :model do
       expect(bulk_download.status).to eq(BulkDownload::STATUS_SUCCESS)
     end
 
-    it "correctly handles empty fastas for download type reads_non_host for single taxa" do
+    it "correctly handles empty fastas for download type reads_non_host for single taxon" do
       create_taxon_lineage(mock_tax_id)
 
       bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_reads" => {
@@ -507,7 +507,7 @@ describe BulkDownload, type: :model do
       expect(bulk_download.status).to eq(BulkDownload::STATUS_SUCCESS)
     end
 
-    it "correctly throws exception if taxa_with_reads param not found for download type reads_non_host for single taxa" do
+    it "correctly throws exception if taxa_with_reads param not found for download type reads_non_host for single taxon" do
       create_taxon_lineage(mock_tax_id)
 
       bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, {})
@@ -519,7 +519,7 @@ describe BulkDownload, type: :model do
       expect(bulk_download.status).to eq(BulkDownload::STATUS_ERROR)
     end
 
-    it "correctly throws exception if taxon count not found for download type reads_non_host for single taxa" do
+    it "correctly throws exception if taxon count not found for download type reads_non_host for single taxon" do
       bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_reads" => {
                                              "value" => mock_tax_id,
                                              "displayName" => "Salmonella enterica",
@@ -532,7 +532,7 @@ describe BulkDownload, type: :model do
       expect(bulk_download.status).to eq(BulkDownload::STATUS_ERROR)
     end
 
-    it "correctly generates download file for download type contigs_non_host for single taxa" do
+    it "correctly generates download file for download type contigs_non_host for single taxon" do
       bulk_download = create_bulk_download(BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_contigs" => {
                                              "value" => mock_tax_id,
                                              "displayName" => "Salmonella enterica",

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -532,6 +532,23 @@ describe BulkDownload, type: :model do
       expect(bulk_download.status).to eq(BulkDownload::STATUS_ERROR)
     end
 
+    it "correctly generates download file for download type contigs_non_host for single taxa" do
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_contigs" => {
+                                             "value" => mock_tax_id,
+                                             "displayName" => "Salmonella enterica",
+                                           })
+      allow_any_instance_of(PipelineRun).to receive(:get_contigs_for_taxid).and_return([object_double(Contig.new, to_fa: "mock_contigs_nonhost_fasta")])
+
+      add_s3_tar_writer_expectations(
+        "Test Sample One__project-test_project_#{@project.id}__contigs_nonhost_Salmonella enterica.fasta" => "mock_contigs_nonhost_fasta",
+        "Test Sample Two__project-test_project_#{@project.id}__contigs_nonhost_Salmonella enterica.fasta" => "mock_contigs_nonhost_fasta"
+      )
+
+      bulk_download.generate_download_file
+
+      expect(bulk_download.status).to eq(BulkDownload::STATUS_SUCCESS)
+    end
+
     it "correctly handles individual sample failures" do
       bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, {})
 


### PR DESCRIPTION
# Notes

* Also fix a bug with contigs non-host all taxon bulk download. Execution-type was being misclassified.

# Tests

* Added model test.
* Verified manually that bulk download works as expected.
