### PR TITLE
[IDSEQ-1751] Fix case-insensitivity in map marker clicks on locations

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -148,8 +148,8 @@ class SamplesController < ApplicationController
 
   def index_v2
     # this method is going to replace 'index' once we fully migrate to the
-    # discovery views (old one was kept to avoid breaking the current inteface
-    # without sacrificing speed of development and avoid breaking the current interface)
+    # discovery views (old one was kept to avoid breaking the current interface
+    # without sacrificing speed of development)
     domain = params[:domain]
     order_by = params[:orderBy] || :id
     order_dir = params[:orderDir] || :desc

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -149,7 +149,7 @@ class SamplesController < ApplicationController
   def index_v2
     # this method is going to replace 'index' once we fully migrate to the
     # discovery views (old one was kept to avoid breaking the current interface
-    # without sacrificing speed of development)
+    # without sacrificing speed of development and avoid breaking the current interface)
     domain = params[:domain]
     order_by = params[:orderBy] || :id
     order_dir = params[:orderDir] || :desc

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -149,7 +149,7 @@ class SamplesController < ApplicationController
   def index_v2
     # this method is going to replace 'index' once we fully migrate to the
     # discovery views (old one was kept to avoid breaking the current interface
-    # without sacrificing speed of development and avoid breaking the current interface)
+    # without sacrificing speed of development)
     domain = params[:domain]
     order_by = params[:orderBy] || :id
     order_dir = params[:orderDir] || :desc
@@ -600,7 +600,7 @@ class SamplesController < ApplicationController
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
     background_id = get_background_id(@sample, params[:background])
     min_contig_size = params[:min_contig_size]
-    @report_csv = PipelineReportService.call(pipeline_run, background_id, true, min_contig_size)
+    @report_csv = PipelineReportService.call(pipeline_run.id, background_id, true, min_contig_size)
     send_data @report_csv, filename: @sample.name + '_report.csv'
   end
 
@@ -800,23 +800,19 @@ class SamplesController < ApplicationController
 
   def report_v2
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
-    background_id = get_background_id(@sample, params[:background])
-
-    skip_cache = params[:skip_cache] || false
-    report_info_params = pipeline_run.report_info_params
-    cache_key = PipelineReportService.report_info_cache_key(
-      request.path,
-      params
-        .permit(report_info_params.keys)
-        .merge(pipeline_run_id: pipeline_run.id)
-    )
-    httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
-
-    json =
-      fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate, "PipelineReport") do
-        PipelineReportService.call(pipeline_run, background_id)
-      end
-    render json: json
+    if pipeline_run
+      background_id = get_background_id(@sample, params[:background])
+      render json: PipelineReportService.call(pipeline_run.id, background_id)
+    else
+      render json: {
+        metadata: {
+          pipelineRunStatus: "WAITING",
+          jobStatus: "Waiting to Start or Receive Files",
+          errorMessage: nil,
+          knownUserError: nil,
+        },
+      }
+    end
   end
 
   def amr

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -149,7 +149,7 @@ class SamplesController < ApplicationController
   def index_v2
     # this method is going to replace 'index' once we fully migrate to the
     # discovery views (old one was kept to avoid breaking the current interface
-    # without sacrificing speed of development and avoid breaking the current interface)
+    # without sacrificing speed of development)
     domain = params[:domain]
     order_by = params[:orderBy] || :id
     order_dir = params[:orderDir] || :desc

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -148,7 +148,7 @@ class SamplesController < ApplicationController
 
   def index_v2
     # this method is going to replace 'index' once we fully migrate to the
-    # discovery views (old one was kept to avoid breaking the current inteface
+    # discovery views (old one was kept to avoid breaking the current interface
     # without sacrificing speed of development and avoid breaking the current interface)
     domain = params[:domain]
     order_by = params[:orderBy] || :id

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -120,13 +120,13 @@ module LocationHelper
     # Plain text locations in string_validated_value + multi-geo-level location search
     if locations_by_geo_level.present?
       samples.where(
-        "`metadata`.`string_validated_value` IN (?)"\
+        "`metadata`.`string_validated_value` IN (BINARY ?)"\
       " OR #{locations_by_geo_level.keys.map { |k| "`locations`.`#{k}_id` IN (?)" }.join(' OR ')}",
         query,
         *locations_by_geo_level.values
       )
     else
-      samples.where("`metadata`.`string_validated_value` IN (?)", query)
+      samples.where("`metadata`.`string_validated_value` IN (BINARY ?)", query)
     end
   end
 

--- a/spec/helpers/location_helper_spec.rb
+++ b/spec/helpers/location_helper_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe LocationHelper, type: :helper do
 
       expect(Location).to receive_message_chain(:where, :pluck, :group_by, :map, :to_h).and_return(country: [147], state: [153], city: [188])
       expect(samples).to receive(:includes).with(metadata: :location).and_return(samples)
-      expect(samples).to receive(:where).with("`metadata`.`string_validated_value` IN (?) OR `locations`.`country_id` IN (?) OR `locations`.`state_id` IN (?) OR `locations`.`city_id` IN (?)", query_text, [147], [153], [188]).and_return(expected)
+      expect(samples).to receive(:where).with("`metadata`.`string_validated_value` IN (BINARY ?) OR `locations`.`country_id` IN (?) OR `locations`.`state_id` IN (?) OR `locations`.`city_id` IN (?)", query_text, [147], [153], [188]).and_return(expected)
 
       result = LocationHelper.filter_by_name(samples, query_text)
       expect(result).to eq(expected)
@@ -100,7 +100,7 @@ RSpec.describe LocationHelper, type: :helper do
 
       expect(Location).to receive(:where).and_return([])
       expect(samples).to receive(:includes).with(metadata: :location).and_return(samples)
-      expect(samples).to receive(:where).with("`metadata`.`string_validated_value` IN (?)", query_text).and_return(expected)
+      expect(samples).to receive(:where).with("`metadata`.`string_validated_value` IN (BINARY ?)", query_text).and_return(expected)
 
       result = LocationHelper.filter_by_name(samples, query_text)
       expect(result).to eq(expected)


### PR DESCRIPTION
### Description
- There was a small bug where the comparisons on discovery map marker sidebar loads were not case sensitive, so "Japan" and a plain text entry "japan" would not be distinguished, and the sidebar counts wouldn't match the marker.

### Notes
- This adds the 'BINARY' keyword to do a case-sensitive comparison instead. There should not be a noticeable perf difference because the previous string comparison was not indexed either.
- The alternative approach would be having a stronger comparison on just the location_id, but the code for sidebar loading also accepts plain text for filtering by the user-inputted plain text values so that would be a larger change in design.

### Tests
- See screenshots here: https://docs.google.com/document/d/1tVt8gk4LnFR-RvYu0eGa97IgKkpb0i6k3bLhtomVV9E/edit