### PR TITLE
[Release fix] Fix caching for new report page

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -803,7 +803,7 @@ class SamplesController < ApplicationController
     background_id = get_background_id(@sample, params[:background])
 
     # If the pipeline run hasn't completed yet, don't cache the report
-    pipeline_run_completed = pipeline_run.all_output_states_terminal? && pipeline_run.all_output_states_loaded? && !pipeline_run.compiling_stats_failed
+    pipeline_run_completed = pipeline_run.all_output_states_terminal? && pipeline_run.all_output_states_loaded?
     skip_cache = params[:skip_cache] || !pipeline_run_completed || false
     report_info_params = pipeline_run.report_info_params
     cache_key = PipelineReportService.report_info_cache_key(

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -804,7 +804,7 @@ class SamplesController < ApplicationController
 
     # Don't cache the response until the pipeline run is report-ready
     # so the displayed pipeline run status will be updated correctly.
-    skip_cache = pipeline_run.report_ready? || params[:skip_cache] || false
+    skip_cache = !pipeline_run.report_ready? || params[:skip_cache] || false
 
     report_info_params = pipeline_run.report_info_params
     # If the pipeline_version wasn't passed in from the client-side,

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -802,7 +802,9 @@ class SamplesController < ApplicationController
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
     background_id = get_background_id(@sample, params[:background])
 
-    skip_cache = params[:skip_cache] || false
+    # If the pipeline run hasn't completed yet, don't cache the report
+    pipeline_run_completed = pipeline_run.all_output_states_terminal? && pipeline_run.all_output_states_loaded? && !pipeline_run.compiling_stats_failed
+    skip_cache = params[:skip_cache] || !pipeline_run_completed || false
     report_info_params = pipeline_run.report_info_params
     cache_key = PipelineReportService.report_info_cache_key(
       request.path,

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -814,13 +814,14 @@ class SamplesController < ApplicationController
     end
     cache_key = PipelineReportService.report_info_cache_key(
       request.path,
-      params
-        .permit(report_info_params.keys)
+      report_info_params
         .merge(
-          pipeline_run_id: pipeline_run.id,
-          background_id: background_id,
-          report_ts: report_info_params[:report_ts]
-        )
+          params
+            .reject { |_, v| v.blank? }
+            .permit(report_info_params.keys)
+        ).merge(
+          background_id: background_id
+        ).symbolize_keys
     )
     httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
 

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1585,7 +1585,7 @@ class PipelineRun < ApplicationRecord
     params = report_info_params
     Background.top_for_sample(sample).pluck(:id).each do |background_id|
       cache_key = PipelineReportService.report_info_cache_key(
-        "/samples/#{sample.id}/report_v2",
+        "/samples/#{sample.id}/report_v2.json",
         params.merge(background_id: background_id)
       )
       Rails.logger.info("Precaching #{cache_key} with background #{background_id}")

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -539,7 +539,7 @@ class PipelineReportService
   end
 
   # Example cache key:
-  # /samples/12303/report_v2?background_id=93&format=json&pipeline_version=3.3&report_ts=1549504990&pipeline_run_id=39185
+  # /samples/12303/report_v2.json?background_id=93&format=json&pipeline_version=3.3&report_ts=1549504990&pipeline_run_id=39185
   def self.report_info_cache_key(path, kvs)
     kvs = kvs.to_h.sort.to_h
     # Increment this if you ever change the response structure of report_info


### PR DESCRIPTION
# Description

If a user visited the report page of a sample whose pipeline run was still in progress, the in-progress report would be cached. The `cache_key` was also being computed incorrectly, resulting in that user always seeing the in progress report even after the pipeline run was completed.

This fix ensures that the report won't be cached until the pipeline run is ready and fixes the `cache_key` computation.

# Tests

* Cleared local cache and checked that in-progress samples would not have their reports cached.
* Cleared local cache and checked that the requested cache_keys were computed as expected.
