### PR TITLE
IDSEQ-1559 - Remove Devise unused fields from the database

### DIFF
--- a/db/migrate/20191212225957_remove_devise_fields_from_user.rb
+++ b/db/migrate/20191212225957_remove_devise_fields_from_user.rb
@@ -1,0 +1,23 @@
+class RemoveDeviseFieldsFromUser < ActiveRecord::Migration[5.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        change_table(:users, bulk: true) do |t|
+          t.remove :encrypted_password
+          t.remove :remember_created_at
+          t.remove :reset_password_token
+          t.remove :reset_password_sent_at
+        end
+      end
+      dir.down do
+        require 'securerandom'
+        change_table(:users, bulk: true) do |t|
+          t.column :encrypted_password, :string, default: SecureRandom.hex
+          t.column :remember_created_at, :datetime
+          t.column :reset_password_token, :string, default: SecureRandom.hex
+          t.column :reset_password_sent_at, :datetime
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

After completely removing Devise, the following fields from users table are not being used anymore:
- encrypted_password
- remember_created_at
- reset_password_token
- reset_password_sent_at

# Notes

I created a reversible migration using random passwords (they are not being used anymore) in case we need to rollback this change for any random reason.

# Tests

* Manual
