### PR TITLE
IDSEQ-1556 - Ensure auth0 role matches database admin role

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -51,7 +51,7 @@ class Auth0Controller < ApplicationController
     error_type = (params["error"] || "").to_sym
     error_code = (params["error_description"] || "").to_sym
     unless params["error"] && params["error_description"]
-      LogUtil.log_err_and_airbrake("omniauth_failure called with missing error or error_description. error=#{error_type}, error_description=#{error_description}")
+      LogUtil.log_err_and_airbrake("omniauth_failure called with missing error or error_description. error=#{error_type}, error_description=#{error_code}")
     end
     Rails.logger.info("Auth0 omniauth_failure: #{error_type}: #{error_code}")
 

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -48,11 +48,11 @@ class Auth0Controller < ApplicationController
   # Handle omniauth errors coming from Auth0.
   def omniauth_failure
     # Error and error_description come from Auth0. Ex: unauthorized and password_expired.
-    unless params["error"] && params["error_description"]
-      LogUtil.log_err_and_airbrake("omniauth_failure called with missing error or error_description")
-    end
     error_type = (params["error"] || "").to_sym
     error_code = (params["error_description"] || "").to_sym
+    unless params["error"] && params["error_description"]
+      LogUtil.log_err_and_airbrake("omniauth_failure called with missing error or error_description. error=#{error_type}, error_description=#{error_description}")
+    end
     Rails.logger.info("Auth0 omniauth_failure: #{error_type}: #{error_code}")
 
     # Display 'unauthorized' errors but go to `failure` endpoint for all others.

--- a/spec/helpers/auth0_helper_spec.rb
+++ b/spec/helpers/auth0_helper_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+require "webmock/rspec"
+
+RSpec.describe Auth0Helper, type: :helper do
+  describe "#auth0_check_user_auth" do
+    subject { helper.auth0_check_user_auth current_user }
+
+    context "when user is blank" do
+      let(:current_user) { nil }
+      it { is_expected.to eq(Auth0Helper::AUTH_INVALID_USER) }
+    end
+
+    context "when checking any user" do
+      let(:current_user) { build_stubbed(:joe) }
+      before { expect(helper).to receive(:auth0_decode_auth_token).and_return(decoded_token) }
+
+      context "and token is expired" do
+        let(:decoded_token) { { authenticated: false } }
+        it { is_expected.to eq(Auth0Helper::AUTH_TOKEN_EXPIRED) }
+      end
+
+      context "and token is not expired" do
+        context "and user email doesn't match" do
+          let(:decoded_token) { { authenticated: true, auth_payload: { "email" => "wrong" + current_user.email } } }
+          it { is_expected.to eq(Auth0Helper::AUTH_INVALID_USER) }
+        end
+        context "and user matches" do
+          let(:decoded_token) { { authenticated: true, auth_payload: { "email" => current_user.email } } }
+          it { is_expected.to eq(Auth0Helper::AUTH_VALID) }
+        end
+      end
+    end
+
+    context "when checking an admin user" do
+      let(:current_user) { build_stubbed(:admin) }
+      before { expect(helper).to receive(:auth0_decode_auth_token).and_return(decoded_token) }
+
+      context "and role custom claim is not present in JWT" do
+        let(:decoded_token) { { authenticated: true, auth_payload: { "email" => current_user.email } } }
+        it { is_expected.to eq(Auth0Helper::AUTH_INVALID_USER) }
+      end
+      context "and role custom claim in JWT doesn't contain admin" do
+        let(:decoded_token) { { authenticated: true, auth_payload: { "email" => current_user.email, Auth0Helper::ROLES_CUSTOM_CLAIM => [] } } }
+        it { is_expected.to eq(Auth0Helper::AUTH_INVALID_USER) }
+      end
+      context "and role custom claim in JWT contains admin" do
+        let(:decoded_token) { { authenticated: true, auth_payload: { "email" => current_user.email, Auth0Helper::ROLES_CUSTOM_CLAIM => ["admin"] } } }
+        it { is_expected.to eq(Auth0Helper::AUTH_VALID) }
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,8 @@ class ActiveSupport::TestCase
     end
 
     # this is emulating a successfully decoded and valid auth0 bearer token
-    decoded_auth0_token = { authenticated: true, auth_payload: { "email" => user.email, "exp" => DateTime.now.to_i + 10.hours } }
+    roles = user.admin? ? ["admin"] : []
+    decoded_auth0_token = { authenticated: true, auth_payload: { "email" => user.email, "exp" => DateTime.now.to_i + 10.hours, Auth0Helper::ROLES_CUSTOM_CLAIM => roles } }
     allow_any_instance_of(Auth0Helper).to receive(:auth0_decode_auth_token) { decoded_auth0_token }
 
     OmniAuth.config.test_mode = true


### PR DESCRIPTION
# Description

IDSEQ-1556
Ensure roles in Auth0 match user database for admins.

# Notes

I'm also adding to this PR an improvement to airbrake error messages when auth0 failures endpoint doesn't get an error description or type.

# Tests

* Manual and automated
