### PR TITLE
[Report Page] Fix issue where table content was not showing in Safari

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -1000,7 +1000,7 @@ export default class SampleViewV2 extends React.Component {
               />
             </div>
           </div>
-          {view == "table" && (
+          {view === "table" && (
             <div className={cs.reportTable}>
               <ReportTable
                 alignVizAvailable={

--- a/app/assets/src/components/views/SampleViewV2/sample_view_v2.scss
+++ b/app/assets/src/components/views/SampleViewV2/sample_view_v2.scss
@@ -26,6 +26,8 @@
   }
 
   .reportTable {
+    display: flex;
+    flex-direction: column;
     flex: 1 0 auto;
   }
 


### PR DESCRIPTION
# Description

* Safari treats flex inheritance differently than chrome and other browsers
* The table height was only the size of the header thus not showing the data
* Fixed by explicitly setting the display flex to the container

# Tests

* Open any report table in safari and see that data contents are displayed.
