### PR TITLE
Use execute flag of aegea ecs command when too many samples in bulk d…

### DIFF
--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -297,7 +297,7 @@ describe BulkDownload, type: :model do
       task_command = [
         "aegea", "ecs", "run", "--command=#{mock_shell_command}",
         "--task-role", "idseq-downloads-prod",
-        "--task-name", "bulk_download_#{@bulk_download.id}",
+        "--task-name", BulkDownload::ECS_TASK_NAME,
         "--ecr-image", "idseq-s3-tar-writer:latest",
         "--fargate-cpu", "4096",
         "--fargate-memory", "8192",


### PR DESCRIPTION
…ownload.

# Description

When the number of samples is above the threshold, use the 'execute' flag of `aegea ecs run` to pass the command instead.

There is a max size on the length of the command, which we reach when the number of samples is too high.

The 'execute' flag lets you store your command in a file, and (after some steps) executes your command from the file.

# Tests

* Wrote tests.
* Verified manually that both versions succeed, and aegea indeed uses the execute file when the number of samples exceeds the min threshold.
