### PR TITLE
Auth0 user management profile sync

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -549,7 +549,6 @@ class ProjectsController < ApplicationController
     # New flow for account creation on Auth0.
     if @user.save!
       # Create the user with Auth0.
-      user_params[:password] = UsersHelper.generate_random_password
       create_response = Auth0UserManagementHelper.create_auth0_user(user_params)
       auth0_id = create_response["user_id"]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,8 +24,7 @@ class UsersController < ApplicationController
     respond_to do |format|
       if @user.save
         # Create the user with Auth0.
-        new_user_params[:password] = UsersHelper.generate_random_password
-        create_response = Auth0UserManagementHelper.create_auth0_user(**new_user_params.slice(:email, :name, :password, :role))
+        create_response = Auth0UserManagementHelper.create_auth0_user(**new_user_params.slice(:email, :name, :role))
 
         if send_activation
           # Get their password reset link so they can set a password.


### PR DESCRIPTION
# Description

In case a user profile is in IDseq database but not on auth0, admins can now fix this situation by just updating the user profile using the user management module.

# Tests

* Manual
