### PR TITLE
[Report page] Display report page if Experimental in progress

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -966,7 +966,7 @@ export default class SampleViewV2 extends React.Component {
       view,
     } = this.state;
     // pipelineRunReportAvailable is true if:
-    // the pipeline run did not fail AND has finished running
+    // the pipeline run has finished running AND did not fail
     // OR if the pipeline run is report-ready (might still be running Experimental,
     // but at least taxon_counts has been loaded).
     if (reportMetadata.pipelineRunReportAvailable) {

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -965,10 +965,11 @@ export default class SampleViewV2 extends React.Component {
       selectedOptions,
       view,
     } = this.state;
-    if (
-      reportMetadata.pipelineRunStatus === "COMPLETE" &&
-      reportMetadata.pipelineRunReportAvailable
-    ) {
+    // pipelineRunReportAvailable is true if:
+    // the pipeline run did not fail AND has finished running
+    // OR if the pipeline run is report-ready (might still be running Experimental,
+    // but at least taxon_counts has been loaded).
+    if (reportMetadata.pipelineRunReportAvailable) {
       return (
         <div className={cs.reportViewContainer}>
           <div className={cs.reportFilters}>


### PR DESCRIPTION
# Description

The report page should be displayed as soon as the pipeline has progressed far enough to generate the report instead of waiting for all jobs, including Experimental, to be complete.

Also added various comments clarifying some of the conditional checks related to the pipeline run's statuses.

# Notes

Tests will be conducted in staging.