### PR TITLE
Reduce fetches of unmapped reads count

### DIFF
--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -199,6 +199,7 @@ module PipelineRunsHelper
   end
 
   def check_for_user_error(failed_stage)
+    # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
     return [nil, nil] unless [1, 2].include? failed_stage.step_number
     # We need to set the pipeline version in the failed pipeline run so that the host_filter_output_s3_path includes it,
     # i.e. "/results/3.7" instead of "/results"

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1098,7 +1098,7 @@ class PipelineRun < ApplicationRecord
       unmapped_reads = unidentified[:reads_after]
 
       # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
-      if supports_assembly? && active_stage.step_number == 3 # assembly
+      if supports_assembly? && active_stage && active_stage.step_number == 3 # assembly
         # see idseq_dag/steps/generate_annotated_fasta.py
         begin
           Rails.logger.info("Fetching file: #{s3_path}")

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -334,7 +334,7 @@ class PipelineRun < ApplicationRecord
   end
 
   def active_stage
-    # TODO: (gdingle):
+    # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
     pipeline_run_stages.order(:step_number).each do |prs|
       return prs unless prs.succeeded?
     end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -316,6 +316,7 @@ class PipelineRun < ApplicationRecord
 
   def create_run_stages
     run_stages = []
+    # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
     PipelineRunStage::STAGE_INFO.each do |step_number, info|
       run_stages << PipelineRunStage.new(
         step_number: step_number,
@@ -333,6 +334,7 @@ class PipelineRun < ApplicationRecord
   end
 
   def active_stage
+    # TODO: (gdingle):
     pipeline_run_stages.order(:step_number).each do |prs|
       return prs unless prs.succeeded?
     end
@@ -1095,7 +1097,8 @@ class PipelineRun < ApplicationRecord
     if unidentified
       unmapped_reads = unidentified[:reads_after]
 
-      if supports_assembly?
+      # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
+      if supports_assembly? && active_stage.step_number == 3 # assembly
         # see idseq_dag/steps/generate_annotated_fasta.py
         begin
           Rails.logger.info("Fetching file: #{s3_path}")

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -68,6 +68,7 @@ class PipelineRunStage < ApplicationRecord
   end
 
   def dag_name
+    # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
     STAGE_INFO[step_number][:dag_name]
   end
 

--- a/db/migrate/20171114193014_create_pipeline_run_stages.rb
+++ b/db/migrate/20171114193014_create_pipeline_run_stages.rb
@@ -2,6 +2,7 @@ class CreatePipelineRunStages < ActiveRecord::Migration[5.1]
   def change
     create_table :pipeline_run_stages do |t|
       t.references :pipeline_run, foreign_key: true
+      # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
       t.integer    :step_number
       t.integer    :job_type
       t.string     :job_status

--- a/spec/factories/pipeline_run_stages.rb
+++ b/spec/factories/pipeline_run_stages.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     # Should be one of the four stages:
     # Host Filtering, GSNAPLgcRAPSEARCH alignment,
     # Post Processing, Experimental
+    # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
     step_number { 1 }
     name { PipelineRunStage::HOST_FILTERING_STAGE_NAME }
     job_status { PipelineRunStage::STATUS_SUCCEEDED }

--- a/spec/models/pipeline_run_spec.rb
+++ b/spec/models/pipeline_run_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe PipelineRun, type: :model do
     let(:previous_pipeline_runs_same_version_relation) { instance_double("PipelineRun::ActiveRecord_Relation", to_a: list_of_previous_pipeline_runs_same_version) }
     let(:pipeline_run_stages) do
       [
+        # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
         build_stubbed(:pipeline_run_stage, step_number: 1, job_status: PipelineRunStage::STATUS_SUCCEEDED),
         build_stubbed(:pipeline_run_stage, step_number: 2, job_status: PipelineRunStage::STATUS_SUCCEEDED),
         build_stubbed(:pipeline_run_stage, step_number: 3, job_status: PipelineRunStage::STATUS_FAILED),


### PR DESCRIPTION
# Description

The new refined unmapped count is working in staging, but it is fetching from s3 way more than needed. The result monitor fetched the same file over 100 times. 

After discussion with @boris-dimitrov , I decided to limit the fetching to the stage during which the file is created. 

# Notes

I also added a bunch of TODOs related to https://jira.czi.team/browse/IDSEQ-1912. 

# Tests

In rails console:

Open a stage 3 pr run stage.  
Run `fetch_unmapped_reads`
See fetch .

Open a stage 4 pr run stage.  
Run `fetch_unmapped_reads`
See no fetch.

On deploy to staging, check frequency in logs.

`aegea grep Fetch --start-time=-1d ecs-logs-staging`