### PR TITLE
IDSEQ-1933 - Fix issues during user creation

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -543,13 +543,14 @@ class ProjectsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def create_new_user_random_password(name, email)
     Rails.logger.info("Going to create new user via project sharing: #{email}")
-    user_params_with_password = { email: email, name: name, password: UsersHelper.generate_random_password }
-    @user = User.new(user_params_with_password.slice(:email, :name))
+    user_params = { email: email, name: name }
+    @user = User.new(user_params)
 
     # New flow for account creation on Auth0.
     if @user.save!
       # Create the user with Auth0.
-      create_response = Auth0UserManagementHelper.create_auth0_user(user_params_with_password)
+      user_params[:password] = UsersHelper.generate_random_password
+      create_response = Auth0UserManagementHelper.create_auth0_user(user_params)
       auth0_id = create_response["user_id"]
 
       # Get their password reset link so they can set a password.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
     respond_to do |format|
       if @user.save
         # Create the user with Auth0.
-        create_response = Auth0UserManagementHelper.create_auth0_user(new_user_params.slice(:email, :name, :password))
+        create_response = Auth0UserManagementHelper.create_auth0_user(**new_user_params.slice(:email, :name, :password, :role))
 
         if send_activation
           # Get their password reset link so they can set a password.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,14 +17,14 @@ class UsersController < ApplicationController
   # POST /users
   # POST /users.json
   def create
-    random_password = UsersHelper.generate_random_password
-    new_user_params = user_params.to_h.symbolize_keys.merge(password: random_password)
+    new_user_params = user_params.to_h.symbolize_keys
     send_activation = new_user_params.delete(:send_activation)
     new_user(new_user_params)
 
     respond_to do |format|
       if @user.save
         # Create the user with Auth0.
+        new_user_params[:password] = UsersHelper.generate_random_password
         create_response = Auth0UserManagementHelper.create_auth0_user(**new_user_params.slice(:email, :name, :password, :role))
 
         if send_activation

--- a/app/helpers/auth0_user_management_helper.rb
+++ b/app/helpers/auth0_user_management_helper.rb
@@ -3,7 +3,7 @@ module Auth0UserManagementHelper
 
   # Create a new user in the Auth0 user database.
   # This method creates the user only in the main user database (Username-Password-Authentication)
-  def self.create_auth0_user(email:, name:, role: User::ROLE_REGULAR_USER)
+  def self.create_auth0_user(email:, name:, password:, role: User::ROLE_REGULAR_USER)
     options = {
       connection: AUTH0_CONNECTION_NAME,
       email: email,

--- a/app/helpers/auth0_user_management_helper.rb
+++ b/app/helpers/auth0_user_management_helper.rb
@@ -3,7 +3,7 @@ module Auth0UserManagementHelper
 
   # Create a new user in the Auth0 user database.
   # This method creates the user only in the main user database (Username-Password-Authentication)
-  def self.create_auth0_user(email:, name:, password:, role: User::ROLE_REGULAR_USER)
+  def self.create_auth0_user(email:, name:, role: User::ROLE_REGULAR_USER)
     options = {
       connection: AUTH0_CONNECTION_NAME,
       email: email,
@@ -41,7 +41,7 @@ module Auth0UserManagementHelper
     (auth0_users.map { |u| u["identities"].map { |i| i.values_at("provider", "user_id").join("|") } }).flatten
   end
 
-  private_class_method def add_role_to_auth0_user(auth0_user_id:, role: User::ROLE_REGULAR_USER)
+  private_class_method def self.add_role_to_auth0_user(auth0_user_id:, role: User::ROLE_REGULAR_USER)
     auth0_roles = auth0_management_client.get_roles
     auth0_admin_role = (auth0_roles.find { |r| r["name"] == "Admin" })["id"]
     if role == User::ROLE_ADMIN

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
     with: /\A[- 'a-zA-ZÀ-ÖØ-öø-ÿ]+\z/, message: "Name must contain only letters, apostrophes, dashes or spaces",
   }
   attr_accessor :email_arguments
+  ROLE_REGULAR_USER = 0
   ROLE_ADMIN = 1
   IDSEQ_BUCKET_PREFIXES = ['idseq-'].freeze
   CZBIOHUB_BUCKET_PREFIXES = ['czb-', 'czbiohub-'].freeze

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -19,7 +19,8 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
             connection: "Username-Password-Authentication",
             email: "help@idseq.net",
             name: "User invited from Power Controller test",
-            password: instance_of(String)
+            password: instance_of(String),
+            app_metadata: { roles: [] }
           )
           .and_return("user_id" => "auth0|FAKE_AUTH0_USER_ID"))
 


### PR DESCRIPTION
# Description

IDSEQ-1933 - [bug] Failing to create users after removing devise
Devise was managing the password field, and user creation was trying to set this field to a random password before saving.

This PR is fixing this issue and another small issue during user creation that wasn't properly setting admin role for admin users.

# Tests

* Manual tests