### PR TITLE
Use ecs clusters defined in idseq-infra for bulk downloads.

### DIFF
--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -91,6 +91,7 @@ class BulkDownload < ApplicationRecord
     shell_command: nil,
     executable_file_path: nil,
     task_role: "idseq-downloads-#{Rails.env}",
+    ecs_cluster: "idseq-fargate-tasks-#{Rails.env}",
     ecr_image: "idseq-s3-tar-writer:latest",
     fargate_cpu: "4096",
     fargate_memory: "8192"
@@ -98,6 +99,11 @@ class BulkDownload < ApplicationRecord
     config_ecr_image = get_app_config(AppConfig::S3_TAR_WRITER_SERVICE_ECR_IMAGE)
     unless config_ecr_image.nil?
       ecr_image = config_ecr_image
+    end
+
+    # Use the staging ecs cluster for development.
+    if Rails.env == "development"
+      ecs_cluster = "idseq-fargate-tasks-staging"
     end
 
     command_flag = shell_command.present? ? "--command=#{shell_command}" : "--execute=#{executable_file_path}"
@@ -108,7 +114,8 @@ class BulkDownload < ApplicationRecord
      "--task-name", ECS_TASK_NAME,
      "--ecr-image", ecr_image,
      "--fargate-cpu", fargate_cpu,
-     "--fargate-memory", fargate_memory,]
+     "--fargate-memory", fargate_memory,
+     "--cluster", ecs_cluster,]
   end
 
   # Returned as an array of strings

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -301,6 +301,7 @@ describe BulkDownload, type: :model do
         "--ecr-image", "idseq-s3-tar-writer:latest",
         "--fargate-cpu", "4096",
         "--fargate-memory", "8192",
+        "--cluster", "idseq-fargate-tasks-prod",
       ]
 
       expect(@bulk_download.aegea_ecs_submit_command(shell_command: mock_shell_command)).to eq(task_command)
@@ -317,6 +318,7 @@ describe BulkDownload, type: :model do
         "--ecr-image", "idseq-s3-tar-writer:latest",
         "--fargate-cpu", "4096",
         "--fargate-memory", "8192",
+        "--cluster", "idseq-fargate-tasks-prod",
       ]
 
       expect(@bulk_download.aegea_ecs_submit_command(executable_file_path: mock_executable_file_path)).to eq(task_command)
@@ -334,6 +336,43 @@ describe BulkDownload, type: :model do
         "--ecr-image", "idseq-s3-tar-writer:v1.0",
         "--fargate-cpu", "4096",
         "--fargate-memory", "8192",
+        "--cluster", "idseq-fargate-tasks-prod",
+      ]
+
+      expect(@bulk_download.aegea_ecs_submit_command(shell_command: mock_shell_command)).to eq(task_command)
+    end
+
+    it "outputs correct command in staging" do
+      AppConfigHelper.set_app_config(AppConfig::S3_TAR_WRITER_SERVICE_ECR_IMAGE, "idseq-s3-tar-writer:v1.0")
+      allow(Rails).to receive(:env).and_return("staging")
+      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-staging")
+
+      task_command = [
+        "aegea", "ecs", "run", "--command=#{mock_shell_command}",
+        "--task-role", "idseq-downloads-staging",
+        "--task-name", BulkDownload::ECS_TASK_NAME,
+        "--ecr-image", "idseq-s3-tar-writer:v1.0",
+        "--fargate-cpu", "4096",
+        "--fargate-memory", "8192",
+        "--cluster", "idseq-fargate-tasks-staging",
+      ]
+
+      expect(@bulk_download.aegea_ecs_submit_command(shell_command: mock_shell_command)).to eq(task_command)
+    end
+
+    it "outputs correct command in development" do
+      AppConfigHelper.set_app_config(AppConfig::S3_TAR_WRITER_SERVICE_ECR_IMAGE, "idseq-s3-tar-writer:v1.0")
+      allow(Rails).to receive(:env).and_return("development")
+      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-development")
+
+      task_command = [
+        "aegea", "ecs", "run", "--command=#{mock_shell_command}",
+        "--task-role", "idseq-downloads-development",
+        "--task-name", BulkDownload::ECS_TASK_NAME,
+        "--ecr-image", "idseq-s3-tar-writer:v1.0",
+        "--fargate-cpu", "4096",
+        "--fargate-memory", "8192",
+        "--cluster", "idseq-fargate-tasks-staging",
       ]
 
       expect(@bulk_download.aegea_ecs_submit_command(shell_command: mock_shell_command)).to eq(task_command)


### PR DESCRIPTION
# Description

This uses ecs clusters that are defined in idseq-infra for bulk downloads. This ensures that aegea won't need to create ecs clusters on the fly, which means we don't need the `ecsCluster` IAM permission for the web server.

# Notes
We use the staging cluster for development.

# Testing
Verify locally that bulk downloads still work.