### PR TITLE
[Report Page] Add caching to new report page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -178,7 +178,7 @@ class ApplicationController < ActionController::Base
     if skip_cache
       yield
     else
-      MetricUtil.log_analytics_event(event_name + "_cache_requested", current_user) unless skip_cache
+      MetricUtil.log_analytics_event(event_name + "_cache-requested", current_user) unless skip_cache
       # This allows 304 Not Modified to be returned so that the client can use its
       # local cache and avoid the large download.
       response.headers["Last-Modified"] = httpdate
@@ -188,7 +188,7 @@ class ApplicationController < ActionController::Base
       Rails.logger.info("Requesting #{cache_key}")
 
       Rails.cache.fetch(cache_key, expires_in: 30.days) do
-        MetricUtil.log_analytics_event(event_name + "_cache_missed", current_user)
+        MetricUtil.log_analytics_event(event_name + "_cache-missed", current_user)
         response.headers["X-IDseq-Cache"] = 'missed'
         yield
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -174,7 +174,12 @@ class ApplicationController < ActionController::Base
     @timer.publish
   end
 
-  def fetch_from_cache(skip_cache, cache_key, httpdate, event_name)
+  # This should wrap a code block whose output should be cached.
+  # If caching is enabled, attempts to fetch the cached response corresponding to the
+  # given cache_key and fills out custom response headers.
+  # If the attempt results in a cache miss, then the response is generated normally and
+  # will be stored in the cache.
+  def fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate, event_name)
     if skip_cache
       yield
     else

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -813,7 +813,7 @@ class SamplesController < ApplicationController
     httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
 
     json =
-      fetch_from_cache(skip_cache, cache_key, httpdate, "pipeline_report") do
+      fetch_from_cache(skip_cache, cache_key, httpdate, "PipelineReport") do
         PipelineReportService.call(pipeline_run, background_id)
       end
     render json: json

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -600,7 +600,7 @@ class SamplesController < ApplicationController
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
     background_id = get_background_id(@sample, params[:background])
     min_contig_size = params[:min_contig_size]
-    @report_csv = PipelineReportService.call(pipeline_run.id, background_id, true, min_contig_size)
+    @report_csv = PipelineReportService.call(pipeline_run, background_id, true, min_contig_size)
     send_data @report_csv, filename: @sample.name + '_report.csv'
   end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -813,7 +813,7 @@ class SamplesController < ApplicationController
     httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
 
     json =
-      fetch_from_cache(skip_cache, cache_key, httpdate, "PipelineReport") do
+      fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate, "PipelineReport") do
         PipelineReportService.call(pipeline_run, background_id)
       end
     render json: json

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -800,19 +800,39 @@ class SamplesController < ApplicationController
 
   def report_v2
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
-    if pipeline_run
-      background_id = get_background_id(@sample, params[:background])
-      render json: PipelineReportService.call(pipeline_run.id, background_id)
-    else
-      render json: {
-        metadata: {
-          pipelineRunStatus: "WAITING",
-          jobStatus: "Waiting to Start or Receive Files",
-          errorMessage: nil,
-          knownUserError: nil,
-        },
-      }
-    end
+    background_id = get_background_id(@sample, params[:background])
+
+    skip_cache = params[:skip_cache] || false
+    MetricUtil.log_analytics_event("samples.cache.requested", current_user) unless skip_cache
+    report_info_params = pipeline_run.report_info_params
+
+    cache_key = PipelineReportService.report_info_cache_key(
+      request.path,
+      params
+        .permit(report_info_params.keys)
+        .merge(pipeline_run_id: pipeline_run.id)
+    )
+
+    json =
+      if skip_cache
+        PipelineReportService.call(pipeline_run, background_id)
+      else
+        # This allows 304 Not Modified to be returned so that the client can use its
+        # local cache and avoid the large download.
+        httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
+        response.headers["Last-Modified"] = httpdate
+        # This is a custom header for testing and debugging
+        response.headers["X-IDseq-Cache"] = 'requested'
+        response.headers["X-IDseq-Cache-Key"] = cache_key
+        Rails.logger.info("Requesting report_info #{cache_key}")
+
+        Rails.cache.fetch(cache_key, expires_in: 30.days) do
+          MetricUtil.log_analytics_event("samples.cache.miss", current_user)
+          response.headers["X-IDseq-Cache"] = 'missed'
+          PipelineReportService.call(pipeline_run, background_id)
+        end
+      end
+    render json: json
   end
 
   def amr

--- a/app/jobs/precache_report_info_v2.rb
+++ b/app/jobs/precache_report_info_v2.rb
@@ -1,0 +1,13 @@
+class PrecacheReportInfoV2
+  @queue = :precache_report_info
+
+  def self.perform(pipeline_run_id)
+    pr = PipelineRun.find(pipeline_run_id)
+    pr.precache_report_info_v2!
+  rescue => err
+    LogUtil.log_err_and_airbrake(
+      "PipelineRun #{pipeline_run_id} failed to precache report_info"
+    )
+    LogUtil.log_backtrace(err)
+  end
+end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1590,7 +1590,7 @@ class PipelineRun < ApplicationRecord
         PipelineReportService.call(self, background_id)
       end
 
-      MetricUtil.log_analytics_event("samples.cache.precached", current_user)
+      MetricUtil.log_analytics_event("pipeline_run_precached", nil)
     end
   end
 

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1590,7 +1590,7 @@ class PipelineRun < ApplicationRecord
         PipelineReportService.call(self, background_id)
       end
 
-      MetricUtil.log_analytics_event("pipeline_run_precached", nil)
+      MetricUtil.log_analytics_event("PipelineReport_precached", nil)
     end
   end
 

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -829,6 +829,7 @@ class PipelineRun < ApplicationRecord
 
         # Precache reports for all backgrounds
         Resque.enqueue(PrecacheReportInfo, id)
+        Resque.enqueue(PrecacheReportInfoV2, id)
 
         # Send to Datadog and Segment
         tags = ["sample_id:#{sample.id}"]
@@ -1574,6 +1575,22 @@ class PipelineRun < ApplicationRecord
       end
 
       MetricUtil.put_metric_now("samples.cache.precached", 1)
+    end
+  end
+
+  def precache_report_info_v2!
+    params = report_info_params
+    Background.top_for_sample(sample).pluck(:id).each do |background_id|
+      cache_key = PipelineReportService.report_info_cache_key(
+        "/samples/#{sample.id}/report_v2",
+        params.merge(background_id: background_id)
+      )
+      Rails.logger.info("Precaching #{cache_key} with background #{background_id}")
+      Rails.cache.fetch(cache_key, expires_in: 30.days) do
+        PipelineReportService.call(self, background_id)
+      end
+
+      MetricUtil.log_analytics_event("samples.cache.precached", current_user)
     end
   end
 

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -239,15 +239,15 @@ class PipelineReportService
     return pipeline_run && (((pipeline_run.adjusted_remaining_reads.to_i > 0 || pipeline_run.finalized?) && !pipeline_run.failed?) || pipeline_run.report_ready?)
   end
 
-  def fetch_taxon_counts(_pipeline_run_id, _background_id)
+  def fetch_taxon_counts(pipeline_run_id, background_id)
     taxon_counts_and_summaries_query = TaxonCount
                                        .joins("LEFT OUTER JOIN"\
                                           " taxon_summaries ON taxon_counts.count_type = taxon_summaries.count_type"\
                                           " AND taxon_counts.tax_level = taxon_summaries.tax_level"\
                                           " AND taxon_counts.tax_id = taxon_summaries.tax_id"\
-                                          " AND taxon_summaries.background_id = #{@background_id}")
+                                          " AND taxon_summaries.background_id = #{background_id}")
                                        .where(
-                                         pipeline_run_id: @pipeline_run_id,
+                                         pipeline_run_id: pipeline_run_id,
                                          count_type: ['NT', 'NR'],
                                          tax_level: [TaxonCount::TAX_LEVEL_SPECIES, TaxonCount::TAX_LEVEL_GENUS]
                                        )
@@ -272,7 +272,7 @@ class PipelineReportService
     return taxon
   end
 
-  def fetch_taxons_absent_from_sample(_pipeline_run_id, _background_id)
+  def fetch_taxons_absent_from_sample(pipeline_run_id, background_id)
     tax_ids = TaxonCount.select(:tax_id).where(pipeline_run_id: @pipeline_run_id).distinct
 
     taxons_absent_from_sample = TaxonSummary
@@ -280,10 +280,10 @@ class PipelineReportService
                                   " taxon_counts ON taxon_counts.count_type = taxon_summaries.count_type"\
                                   " AND taxon_counts.tax_level = taxon_summaries.tax_level"\
                                   " AND taxon_counts.tax_id = taxon_summaries.tax_id"\
-                                  " AND taxon_counts.pipeline_run_id = #{@pipeline_run_id}")
+                                  " AND taxon_counts.pipeline_run_id = #{pipeline_run_id}")
                                 .where(
                                   taxon_summaries: {
-                                    background_id: @background_id,
+                                    background_id: background_id,
                                     tax_id: tax_ids,
                                     tax_level: [TaxonCount::TAX_LEVEL_SPECIES, TaxonCount::TAX_LEVEL_GENUS],
                                     count_type: ['NT', 'NR'],

--- a/spec/services/pipeline_report_service_spec.rb
+++ b/spec/services/pipeline_report_service_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe PipelineReportService, type: :service do
                              stdev: 64.2056,
                            },])
 
-      @report = PipelineReportService.call(@pipeline_run.id, @background.id)
+      @report = PipelineReportService.call(@pipeline_run, @background.id)
     end
 
     it "should get correct values for species 573" do
@@ -243,7 +243,7 @@ RSpec.describe PipelineReportService, type: :service do
                              stdev: 374.243,
                            },])
 
-      @report = PipelineReportService.call(@pipeline_run.id, @background.id)
+      @report = PipelineReportService.call(@pipeline_run, @background.id)
     end
 
     it "should get correct values for species 1313" do
@@ -346,7 +346,7 @@ RSpec.describe PipelineReportService, type: :service do
                                     sample: create(:sample, project: create(:project))).id,
                            ])
 
-      @report = PipelineReportService.call(@pipeline_run.id, @background.id)
+      @report = PipelineReportService.call(@pipeline_run, @background.id)
     end
 
     it "should return correct z-score values" do


### PR DESCRIPTION
# Description

Adds caching for the new pipeline report page.

Follows the caching pattern used in the previous report: once a pipeline run has finished, reports against all backgrounds will be precached.

# Notes

`PipelineReportService.call` was modified to take a `pipeline_run` instead of a `pipeline_run.id` to reduce some redundancy in the code. Calls to the function were updated accordingly.

When porting the cache-related code in `report_info` into `report_v2`, calls to `MetricUtil.put_metric_now` were replaced with `MetricUtil.log_analytics_event`.

# Tests

* Enabled caching in development and verified that the report information would be fetched from the cache rather than re-computed from scratch.
