### PR TITLE
Tweak text in bulk downloads display name and taxon options.

### DIFF
--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -280,11 +280,11 @@ class ChooseStep extends React.Component {
       case "taxa_with_reads":
         dropdownOptions = [
           {
-            text: "All Taxon",
+            text: "All Taxa",
             value: "all",
             customNode: (
               <div className={cs.taxaWithReadsOption}>
-                <div className={cs.taxonName}>All taxon</div>
+                <div className={cs.taxonName}>All taxa</div>
                 <div className={cs.fill} />
                 <div className={cs.sampleCount}>{selectedSampleIds.size}</div>
               </div>
@@ -295,8 +295,8 @@ class ChooseStep extends React.Component {
           ...(this.sortTaxaWithReadsOptions(taxaWithReadsOptions) || []),
         ];
 
-        placeholder = "Select taxa";
-        menuLabel = "Select taxa";
+        placeholder = "Select taxon";
+        menuLabel = "Select taxon";
         showNoResultsMessage = true;
         search = true;
         onFilterChange = this.handleTaxaWithReadsSelectFilterChange;
@@ -305,7 +305,7 @@ class ChooseStep extends React.Component {
 
         optionsHeader = (
           <div className={cs.taxaWithReadsOptionsHeader}>
-            <div className={cs.header}>Taxa</div>
+            <div className={cs.header}>Taxon</div>
             <div className={cs.fill} />
             <div className={cs.header}>Samples</div>
           </div>

--- a/app/assets/src/components/views/bulk_download/TaxonContigSelect.jsx
+++ b/app/assets/src/components/views/bulk_download/TaxonContigSelect.jsx
@@ -74,11 +74,11 @@ class TaxonContigSelect extends React.Component {
 
     const dropdownOptions = [
       {
-        text: "All Taxon",
+        text: "All Taxa",
         value: "all",
         customNode: (
           <div className={cs.option}>
-            <div className={cs.taxonName}>All taxon</div>
+            <div className={cs.taxonName}>All taxa</div>
             <div className={cs.fill} />
             <div className={cs.sampleCount}>{sampleIds.size}</div>
           </div>
@@ -91,7 +91,7 @@ class TaxonContigSelect extends React.Component {
 
     const optionsHeader = (
       <div className={cs.optionsHeader}>
-        <div className={cs.header}>Taxa</div>
+        <div className={cs.header}>Taxon</div>
         <div className={cs.fill} />
         <div className={cs.header}>Samples</div>
       </div>
@@ -100,12 +100,12 @@ class TaxonContigSelect extends React.Component {
     return (
       <Dropdown
         fluid
-        placeholder="Select taxa"
+        placeholder="Select taxon"
         options={dropdownOptions}
         onChange={onChange}
         value={value}
         optionsHeader={optionsHeader}
-        menuLabel="Select taxa"
+        menuLabel="Select taxon"
         className={cs.taxaWithContigsDropdown}
         search
         onFilterChange={this.handleFilterChange}

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -37,7 +37,7 @@ module BulkDownloadTypesHelper
     {
       type: COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE,
       display_name: "Combined Sample Taxon Results",
-      description: "The value of a particular metric (e.g. total reads, rPM) for all taxons in all selected samples, in a single data table",
+      description: "The value of a particular metric (e.g. total reads, rPM) for all taxa in all selected samples, in a single data table",
       category: "report",
       fields: [
         {
@@ -72,7 +72,7 @@ module BulkDownloadTypesHelper
       category: "raw",
       fields: [
         {
-          display_name: "Taxa",
+          display_name: "Taxon",
           type: "taxa_with_reads",
         },
         {
@@ -90,7 +90,7 @@ module BulkDownloadTypesHelper
       category: "raw",
       fields: [
         {
-          display_name: "Taxa",
+          display_name: "Taxon",
           type: "taxa_with_contigs",
         },
       ],

--- a/app/helpers/bulk_downloads_helper.rb
+++ b/app/helpers/bulk_downloads_helper.rb
@@ -42,8 +42,9 @@ module BulkDownloadsHelper
   def format_bulk_download(bulk_download, with_pipeline_runs = false)
     formatted_bulk_download = bulk_download.as_json(except: [:access_token])
     formatted_bulk_download[:num_samples] = bulk_download.pipeline_runs.length
-    formatted_bulk_download[:download_name] = BulkDownloadTypesHelper.bulk_download_type_display_name(bulk_download.download_type)
+    formatted_bulk_download[:download_name] = bulk_download.download_display_name
     formatted_bulk_download[:file_size] = ActiveSupport::NumberHelper.number_to_human_size(bulk_download.output_file_size)
+
     unless bulk_download.params_json.nil?
       formatted_bulk_download[:params] = JSON.parse(bulk_download.params_json)
     end

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -525,6 +525,21 @@ class BulkDownload < ApplicationRecord
     end
   end
 
+  def download_display_name
+    display_name = BulkDownloadTypesHelper.bulk_download_type_display_name(download_type)
+
+    # For reads non-host and contigs non-host for a single taxon, add the name of the taxon.
+    if download_type == READS_NON_HOST_BULK_DOWNLOAD_TYPE && get_param_value("taxa_with_reads") != "all"
+      display_name += " - #{get_param_display_name('taxa_with_reads')}"
+    end
+
+    if download_type == CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE && get_param_value("taxa_with_contigs") != "all"
+      display_name += " - #{get_param_display_name('taxa_with_contigs')}"
+    end
+
+    display_name
+  end
+
   def execution_type
     execution_type = BulkDownloadTypesHelper.bulk_download_type(download_type)[:execution_type]
     if [RESQUE_EXECUTION_TYPE, ECS_EXECUTION_TYPE]

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -891,4 +891,79 @@ describe BulkDownload, type: :model do
       bulk_download.kickoff
     end
   end
+
+  context "#download_display_name" do
+    before do
+      @joe = create(:joe)
+      @project = create(:project, users: [@joe], name: "Test Project")
+      @sample_one = create(:sample, project: @project, name: "Test Sample One",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+    end
+
+    it "returns the download type display name in basic case" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id],
+        download_type: BulkDownloadTypesHelper::SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE
+      )
+
+      expect(bulk_download.download_display_name).to eq("Sample Overviews")
+    end
+
+    it "includes taxon for single-taxon reads non host download" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id],
+        download_type: BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE,
+        params: {
+          "taxa_with_reads" => {
+            "value" => 100,
+            "displayName" => "Mock Taxon",
+          },
+        }
+      )
+
+      expect(bulk_download.download_display_name).to eq("Reads (Non-host) - Mock Taxon")
+    end
+
+    it "includes taxon for single-taxon contigs non host download" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id],
+        download_type: BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE,
+        params: {
+          "taxa_with_contigs" => {
+            "value" => 200,
+            "displayName" => "Mock Taxon 2",
+          },
+        }
+      )
+
+      expect(bulk_download.download_display_name).to eq("Contigs (Non-host) - Mock Taxon 2")
+    end
+
+    it "returns expected display name for all-taxon contigs non host download" do
+      bulk_download = create(
+        :bulk_download,
+        user: @joe,
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id],
+        download_type: BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE,
+        params: {
+          "taxa_with_contigs" => {
+            "value" => "all",
+            "displayName" => "All Taxon",
+          },
+          "file_format" => {
+            "value" => ".fastq",
+            "displayName" => ".fastq",
+          },
+        }
+      )
+
+      expect(bulk_download.download_display_name).to eq("Contigs (Non-host)")
+    end
+  end
 end


### PR DESCRIPTION
# Description

Correct taxa/taxon usage for contigs and reads non-host downloads.

<img width="518" alt="Screen Shot 2019-12-16 at 8 03 53 PM" src="https://user-images.githubusercontent.com/837004/70964074-5b005b80-203f-11ea-9828-f8f5f84e6d23.png">

Append the single taxon to the display name for contigs and reads non-host downloads that specified a single taxon.

<img width="663" alt="Screen Shot 2019-12-16 at 8 04 04 PM" src="https://user-images.githubusercontent.com/837004/70964071-59369800-203f-11ea-98c4-94621a2a9f1f.png">

# Tests

* Added tests for download_display_name.
