### PR TITLE
[bug] IDSEQ-1720 - Lost session during restarts

### DIFF
--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -40,6 +40,8 @@ module Auth0Helper
     if access_token[:authenticated]
       auth_payload = access_token[:auth_payload]
       auth_user = User.find_by(email: auth_payload["email"])
+      # logout users from previous Devise scope
+      warden.logout(:user)
       warden.set_user(auth_user, scope: :auth0_user)
       true
     else
@@ -71,6 +73,8 @@ module Auth0Helper
   def auth0_invalidate_application_session
     session.delete(:auth0_credentials)
     warden&.logout(:auth0_user)
+    # logout users from previous Devise scope
+    warden&.logout(:user)
   end
 
   # URL used to remove auth0 session from Auth0 Session Layer

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,3 +1,4 @@
+require 'digest/sha1'
 
 Rails.application.config.middleware.use Warden::Manager do |manager|
   manager.failure_app = proc { |_env| ['401', { 'Content-Type' => 'application/json' }, { error: 'Unauthorized', code: 401 }] }
@@ -7,7 +8,7 @@ Warden::Manager.serialize_into_session do |user|
   # convert to warden_session_obj
   serialized = user.slice("id", "role")
   # extra field to improve security
-  serialized["authentication_token_hash"] = user["authentication_token"].hash
+  serialized["authentication_token_hash"] = Digest::SHA1.hexdigest(user["authentication_token"])
   serialized
 end
 
@@ -15,7 +16,7 @@ Warden::Manager.serialize_from_session do |warden_session_obj|
   return nil unless warden_session_obj.instance_of?(Hash)
   id, role, authentication_token_hash = warden_session_obj.values_at("id", "role", "authentication_token_hash")
   user = User.find_by(id: id, role: role)
-  if user && authentication_token_hash == user.authentication_token.hash
+  if user && authentication_token_hash == Digest::SHA1.hexdigest(user.authentication_token)
     user
   end
 end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -8,7 +8,7 @@ Warden::Manager.serialize_into_session do |user|
   # convert to warden_session_obj
   serialized = user.slice("id", "role")
   # extra field to improve security
-  serialized["authentication_token_hash"] = Digest::SHA1.hexdigest(user["authentication_token"])
+  serialized["authentication_token_hash"] = Digest::SHA1.hexdigest(user["authentication_token"] || "")
   serialized
 end
 
@@ -16,7 +16,7 @@ Warden::Manager.serialize_from_session do |warden_session_obj|
   return nil unless warden_session_obj.instance_of?(Hash)
   id, role, authentication_token_hash = warden_session_obj.values_at("id", "role", "authentication_token_hash")
   user = User.find_by(id: id, role: role)
-  if user && authentication_token_hash == Digest::SHA1.hexdigest(user.authentication_token)
+  if user && authentication_token_hash == Digest::SHA1.hexdigest(user.authentication_token || "")
     user
   end
 end


### PR DESCRIPTION
# Description

Fix an issue with warden sessions being lost during server restarts.
Also cleans up any previous devise session to reduce session size.

# Notes

This issue was related to the fact `String#hash` is not consistent across different ruby instances, and it creates different values on each restart. Replaced by SHA1.

# Tests

* Manual
