### PR TITLE
Remove text crop mixins.

### DIFF
--- a/app/assets/src/components/common/blank_screen_message.scss
+++ b/app/assets/src/components/common/blank_screen_message.scss
@@ -21,11 +21,11 @@
   }
 
   .message {
-    @include font-header-l-crop;
-    margin-bottom: $space-s;
+    @include font-header-l;
+    margin-bottom: $space-xxxs;
   }
 
   .tagline {
-    @include font-body-s-crop;
+    @include font-body-s;
   }
 }

--- a/app/assets/src/components/common/loading_message.scss
+++ b/app/assets/src/components/common/loading_message.scss
@@ -12,6 +12,6 @@
   }
 
   .text {
-    @include font-body-xxs-crop;
+    @include font-body-xxs;
   }
 }

--- a/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/bare_dropdown.scss
@@ -126,7 +126,7 @@
   }
 
   .noResultsMessage {
-    @include font-body-xxs-crop;
+    @include font-body-xxs;
     padding: $space-xxs $space-m;
     color: $medium-grey;
   }

--- a/app/assets/src/components/ui/labels/status_label.scss
+++ b/app/assets/src/components/ui/labels/status_label.scss
@@ -3,7 +3,8 @@
 @import "~styles/themes/elements";
 
 .statusLabel {
-  @include font-label-xxs-crop;
+  @include font-label-xxs;
+  line-height: 9px;
   border-radius: 13px;
   margin-left: $space-xxs;
   padding: $space-xxxs $space-xxs;

--- a/app/assets/src/components/views/SampleViewV2/report_table.scss
+++ b/app/assets/src/components/views/SampleViewV2/report_table.scss
@@ -3,7 +3,7 @@
 @import "~styles/themes/typography";
 
 .header {
-  @include font-body-xxs-crop;
+  @include font-body-xxs;
 
   color: $medium-grey;
   justify-content: flex-end;
@@ -38,7 +38,7 @@
 }
 
 .cell {
-  @include font-body-s-crop;
+  @include font-body-s;
 
   color: $darkest-grey;
   font-weight: $font-weight-bold;
@@ -50,13 +50,12 @@
   display: inline-block;
 
   .stackElement {
-    @include font-body-s-crop;
+    @include font-body-s;
 
     font-weight: $font-weight-bold;
-    padding: $space-xxs 0;
 
     &.lowlightValue {
-      @include font-body-xxs-crop;
+      @include font-body-xxs;
 
       color: $medium-grey;
     }

--- a/app/assets/src/components/views/bulk_download/bulk_download_details_modal.scss
+++ b/app/assets/src/components/views/bulk_download/bulk_download_details_modal.scss
@@ -2,19 +2,19 @@
 @import "~styles/themes/elements";
 
 .title {
-  @include font-header-xl-crop;
+  @include font-header-xl;
 }
 
 .loadingContainer {
-  margin-top: $space-s;
+  margin-top: $space-m;
 }
 
 .details {
-  margin-top: $space-l;
+  margin-top: $space-m;
 
   .samplesHeader {
-    @include font-header-xs-crop;
-    padding: $space-l $space-m $space-xs;
+    @include font-header-xs;
+    padding: $space-m $space-m $space-xxxs;
   }
 
   .samplesList {
@@ -23,8 +23,8 @@
     padding: 0 $space-m;
 
     .sampleName {
-      @include font-body-xs-crop;
-      padding: $space-xs 0;
+      @include font-body-xs;
+      padding: $space-xxxs 0;
     }
   }
 }

--- a/app/assets/src/components/views/bulk_download/bulk_download_summary.scss
+++ b/app/assets/src/components/views/bulk_download/bulk_download_summary.scss
@@ -4,36 +4,35 @@
 
 .bulkDownloadSummary {
   background-color: $off-white;
-  padding: 14px;
+  padding: $space-s $space-m;
 
   .title {
     display: flex;
 
     .name {
-      @include font-header-xs-crop;
+      @include font-header-xs;
     }
 
     .numSamples {
-      @include font-body-xs-crop;
+      @include font-body-xs;
       color: $medium-grey;
     }
   }
 
   .params {
     display: flex;
-    margin-top: $space-l;
+    margin-top: $space-m;
 
     .param {
       flex: 1 1 0;
       min-width: 0;
 
       .name {
-        @include font-body-xs-crop;
-        margin-bottom: $space-xxxs;
+        @include font-body-xs;
       }
 
       .value {
-        @include font-body-xs-crop;
+        @include font-body-xs;
         color: $medium-grey;
       }
     }

--- a/app/assets/src/components/views/bulk_download/bulk_download_table_renderers.scss
+++ b/app/assets/src/components/views/bulk_download/bulk_download_table_renderers.scss
@@ -14,16 +14,13 @@
   }
 
   .downloadRightPane {
-    padding: $space-xxs 0;
-
     .downloadNameContainer {
       display: flex;
       align-items: center;
-      margin-bottom: $space-xs;
     }
 
     .downloadName {
-      @include font-header-s-crop;
+      @include font-header-s;
     }
 
     .downloadStatus {
@@ -31,7 +28,7 @@
     }
 
     .sampleCount {
-      @include font-body-xxs-crop;
+      @include font-body-xxs;
       color: $medium-grey;
       cursor: pointer;
 
@@ -75,26 +72,14 @@
     }
   }
 
-  .warningTooltip {
-    @include font-body-xxs-crop;
-    margin-left: $space-xxs;
-    color: $medium-grey;
-    text-decoration: underline;
-    text-decoration-style: dashed;
-  }
-
-  .message {
-    @include font-body-xxs-crop;
-  }
-
   .separator {
-    @include font-body-xxs-crop;
+    @include font-body-xxs;
     margin: 0 $space-xs;
     color: $medium-grey;
   }
 
   .link {
-    @include font-label-s-crop;
+    @include font-label-s;
     /* overwrite header.scss */
     color: $primary-light !important;
     cursor: pointer;

--- a/app/assets/src/components/views/bulk_download/choose_step.scss
+++ b/app/assets/src/components/views/bulk_download/choose_step.scss
@@ -43,10 +43,10 @@
 
   .taxaWithReadsOptionsHeader {
     display: flex;
-    padding: $space-s $space-m;
+    padding: $space-xxs $space-m;
 
     .header {
-      @include font-header-xs-crop;
+      @include font-header-xs;
       color: $dark-grey;
     }
 
@@ -58,10 +58,10 @@
 
   .taxaWithReadsOption {
     display: flex;
-    padding: $space-s $space-m;
+    padding: $space-xxs $space-m;
 
     .taxonName {
-      @include font-body-xxs-crop;
+      @include font-body-xxs;
       flex-shrink: 1;
       text-overflow: ellipsis;
       overflow: hidden;
@@ -74,7 +74,7 @@
     }
 
     .sampleCount {
-      @include font-body-xxs-crop;
+      @include font-body-xxs;
       color: $medium-grey;
     }
   }

--- a/app/assets/src/components/views/bulk_download/taxon_contig_select.scss
+++ b/app/assets/src/components/views/bulk_download/taxon_contig_select.scss
@@ -7,10 +7,10 @@
 
   .optionsHeader {
     display: flex;
-    padding: $space-s $space-m;
+    padding: $space-xxs $space-m;
 
     .header {
-      @include font-header-xs-crop;
+      @include font-header-xs;
       color: $dark-grey;
     }
 
@@ -22,10 +22,10 @@
 
   .option {
     display: flex;
-    padding: $space-s $space-m;
+    padding: $space-xxs $space-m;
 
     .taxonName {
-      @include font-body-xxs-crop;
+      @include font-body-xxs;
       flex-shrink: 1;
       text-overflow: ellipsis;
       overflow: hidden;
@@ -38,7 +38,7 @@
     }
 
     .sampleCount {
-      @include font-body-xxs-crop;
+      @include font-body-xxs;
       color: $medium-grey;
     }
   }

--- a/app/assets/src/components/views/compare/samples_heatmap_vis.scss
+++ b/app/assets/src/components/views/compare/samples_heatmap_vis.scss
@@ -91,7 +91,7 @@
     }
 
     .bannerText {
-      @include font-body-xxs-crop;
+      @include font-body-xxs;
       color: $medium-grey;
       background: $white;
       border-radius: 4px;
@@ -99,7 +99,7 @@
       cursor: default;
       display: inline-block;
       margin: $space-xs auto auto;
-      padding: $space-xxs $space-xs;
+      padding: $space-xxxs $space-xs;
       text-align: center;
     }
 

--- a/app/assets/src/components/views/playgrounds/PlaygroundTypography.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundTypography.jsx
@@ -9,14 +9,7 @@ import cs from "./playground_typography.scss";
 
 class PlaygroundTypography extends React.Component {
   state = {
-    highlightBorder: false,
     upperCase: false,
-  };
-
-  toggleHighlightBorder = () => {
-    this.setState({
-      highlightBorder: !this.state.highlightBorder,
-    });
   };
 
   toggleUpperCase = () => {
@@ -26,7 +19,7 @@ class PlaygroundTypography extends React.Component {
   };
 
   render() {
-    const { highlightBorder, upperCase } = this.state;
+    const { upperCase } = this.state;
 
     // Display all the CSS classes starting with "font".
     const fontClasses = filter(
@@ -57,28 +50,10 @@ class PlaygroundTypography extends React.Component {
           <div className={cs.controls}>
             <Checkbox
               className={cs.checkbox}
-              checked={highlightBorder}
-              label="Show borders"
-              onChange={this.toggleHighlightBorder}
-            />
-            <Checkbox
-              className={cs.checkbox}
               checked={upperCase}
               label="Upper case"
               onChange={this.toggleUpperCase}
             />
-          </div>
-        </div>
-        <div
-          className={cx(
-            cs.multilineText,
-            cs.borderContainer,
-            highlightBorder && cs.highlight
-          )}
-        >
-          <div className={cs.container}>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </div>
         </div>
         <div className={cs.playgroundTypography}>
@@ -86,13 +61,7 @@ class PlaygroundTypography extends React.Component {
             (classes, index) => (
               <div className={cs.column} key={index}>
                 {classes.map(fontClass => (
-                  <div
-                    className={cx(
-                      cs.borderContainer,
-                      highlightBorder && cs.highlight
-                    )}
-                    key={fontClass}
-                  >
+                  <div className={cx(cs.borderContainer)} key={fontClass}>
                     <div
                       className={cx(
                         cs.container,

--- a/app/assets/src/components/views/playgrounds/playground_typography.scss
+++ b/app/assets/src/components/views/playgrounds/playground_typography.scss
@@ -5,11 +5,11 @@
   margin-top: 40px;
 
   .title {
-    @include font-header-xxl-crop;
+    @include font-header-xxl;
   }
 
   .controls {
-    @include font-body-s-crop;
+    @include font-body-s;
     color: $medium-grey;
     margin-top: 10px;
     display: flex;
@@ -37,48 +37,9 @@
   margin-bottom: 40px;
 }
 
-.multilineText {
-  width: 350px;
-  margin: 20px 0;
-  border-bottom: none !important;
-
-  .container {
-    @include font-body-s-crop;
-  }
-}
-
 .borderContainer {
   position: relative;
   border-bottom: 1px solid #eee;
-
-  &.highlight {
-    border-bottom: 1px solid $primary-lighter;
-
-    &::before,
-    &::after {
-      content: "";
-      display: block;
-      background-color: $primary-light;
-      opacity: 0.2;
-      position: absolute;
-    }
-
-    &::before {
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 20px;
-      width: 100%;
-    }
-
-    &::after {
-      bottom: 0;
-      left: 0;
-      right: 0;
-      height: 20px;
-      width: 100%;
-    }
-  }
 
   &:last-child {
     border-bottom: none;
@@ -94,105 +55,105 @@
 }
 
 .font-header-xxl {
-  @include font-header-xxl-crop;
+  @include font-header-xxl;
 }
 
 .font-header-xl {
-  @include font-header-xl-crop;
+  @include font-header-xl;
 }
 
 .font-header-l {
-  @include font-header-l-crop;
+  @include font-header-l;
 }
 
 .font-header-m {
-  @include font-header-m-crop;
+  @include font-header-m;
 }
 
 .font-header-s {
-  @include font-header-s-crop;
+  @include font-header-s;
 }
 
 .font-header-xs {
-  @include font-header-xs-crop;
+  @include font-header-xs;
 }
 
 .font-header-xxs {
-  @include font-header-xxs-crop;
+  @include font-header-xxs;
 }
 
 .font-header-xxxs {
-  @include font-header-xxxs-crop;
+  @include font-header-xxxs;
 }
 
 .font-header-accordion {
-  @include font-header-accordion-crop;
+  @include font-header-accordion;
 }
 
 .font-header-node-l {
-  @include font-header-node-l-crop;
+  @include font-header-node-l;
 }
 
 .font-header-node-s {
-  @include font-header-node-s-crop;
+  @include font-header-node-s;
 }
 
 .font-body-xl {
-  @include font-body-xl-crop;
+  @include font-body-xl;
 }
 
 .font-body-l {
-  @include font-body-l-crop;
+  @include font-body-l;
 }
 
 .font-body-m {
-  @include font-body-m-crop;
+  @include font-body-m;
 }
 
 .font-body-s {
-  @include font-body-s-crop;
+  @include font-body-s;
 }
 
 .font-body-xs {
-  @include font-body-xs-crop;
+  @include font-body-xs;
 }
 
 .font-body-xxs {
-  @include font-body-xxs-crop;
+  @include font-body-xxs;
 }
 
 .font-body-xxxs {
-  @include font-body-xxxs-crop;
+  @include font-body-xxxs;
 }
 
 .font-label-s {
-  @include font-label-s-crop;
+  @include font-label-s;
 }
 
 .font-label-xs {
-  @include font-label-xs-crop;
+  @include font-label-xs;
 }
 
 .font-label-xxs {
-  @include font-label-xxs-crop;
+  @include font-label-xxs;
 }
 
 .font-tag-s {
-  @include font-tag-s-crop;
+  @include font-tag-s;
 }
 
 .font-viz-label {
-  @include font-viz-label-crop;
+  @include viz-label;
 }
 
 .font-search-result-title {
-  @include font-search-result-title-crop;
+  @include font-search-result-title;
 }
 
 .font-search-result-description {
-  @include font-search-result-description-crop;
+  @include font-search-result-description;
 }
 
 .font-code {
-  @include font-code-crop;
+  @include font-code;
 }

--- a/app/assets/src/components/views/samples/toolbar_icon.scss
+++ b/app/assets/src/components/views/samples/toolbar_icon.scss
@@ -29,7 +29,7 @@
 }
 
 .popupText {
-  @include font-body-xxs-crop;
+  @include font-body-xxs;
 
   .popupSubtitle {
     color: $medium-grey;

--- a/app/assets/src/styles/themes/_typography.scss
+++ b/app/assets/src/styles/themes/_typography.scss
@@ -27,42 +27,12 @@ $font-weight-semibold: 600;
 $font-weight-bold: 700;
 $font-weight-heavy: 800;
 
-// Adapted from http://text-crop.eightshapes.com/
-// There isn't an easy formula for calculating the distance between the font-size box
-// and the cap height (top of text) and baseline (bottom of text).
-// All the top-crop and bottom-crop values are manually determined.
-@mixin text-crop($top-crop, $bottom-crop) {
-  &::before,
-  &::after {
-    content: "";
-    display: block;
-    height: 0;
-    width: 0;
-  }
-
-  &::before {
-    margin-bottom: -#{$top-crop}px;
-  }
-
-  &::after {
-    margin-top: -#{$bottom-crop}px;
-  }
-}
-
 // Font mixins. Use the cropped versions whenever possible.
 @mixin font-header-xxl {
   font-size: 26px;
   line-height: 34px;
   font-weight: $font-weight-semibold;
   letter-spacing: 0.3px;
-}
-
-// Apply this to the immediate container of your text.
-// This gets rid of the extra space above and below a block of text due to line-height.
-// TODO(mark): Once the cropped versions are stable, refactor everything to use them and delete the old mixins.
-@mixin font-header-xxl-crop {
-  @include font-header-xxl;
-  @include text-crop(8, 7);
 }
 
 @mixin font-header-xl {
@@ -72,21 +42,11 @@ $font-weight-heavy: 800;
   letter-spacing: 0.3px;
 }
 
-@mixin font-header-xl-crop {
-  @include font-header-xl;
-  @include text-crop(8, 6);
-}
-
 @mixin font-header-l {
   font-size: 18px;
   line-height: 24px;
   font-weight: $font-weight-semibold;
   letter-spacing: 0.3px;
-}
-
-@mixin font-header-l-crop {
-  @include font-header-l;
-  @include text-crop(6, 5);
 }
 
 @mixin font-header-m {
@@ -96,21 +56,11 @@ $font-weight-heavy: 800;
   letter-spacing: 0.3px;
 }
 
-@mixin font-header-m-crop {
-  @include font-header-m;
-  @include text-crop(5, 5);
-}
-
 @mixin font-header-s {
   font-size: 14px;
   line-height: 24px;
   font-weight: $font-weight-semibold;
   letter-spacing: 0.3px;
-}
-
-@mixin font-header-s-crop {
-  @include font-header-s;
-  @include text-crop(7, 7);
 }
 
 @mixin font-header-xs {
@@ -120,11 +70,6 @@ $font-weight-heavy: 800;
   letter-spacing: 0.3px;
 }
 
-@mixin font-header-xs-crop {
-  @include font-header-xs;
-  @include text-crop(5, 5);
-}
-
 @mixin font-header-xxs {
   font-size: 12px;
   line-height: 18px;
@@ -132,21 +77,11 @@ $font-weight-heavy: 800;
   letter-spacing: 0.3px;
 }
 
-@mixin font-header-xxs-crop {
-  @include font-header-xxs;
-  @include text-crop(4, 4);
-}
-
 @mixin font-header-xxxs {
   font-size: 11px;
   line-height: 16px;
   font-weight: $font-weight-semibold;
   letter-spacing: 0.3px;
-}
-
-@mixin font-header-xxxs-crop {
-  @include font-header-xxxs;
-  @include text-crop(4, 4);
 }
 
 @mixin font-header-accordion {
@@ -157,22 +92,12 @@ $font-weight-heavy: 800;
   text-transform: uppercase;
 }
 
-@mixin font-header-accordion-crop {
-  @include font-header-accordion;
-  @include text-crop(15, 16);
-}
-
 @mixin font-header-node-l {
   font-size: 12px;
   line-height: 13px;
   font-weight: 600;
   letter-spacing: 1px;
   text-transform: uppercase;
-}
-
-@mixin font-header-node-l-crop {
-  @include font-header-node-l;
-  @include text-crop(2, 2);
 }
 
 @mixin font-header-node-s {
@@ -182,21 +107,11 @@ $font-weight-heavy: 800;
   letter-spacing: 0.3px;
 }
 
-@mixin font-header-node-s-crop {
-  @include font-header-node-s;
-  @include text-crop(3, 3);
-}
-
 @mixin font-body-xl {
   font-size: 22px;
   line-height: 30px;
   letter-spacing: 0.3px;
   font-weight: $font-weight-regular;
-}
-
-@mixin font-body-xl-crop {
-  @include font-body-xl;
-  @include text-crop(8, 7);
 }
 
 @mixin font-body-l {
@@ -206,21 +121,11 @@ $font-weight-heavy: 800;
   font-weight: $font-weight-regular;
 }
 
-@mixin font-body-l-crop {
-  @include font-body-l;
-  @include text-crop(8, 7);
-}
-
 @mixin font-body-m {
   font-size: 16px;
   line-height: 26px;
   letter-spacing: 0.3px;
   font-weight: $font-weight-regular;
-}
-
-@mixin font-body-m-crop {
-  @include font-body-m;
-  @include text-crop(7, 7);
 }
 
 @mixin font-body-s {
@@ -230,21 +135,11 @@ $font-weight-heavy: 800;
   font-weight: $font-weight-regular;
 }
 
-@mixin font-body-s-crop {
-  @include font-body-s;
-  @include text-crop(7, 7);
-}
-
 @mixin font-body-xs {
   font-size: 13px;
   line-height: 20px;
   letter-spacing: 0.3px;
   font-weight: $font-weight-regular;
-}
-
-@mixin font-body-xs-crop {
-  @include font-body-xs;
-  @include text-crop(5, 5);
 }
 
 @mixin font-body-xxs {
@@ -254,21 +149,11 @@ $font-weight-heavy: 800;
   font-weight: $font-weight-regular;
 }
 
-@mixin font-body-xxs-crop {
-  @include font-body-xxs;
-  @include text-crop(4, 5);
-}
-
 @mixin font-body-xxxs {
   font-size: 11px;
   line-height: 16px;
   letter-spacing: 0.3px;
   font-weight: $font-weight-regular;
-}
-
-@mixin font-body-xxxs-crop {
-  @include font-body-xxxs;
-  @include text-crop(4, 4);
 }
 
 @mixin font-label-s {
@@ -279,21 +164,11 @@ $font-weight-heavy: 800;
   font-weight: $font-weight-semibold;
 }
 
-@mixin font-label-s-crop {
-  @include font-label-s;
-  @include text-crop(8, 8);
-}
-
 @mixin font-label-xs {
   font-size: 10px;
   line-height: 24px;
   letter-spacing: 1.4px;
   text-transform: uppercase;
-}
-
-@mixin font-label-xs-crop {
-  @include font-label-xs;
-  @include text-crop(9, 8);
 }
 
 @mixin font-label-xxs {
@@ -303,11 +178,6 @@ $font-weight-heavy: 800;
   text-transform: uppercase;
 }
 
-@mixin font-label-xxs-crop {
-  @include font-label-xxs;
-  @include text-crop(8, 9);
-}
-
 @mixin font-tag-s {
   font-size: 11px;
   line-height: 11px;
@@ -315,20 +185,10 @@ $font-weight-heavy: 800;
   font-weight: 400;
 }
 
-@mixin font-tag-s-crop {
-  @include font-tag-s;
-  @include text-crop(2, 1);
-}
-
 @mixin viz-label {
   font-size: 9px;
   line-height: 13px;
   font-weight: $font-weight-semibold;
-}
-
-@mixin font-viz-label-crop {
-  @include viz-label;
-  @include text-crop(3, 3);
 }
 
 @mixin font-search-result-title {
@@ -338,29 +198,14 @@ $font-weight-heavy: 800;
   font-weight: $font-weight-semibold;
 }
 
-@mixin font-search-result-title-crop {
-  @include font-search-result-title;
-  @include text-crop(7, 7);
-}
-
 @mixin font-search-result-description {
   font-size: 10px;
   line-height: 14px;
   letter-spacing: 1px;
 }
 
-@mixin font-search-result-description-crop {
-  @include font-search-result-description;
-  @include text-crop(3, 3);
-}
-
 @mixin font-code {
   font-face: $font-family-monospace;
   font-size: 13px;
   line-height: 16px;
-}
-
-@mixin font-code-crop {
-  @include font-code;
-  @include text-crop(3, 3);
 }


### PR DESCRIPTION
# Description

After trying out this approach, we found that it caused bugs, was hard to reason about, and didn't always behave as expected.

This PR removes the text crop mixins from the code base.

Also updated the typography playground.

<img width="1593" alt="Screen Shot 2019-12-12 at 7 06 57 PM" src="https://user-images.githubusercontent.com/837004/70766626-29238800-1d13-11ea-8c09-bacf1da83812.png">


# Tests

* I did my best to manually inspect each instance and verify that the styling looks the same.
