### PR TITLE
[Report Page] Fix perf bug on report v2 due to recomputing all pathogen counts for every genus

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -216,6 +216,10 @@ export default class SampleViewV2 extends React.Component {
     const reportData = [];
     const highlightedTaxIds = new Set(rawReportData.highlightedTaxIds);
     if (rawReportData.sortedGenus) {
+      const generaPathogenCounts = getGeneraPathogenCounts(
+        rawReportData.counts[SPECIES_LEVEL_INDEX]
+      );
+
       rawReportData.sortedGenus.forEach(genusTaxId => {
         let hasHighlightedChildren = false;
         const childrenSpecies =
@@ -232,9 +236,6 @@ export default class SampleViewV2 extends React.Component {
             }
           );
         });
-        const generaPathogenCounts = getGeneraPathogenCounts(
-          rawReportData.counts[SPECIES_LEVEL_INDEX]
-        );
         reportData.push(
           merge(rawReportData.counts[GENUS_LEVEL_INDEX][genusTaxId], {
             highlighted:


### PR DESCRIPTION
# Description

* The call to computeGeneraCounts was being done "per genus" instead of just once.
* This would add a loading time of 10s! on a sample with 2k genus

# Tests

* Load report page and see it loads faster.
