### PR TITLE
[Report Page] Improve perf of report info params used for cache key

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1563,7 +1563,7 @@ class PipelineRun < ApplicationRecord
   # Gets last update time of all has_many relations and current pipeline run
   def max_updated_at
     assocs = PipelineRun.reflect_on_all_associations(:has_many)
-    assocs_max = assocs.map { |assoc| send(assoc.name).pluck(:updated_at).max }
+    assocs_max = assocs.map { |assoc| send(assoc.name).maximum(:updated_at) }
     [updated_at, assocs_max.compact.max].compact.max
   end
 


### PR DESCRIPTION
# Description

* Report info parameters compute the maximum of update_at of associations of pipeline run object. This was being computed on rails, instead of the database.

# Tests

* Check that report info parameters still show the correct timestamp.
