### PR TITLE
Protect omniauth_failure endpoint from missing params

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -47,6 +47,9 @@ class Auth0Controller < ApplicationController
   # Handle omniauth errors coming from Auth0.
   def omniauth_failure
     # Error and error_description come from Auth0. Ex: unauthorized and password_expired.
+    unless params["error"] && params["error_description"]
+      LogUtil.log_err_and_airbrake("omniauth_failure called with missing error or error_description")
+    end
     error_type = (params["error"] || "").to_sym
     error_code = (params["error_description"] || "").to_sym
     Rails.logger.info("Auth0 omniauth_failure: #{error_type}: #{error_code}")

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -47,8 +47,8 @@ class Auth0Controller < ApplicationController
   # Handle omniauth errors coming from Auth0.
   def omniauth_failure
     # Error and error_description come from Auth0. Ex: unauthorized and password_expired.
-    error_type = params["error"].to_sym
-    error_code = params["error_description"].to_sym
+    error_type = (params["error"] || "").to_sym
+    error_code = (params["error_description"] || "").to_sym
     Rails.logger.info("Auth0 omniauth_failure: #{error_type}: #{error_code}")
 
     # Display 'unauthorized' errors but go to `failure` endpoint for all others.


### PR DESCRIPTION
### Description
- This should never happen in a deployed env but was encountered in local development. Fixes a potential `nil.to_sym` call which would throw an exception.

### Notes
- In this case, the user will be directed to the `failure` endpoint and logged out.

# Tests
- Visit a link such as: `http://localhost:3000/auth/auth0/callback` and see the redirection.