### PR TITLE
[Hot fix] Fix call to PipelineReportService in sample taxon report download..

### DIFF
--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -379,7 +379,7 @@ class BulkDownload < ApplicationRecord
       begin
         Rails.logger.info("Processing pipeline run #{pipeline_run.id} (#{index + 1} of #{pipeline_runs.length})...")
         if download_type == SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE
-          report_csv = PipelineReportService.call(pipeline_run, get_param_value("background"), true)
+          report_csv = PipelineReportService.call(pipeline_run.id, get_param_value("background"), true)
           s3_tar_writer.add_file_with_data(
             "#{get_output_file_prefix(pipeline_run.sample, cleaned_project_names)}" \
               "taxon_report.csv",


### PR DESCRIPTION
# Description

The PipelineReportService API has been changed so that you pass in a PipelineRun object instead of a pipeline run id. However, this API change is currently in staging, not prod. My recent hot fix used the new API, so the hot fix failed on prod.

This hot fix only needs to be applied to prod, not to staging or master (because the API is correct in those cases).

This is a case where doing the hot fix on prod branch first may have caught this issue.