### PR TITLE
[Hot fix] Truncate long file names for bulk downloads. (#2846)

### DIFF
--- a/app/lib/s3_tar_writer.rb
+++ b/app/lib/s3_tar_writer.rb
@@ -14,6 +14,8 @@ class S3TarWriter
     @tar = Gem::Package::TarWriter.new(@gz)
   end
 
+  # The Ruby Tarwriter requires the file name to be 100 chars max (including file extension) and
+  # the complete file path to be 256 chars or less.
   def add_file_with_data(file_path, data)
     # 600 is the default permission the file will have. Readable/writable by owner only.
     @tar.add_file_simple(file_path, 0o600, data.bytesize) do |io|

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -209,9 +209,19 @@ class BulkDownload < ApplicationRecord
   end
 
   # cleaned_project_names is a map from project id to cleaned project name
+  # The prefix is designed to be <= 75 chars.
+  # Bulk downloads should ensure that the suffix they add (e.g. contigs_nh.fasta, reads_per_gene.star.tab)
+  # is <= 25 chars, so that the total file name is <= 100 chars.
   def get_output_file_prefix(sample, cleaned_project_names)
-    "#{sample.name}__" \
-      "#{cleaned_project_names[sample.project_id]}_#{sample.project_id}__"
+    # Truncate the project name to 100 chars.
+    project_name_truncated = cleaned_project_names[sample.project_id][0...100]
+    sample_id_str = "_#{sample.id}_"
+    # Truncate the sample name to 65 chars (we keep the truncation fixed so users can parse the file name easier)
+    # However, if we ever get to 100M samples, we will need to truncate further.
+    max_sample_name_length = [65, 75 - sample_id_str.length].min
+    sample_name_truncated = sample.name[0...max_sample_name_length]
+
+    "#{project_name_truncated}_#{sample.project_id}/#{sample_name_truncated}#{sample_id_str}"
   end
 
   def bulk_download_ecs_task_command
@@ -259,7 +269,7 @@ class BulkDownload < ApplicationRecord
 
       download_tar_names = samples.map do |sample|
         "#{get_output_file_prefix(sample, cleaned_project_names)}" \
-          "reads_nonhost_all.fasta"
+          "reads_nh.fasta"
       end
     end
 
@@ -275,7 +285,7 @@ class BulkDownload < ApplicationRecord
         sample.input_files.map.with_index do |_input_file, input_file_index|
           # Include the project id because the cleaned project names might have duplicates as well.
           "#{get_output_file_prefix(sample, cleaned_project_names)}" \
-            "reads_nonhost_all_R#{input_file_index + 1}.#{file_ext}"
+            "reads_nh_R#{input_file_index + 1}.#{file_ext}"
         end
       end.flatten
     end
@@ -285,7 +295,7 @@ class BulkDownload < ApplicationRecord
 
       download_tar_names = samples.map do |sample|
         "#{get_output_file_prefix(sample, cleaned_project_names)}" \
-            "contigs_nonhost_all.fasta"
+            "contigs_nh.fasta"
       end
     end
 
@@ -389,9 +399,12 @@ class BulkDownload < ApplicationRecord
             reads_nonhost_for_taxid_fasta = ""
           end
 
+          # Truncate the taxon so that the total size of the file suffix is 25 characters max.
+          taxon_truncated = get_param_display_name('taxa_with_reads')[0...10]
+
           s3_tar_writer.add_file_with_data(
             "#{get_output_file_prefix(pipeline_run.sample, cleaned_project_names)}" \
-              "reads_nonhost_#{get_param_display_name('taxa_with_reads')}.fasta",
+              "reads_nh_#{taxon_truncated}.fasta",
             reads_nonhost_for_taxid_fasta
           )
         elsif download_type == CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE
@@ -399,9 +412,12 @@ class BulkDownload < ApplicationRecord
           contigs_nonhost_for_taxid_fasta = ''
           contigs.each { |contig| contigs_nonhost_for_taxid_fasta += contig.to_fa }
 
+          # Truncate the taxon so that the total size of the file suffix is 25 characters max.
+          taxon_truncated = get_param_display_name('taxa_with_contigs')[0...8]
+
           s3_tar_writer.add_file_with_data(
             "#{get_output_file_prefix(pipeline_run.sample, cleaned_project_names)}" \
-              "contigs_nonhost_#{get_param_display_name('taxa_with_contigs')}.fasta",
+              "contigs_nh_#{taxon_truncated}.fasta",
             contigs_nonhost_for_taxid_fasta
           )
         end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -61,7 +61,7 @@ class Project < ApplicationRecord
   end
 
   def cleaned_project_name
-    "project-#{name.downcase.split(' ').join('_')}"
+    name.downcase.split(' ').join('_')
   end
 
   def host_gene_counts_from_params(params)

--- a/spec/controllers/bulk_downloads_controller_spec.rb
+++ b/spec/controllers/bulk_downloads_controller_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe BulkDownloadsController, type: :controller do
         AppConfigHelper.set_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD, 100)
       end
 
+      def get_expected_tar_name(project, sample, suffix)
+        Shellwords.escape(
+          "#{project.cleaned_project_name[0...100]}_#{project.id}/#{sample.name[0...65]}_#{sample.id}_#{suffix}"
+        )
+      end
+
       it "should create new bulk download and kickoff the aegea ecs task" do
         @sample_one = create(:sample, project: @project, name: "Test Sample One",
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
@@ -32,10 +38,10 @@ RSpec.describe BulkDownloadsController, type: :controller do
           "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/fastqs/#{@sample_one.input_files[1].name}",
           "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/fastqs/#{@sample_two.input_files[0].name}",
           "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/fastqs/#{@sample_two.input_files[1].name}",
-          "--tar-names Test\\ Sample\\ One__project-test_project_#{@project.id}__original_R1.fastq.gz",
-          "Test\\ Sample\\ One__project-test_project_#{@project.id}__original_R2.fastq.gz",
-          "Test\\ Sample\\ Two__project-test_project_#{@project.id}__original_R1.fastq.gz",
-          "Test\\ Sample\\ Two__project-test_project_#{@project.id}__original_R2.fastq.gz",
+          "--tar-names #{get_expected_tar_name(@project, @sample_one, 'original_R1.fastq.gz')}",
+          get_expected_tar_name(@project, @sample_one, "original_R2.fastq.gz"),
+          get_expected_tar_name(@project, @sample_two, "original_R1.fastq.gz"),
+          get_expected_tar_name(@project, @sample_two, "original_R2.fastq.gz"),
           # Omit the dest-url, success-url, error-url, progress-url since they require the bulk download id.
           # Tested further in the model spec.
         ].join(" ")

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -68,6 +68,10 @@ describe BulkDownload, type: :model do
     end
   end
 
+  def get_expected_tar_name(project, sample, suffix)
+    "#{project.cleaned_project_name[0...100]}_#{project.id}/#{sample.name[0...65]}_#{sample.id}_#{suffix}"
+  end
+
   context "#bulk_download_ecs_task_command" do
     before do
       @joe = create(:joe)
@@ -95,10 +99,10 @@ describe BulkDownload, type: :model do
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/fastqs/#{@sample_two.input_files[0].name}",
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/fastqs/#{@sample_two.input_files[1].name}",
         "--tar-names",
-        "Test Sample One__project-test_project_#{@project.id}__original_R1.fastq.gz",
-        "Test Sample One__project-test_project_#{@project.id}__original_R2.fastq.gz",
-        "Test Sample Two__project-test_project_#{@project.id}__original_R1.fastq.gz",
-        "Test Sample Two__project-test_project_#{@project.id}__original_R2.fastq.gz",
+        get_expected_tar_name(@project, @sample_one, "original_R1.fastq.gz"),
+        get_expected_tar_name(@project, @sample_one, "original_R2.fastq.gz"),
+        get_expected_tar_name(@project, @sample_two, "original_R1.fastq.gz"),
+        get_expected_tar_name(@project, @sample_two, "original_R2.fastq.gz"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Original Input Files.tar.gz",
         "--success-url",
@@ -128,8 +132,8 @@ describe BulkDownload, type: :model do
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/assembly/refined_unidentified.fa",
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/assembly/refined_unidentified.fa",
         "--tar-names",
-        "Test Sample One__project-test_project_#{@project.id}__unmapped.fasta",
-        "Test Sample Two__project-test_project_#{@project.id}__unmapped.fasta",
+        get_expected_tar_name(@project, @sample_one, "unmapped.fasta"),
+        get_expected_tar_name(@project, @sample_two, "unmapped.fasta"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Unmapped Reads.tar.gz",
         "--success-url",
@@ -164,8 +168,8 @@ describe BulkDownload, type: :model do
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/assembly/refined_taxid_annot.fasta",
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/assembly/refined_taxid_annot.fasta",
         "--tar-names",
-        "Test Sample One__project-test_project_#{@project.id}__reads_nonhost_all.fasta",
-        "Test Sample Two__project-test_project_#{@project.id}__reads_nonhost_all.fasta",
+        get_expected_tar_name(@project, @sample_one, "reads_nh.fasta"),
+        get_expected_tar_name(@project, @sample_two, "reads_nh.fasta"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
         "--success-url",
@@ -202,10 +206,10 @@ describe BulkDownload, type: :model do
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/nonhost_R1.fastq",
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/nonhost_R2.fastq",
         "--tar-names",
-        "Test Sample One__project-test_project_#{@project.id}__reads_nonhost_all_R1.fastq",
-        "Test Sample One__project-test_project_#{@project.id}__reads_nonhost_all_R2.fastq",
-        "Test Sample Two__project-test_project_#{@project.id}__reads_nonhost_all_R1.fastq",
-        "Test Sample Two__project-test_project_#{@project.id}__reads_nonhost_all_R2.fastq",
+        get_expected_tar_name(@project, @sample_one, "reads_nh_R1.fastq"),
+        get_expected_tar_name(@project, @sample_one, "reads_nh_R2.fastq"),
+        get_expected_tar_name(@project, @sample_two, "reads_nh_R1.fastq"),
+        get_expected_tar_name(@project, @sample_two, "reads_nh_R2.fastq"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
         "--success-url",
@@ -234,8 +238,8 @@ describe BulkDownload, type: :model do
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/assembly/contigs.fasta",
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/assembly/contigs.fasta",
         "--tar-names",
-        "Test Sample One__project-test_project_#{@project.id}__contigs_nonhost_all.fasta",
-        "Test Sample Two__project-test_project_#{@project.id}__contigs_nonhost_all.fasta",
+        get_expected_tar_name(@project, @sample_one, "contigs_nh.fasta"),
+        get_expected_tar_name(@project, @sample_two, "contigs_nh.fasta"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Contigs (Non-host).tar.gz",
         "--success-url",
@@ -265,8 +269,8 @@ describe BulkDownload, type: :model do
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/results/3.12/reads_per_gene.star.tab",
         "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/results/3.12/reads_per_gene.star.tab",
         "--tar-names",
-        "Test Sample One__project-test_project_#{@project.id}__reads_per_gene.star.tab",
-        "Test Sample Two__project-test_project_#{@project.id}__reads_per_gene.star.tab",
+        get_expected_tar_name(@project, @sample_one, "reads_per_gene.star.tab"),
+        get_expected_tar_name(@project, @sample_two, "reads_per_gene.star.tab"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Host Gene Counts.tar.gz",
         "--success-url",
@@ -453,8 +457,8 @@ describe BulkDownload, type: :model do
       expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv_2")
 
       add_s3_tar_writer_expectations(
-        "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv",
-        "Test Sample Two__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv_2"
+        get_expected_tar_name(@project, @sample_one, "taxon_report.csv") => "mock_report_csv",
+        get_expected_tar_name(@project, @sample_two, "taxon_report.csv") => "mock_report_csv_2"
       )
 
       bulk_download.generate_download_file
@@ -472,8 +476,8 @@ describe BulkDownload, type: :model do
       expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv_2")
 
       add_s3_tar_writer_expectations(
-        "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv",
-        "Test Sample Two__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv_2"
+        get_expected_tar_name(@project, @sample_one, "taxon_report.csv") => "mock_report_csv",
+        get_expected_tar_name(@project, @sample_two, "taxon_report.csv") => "mock_report_csv_2"
       )
 
       expect(bulk_download).to receive(:progress_update_delay).exactly(2).times.and_return(0)
@@ -507,8 +511,8 @@ describe BulkDownload, type: :model do
       allow_any_instance_of(PipelineRun).to receive(:generate_contig_mapping_table_csv).and_return("mock_contigs_summary_csv")
 
       add_s3_tar_writer_expectations(
-        "Test Sample One__project-test_project_#{@project.id}__contig_summary_report.csv" => "mock_contigs_summary_csv",
-        "Test Sample Two__project-test_project_#{@project.id}__contig_summary_report.csv" => "mock_contigs_summary_csv"
+        get_expected_tar_name(@project, @sample_one, "contig_summary_report.csv") => "mock_contigs_summary_csv",
+        get_expected_tar_name(@project, @sample_two, "contig_summary_report.csv") => "mock_contigs_summary_csv"
       )
 
       bulk_download.generate_download_file
@@ -530,8 +534,8 @@ describe BulkDownload, type: :model do
       expect(bulk_download).to receive(:get_taxon_fasta_from_pipeline_run_combined_nt_nr).with(anything, mock_tax_id, mock_tax_level).exactly(2).times.and_return("mock_reads_nonhost_fasta")
 
       add_s3_tar_writer_expectations(
-        "Test Sample One__project-test_project_#{@project.id}__reads_nonhost_Salmonella enterica.fasta" => "mock_reads_nonhost_fasta",
-        "Test Sample Two__project-test_project_#{@project.id}__reads_nonhost_Salmonella enterica.fasta" => "mock_reads_nonhost_fasta"
+        get_expected_tar_name(@project, @sample_one, "reads_nh_Salmonella.fasta") => "mock_reads_nonhost_fasta",
+        get_expected_tar_name(@project, @sample_two, "reads_nh_Salmonella.fasta") => "mock_reads_nonhost_fasta"
       )
 
       bulk_download.generate_download_file
@@ -550,8 +554,8 @@ describe BulkDownload, type: :model do
       expect(bulk_download).to receive(:get_taxon_fasta_from_pipeline_run_combined_nt_nr).with(anything, mock_tax_id, mock_tax_level).exactly(2).times.and_return(nil)
 
       add_s3_tar_writer_expectations(
-        "Test Sample One__project-test_project_#{@project.id}__reads_nonhost_Salmonella enterica.fasta" => "",
-        "Test Sample Two__project-test_project_#{@project.id}__reads_nonhost_Salmonella enterica.fasta" => ""
+        get_expected_tar_name(@project, @sample_one, "reads_nh_Salmonella.fasta") => "",
+        get_expected_tar_name(@project, @sample_two, "reads_nh_Salmonella.fasta") => ""
       )
 
       bulk_download.generate_download_file
@@ -644,8 +648,8 @@ describe BulkDownload, type: :model do
       allow_any_instance_of(PipelineRun).to receive(:get_contigs_for_taxid).and_return([object_double(Contig.new, to_fa: "mock_contigs_nonhost_fasta")])
 
       add_s3_tar_writer_expectations(
-        "Test Sample One__project-test_project_#{@project.id}__contigs_nonhost_Salmonella enterica.fasta" => "mock_contigs_nonhost_fasta",
-        "Test Sample Two__project-test_project_#{@project.id}__contigs_nonhost_Salmonella enterica.fasta" => "mock_contigs_nonhost_fasta"
+        get_expected_tar_name(@project, @sample_one, "contigs_nh_Salmonel.fasta") => "mock_contigs_nonhost_fasta",
+        get_expected_tar_name(@project, @sample_two, "contigs_nh_Salmonel.fasta") => "mock_contigs_nonhost_fasta"
       )
 
       bulk_download.generate_download_file
@@ -664,7 +668,7 @@ describe BulkDownload, type: :model do
       expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_raise("error")
 
       add_s3_tar_writer_expectations(
-        "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv"
+        get_expected_tar_name(@project, @sample_one, "taxon_report.csv") => "mock_report_csv"
       )
 
       bulk_download.generate_download_file
@@ -685,8 +689,8 @@ describe BulkDownload, type: :model do
 
       add_s3_tar_writer_expectations(
         {
-          "Test Sample One__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv",
-          "Test Sample Two__project-test_project_#{@project.id}__taxon_report.csv" => "mock_report_csv_2",
+          get_expected_tar_name(@project, @sample_one, "taxon_report.csv") => "mock_report_csv",
+          get_expected_tar_name(@project, @sample_two, "taxon_report.csv") => "mock_report_csv_2",
         },
         99,
         false


### PR DESCRIPTION
Hot fix for https://github.com/chanzuckerberg/idseq-web/pull/2846