### PR TITLE
[Release fix] Support reportReady and pipelineRunReportAvailable in case of caching

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -968,7 +968,7 @@ export default class SampleViewV2 extends React.Component {
     // but at least taxon_counts has been loaded).
     // pipelineRunReportAvailable was renamed to reportReady, but we check both in case the old variable
     // name was cached.
-    // TODO(julie): remove pipelinRunReportAvailable during cleanup.
+    // TODO(julie): remove pipelineRunReportAvailable during cleanup.
     if (
       reportMetadata.reportReady ||
       reportMetadata.pipelineRunReportAvailable

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -966,7 +966,13 @@ export default class SampleViewV2 extends React.Component {
     } = this.state;
     // reportReady is true if the pipeline run is report-ready (might still be running Experimental,
     // but at least taxon_counts has been loaded).
-    if (reportMetadata.reportReady) {
+    // pipelineRunReportAvailable was renamed to reportReady, but we check both in case the old variable
+    // name was cached.
+    // TODO(julie): remove pipelinRunReportAvailable during cleanup.
+    if (
+      reportMetadata.reportReady ||
+      reportMetadata.pipelineRunReportAvailable
+    ) {
       return (
         <div className={cs.reportViewContainer}>
           <div className={cs.reportFilters}>
@@ -1070,7 +1076,13 @@ export default class SampleViewV2 extends React.Component {
               pipelineRun={pipelineRun}
               project={project}
               projectSamples={projectSamples}
-              reportPresent={reportMetadata.reportReady === true}
+              // report_ready was consolidated with reportReady but we check both in case
+              // the old variable name was cached.
+              // TODO(julie): remove report_ready during cleanup.
+              reportPresent={
+                reportMetadata.reportReady === true ||
+                reportMetadata.report_ready === true
+              }
               sample={sample}
               view={view}
               minContigSize={selectedOptions.minContigSize}


### PR DESCRIPTION
# Description

The variables `pipelineRunReportAvailable` and `report_ready` were consolidated and renamed to `reportReady`, but a version of the code using the old variable names may have been cached in the browser. Since the front-end only checks for the new `reportReady`, this can result in a sample report appearing as failed even if it succeeded.

This change makes it so that so both versions of the variables are supported, and will be removed as part of cleanup when the caches have been cleared.
