### PR TITLE
Add max sample app config field for bulk downloads.

### DIFF
--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -474,7 +474,14 @@ class SamplesView extends React.Component {
 
   handleBulkDownloadModalOpen = () => {
     const { maxSamplesBulkDownload } = this.context || {};
-    if (this.props.selectedSampleIds.size > parseInt(maxSamplesBulkDownload)) {
+    if (!maxSamplesBulkDownload) {
+      this.setState({
+        bulkDownloadButtonTempTooltip:
+          "Unexpected issue. Please contact us for help.",
+      });
+    } else if (
+      this.props.selectedSampleIds.size > parseInt(maxSamplesBulkDownload)
+    ) {
       this.setState({
         bulkDownloadButtonTempTooltip: `No more than ${maxSamplesBulkDownload} samples allowed in one download.`,
       });

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -22,6 +22,7 @@ import { DownloadIconDropdown } from "~ui/controls/dropdowns";
 import { getURLParamString } from "~/helpers/url";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import { ObjectCollectionView } from "../discovery/DiscoveryDataLayer";
+import { UserContext } from "~/components/common/UserContext";
 
 import ToolbarIcon from "./ToolbarIcon";
 import { SAMPLE_TABLE_COLUMNS_V2 } from "./constants";
@@ -35,6 +36,8 @@ class SamplesView extends React.Component {
     this.state = {
       phyloTreeCreationModalOpen: false,
       bulkDownloadModalOpen: false,
+      // This tooltip is reset whenever the selectedSampleIds changes.
+      bulkDownloadButtonTempTooltip: null,
     };
 
     this.columns = [
@@ -139,6 +142,15 @@ class SamplesView extends React.Component {
 
     for (let column of this.columns) {
       column["columnData"] = SAMPLE_TABLE_COLUMNS_V2[column["dataKey"]];
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    // Reset the tooltip whenever the selected samples changes.
+    if (this.props.selectedSampleIds !== prevProps.selectedSampleIds) {
+      this.setState({
+        bulkDownloadButtonTempTooltip: null,
+      });
     }
   }
 
@@ -289,12 +301,14 @@ class SamplesView extends React.Component {
 
   renderBulkDownloadTrigger = () => {
     const { selectedSampleIds } = this.props;
+    const { bulkDownloadButtonTempTooltip } = this.state;
     const downloadIcon = <DownloadIcon className={cx(cs.icon, cs.download)} />;
     return (
       <ToolbarIcon
         className={cs.action}
         icon={downloadIcon}
-        popupText="Download"
+        popperDependencies={[bulkDownloadButtonTempTooltip]}
+        popupText={bulkDownloadButtonTempTooltip || "Download"}
         disabled={selectedSampleIds.size === 0}
         onClick={withAnalytics(
           this.handleBulkDownloadModalOpen,
@@ -359,9 +373,9 @@ class SamplesView extends React.Component {
           {this.renderCollectionTrigger()}
           {this.renderHeatmapTrigger()}
           {this.renderPhyloTreeTrigger()}
-          {this.renderDownloadTrigger()}
-          {allowedFeatures.includes("bulk_downloads") &&
-            this.renderBulkDownloadTrigger()}
+          {allowedFeatures.includes("bulk_downloads")
+            ? this.renderBulkDownloadTrigger()
+            : this.renderDownloadTrigger()}
         </div>
       </div>
     );
@@ -459,7 +473,14 @@ class SamplesView extends React.Component {
   };
 
   handleBulkDownloadModalOpen = () => {
-    this.setState({ bulkDownloadModalOpen: true });
+    const { maxSamplesBulkDownload } = this.context || {};
+    if (this.props.selectedSampleIds.size > parseInt(maxSamplesBulkDownload)) {
+      this.setState({
+        bulkDownloadButtonTempTooltip: `No more than ${maxSamplesBulkDownload} samples allowed in one download.`,
+      });
+    } else {
+      this.setState({ bulkDownloadModalOpen: true });
+    }
   };
 
   handleBulkDownloadModalClose = () => {
@@ -551,5 +572,7 @@ SamplesView.propTypes = {
   selectableIds: PropTypes.array.isRequired,
   selectedSampleIds: PropTypes.instanceOf(Set),
 };
+
+SamplesView.contextType = UserContext;
 
 export default SamplesView;

--- a/app/assets/src/components/views/samples/ToolbarIcon.jsx
+++ b/app/assets/src/components/views/samples/ToolbarIcon.jsx
@@ -17,6 +17,7 @@ class ToolbarIcon extends React.Component {
       disabled,
       onClick,
       icon,
+      popperDependencies,
     } = this.props;
 
     const iconWrapper = (
@@ -43,6 +44,7 @@ class ToolbarIcon extends React.Component {
         }
         position="top center"
         basic={false}
+        popperDependencies={popperDependencies}
       />
     );
   }
@@ -55,6 +57,9 @@ ToolbarIcon.propTypes = {
   popupSubtitle: PropTypes.string,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
+  // The popup will re-render and re-position whenever any value in this array changes.
+  // Allows us to gracefully handle popups with changing content.
+  popperDependencies: PropTypes.arrayOf(PropTypes.any),
 };
 
 export default ToolbarIcon;

--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -28,6 +28,11 @@ class BulkDownloadsController < ApplicationController
       # Max samples check.
       max_samples_allowed = get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD)
 
+      # Max samples should be string containing an integer, but just in case.
+      if max_samples_allowed.nil?
+        raise KICKOFF_FAILURE_HUMAN_READABLE
+      end
+
       if sample_ids.length > Integer(max_samples_allowed)
         raise BulkDownloadsHelper::MAX_SAMPLES_EXCEEDED_ERROR_TEMPLATE % max_samples_allowed
       end

--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -1,6 +1,7 @@
 class BulkDownloadsController < ApplicationController
   include BulkDownloadTypesHelper
   include BulkDownloadsHelper
+  include AppConfigHelper
 
   UPDATE_WITH_TOKEN_ACTIONS = [:success_with_token, :error_with_token, :progress_with_token].freeze
 
@@ -23,6 +24,14 @@ class BulkDownloadsController < ApplicationController
     # Convert sample ids to pipeline run ids.
     begin
       sample_ids = create_params[:sample_ids]
+
+      # Max samples check.
+      max_samples_allowed = get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD)
+
+      if sample_ids.length > Integer(max_samples_allowed)
+        raise BulkDownloadsHelper::MAX_SAMPLES_EXCEEDED_ERROR_TEMPLATE % max_samples_allowed
+      end
+
       # Access control check.
       viewable_samples = current_power.viewable_samples.where(id: sample_ids)
       if viewable_samples.length != sample_ids.length

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,6 +26,7 @@ module ApplicationHelper
     {
       admin: current_user ? current_user.role == 1 : false,
       allowedFeatures: current_user && current_user.allowed_feature_list,
+      maxSamplesBulkDownload: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD),
     }
   end
 

--- a/app/helpers/bulk_downloads_helper.rb
+++ b/app/helpers/bulk_downloads_helper.rb
@@ -4,6 +4,7 @@ module BulkDownloadsHelper
   SAMPLE_NO_PERMISSION_ERROR = "You do not have permission to access all of the selected samples. Please contact us for help.".freeze
   SAMPLE_STILL_RUNNING_ERROR = "Some selected samples have not finished running yet. Please remove these samples and try again.".freeze
   SAMPLE_FAILED_ERROR = "Some selected samples failed their most recent run. Please remove these samples and try again.".freeze
+  MAX_SAMPLES_EXCEEDED_ERROR_TEMPLATE = "No more than %s samples allowed in one download.".freeze
   BULK_DOWNLOAD_NOT_FOUND = "No bulk download was found with this id.".freeze
   OUTPUT_FILE_NOT_SUCCESSFUL = "Bulk download has not succeeded. Can't get output file url.".freeze
   INVALID_ACCESS_TOKEN = "The access token was invalid for this bulk download.".freeze

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -10,4 +10,6 @@ class AppConfig < ApplicationRecord
   # When this is "1", new users will also be created in the Auth0 database.
   # Enable when Auth0 rolls out.
   USE_AUTH0_FOR_NEW_USERS = 'use_auth0_for_new_users'.freeze
+  # The maximum number of samples that can be part of one bulk download.
+  MAX_SAMPLES_BULK_DOWNLOAD = 'max_samples_bulk_download'.freeze
 end

--- a/app/views/home/all_data.html.erb
+++ b/app/views/home/all_data.html.erb
@@ -5,5 +5,5 @@
     projectId: <%= params[:project_id] || "null" %>,
     allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
     mapTilerKey: '<%= ENV["MAPTILER_API_KEY"] %>',
-  }, 'page_content');
+  }, 'page_content', JSON.parse('<%= raw escape_json(user_context)%>'));
 <% end %>

--- a/app/views/home/my_data.html.erb
+++ b/app/views/home/my_data.html.erb
@@ -5,5 +5,5 @@
     projectId: <%= params[:project_id] || "null" %>,
     allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
     mapTilerKey: '<%= ENV["MAPTILER_API_KEY"] %>',
-  }, 'page_content');
+  }, 'page_content', JSON.parse('<%= raw escape_json(user_context)%>'));
 <% end %>

--- a/app/views/home/public.html.erb
+++ b/app/views/home/public.html.erb
@@ -5,5 +5,5 @@
     projectId: <%= params[:project_id] || "null" %>,
     allowedFeatures: JSON.parse('<%= raw escape_json(current_user.allowed_feature_list) %>'),
     mapTilerKey: '<%= ENV["MAPTILER_API_KEY"] %>',
-  }, 'page_content');
+  }, 'page_content', JSON.parse('<%= raw escape_json(user_context)%>'));
 <% end %>


### PR DESCRIPTION
# Description

Adds value in AppConfig for controlling the max samples per bulk download.

If user exceeds max samples, when they try to click on the button, they get a temporary tooltip:

<img width="397" alt="Screen Shot 2019-12-05 at 8 38 20 PM" src="https://user-images.githubusercontent.com/837004/70297308-62537980-17a2-11ea-8ae4-70d7c250e990.png">

Also added validation on the back-end. The user should never get this message (I had to disable the temporary tooltip above to get it), but it verifies that the back-end validation is working.

<img width="701" alt="Screen Shot 2019-12-05 at 8 50 23 PM" src="https://user-images.githubusercontent.com/837004/70297335-7dbe8480-17a2-11ea-9145-e9abd1d6cfa7.png">

# Notes

* Also removed the double download icons on SamplesView, in preparation for launch.

# Tests

* Verified manually that front-end and back-end validation behave as expected.
* Added controller test.
