### PR TITLE
[IDSEQ-1885] Implement low-support mode banner / general announcement banner

### DIFF
--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -9,6 +9,7 @@ import { showToast } from "~/components/utils/toast";
 import Notification from "~ui/notifications/Notification";
 import ToastContainer from "~ui/containers/ToastContainer";
 import BareDropdown from "~ui/controls/dropdowns/BareDropdown";
+import AlertIcon from "~ui/icons/AlertIcon";
 import LogoIcon from "~ui/icons/LogoIcon";
 import {
   DISCOVERY_DOMAIN_MY_DATA,
@@ -98,6 +99,7 @@ class Header extends React.Component {
     return (
       userSignedIn && (
         <div>
+          <AnnouncementBanner />
           <div className={cs.header}>
             <div className={cs.logo}>
               <a href="/">
@@ -136,6 +138,14 @@ Header.propTypes = {
 };
 
 Header.contextType = UserContext;
+
+const AnnouncementBanner = () => {
+  return (
+    <div className={cs.announcementBanner}>
+      <AlertIcon className={cs.icon} />
+    </div>
+  );
+};
 
 const UserMenuDropDown = ({
   adminUser,

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -4,6 +4,7 @@ import moment from "moment";
 import { forbidExtraProps } from "airbnb-prop-types";
 import cx from "classnames";
 
+import BasicPopup from "~/components/BasicPopup";
 import { UserContext } from "~/components/common/UserContext";
 import { showToast } from "~/components/utils/toast";
 import Notification from "~ui/notifications/Notification";
@@ -143,20 +144,37 @@ Header.contextType = UserContext;
 const AnnouncementBanner = () => {
   return (
     <div className={cs.announcementBanner}>
-      <span className={cs.content}>
-        <AlertIcon className={cs.icon} />
-        <span className={cs.title}>Low-Support Mode:</span>
-        We will only be responding to highly urgent issues from 12/21–12/29. For
-        now, check out our
-        <ExternalLink
-          className={cs.link}
-          href="https://help.idseq.net"
-          onClick={() => logAnalyticsEvent("AnnouncementBanner_link_clicked")}
-        >
-          Help Center
-        </ExternalLink>. Happy Holidays!
-      </span>
-      <RemoveIcon className={cs.close} />
+      <BasicPopup
+        content={
+          "Low-Support Mode: We will only be responding to highly urgent issues from 12/21–12/29. For now, check out our Help Center. Happy Holidays!"
+        }
+        position="bottom center"
+        wide="very"
+        trigger={
+          <span className={cs.content}>
+            <AlertIcon className={cs.icon} />
+            <span className={cs.title}>Low-Support Mode:</span>
+            We will only be responding to highly urgent issues from 12/21–12/29.
+            For now, check out our
+            <ExternalLink
+              className={cs.link}
+              href="https://help.idseq.net"
+              onClick={() =>
+                logAnalyticsEvent("AnnouncementBanner_link_clicked")
+              }
+            >
+              Help Center
+            </ExternalLink>. Happy Holidays!
+          </span>
+        }
+      />
+      <RemoveIcon
+        className={cs.close}
+        onClick={() => {
+          logAnalyticsEvent("AnnouncementBanner_close_clicked");
+          console.log("clicked");
+        }}
+      />
     </div>
   );
 };

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -59,11 +59,30 @@ const showPrivacyUpdateNotification = () => {
   }
 };
 
+const setAnnouncementBannerViewed = () => {
+  localStorage.setItem("dismissedAnnouncementBanner", "true");
+};
+
 class Header extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showAnnouncementBanner: false,
+    };
+  }
+
   componentDidMount() {
-    const { userSignedIn } = this.props;
+    const { userSignedIn, announcementBannerEnabled } = this.props;
     if (userSignedIn) {
       this.displayPrivacyUpdateNotification();
+    }
+    if (announcementBannerEnabled) {
+      const dismissedAnnouncementBanner = localStorage.getItem(
+        "dismissedAnnouncementBanner"
+      );
+      if (dismissedAnnouncementBanner !== "true") {
+        this.setState({ showAnnouncementBanner: true });
+      }
     }
   }
 
@@ -85,6 +104,7 @@ class Header extends React.Component {
       disableNavigation,
       ...userMenuProps
     } = this.props;
+    const { showAnnouncementBanner } = this.state;
 
     const { allowedFeatures } = this.context || {};
 
@@ -101,7 +121,7 @@ class Header extends React.Component {
     return (
       userSignedIn && (
         <div>
-          <AnnouncementBanner />
+          {showAnnouncementBanner && <AnnouncementBanner />}
           <div className={cs.header}>
             <div className={cs.logo}>
               <a href="/">
@@ -134,9 +154,10 @@ class Header extends React.Component {
 
 Header.propTypes = {
   adminUser: PropTypes.bool,
-  userSignedIn: PropTypes.bool,
+  announcementBannerEnabled: PropTypes.bool,
   disableNavigation: PropTypes.bool,
   showBlank: PropTypes.bool,
+  userSignedIn: PropTypes.bool,
 };
 
 Header.contextType = UserContext;

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -59,10 +59,6 @@ const showPrivacyUpdateNotification = () => {
   }
 };
 
-const setAnnouncementBannerViewed = () => {
-  localStorage.setItem("dismissedAnnouncementBanner", "true");
-};
-
 class Header extends React.Component {
   constructor(props) {
     super(props);
@@ -96,12 +92,18 @@ class Header extends React.Component {
     }
   };
 
+  handleAnnouncementBannerClose = () => {
+    this.setState({ showAnnouncementBanner: false });
+    localStorage.setItem("dismissedAnnouncementBanner", "true");
+  };
+
   render() {
     const {
       adminUser,
-      userSignedIn,
-      showBlank,
+      announcementBannerEnabled,
       disableNavigation,
+      showBlank,
+      userSignedIn,
       ...userMenuProps
     } = this.props;
     const { showAnnouncementBanner } = this.state;
@@ -121,7 +123,14 @@ class Header extends React.Component {
     return (
       userSignedIn && (
         <div>
-          {showAnnouncementBanner && <AnnouncementBanner />}
+          {showAnnouncementBanner && (
+            <AnnouncementBanner
+              onClose={withAnalytics(
+                this.handleAnnouncementBannerClose,
+                "AnnouncementBanner_close_clicked"
+              )}
+            />
+          )}
           <div className={cs.header}>
             <div className={cs.logo}>
               <a href="/">
@@ -162,7 +171,7 @@ Header.propTypes = {
 
 Header.contextType = UserContext;
 
-const AnnouncementBanner = () => {
+const AnnouncementBanner = ({ onClose }) => {
   return (
     <div className={cs.announcementBanner}>
       <BasicPopup
@@ -189,15 +198,13 @@ const AnnouncementBanner = () => {
           </span>
         }
       />
-      <RemoveIcon
-        className={cs.close}
-        onClick={() => {
-          logAnalyticsEvent("AnnouncementBanner_close_clicked");
-          console.log("clicked");
-        }}
-      />
+      <RemoveIcon className={cs.close} onClick={() => onClose && onClose()} />
     </div>
   );
+};
+
+AnnouncementBanner.propTypes = {
+  onClose: PropTypes.func,
 };
 
 const UserMenuDropDown = ({

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -11,6 +11,7 @@ import ToastContainer from "~ui/containers/ToastContainer";
 import BareDropdown from "~ui/controls/dropdowns/BareDropdown";
 import AlertIcon from "~ui/icons/AlertIcon";
 import LogoIcon from "~ui/icons/LogoIcon";
+import RemoveIcon from "~ui/icons/RemoveIcon";
 import {
   DISCOVERY_DOMAIN_MY_DATA,
   DISCOVERY_DOMAIN_ALL_DATA,
@@ -142,7 +143,20 @@ Header.contextType = UserContext;
 const AnnouncementBanner = () => {
   return (
     <div className={cs.announcementBanner}>
-      <AlertIcon className={cs.icon} />
+      <span className={cs.content}>
+        <AlertIcon className={cs.icon} />
+        <span className={cs.title}>Low-Support Mode:</span>
+        We will only be responding to highly urgent issues from 12/21–12/29. For
+        now, check out our
+        <ExternalLink
+          className={cs.link}
+          href="https://help.idseq.net"
+          onClick={() => logAnalyticsEvent("AnnouncementBanner_link_clicked")}
+        >
+          Help Center
+        </ExternalLink>. Happy Holidays!
+      </span>
+      <RemoveIcon className={cs.close} />
     </div>
   );
 };

--- a/app/assets/src/components/common/header.scss
+++ b/app/assets/src/components/common/header.scss
@@ -114,5 +114,11 @@
     position: absolute;
     right: $space-m;
     top: $space-m;
+    fill: $dark-grey;
+    cursor: pointer;
+
+    &:hover {
+      fill: $black;
+    }
   }
 }

--- a/app/assets/src/components/common/header.scss
+++ b/app/assets/src/components/common/header.scss
@@ -78,21 +78,25 @@
 
 .announcementBanner {
   @include font-body-xs;
-  height: 40px;
   background: $primary-lightest;
+  height: 40px;
   text-align: center;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  white-space: nowrap;
 
   .content {
-    display: flex;
+    display: block;
+    line-height: 40px;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: calc(100% - 50px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     .icon {
-      height: 20px;
       fill: $primary-light;
+      height: 20px;
       margin-right: $space-xs;
+      vertical-align: text-bottom;
     }
 
     .title {
@@ -108,6 +112,7 @@
 
   .close {
     position: absolute;
-    right: $space-s;
+    right: $space-m;
+    top: $space-m;
   }
 }

--- a/app/assets/src/components/common/header.scss
+++ b/app/assets/src/components/common/header.scss
@@ -77,10 +77,37 @@
 }
 
 .announcementBanner {
+  @include font-body-xs;
   height: 40px;
   background: $primary-lightest;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
 
-  .icon {
-    height: 100%;
+  .content {
+    display: flex;
+
+    .icon {
+      height: 20px;
+      fill: $primary-light;
+      margin-right: $space-xs;
+    }
+
+    .title {
+      @include font-header-xs;
+      margin-right: $space-xxxs;
+    }
+
+    .link {
+      margin-left: 3px;
+      text-decoration: underline;
+    }
+  }
+
+  .close {
+    position: absolute;
+    right: $space-s;
   }
 }

--- a/app/assets/src/components/common/header.scss
+++ b/app/assets/src/components/common/header.scss
@@ -75,3 +75,12 @@
 .backgroundRefreshFrame {
   display: none;
 }
+
+.announcementBanner {
+  height: 40px;
+  background: $primary-lightest;
+
+  .icon {
+    height: 100%;
+  }
+}

--- a/app/assets/src/components/common/header.scss
+++ b/app/assets/src/components/common/header.scss
@@ -80,7 +80,9 @@
   @include font-body-xs;
   background: $primary-lightest;
   height: 40px;
+  position: relative;
   text-align: center;
+  z-index: 900;
 
   .content {
     display: block;
@@ -111,11 +113,11 @@
   }
 
   .close {
+    cursor: pointer;
+    fill: $dark-grey;
     position: absolute;
     right: $space-m;
     top: $space-m;
-    fill: $dark-grey;
-    cursor: pointer;
 
     &:hover {
       fill: $black;

--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -91,13 +91,20 @@ class Landing extends React.Component {
           <div className="fill" />
           <div className="hiring-ad">
             {"Join our team! We're hiring "}
-            <a
-              href="https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1620152"
-              target="_blank"
-              rel="noopener noreferrer"
+            <ExternalLink
+              // Specific position was filled.
+              href="https://boards.greenhouse.io/chanzuckerberginitiative"
+              analyticsEventName="Landing_engineer-job-link_clicked"
             >
               engineers
-            </a>
+            </ExternalLink>
+            {` and `}
+            <ExternalLink
+              href="https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1919743"
+              analyticsEventName="Landing_scientist-job-link_clicked"
+            >
+              scientists
+            </ExternalLink>
             !
           </div>
           {this.props.browserInfo.supported ? (

--- a/app/assets/src/components/views/Landing.jsx
+++ b/app/assets/src/components/views/Landing.jsx
@@ -92,7 +92,7 @@ class Landing extends React.Component {
           <div className="hiring-ad">
             {"Join our team! We're hiring "}
             <ExternalLink
-              // Specific position was filled.
+              // No number because specific position was filled.
               href="https://boards.greenhouse.io/chanzuckerberginitiative"
               analyticsEventName="Landing_engineer-job-link_clicked"
             >

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -195,8 +195,8 @@ class ApplicationController < ActionController::Base
     if get_app_config(AppConfig::SHOW_ANNOUNCEMENT_BANNER) == "1"
       time_zone = ActiveSupport::TimeZone.new("Pacific Time (US & Canada)")
       now = time_zone.now
-      start_time = time_zone.parse("2019-12-13 11:00:00")
-      end_time = time_zone.parse("2019-12-13 15:00:00")
+      start_time = time_zone.parse("2019-12-20 18:00:00")
+      end_time = time_zone.parse("2019-12-30 9:00:00")
 
       if start_time < now && now < end_time
         return true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -191,13 +191,18 @@ class ApplicationController < ActionController::Base
   end
 
   def announcement_banner_enabled
+    # Enabled if the flag is enabled AND it's in the active time range.
     if get_app_config(AppConfig::SHOW_ANNOUNCEMENT_BANNER) == "1"
       time_zone = ActiveSupport::TimeZone.new("Pacific Time (US & Canada)")
-      start_time = time_zone.parse("2018-10-16 05:00:00")
-      end_time = time_zone.parse("2018-12-05 11:30:00")
-      if start_time < Time.now.utc && Time.now.utc < end_time
-        @show_bulletin = true
+      now = time_zone.now
+      start_time = time_zone.parse("2019-12-20 18:00:00")
+      end_time = time_zone.parse("2019-12-30 9:00:00")
+
+      if start_time < now && now < end_time
+        return true
       end
     end
+
+    false
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -195,8 +195,8 @@ class ApplicationController < ActionController::Base
     if get_app_config(AppConfig::SHOW_ANNOUNCEMENT_BANNER) == "1"
       time_zone = ActiveSupport::TimeZone.new("Pacific Time (US & Canada)")
       now = time_zone.now
-      start_time = time_zone.parse("2019-12-20 18:00:00")
-      end_time = time_zone.parse("2019-12-30 9:00:00")
+      start_time = time_zone.parse("2019-12-13 11:00:00")
+      end_time = time_zone.parse("2019-12-13 15:00:00")
 
       if start_time < now && now < end_time
         return true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -141,6 +141,7 @@ class ApplicationController < ActionController::Base
 
   def set_application_view_variables
     @disable_header_navigation = false
+    @announcement_banner_enabled = announcement_banner_enabled
   end
 
   # Set current user and request to global for use in logging in ActiveRecord.
@@ -185,6 +186,17 @@ class ApplicationController < ActionController::Base
         MetricUtil.log_analytics_event(event_name + "_cache-missed", current_user)
         response.headers["X-IDseq-Cache"] = 'missed'
         yield
+      end
+    end
+  end
+
+  def announcement_banner_enabled
+    if get_app_config(AppConfig::SHOW_ANNOUNCEMENT_BANNER) == "1"
+      time_zone = ActiveSupport::TimeZone.new("Pacific Time (US & Canada)")
+      start_time = time_zone.parse("2018-10-16 05:00:00")
+      end_time = time_zone.parse("2018-12-05 11:30:00")
+      if start_time < Time.now.utc && Time.now.utc < end_time
+        @show_bulletin = true
       end
     end
   end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -12,4 +12,7 @@ class AppConfig < ApplicationRecord
   USE_AUTH0_FOR_NEW_USERS = 'use_auth0_for_new_users'.freeze
   # The maximum number of samples that can be part of one bulk download.
   MAX_SAMPLES_BULK_DOWNLOAD = 'max_samples_bulk_download'.freeze
+  # When this is "1", the announcement banner on the top of the site header will be enabled.
+  # Other conditions may check a time constraint.
+  SHOW_ANNOUNCEMENT_BANNER = 'show_announcement_banner'.freeze
 end

--- a/app/views/layouts/_page_header.html.erb
+++ b/app/views/layouts/_page_header.html.erb
@@ -9,6 +9,7 @@
         userName: '<%= current_user.name %>',
         userSignedIn: true,
         disableNavigation: <%= @disable_header_navigation %>,
+        announcementBannerEnabled: <%= @announcement_banner_enabled %>,
       }, 'page_header', JSON.parse('<%= raw escape_json(user_context)%>'))
 
 


### PR DESCRIPTION
### Description
- Add the low-support banner for the holiday week. Can be re-used for promoting new features in the future.
- Addendum: I decided to bundle an updated jobs link since I noticed the current posting was out of date when looking at the header.

### Notes
- Mock: https://chanzuckerberg.invisionapp.com/share/V2V8AV8HX5Y#/screens/397426072
- Copy made/approved by Olivia/Jenn.
- Only shows for logged-in users.
- Flagged by `AppConfig::SHOW_ANNOUNCEMENT_BANNER` and also a time range check.
- Dismissed with Local Storage `dismissedAnnouncementBanner`. Won't show again per-device.
- Tooltip for small screen widths.
- Links out to help center.
- Includes click analytics.
- Set times:
```
start_time = time_zone.parse("2019-12-20 18:00:00")
end_time = time_zone.parse("2019-12-30 9:00:00")
```

### Tests
- Tested the behaviors described above.

![Screen Shot 2019-12-13 at 11 50 03 AM](https://user-images.githubusercontent.com/5652739/70835733-d7323f00-1db2-11ea-82c0-17f1e29664bf.png)
![Screen Shot 2019-12-13 at 11 50 19 AM](https://user-images.githubusercontent.com/5652739/70835735-d8636c00-1db2-11ea-8635-ed68edb5e4c1.png)
![Dec-13-2019 11-51-19](https://user-images.githubusercontent.com/5652739/70835741-ddc0b680-1db2-11ea-8dcb-5ec9e121b3ee.gif)
![Screen Shot 2019-12-13 at 11 51 48 AM](https://user-images.githubusercontent.com/5652739/70835745-e0bba700-1db2-11ea-9dbf-68401e565d05.png)