### PR TITLE
[Hot fix] Update v2 of report csv for sample taxon reports bulk download.

### DIFF
--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -376,8 +376,7 @@ class BulkDownload < ApplicationRecord
       begin
         Rails.logger.info("Processing pipeline run #{pipeline_run.id} (#{index + 1} of #{pipeline_runs.length})...")
         if download_type == SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE
-          tax_details = ReportHelper.taxonomy_details(pipeline_run.id, get_param_value("background"), TaxonScoringModel::DEFAULT_MODEL_NAME, ReportHelper::DEFAULT_SORT_PARAM)
-          report_csv = ReportHelper.generate_report_csv(tax_details)
+          report_csv = PipelineReportService.call(pipeline_run, get_param_value("background"), true)
           s3_tar_writer.add_file_with_data(
             "#{get_output_file_prefix(pipeline_run.sample, cleaned_project_names)}" \
               "taxon_report.csv",

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -483,11 +483,13 @@ describe BulkDownload, type: :model do
     end
 
     it "correctly generates download file for download type sample_taxon_report" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, {})
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background" => {
+                                             "value" => mock_background_id,
+                                             "displayName" => "Mock Background",
+                                           })
 
-      expect(ReportHelper).to receive(:taxonomy_details).exactly(2).times
-      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv")
-      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv_2")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv_2")
 
       add_s3_tar_writer_expectations(
         "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv",
@@ -500,11 +502,13 @@ describe BulkDownload, type: :model do
     end
 
     it "correctly updates the bulk_download status and progress as the sample_taxon_report runs" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, {})
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background" => {
+                                             "value" => mock_background_id,
+                                             "displayName" => "Mock Background",
+                                           })
 
-      expect(ReportHelper).to receive(:taxonomy_details).exactly(2).times
-      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv")
-      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv_2")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv_2")
 
       add_s3_tar_writer_expectations(
         "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv",
@@ -689,12 +693,14 @@ describe BulkDownload, type: :model do
     end
 
     it "correctly handles individual sample failures" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, {})
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background" => {
+                                             "value" => mock_background_id,
+                                             "displayName" => "Mock Background",
+                                           })
 
-      expect(ReportHelper).to receive(:taxonomy_details).exactly(2).times
-      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv")
       # The second sample raises an error while generating.
-      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_raise("error")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_raise("error")
 
       add_s3_tar_writer_expectations(
         "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv"
@@ -708,11 +714,13 @@ describe BulkDownload, type: :model do
     end
 
     it "correctly handles s3 tar file upload error" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, {})
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background" => {
+                                             "value" => mock_background_id,
+                                             "displayName" => "Mock Background",
+                                           })
 
-      expect(ReportHelper).to receive(:taxonomy_details).exactly(2).times
-      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv")
-      expect(ReportHelper).to receive(:generate_report_csv).exactly(1).times.and_return("mock_report_csv_2")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv_2")
 
       add_s3_tar_writer_expectations(
         {


### PR DESCRIPTION
# Description

The recent report page refactor changed how the report csv is generated. Bulk downloads was originally calling pieces of the v1 code, in a way that wasn't intended and ended up breaking with the refactor. (Note that the normal report csv download on the report page is not broken, just the bulk download) This switches the sample taxon report bulk download to use the v2 version of the csv code, which will be launched to users soon.

We decided not to gate on `report_v2` allowed feature because the v1 code path is still not working and we don't want to try to fix that in a hot fix.

# Notes

*Optional observations, comments or explanations.*

# Tests

* Updated tests.
* Verified that these changes fix the broken bulk download, and the downloaded file matches the file you get from downloading the csv on the report page.
