### PR TITLE
[Bulk Download] Upgrade aegea to 3.2.7 and specify staging-s3-bucket.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aegea==3.2.3
+aegea==3.2.7
 pyOpenSSL==19.0.0
 setuptools==41.0.1

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -323,6 +323,7 @@ describe BulkDownload, type: :model do
         "--fargate-cpu", "4096",
         "--fargate-memory", "8192",
         "--cluster", "idseq-fargate-tasks-prod",
+        "--staging-s3-bucket", "aegea-ecs-execute-prod",
       ]
 
       expect(@bulk_download.aegea_ecs_submit_command(executable_file_path: mock_executable_file_path)).to eq(task_command)


### PR DESCRIPTION
# Description

For commands that use an executable file, explicitly specify the s3 bucket that the executable file is temporarily uploaded to.

This allows us to define the s3 bucket and give permissions to only that specific bucket in idseq-infra.

# Tests

* Updated tests
* Verified that bulk downloads behave as expected when using the staging s3 bucket for both staging and prod.
