### PR TITLE
[Report page] Change contigs query to use new columns

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -809,7 +809,7 @@ class SamplesController < ApplicationController
     report_info_params = pipeline_run.report_info_params
     # If the pipeline_version wasn't passed in from the client-side,
     # then set it to version for the selected default pipeline run.
-    if params[:pipeline_verison].nil?
+    if params[:pipeline_version].nil?
       params[:pipeline_version] = pipeline_run.pipeline_version
     end
     cache_key = PipelineReportService.report_info_cache_key(

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1444,12 +1444,12 @@ class PipelineRun < ApplicationRecord
   end
 
   def get_summary_contig_counts_v2(min_contig_size)
-    # key: taxid:count_type, value: read_counts: count
+    # Stores the number of contigs that match a given taxid, count_type (nt or nr), and read_count (number of reads aligned to that contig).
     # Create and store default values for the hash if the key doesn't exist yet
     summary_dict = Hash.new do |summary, taxid|
-      summary[taxid] = Hash.new do |taxid_, count_type| # rubocop forces different variable names
-        taxid_[count_type] = Hash.new do |count_type_, read_count|
-          count_type_[read_count] = 0
+      summary[taxid] = Hash.new do |taxid_hash, count_type| # rubocop forces different variable names
+        taxid_hash[count_type] = Hash.new do |count_type_hash, read_count|
+          count_type_hash[read_count] = 0
         end
       end
     end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1447,9 +1447,9 @@ class PipelineRun < ApplicationRecord
     # key: taxid:count_type, value: read_counts: count
     # Create and store default values for the hash if the key doesn't exist yet
     summary_dict = Hash.new do |summary, taxid|
-      summary[taxid] = Hash.new do |tax_id, count_type| # rubocop forces different variable names
-        tax_id[count_type] = Hash.new do |counttype, read_count|
-          counttype[read_count] = 0
+      summary[taxid] = Hash.new do |taxid_, count_type| # rubocop forces different variable names
+        taxid_[count_type] = Hash.new do |count_type_, read_count|
+          count_type_[read_count] = 0
         end
       end
     end


### PR DESCRIPTION
# Description

Update the contigs query used for the new report page to use the new columns (species_taxid_nt, species_taxid_nr, genus_taxid_nt, genus_taxid_nr) rather than lineage_json.

Based on a few local tests, this cuts the time for the query into roughly  third of what it was previously.

# Tests

* Verified that the contigs are still calculated and displayed as expected.
