### PR TITLE
[Report Page] Parallelize contig and taxon counts requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,8 @@ gem 'silencer'
 gem 'elasticsearch-model'
 # Use mysql as the database for Active Record
 gem 'mysql2'
-gem 'parallel', '1.14.0'
 gem 'oj'
+gem 'parallel', '1.14.0'
 gem 'prometheus-client', '0.7.1'
 # Use Puma as the app server
 gem 'puma', '~> 3.12'

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'silencer'
 gem 'elasticsearch-model'
 # Use mysql as the database for Active Record
 gem 'mysql2'
+gem 'parallel', '1.14.0'
 gem 'prometheus-client', '0.7.1'
 # Use Puma as the app server
 gem 'puma', '~> 3.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1203,6 +1203,7 @@ DEPENDENCIES
   nokogiri
   omniauth-auth0 (~> 2.2)
   omniauth-rails_csrf_protection (~> 0.1.2)
+  parallel (= 1.14.0)
   prometheus-client (= 0.7.1)
   puma (~> 3.12)
   rack-cors

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -600,7 +600,7 @@ class SamplesController < ApplicationController
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
     background_id = get_background_id(@sample, params[:background])
     min_contig_size = params[:min_contig_size]
-    @report_csv = PipelineReportService.call(pipeline_run, background_id, true, min_contig_size)
+    @report_csv = PipelineReportService.call(pipeline_run, background_id, csv: true, min_contig_size: min_contig_size)
     send_data @report_csv, filename: @sample.name + '_report.csv'
   end
 

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -386,7 +386,7 @@ class BulkDownload < ApplicationRecord
       begin
         Rails.logger.info("Processing pipeline run #{pipeline_run.id} (#{index + 1} of #{pipeline_runs.length})...")
         if download_type == SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE
-          report_csv = PipelineReportService.call(pipeline_run, get_param_value("background"), true)
+          report_csv = PipelineReportService.call(pipeline_run, get_param_value("background"), csv: true)
           s3_tar_writer.add_file_with_data(
             "#{get_output_file_prefix(pipeline_run.sample, cleaned_project_names)}" \
               "taxon_report.csv",

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -492,8 +492,8 @@ describe BulkDownload, type: :model do
                                              "displayName" => "Mock Background",
                                            })
 
-      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv")
-      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv_2")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv_2")
 
       add_s3_tar_writer_expectations(
         get_expected_tar_name(@project, @sample_one, "taxon_report.csv") => "mock_report_csv",
@@ -511,8 +511,8 @@ describe BulkDownload, type: :model do
                                              "displayName" => "Mock Background",
                                            })
 
-      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv")
-      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv_2")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv_2")
 
       add_s3_tar_writer_expectations(
         get_expected_tar_name(@project, @sample_one, "taxon_report.csv") => "mock_report_csv",
@@ -702,9 +702,9 @@ describe BulkDownload, type: :model do
                                              "displayName" => "Mock Background",
                                            })
 
-      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv")
       # The second sample raises an error while generating.
-      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_raise("error")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_raise("error")
 
       add_s3_tar_writer_expectations(
         get_expected_tar_name(@project, @sample_one, "taxon_report.csv") => "mock_report_csv"
@@ -723,8 +723,8 @@ describe BulkDownload, type: :model do
                                              "displayName" => "Mock Background",
                                            })
 
-      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv")
-      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, true).exactly(1).times.and_return("mock_report_csv_2")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv")
+      expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv_2")
 
       add_s3_tar_writer_expectations(
         {


### PR DESCRIPTION
# Description

* Parallelize requests to the database to fetch taxa (twice) and contigs
* Left as default but optional for now for performance analysis
* Rough comparison pointed to an improvement of 25-35% of the time taken by those three tasks in sequence (not total time). Further analysis to do in prod.

# Tests

* Create a report and verify that is loaded correctly
