### PR TITLE
[Hot fix] Fix file size bug with s3_tar_writer.

### DIFF
--- a/app/lib/s3_tar_writer.rb
+++ b/app/lib/s3_tar_writer.rb
@@ -16,10 +16,10 @@ class S3TarWriter
 
   def add_file_with_data(file_path, data)
     # 600 is the default permission the file will have. Readable/writable by owner only.
-    @tar.add_file_simple(file_path, 0o600, data.length) do |io|
+    @tar.add_file_simple(file_path, 0o600, data.bytesize) do |io|
       io.write(data)
     end
-    @total_size_processed += data.length
+    @total_size_processed += data.bytesize
   end
 
   def close


### PR DESCRIPTION
# Description

Fix a bug with the s3 tar writer library in bulk downloads.

For a string, bytesize is sometimes different from length. (it can be bigger)

The tar writer library uses bytesize and throws an error when bytesize is larger than length (since I'm passing in length)
See: https://github.com/rubygems/rubygems/blob/master/lib/rubygems/package/tar_writer.rb

# Notes

* Verified locally. Would like to cherry-pick to staging, verify that a bulk download works. and then cherry-pick to prod since it's a simple change that is causing bulk downloads to occasionally crash on prod.
