### PR TITLE
Fix unmapped reads 2

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1095,7 +1095,7 @@ class PipelineRun < ApplicationRecord
     if unidentified
       unmapped_reads = unidentified[:reads_after]
 
-      if supports_assembly? && finalized?
+      if supports_assembly?
         # see idseq_dag/steps/generate_annotated_fasta.py
         begin
           Rails.logger.info("Fetching file: #{s3_path}")


### PR DESCRIPTION
# Description

The new unmapped reads refinement code did not appear to execute in staging. I guess that was because of the `finalized` condition, which was only put in place as a performance optimization. 

# Notes

* I'm not sure how to test such interactions between pipeline monitor and result monitor locally

# Tests

check logs in staging for "Fetching file" log lines