### PR TITLE
[Release Fix] Fix pipeline run status check

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -965,7 +965,10 @@ export default class SampleViewV2 extends React.Component {
       selectedOptions,
       view,
     } = this.state;
-    if (reportMetadata.pipelineRunStatus === "COMPLETE") {
+    if (
+      reportMetadata.pipelineRunStatus === "COMPLETE" &&
+      !reportMetadata.hasErrors
+    ) {
       return (
         <div className={cs.reportViewContainer}>
           <div className={cs.reportFilters}>

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -967,7 +967,7 @@ export default class SampleViewV2 extends React.Component {
     } = this.state;
     if (
       reportMetadata.pipelineRunStatus === "COMPLETE" &&
-      !reportMetadata.hasErrors
+      reportMetadata.pipelineRunReportAvailable
     ) {
       return (
         <div className={cs.reportViewContainer}>

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -764,7 +764,7 @@ class SamplesController < ApplicationController
               },
             }
           ).merge(
-            default_pipeline_run_id: @sample.first_pipeline_run.id,
+            default_pipeline_run_id: @sample.first_pipeline_run.present? ? @sample.first_pipeline_run.id : nil,
             pipeline_runs: @sample.pipeline_runs_info,
             editable: current_power.updatable_sample?(@sample)
           )

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -112,7 +112,7 @@ class Sample < ApplicationRecord
 
   def pipeline_runs_info
     prvs = {}
-    pipeline_runs.joins(:taxon_counts, :alignment_config).order(created_at: :desc).distinct.each do |pr|
+    pipeline_runs.left_joins(:taxon_counts, :alignment_config).order(created_at: :desc).distinct.each do |pr|
       prvs[pr.pipeline_version] ||= {
         id: pr.id,
         pipeline_version: pr.pipeline_version.nil? ? PipelineRun::PIPELINE_VERSION_WHEN_NULL : pr.pipeline_version,

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -68,7 +68,7 @@ class PipelineReportService
 
   def generate
     pipeline_run, metadata = get_pipeline_status(@pipeline_run_id)
-    unless pipeline_run_succeeded?(pipeline_run)
+    unless pipeline_run_report_available?(pipeline_run)
       return JSON.dump(
         metadata: metadata
       )
@@ -213,6 +213,7 @@ class PipelineReportService
           errorMessage: nil,
           knownUserError: nil,
           jobStatus: "Waiting to Start or Receive Files",
+          pipelineRunReportAvailable: false,
         },
       ]
     end
@@ -232,12 +233,13 @@ class PipelineReportService
         errorMessage: pipeline_run.error_message,
         knownUserError: pipeline_run.known_user_error,
         jobStatus: pipeline_run.job_status_display,
+        pipelineRunReportAvailable: pipeline_run_report_available?(pipeline_run),
       },
     ]
   end
 
-  def pipeline_run_succeeded?(pipeline_run)
-    # This condition is carried over from the previous version of the report page (report_helper.rb ln95).
+  def pipeline_run_report_available?(pipeline_run)
+    # This condition is carried over from the previous version of the report page (report_helper.rb).
     # TODO: review this condition and clean up the implementation of pipeline_run statuses.
     # JIRA: https://jira.czi.team/browse/IDSEQ-1890
     return pipeline_run && (((pipeline_run.adjusted_remaining_reads.to_i > 0 || pipeline_run.finalized?) && !pipeline_run.failed?) || pipeline_run.report_ready?)

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -68,7 +68,7 @@ class PipelineReportService
 
   def generate
     pipeline_run, metadata = get_pipeline_status(@pipeline_run_id)
-    if @pipeline_run_id.nil? || !pipeline_run.completed?
+    unless pipeline_run_succeeded?(pipeline_run)
       return JSON.dump(
         metadata: metadata
       )
@@ -234,6 +234,13 @@ class PipelineReportService
         jobStatus: pipeline_run.job_status_display,
       },
     ]
+  end
+
+  def pipeline_run_succeeded?(pipeline_run)
+    # This condition is carried over from the previous version of the report page (report_helper.rb ln95).
+    # TODO: review this condition and clean up the implementation of pipeline_run statuses.
+    # JIRA: https://jira.czi.team/browse/IDSEQ-1890
+    return pipeline_run && (((pipeline_run.adjusted_remaining_reads.to_i > 0 || pipeline_run.finalized?) && !pipeline_run.failed?) || pipeline_run.report_ready?)
   end
 
   def fetch_taxon_counts(_pipeline_run_id, _background_id)


### PR DESCRIPTION
# Description

The pipeline run status check was incorrect, resulting in an error rather than displaying an alert warning the user that their pipeline run had failed when attempting to view the report page.

# Notes

Related JIRA task for future cleanup of pipeline run statuses: https://jira.czi.team/browse/IDSEQ-1890

# Tests

* Verified that samples with failed pipeline runs now correctly display an alert rather than causing the page to error and crash.
