### PR TITLE
IDSEQ-1558 - Implement sign_in metrics

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -79,10 +79,17 @@ class Auth0Controller < ApplicationController
     # Auth0Helper#auth0_session
     bearer_token = request.env['omniauth.auth']&.credentials.to_h
 
+    user_was_not_present = current_user.nil?
+
     authenticated = auth0_authenticate_with_bearer_token(bearer_token)
     if authenticated
       # https://github.com/omniauth/omniauth-oauth2/issues/31#issuecomment-23806447
       mode = filter_value(request.env['omniauth.params']['mode'], SUPPORTED_MODES)
+
+      # Update login counters if this is a new login
+      if (mode == "login") || user_was_not_present
+        current_user.update_tracked_fields!(request)
+      end
 
       case mode
       when "background_refresh"

--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -37,7 +37,7 @@ module Auth0Helper
   # (see https://auth0.com/docs/sessions/concepts/session-layers)
   def auth0_invalidate_application_session
     session.delete(:auth0_credentials)
-    warden.logout(:user)
+    warden&.logout(:user)
   end
 
   # URL used to remove auth0 session from Auth0 Session Layer

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -28,4 +28,11 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     post projects_url, params: { project: { name: 'New Project' } }
     assert_redirected_to new_user_session_url
   end
+
+  test 'should increment login counter' do
+    previous_count = User.find(@user.id).sign_in_count
+    sign_in @user
+    new_count = User.find(@user.id).sign_in_count
+    assert_equal previous_count + 1, new_count
+  end
 end


### PR DESCRIPTION
# Description

IDSEQ-1558
Implement database sign_in metrics to match previous Devise behavior

# Notes

I also fixing a tiny in auth0 helper that occurred when refreshing failed callback url and warden env was not set. That issue was probably not affecting any users, but it was annoying during my tests.

# Tests

* Manual and automated test
