### PR TITLE
Remove remaining references to old sample metadata fields.

### DIFF
--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -240,8 +240,8 @@ class PhyloTreeCreation extends React.Component {
         let entry = {
           name: row.name,
           host: row.host,
-          tissue: row.sample_tissue,
-          location: row.sample_location,
+          tissue: row.sample_type,
+          location: row.collection_location,
           date: <Moment fromNow date={row.created_at} />,
           reads: `${(row.taxid_reads || {}).NT} | ${
             (row.taxid_reads || {}).NR

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -288,7 +288,7 @@ class PhyloTreesController < ApplicationController
       end
       if metadata_by_sample_id[sp["sample_id"]]
         sp["sample_type"] = metadata_by_sample_id[sp["sample_id"]][:sample_type]
-        sp["collection_location"] = metadata_by_sample_id[sp["sample_id"]][:collection_location_v2] || metadata_by_sample_id[sp["sample_id"]][:collection_location]
+        sp["collection_location"] = metadata_by_sample_id[sp["sample_id"]][:collection_location_v2]
       end
     end
 

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -259,12 +259,11 @@ class PhyloTreesController < ApplicationController
       select
         samples.name,
         samples.project_id,
-        samples.sample_tissue,
-        samples.sample_location,
         samples.created_at,
         host_genomes.name as host,
         projects.name as project_name,
-        pipeline_runs.id as pipeline_run_id
+        pipeline_runs.id as pipeline_run_id,
+        samples.id as sample_id
       from pipeline_runs, projects, samples, host_genomes
       where
         pipeline_runs.id in (#{pipeline_run_ids.join(',')}) and
@@ -278,11 +277,18 @@ class PhyloTreesController < ApplicationController
     # Do not include the query on taxon_counts in the previous query above using a join,
     # because the taxon_counts table is large.
     taxon_counts = TaxonCount.where(pipeline_run_id: pipeline_run_ids).where(tax_id: taxid).index_by { |tc| "#{tc.pipeline_run_id},#{tc.count_type}" }
+
+    metadata_by_sample_id = Metadatum.by_sample_ids(samples_projects.pluck("sample_id"))
+
     samples_projects.each do |sp|
       sp["taxid_reads"] ||= {}
       %w[NT NR].each do |count_type|
         key = "#{sp['pipeline_run_id']},#{count_type}"
         sp["taxid_reads"][count_type] = (taxon_counts[key] || []).count # count is a column of taxon_counts indicating number of reads
+      end
+      if metadata_by_sample_id[sp["sample_id"]]
+        sp["sample_type"] = metadata_by_sample_id[sp["sample_id"]][:sample_type]
+        sp["collection_location"] = metadata_by_sample_id[sp["sample_id"]][:collection_location_v2] || metadata_by_sample_id[sp["sample_id"]][:collection_location]
       end
     end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1432,11 +1432,9 @@ class SamplesController < ApplicationController
   def sample_params
     permitted_params = [:name, :project_name, :project_id, :status,
                         :s3_star_index_path, :s3_bowtie2_index_path,
-                        :host_genome_id, :host_genome_name, :sample_location, :sample_date, :sample_tissue,
-                        :sample_template, :sample_library, :sample_sequencer,
+                        :host_genome_id, :host_genome_name,
                         :sample_notes, :search, :subsample, :max_input_fragments,
-                        :basespace_dataset_id, :basespace_access_token,
-                        :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection, :client,
+                        :basespace_dataset_id, :basespace_access_token, :client,
                         input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts],]
     permitted_params.concat([:pipeline_branch, :dag_vars, :s3_preload_result_path, :alignment_config_name, :subsample]) if current_user.admin?
     params.require(:sample).permit(*permitted_params)

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -62,38 +62,6 @@ module SamplesHelper
     end
   end
 
-  # Load bulk metadata from a CSV file
-  # NOTE: Succeeded by Metadatum#load_csv_from_s3 for new Metadatum objects.
-  def populate_metadata_bulk(csv_s3_path)
-    # Load the CSV data. CSV should have columns "sample_name", "project_name", and any desired columns from Sample::METADATA_FIELDS.
-    csv_data = get_s3_file(csv_s3_path)
-    csv_data.delete!("\uFEFF") # Remove BOM if present (file likely comes from Excel)
-    CSV.parse(csv_data, headers: true) do |row|
-      # Find the right project and sample
-      row_details = row.to_h
-      proj = Project.find_by(name: row_details['project_name'])
-      next unless proj
-      sampl = Sample.find_by(project_id: proj, name: row_details['sample_name'])
-      next unless sampl
-
-      # Format the new details. Append to existing notes.
-      new_details = {}
-      new_details['sample_notes'] = sampl.sample_notes || ''
-      row_details.each do |key, value|
-        if !key || !value || key == 'sample_name' || key == 'project_name'
-          next
-        end
-        if Sample::METADATA_FIELDS.include?(key.to_sym)
-          new_details[key] = value
-        else # Otherwise throw in notes
-          new_details['sample_notes'] << format("\n- %s: %s", key, value)
-        end
-      end
-      new_details['sample_notes'].strip!
-      sampl.update_attributes!(new_details)
-    end
-  end
-
   def host_genomes_list
     HostGenome.all.map { |h| h.slice('name', 'id') }
   end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -54,10 +54,7 @@ class Sample < ApplicationRecord
   DEFAULT_QUEUE_HIMEM = (Rails.env == 'prod' ? 'idseq-prod-himem' : 'idseq-staging-himem').freeze
   DEFAULT_VCPUS_HIMEM = 32
 
-  METADATA_FIELDS = [:sample_unique_id, # 'Unique ID' (e.g. in human case, patient ID)
-                     :sample_location, :sample_date, :sample_tissue,
-                     :sample_template, # this refers to nucleotide type (RNA or DNA)
-                     :sample_library, :sample_sequencer, :sample_notes, :sample_input_pg, :sample_batch, :sample_diagnosis, :sample_organism, :sample_detection,].freeze
+  METADATA_FIELDS = [:sample_notes].freeze
 
   SLEEP_SECONDS_BETWEEN_RETRIES = 10
 
@@ -88,9 +85,6 @@ class Sample < ApplicationRecord
 
   before_save :check_host_genome, :concatenate_input_parts, :check_status
   after_save :set_presigned_url_for_local_upload
-
-  # Error on trying to save string values to float
-  validates :sample_input_pg, :sample_batch, numericality: true, allow_nil: true
 
   # getter
   attr_reader :bulk_mode
@@ -195,8 +189,7 @@ class Sample < ApplicationRecord
     if search
       search = search.strip
       results = where('samples.name LIKE :search
-        OR samples.sample_notes LIKE :search
-        OR samples.sample_unique_id LIKE :search', search: "%#{search}%")
+        OR samples.sample_notes LIKE :search', search: "%#{search}%")
 
       unless eligible_pr_ids.empty?
         # Require scope of eligible pipeline runs for pathogen search

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -197,7 +197,6 @@ class CheckPipelineRuns
       project_id: bm_project.id,
       user_id: bm_user.id,
       input_files_attributes: input_files_attributes,
-      sample_organism: known_organisms,
       web_commit: web_commit,
       pipeline_commit: pipeline_commit,
       pipeline_branch: bm_pipeline_branch,

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -187,10 +187,6 @@ class CheckPipelineRuns
       next if k == "ORIGIN"
       new_metadata[k] = v
     end
-    # HACK: for benchmark 5 this string is always too long for the DB
-    #   depending on the connection type you are using it may be truncated or throw an error
-    #   truncating manually prevents an error
-    known_organisms = metadata['verified_contents'].pluck('genome').join(", ")[0..254]
     bm_sample_params = {
       name: bm_sample_name,
       host_genome_id: bm_host.id,

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -41,19 +41,19 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
   test 'joe can update sample to joe_project' do
     sign_in(:joe)
     @joe_sample = samples(:joe_sample)
-    post "#{save_metadata_sample_url(@joe_sample)}.json", params: { field: 'sample_tissue', value: 'bone' }
+    post "#{save_metadata_sample_url(@joe_sample)}.json", params: { field: 'sample_notes', value: 'Test note' }
     assert_response :success
     @joe_sample.reload
-    assert @joe_sample.sample_tissue == 'bone'
+    assert @joe_sample.sample_notes == 'Test note'
   end
 
   test 'joe can update sample to joe_project v2' do
     sign_in(:joe)
     @joe_sample = samples(:joe_sample)
-    post "#{save_metadata_v2_sample_url(@joe_sample)}.json", params: { field: "sample_type", value: "Whole blood" }
+    post "#{save_metadata_v2_sample_url(@joe_sample)}.json", params: { field: "sample_notes", value: "Test note 2" }
     assert_response :success
     @joe_sample.reload
-    assert @joe_sample.metadata.find_by(key: "sample_type").string_validated_value == 'Whole blood'
+    assert @joe_sample.metadata.find_by(key: "sample_notes").string_validated_value == 'Test note 2'
   end
 
   # ===== START: /samples/index
@@ -273,10 +273,10 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     sign_in(:joe)
     @public_sample = samples(:public_sample)
     assert_raises(ActiveRecord::RecordNotFound) do
-      post "#{save_metadata_sample_url(@public_sample)}.json", params: { field: 'sample_tissue', value: 'bone' }
+      post "#{save_metadata_sample_url(@public_sample)}.json", params: { field: 'sample_notes', value: 'Test note' }
     end
     @public_sample.reload
-    assert @public_sample.sample_tissue != 'bone'
+    assert @public_sample.sample_notes != 'Test note'
   end
 
   test 'joe can see public_sample' do
@@ -349,10 +349,10 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     sign_in(:joe)
     @sample = samples(:one)
     assert_raises(ActiveRecord::RecordNotFound) do
-      post "#{save_metadata_sample_url(@sample)}.json", params: { field: 'sample_tissue', value: 'bone' }
+      post "#{save_metadata_sample_url(@sample)}.json", params: { field: 'sample_notes', value: 'Test note' }
     end
     @sample.reload
-    assert @sample.sample_tissue != 'bone'
+    assert @sample.sample_notes != 'Test note'
   end
 
   test 'joe cannot see sample one' do
@@ -392,10 +392,10 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     sign_in(:joe)
     @sample = samples(:expired_sample)
     assert_raises(ActiveRecord::RecordNotFound) do
-      post "#{save_metadata_sample_url(@sample)}.json", params: { field: 'sample_tissue', value: 'bone' }
+      post "#{save_metadata_sample_url(@sample)}.json", params: { field: 'sample_notes', value: 'Test note' }
     end
     @sample.reload
-    assert @sample.sample_tissue != 'bone'
+    assert @sample.sample_notes != 'Test note'
   end
 
   test 'joe can see expired_sample' do


### PR DESCRIPTION
# Description

Remove remaining references to fields, in preparation for removing the fields via migration.

# Notes

* Migration will be in follow-up PR, which will wait until the next deploy.

# Tests

* Verify that the Phylo Tree creation modal works with the new code.

![Screen Shot 2019-12-09 at 12 23 33 PM](https://user-images.githubusercontent.com/837004/70471147-7ee10180-1a81-11ea-8a48-e3e16292344e.png)

* Verify that you can still upload samples and update the sample name and sample notes via the sidebar.

* Migrated any remaining values in these fields in prod to the Metadata table. See: https://czi.quip.com/v6waAR0JgdLZ/Old-sample-metadata-migration#JSKACAZ6OCT