### PR TITLE
Make water_control a required metadata field

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,6 @@
 // This file needs to be in sync with webpack.config.prod.js. The first file
-// should contain idseq-written JS and the second file should contain JS from
-// node_modules.
+// should contain JS from node_modules and the second file should contain
+// idseq-written JS. The order of requires is important!
 
 //= require vendors~main.bundle.min.js
 //= require main.bundle.min.js

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -10,6 +10,7 @@ import GeoSearchInputBox, {
   getLocationWarning,
 } from "~/components/ui/controls/GeoSearchInputBox";
 import AlertIcon from "~ui/icons/AlertIcon";
+import Toggle from "~ui/controls/Toggle";
 
 import cs from "./metadata_input.scss";
 
@@ -58,7 +59,19 @@ class MetadataInput extends React.Component {
     } = this.props;
     const { warning } = this.state;
 
-    if (isArray(metadataType.options)) {
+    if (metadataType.isBoolean) {
+      const onLabel = metadataType.options[0];
+      const offLabel = metadataType.options[1];
+      return (
+        <Toggle
+          initialChecked={value === onLabel ? true : false}
+          onLabel={onLabel}
+          offLabel={offLabel}
+          onChange={label => onChange(metadataType.key, label, true)}
+          className={className}
+        />
+      );
+    } else if (isArray(metadataType.options)) {
       const options = metadataType.options.map(option => ({
         text: option,
         value: option,
@@ -144,6 +157,7 @@ MetadataInput.propTypes = {
     key: PropTypes.string,
     dataType: PropTypes.oneOf(["number", "string", "date", "location"]),
     options: PropTypes.arrayOf(PropTypes.string),
+    isBoolean: PropTypes.bool,
   }),
   // Third optional parameter signals to the parent whether to immediately save. false means "wait for onSave to fire".
   // This is useful for the text input, where the parent wants to save onBlur, not onChange.

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -295,10 +295,7 @@ class MetadataManualInput extends React.Component {
           const inputClasses = cx(
             cs.input,
             // Add extra width to location inputs for long names.
-            column.startsWith("collection_location") && cs.extraWidth,
-            // Remove extra width for short names.
-            column.startsWith("water_control") && cs.lessWidth,
-            column.startsWith("nucleotide_type") && cs.lessWidth
+            column.startsWith("collection_location") && cs.extraWidth
           );
 
           const sampleHostGenomeId = this.getSampleHostGenomeId(sample);

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -354,7 +354,7 @@ class MetadataManualInput extends React.Component {
 
   getColumnWidth = column => {
     if (["Sample Name", "collection_location_v2"].includes(column)) {
-      return 230;
+      return 240;
     } else {
       return 110;
     }

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -353,10 +353,12 @@ class MetadataManualInput extends React.Component {
   };
 
   getColumnWidth = column => {
+    // The width of the input needs to be about 15px smaller than the width of
+    // the column to maintain some padding. See also getColumnWidth.
     if (["Sample Name", "collection_location_v2"].includes(column)) {
-      return 240;
+      return parseInt(cs.metadataInputExtraWidth) + 15;
     } else {
-      return 110;
+      return parseInt(cs.metadataInputWidth) + 15;
     }
   };
 

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -295,7 +295,10 @@ class MetadataManualInput extends React.Component {
           const inputClasses = cx(
             cs.input,
             // Add extra width to location inputs for long names.
-            column.startsWith("collection_location") && cs.extraWidth
+            column.startsWith("collection_location") && cs.extraWidth,
+            // Remove extra width for short names.
+            column.startsWith("water_control") && cs.lessWidth,
+            column.startsWith("nucleotide_type") && cs.lessWidth
           );
 
           const sampleHostGenomeId = this.getSampleHostGenomeId(sample);
@@ -354,9 +357,9 @@ class MetadataManualInput extends React.Component {
 
   getColumnWidth = column => {
     if (["Sample Name", "collection_location_v2"].includes(column)) {
-      return 240;
+      return 230;
     } else {
-      return 145;
+      return 110;
     }
   };
 

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import cx from "classnames";
-import _fp, { filter, keyBy, concat, find } from "lodash/fp";
+import _fp, { filter, keyBy, concat, find, sortBy } from "lodash/fp";
 
 import MetadataCSVUpload from "~/components/common/MetadataCSVUpload";
 import MetadataCSVLocationsMenu, {
@@ -35,6 +35,19 @@ class MetadataUpload extends React.Component {
     CSVLocationWarnings: {},
   };
 
+  // Define the order in which metadata fields should be render in the upload
+  // grid. The order was defined by the perceived affinity of fields.
+  // Any field not defined will appear after in the pre-existing order.
+  ordering = {
+    host_genome: 1, // currently, this is not a MetadataField technically
+    sample_type: 2,
+    nucleotide_type: 3,
+    water_control: 4,
+    collection_date: 5,
+    collection_location: 6, // legacy, code for both cases to be safe
+    collection_location_v2: 7,
+  };
+
   async componentDidMount() {
     const [projectMetadataFields, hostGenomes, sampleTypes] = await Promise.all(
       [
@@ -43,8 +56,13 @@ class MetadataUpload extends React.Component {
         getAllSampleTypes(),
       ]
     );
+    const sorted = sortBy(
+      metadataField =>
+        this.ordering[metadataField.key] || Number.MAX_SAFE_INTEGER,
+      projectMetadataFields
+    );
     this.setState({
-      projectMetadataFields: keyBy("key", projectMetadataFields),
+      projectMetadataFields: keyBy("key", sorted),
       hostGenomes,
       sampleTypes,
     });

--- a/app/assets/src/components/common/metadata_manual_input.scss
+++ b/app/assets/src/components/common/metadata_manual_input.scss
@@ -54,7 +54,7 @@
       }
 
       &.lessWidth {
-        width: 80px;
+        width: 110px;
       }
     }
 

--- a/app/assets/src/components/common/metadata_manual_input.scss
+++ b/app/assets/src/components/common/metadata_manual_input.scss
@@ -2,6 +2,15 @@
 @import "~styles/themes/colors";
 @import "~styles/themes/elements";
 
+// NOTE: Omit px so value can be exported for parseInt
+$metadata-input-width: 95;
+$metadata-input-extra-width: 225;
+
+:export {
+  metadataInputWidth: $metadata-input-width;
+  metadataInputExtraWidth: $metadata-input-extra-width;
+}
+
 .metadataManualInput {
   .columnPicker {
     /* Override semantic ui */
@@ -47,12 +56,10 @@
 
     .input {
       margin: $space-xxs $space-m $space-xxs 0;
-      // The width of the input needs to be about 15px smaller than the width of
-      // the column to maintain some padding. See also getColumnWidth.
-      width: 95px;
+      width: $metadata-input-width + 0px;
 
       &.extraWidth {
-        width: 225px;
+        width: $metadata-input-extra-width + 0px;
       }
     }
 

--- a/app/assets/src/components/common/metadata_manual_input.scss
+++ b/app/assets/src/components/common/metadata_manual_input.scss
@@ -47,10 +47,14 @@
 
     .input {
       margin: $space-xxs $space-m $space-xxs 0;
-      width: 130px;
+      width: 110px; // see also getColumnWidth
 
       &.extraWidth {
         width: 240px;
+      }
+
+      &.lessWidth {
+        width: 80px;
       }
     }
 

--- a/app/assets/src/components/common/metadata_manual_input.scss
+++ b/app/assets/src/components/common/metadata_manual_input.scss
@@ -52,10 +52,6 @@
       &.extraWidth {
         width: 240px;
       }
-
-      &.lessWidth {
-        width: 110px;
-      }
     }
 
     .noInput {

--- a/app/assets/src/components/common/metadata_manual_input.scss
+++ b/app/assets/src/components/common/metadata_manual_input.scss
@@ -47,10 +47,12 @@
 
     .input {
       margin: $space-xxs $space-m $space-xxs 0;
-      width: 110px; // see also getColumnWidth
+      // The width of the input needs to be about 15px smaller than the width of
+      // the column to maintain some padding. See also getColumnWidth.
+      width: 95px;
 
       &.extraWidth {
-        width: 240px;
+        width: 225px;
       }
     }
 

--- a/app/assets/src/components/ui/controls/Toggle.jsx
+++ b/app/assets/src/components/ui/controls/Toggle.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Radio } from "semantic-ui-react";
+import PropTypes from "prop-types";
+import cx from "classnames";
+
+import cs from "./toggle.scss";
+
+/**
+ * Extension of semantic-ui radio toggle that shows on/off labels. The current
+ * label is sent to the onChange handler. The current state can be overriden
+ * by passing in new props.
+ */
+class Toggle extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  // For "apply all" to work, it needs to override local state
+  static getDerivedStateFromProps(props, state) {
+    if (props.initialChecked !== state.prevInitialChecked) {
+      return {
+        prevInitialChecked: props.initialChecked,
+        checked: props.initialChecked,
+      };
+    } else {
+      return {
+        prevInitialChecked: props.initialChecked,
+        checked: state.checked,
+      };
+    }
+  }
+
+  render() {
+    const { onLabel, offLabel, onChange } = this.props;
+    return (
+      <Radio
+        toggle
+        checked={this.state.checked}
+        label={this.state.checked ? onLabel : offLabel}
+        onChange={(_, inputProps) => {
+          const checked = inputProps.checked;
+          this.setState({ checked: checked });
+          onChange && onChange(checked ? onLabel : offLabel);
+        }}
+        className={cx(this.props.className, cs.toggle)}
+      />
+    );
+  }
+}
+
+Toggle.propTypes = {
+  className: PropTypes.string,
+  onChange: PropTypes.func,
+  onLabel: PropTypes.string.isRequired,
+  offLabel: PropTypes.string.isRequired,
+  initialChecked: PropTypes.bool.isRequired,
+};
+
+Toggle.defaultProps = {
+  onLabel: "On",
+  offLabel: "Off",
+  initialChecked: false,
+};
+
+export default Toggle;

--- a/app/assets/src/components/ui/controls/toggle.scss
+++ b/app/assets/src/components/ui/controls/toggle.scss
@@ -1,0 +1,73 @@
+@import "~styles/themes/colors";
+@import "~styles/themes/typography";
+
+// NOTE: Classname .toggle is repeated here as .toggle.toggle.toggle to increase
+// specificity and always override semantic-ui.
+
+// For unknown reasons, semantic-ui is adding the rule
+//  [type=radio]:not(:checked)+label:after { transform: scale(0); }
+// which has the effect of hiding the circle part of the toggle when off.
+// The circle is always visible on the official example page at:
+// https://react.semantic-ui.com/modules/checkbox/#types-toggle
+.toggle.toggle.toggle label:after {
+  transform: scale(1) !important;
+}
+
+.toggle.toggle.toggle label:before {
+  margin-left: 0px; // remove 4px margin
+  margin-right: 0px; // remove 4px margin
+  height: 28px;
+  line-height: 28px;
+  width: 68px;
+}
+
+.toggle.toggle.toggle label {
+  padding-top: 6px; // vertical align text
+  min-height: 34px;
+  min-width: 58px; // enough space for text
+  font-size: $font-size-small;
+}
+
+// Place text to the left
+.toggle.toggle.toggle input:checked ~ label {
+  padding-left: 17px;
+  padding-right: 17px;
+}
+
+// Place text to the right
+.toggle.toggle.toggle input:indeterminate ~ label {
+  padding-left: 34px;
+  color: $dark-grey !important;
+}
+
+.toggle.toggle.toggle input:checked ~ label:before {
+  background-color: transparent !important; // override semantic-ui
+  border: 1px solid $primary-light;
+  padding-left: 4px;
+}
+
+.toggle.toggle.toggle input:indeterminate ~ label:before {
+  background-color: transparent !important; // override semantic-ui
+  border: 1px solid $light-grey;
+}
+
+.toggle.toggle.toggle label:after {
+  top: 5px; // vertically align the circle in the height of the container
+  height: 18px;
+  width: 18px;
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+  transition-duration: 0.2s, 0.2s; // down from 0.3s
+}
+
+.toggle.toggle.toggle input:checked ~ label:after {
+  background-color: $primary-light;
+  left: calc(
+    68px - 9px - 18px
+  ); // inner width of toggle minus inner padding minus width of circle
+}
+
+.toggle.toggle.toggle input:indeterminate ~ label:after {
+  background-color: $lightest-grey;
+  left: 2px;
+}

--- a/app/assets/src/components/views/playgrounds/PlaygroundControls.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundControls.jsx
@@ -1,18 +1,20 @@
-import CompareButton from "../../ui/controls/buttons/CompareButton";
-import DownloadButton from "../../ui/controls/buttons/DownloadButton";
-import Dropdown from "../../ui/controls/dropdowns/Dropdown";
-import ButtonDropdown from "../../ui/controls/dropdowns/ButtonDropdown";
-import BetaLabel from "../../ui/labels/BetaLabel";
-import DownloadButtonDropdown from "../../ui/controls/dropdowns/DownloadButtonDropdown";
-import MultipleDropdown from "../../ui/controls/dropdowns/MultipleDropdown";
-import ThresholdFilterDropdown from "../../ui/controls/dropdowns/ThresholdFilterDropdown";
-import PrimaryButton from "../../ui/controls/buttons/PrimaryButton";
 import PropTypes from "prop-types";
 import React from "react";
-import SecondaryButton from "../../ui/controls/buttons/SecondaryButton";
-import Slider from "../../ui/controls/Slider";
-import Checkbox from "../../ui/controls/Checkbox";
-import MultipleNestedDropdown from "../../ui/controls/dropdowns/MultipleNestedDropdown";
+
+import CompareButton from "~ui/controls/buttons/CompareButton";
+import DownloadButton from "~ui/controls/buttons/DownloadButton";
+import Dropdown from "~ui/controls/dropdowns/Dropdown";
+import ButtonDropdown from "~ui/controls/dropdowns/ButtonDropdown";
+import BetaLabel from "~ui/labels/BetaLabel";
+import DownloadButtonDropdown from "~ui/controls/dropdowns/DownloadButtonDropdown";
+import MultipleDropdown from "~ui/controls/dropdowns/MultipleDropdown";
+import ThresholdFilterDropdown from "~ui/controls/dropdowns/ThresholdFilterDropdown";
+import PrimaryButton from "~ui/controls/buttons/PrimaryButton";
+import SecondaryButton from "~ui/controls/buttons/SecondaryButton";
+import Slider from "~ui/controls/Slider";
+import Checkbox from "~ui/controls/Checkbox";
+import MultipleNestedDropdown from "~ui/controls/dropdowns/MultipleNestedDropdown";
+import Toggle from "~ui/controls/Toggle";
 
 class PlaygroundControls extends React.Component {
   constructor(props) {
@@ -40,317 +42,262 @@ class PlaygroundControls extends React.Component {
     return (
       <div className="playground">
         <div className="playground-grid">
-          <ComponentCard
-            title="Primary Button"
-            width={3}
-            components={[
-              <PrimaryButton
-                key={0}
-                text="Submit"
-                onClick={() => this.setState({ event: "PrimaryButton:Click" })}
-              />,
-              <PrimaryButton
-                key={1}
-                text="Submit"
-                disabled
-                onClick={() => this.setState({ event: "PrimaryButton:Click" })}
-              />,
-              <PrimaryButton
-                key={1}
-                label={<BetaLabel />}
-                text="Submit"
-                onClick={() => this.setState({ event: "PrimaryButton:Click" })}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Secondary Button"
-            width={3}
-            components={[
-              <SecondaryButton
-                key={0}
-                text="Submit"
-                onClick={() =>
-                  this.setState({ event: "SecondaryButton:Click" })
-                }
-              />,
-              <SecondaryButton
-                key={1}
-                text="Submit"
-                disabled
-                onClick={() =>
-                  this.setState({ event: "SecondaryButton:Click" })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Icon Button"
-            width={3}
-            components={[
-              <CompareButton
-                key={0}
-                onClick={() => this.setState({ event: "CompareButton:Click" })}
-              />,
-              <CompareButton
-                key={1}
-                disabled
-                onClick={() =>
-                  this.setState({
-                    event: "CompareButton:Click: should not show up!",
-                  })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Button Dropdown"
-            width={3}
-            components={[
-              <ButtonDropdown
-                primary
-                key={0}
-                fluid
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-              <ButtonDropdown
-                primary
-                key={1}
-                fluid
-                disabled
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Change", option })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Secondary Button Dropdown"
-            width={3}
-            components={[
-              <ButtonDropdown
-                secondary
-                key={0}
-                fluid
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-              <ButtonDropdown
-                secondary
-                key={1}
-                fluid
-                disabled
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Change", option })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Download Button"
-            width={3}
-            components={[
-              <DownloadButton
-                key={0}
-                fluid
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-              <DownloadButton
-                key={1}
-                fluid
-                disabled
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Download Dropdown Button"
-            width={4}
-            components={[
-              <DownloadButtonDropdown
-                key={0}
-                fluid
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-              <DownloadButtonDropdown
-                key={1}
-                fluid
-                disabled
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Threshold Filter Dropdown"
-            width={5}
-            components={[
-              <ThresholdFilterDropdown
-                key={0}
-                options={this.thresholdOptions}
-                onApply={vars => {
-                  this.setState({
-                    event: "ThresholdFilterDropdown:Apply",
-                    vars,
-                  });
-                }}
-              />,
-              <ThresholdFilterDropdown
-                key={1}
-                options={this.thresholdOptions}
-                disabled
-                onApply={vars => {
-                  this.setState({
-                    event: "ThresholdFilterDropdown:Apply",
-                    vars,
-                  });
-                }}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Dropdown"
-            width={4}
-            components={[
-              <Dropdown
-                key={0}
-                fluid
-                rounded
-                options={this.dropdownOptions}
-                label="Option"
-                onChange={() => this.setState({ event: "Dropdown:Change" })}
-              />,
-              <Dropdown
-                key={1}
-                fluid
-                disabled
-                rounded
-                options={this.dropdownOptions}
-                label="Option"
-                onChange={() => this.setState({ event: "Dropdown:Change" })}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Multiple Option Dropdown"
-            width={4}
-            components={[
-              <MultipleDropdown
-                key={0}
-                fluid
-                rounded
-                search
-                options={this.dropdownOptions}
-                label="Options"
-                onChange={() =>
-                  this.setState({ event: "MultipleDropdown:Change" })
-                }
-              />,
-              <MultipleDropdown
-                key={1}
-                fluid
-                rounded
-                disabled
-                options={this.dropdownOptions}
-                label="Options"
-                onChange={() =>
-                  this.setState({ event: "MultipleDropdown:Change" })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Multiple Nested Dropdown"
-            width={4}
-            components={[
-              <MultipleNestedDropdown
-                key={0}
-                fluid
-                rounded
-                options={this.dropdownOptions}
-                label="Options"
-                onChange={(a, b) => {
-                  this.setState({ event: "MultipleDropdown:Change" });
-                }}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Slider"
-            width={4}
-            components={[
-              <Slider
-                key={0}
-                options={this.dropdownOptions}
-                label="Slider: "
-                onChange={() => this.setState({ event: "Slider:Change" })}
-                onAfterChange={() =>
-                  this.setState({ event: "Slider:onAfterChange" })
-                }
-                min={0}
-                max={100}
-                value={20}
-              />,
-              <Slider
-                key={1}
-                disabled
-                options={this.dropdownOptions}
-                label="Slider: "
-                onChange={() => this.setState({ event: "Slider:Change" })}
-                onAfterChange={() =>
-                  this.setState({ event: "Slider:onAfterChange" })
-                }
-                min={0}
-                max={100}
-                value={20}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Checkbox"
-            width={4}
-            components={[
-              <Checkbox
-                key={0}
-                label="Checkbox"
-                onChange={() => this.setState({ event: "Checkbox:Change" })}
-                value={0}
-                checked={true}
-              />,
-              <Checkbox
-                key={1}
-                label="Checkbox"
-                onChange={() => this.setState({ event: "Checkbox:Change" })}
-                value={1}
-              />,
-            ]}
-          />
+          <ComponentCard title="Primary Button" width={3}>
+            <PrimaryButton
+              key={0}
+              text="Submit"
+              onClick={() => this.setState({ event: "PrimaryButton:Click" })}
+            />
+            <PrimaryButton
+              key={1}
+              text="Submit"
+              disabled
+              onClick={() => this.setState({ event: "PrimaryButton:Click" })}
+            />
+            <PrimaryButton
+              key={1}
+              label={<BetaLabel />}
+              text="Submit"
+              onClick={() => this.setState({ event: "PrimaryButton:Click" })}
+            />
+          </ComponentCard>
+          <ComponentCard title="Secondary Button" width={3}>
+            <SecondaryButton
+              key={0}
+              text="Submit"
+              onClick={() => this.setState({ event: "SecondaryButton:Click" })}
+            />
+            <SecondaryButton
+              key={1}
+              text="Submit"
+              disabled
+              onClick={() => this.setState({ event: "SecondaryButton:Click" })}
+            />
+          </ComponentCard>
+          <ComponentCard title="Icon Button" width={3}>
+            <CompareButton
+              key={0}
+              onClick={() => this.setState({ event: "CompareButton:Click" })}
+            />
+            <CompareButton
+              key={1}
+              disabled
+              onClick={() =>
+                this.setState({
+                  event: "CompareButton:Click: should not show up!",
+                })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Button Dropdown" width={3}>
+            <ButtonDropdown
+              primary
+              key={0}
+              fluid
+              options={this.dropdownOptions}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+            <ButtonDropdown
+              primary
+              key={1}
+              fluid
+              disabled
+              options={this.dropdownOptions}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Change", option })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Secondary Button Dropdown" width={3}>
+            <ButtonDropdown
+              secondary
+              key={0}
+              fluid
+              options={this.dropdownOptions}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+            <ButtonDropdown
+              secondary
+              key={1}
+              fluid
+              disabled
+              options={this.dropdownOptions}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Change", option })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Download Button" width={3}>
+            <DownloadButton
+              key={0}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+            <DownloadButton
+              key={1}
+              disabled
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Download Dropdown Button" width={4}>
+            <DownloadButtonDropdown
+              key={0}
+              options={this.dropdownOptions}
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+            <DownloadButtonDropdown
+              key={1}
+              disabled
+              options={this.dropdownOptions}
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Threshold Filter Dropdown" width={5}>
+            <ThresholdFilterDropdown
+              key={0}
+              options={this.thresholdOptions}
+              onApply={vars => {
+                this.setState({
+                  event: "ThresholdFilterDropdown:Apply",
+                  vars,
+                });
+              }}
+            />
+            <ThresholdFilterDropdown
+              key={1}
+              options={this.thresholdOptions}
+              disabled
+              onApply={vars => {
+                this.setState({
+                  event: "ThresholdFilterDropdown:Apply",
+                  vars,
+                });
+              }}
+            />
+          </ComponentCard>
+          <ComponentCard title="Dropdown" width={4}>
+            <Dropdown
+              key={0}
+              fluid
+              rounded
+              options={this.dropdownOptions}
+              label="Option"
+              onChange={() => this.setState({ event: "Dropdown:Change" })}
+            />
+            <Dropdown
+              key={1}
+              fluid
+              disabled
+              rounded
+              options={this.dropdownOptions}
+              label="Option"
+              onChange={() => this.setState({ event: "Dropdown:Change" })}
+            />
+          </ComponentCard>
+          <ComponentCard title="Multiple Option Dropdown" width={4}>
+            <MultipleDropdown
+              key={0}
+              fluid
+              rounded
+              search
+              options={this.dropdownOptions}
+              label="Options"
+              onChange={() =>
+                this.setState({ event: "MultipleDropdown:Change" })
+              }
+            />
+            <MultipleDropdown
+              key={1}
+              fluid
+              rounded
+              disabled
+              options={this.dropdownOptions}
+              label="Options"
+              onChange={() =>
+                this.setState({ event: "MultipleDropdown:Change" })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Multiple Nested Dropdown" width={4}>
+            <MultipleNestedDropdown
+              key={0}
+              fluid
+              rounded
+              options={this.dropdownOptions}
+              label="Options"
+              onChange={(a, b) => {
+                this.setState({ event: "MultipleDropdown:Change" });
+              }}
+            />
+          </ComponentCard>
+          <ComponentCard title="Slider" width={4}>
+            <Slider
+              key={0}
+              options={this.dropdownOptions}
+              label="Slider: "
+              onChange={() => this.setState({ event: "Slider:Change" })}
+              onAfterChange={() =>
+                this.setState({ event: "Slider:onAfterChange" })
+              }
+              min={0}
+              max={100}
+              value={20}
+            />
+            <Slider
+              key={1}
+              disabled
+              options={this.dropdownOptions}
+              label="Slider: "
+              onChange={() => this.setState({ event: "Slider:Change" })}
+              onAfterChange={() =>
+                this.setState({ event: "Slider:onAfterChange" })
+              }
+              min={0}
+              max={100}
+              value={20}
+            />
+          </ComponentCard>
+          <ComponentCard title="Checkbox" width={4}>
+            <Checkbox
+              key={0}
+              label="Checkbox"
+              onChange={() => this.setState({ event: "Checkbox:Change" })}
+              value={0}
+              checked={true}
+            />
+            <Checkbox
+              key={1}
+              label="Checkbox"
+              onChange={() => this.setState({ event: "Checkbox:Change" })}
+              value={1}
+            />
+          </ComponentCard>
+          <ComponentCard title="Toggle" width={3}>
+            <Toggle key={1} onLabel="Yes" offLabel="No" initialChecked={true} />
+            <Toggle
+              key={2}
+              onLabel="Yes"
+              offLabel="No"
+              initialChecked={false}
+            />
+          </ComponentCard>
         </div>
         <div className="playground-console">
           <span className="playground-console-label">Last Event:</span>
@@ -365,14 +312,14 @@ PlaygroundControls.propTypes = {
   thresholdFilters: PropTypes.object,
 };
 
-const ComponentCard = ({ title, components, width }) => {
+const ComponentCard = ({ title, width, children }) => {
   return (
     <div
       className="component-card"
       style={{ gridColumn: `auto / span ${width}` }}
     >
       <div className="title">{title}</div>
-      {components.map((component, idx) => (
+      {React.Children.map(children, (component, idx) => (
         <div key={idx} className="component">
           {component}
         </div>
@@ -382,7 +329,7 @@ const ComponentCard = ({ title, components, width }) => {
 };
 
 ComponentCard.propTypes = {
-  components: PropTypes.arrayOf(PropTypes.node),
+  children: PropTypes.node,
   title: PropTypes.string,
   width: PropTypes.number,
 };

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,6 +1,6 @@
 // This file needs to be in sync with webpack.config.prod.js. The first file
-// should contain idseq-written CSS and the second file should contain CSS from
-// node_modules. The order of requires is important!
+// should contain should contain CSS from node_modules and the second file
+// idseq-written CSS. The order of requires is important!
 
 //= require vendors~main.bundle.min.css
 //= require main.bundle.min.css

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -170,8 +170,10 @@ module MetadataHelper
   end
 
   # Receives an array of samples, and validates metadata from a csv.
+  # NOTE: validation depends on fields of each sample which depends on fields of each sample project.
   def validate_metadata_csv_for_samples(samples, metadata, new_samples = false)
-    # If new samples, enforce required metadata constraint, and pull the host genome from the metadata rows for validation.
+    # If new samples, enforce required metadata constraint, and pull the host genome from the
+    # metadata rows for validation.
     enforce_required = new_samples
     extract_host_genome_from_metadata = new_samples
 

--- a/app/helpers/test_helper.rb
+++ b/app/helpers/test_helper.rb
@@ -3,7 +3,8 @@ require 'csv'
 
 module TestHelper
   # Consider this a fixture for tests. Needs to integrate with dag_json for public_sample_run_stage.
-  TEST_RESULT_FOLDER = %w[
+  # Avoid "warning: already initialized constant" by conditional assignment
+  TEST_RESULT_FOLDER ||= %w[
     unmapped1.fq
     trimmomatic1.fq
     priceseq1.fa

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -14,6 +14,7 @@ class MetadataField < ApplicationRecord
     NUMBER_TYPE,
     DATE_TYPE,
     LOCATION_TYPE,
+    # see also boolean? method
   ], }
 
   # NOTE: not sure why these columns were not created as booleans
@@ -124,6 +125,7 @@ class MetadataField < ApplicationRecord
       is_required: is_required,
       examples: examples && JSON.parse(examples),
       default_for_new_host_genome: default_for_new_host_genome,
+      isBoolean: boolean?,
     }
   end
 
@@ -165,6 +167,18 @@ class MetadataField < ApplicationRecord
       return "location"
     end
     ""
+  end
+
+  # If the field has exactly two forced options, it is effectively a boolean.
+  # For now, we only support Yes/No, in that order.
+  def boolean?
+    return false unless options && force_options == 1
+
+    parsed = JSON.parse(options)
+
+    return false unless parsed.length == 2
+
+    return parsed[0] == "Yes" && parsed[1] == "No"
   end
 
   private

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -76,6 +76,7 @@ class MetadataField < ApplicationRecord
 
   # Default fields are a subset of the core fields that will appear on a project when someone
   # creates a project. These can be removed from a project.
+  # See add_default_metadata_fields in project.rb.
   # t.integer :is_default
 
   # Required fields are a subset of the core/default fields that cannot be removed from the
@@ -98,6 +99,7 @@ class MetadataField < ApplicationRecord
   # create_join_table :projects, :metadata_fields
 
   # Whether this metadata field should be added automatically to new host genomes.
+  # See add_default_metadata_fields in host_genome.rb.
   # t.integer :default_for_new_host_genome, limit: 1, default: 0
 
   def metadata_field_subsets

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -3,10 +3,24 @@ class MetadataField < ApplicationRecord
   has_and_belongs_to_many :projects
   has_many :metadata, dependent: :destroy
 
+  validate :metadata_field_subsets
+
   STRING_TYPE = 0
   NUMBER_TYPE = 1
   DATE_TYPE = 2
   LOCATION_TYPE = 3
+  validates :base_type, presence: true, inclusion: { in: [
+    STRING_TYPE,
+    NUMBER_TYPE,
+    DATE_TYPE,
+    LOCATION_TYPE,
+  ], }
+
+  # NOTE: not sure why these columns were not created as booleans
+  validates :force_options, inclusion: { in: [0, 1] }
+  validates :is_core, inclusion: { in: [0, 1] }
+  validates :is_default, inclusion: { in: [0, 1] }
+  validates :is_required, inclusion: { in: [0, 1] }
 
   # ActiveRecord documentation summary
 
@@ -85,6 +99,15 @@ class MetadataField < ApplicationRecord
 
   # Whether this metadata field should be added automatically to new host genomes.
   # t.integer :default_for_new_host_genome, limit: 1, default: 0
+
+  def metadata_field_subsets
+    if is_default == 1 && is_core == 0
+      errors[:name] << 'Default field must also be core field'
+    end
+    if is_required == 1 && is_default == 0
+      errors[:name] << 'Required field must also be default field'
+    end
+  end
 
   # Important attributes for the frontend
   def field_info

--- a/db/migrate/20190116005251_seed_metadata_fields.rb
+++ b/db/migrate/20190116005251_seed_metadata_fields.rb
@@ -1,3 +1,4 @@
+# NOTE: we should probably be using seeds.rb instead of migrations for initializing data.
 class SeedMetadataFields < ActiveRecord::Migration[5.1]
   def up
     # TODO: All the validation_types, proper association with Metadata-data entries, project associations, etc.

--- a/db/migrate/20190214210719_update_metadata_fields.rb
+++ b/db/migrate/20190214210719_update_metadata_fields.rb
@@ -1,3 +1,4 @@
+# NOTE: we should probably be using seeds.rb instead of migrations for initializing data.
 class UpdateMetadataFields < ActiveRecord::Migration[5.1]
   def up
     #########################

--- a/db/migrate/20190220211036_add_new_host_genome_default_to_metadata_fields.rb
+++ b/db/migrate/20190220211036_add_new_host_genome_default_to_metadata_fields.rb
@@ -1,3 +1,4 @@
+# NOTE: we should probably be using seeds.rb instead of migrations for initializing data.
 class AddNewHostGenomeDefaultToMetadataFields < ActiveRecord::Migration[5.1]
   DEFAULTS = [
     "collection_date",

--- a/db/migrate/20191217193112_update_water_control_metadata_field.rb
+++ b/db/migrate/20191217193112_update_water_control_metadata_field.rb
@@ -1,0 +1,17 @@
+# See SeedMetadataFields. This migration changes water control to be required.
+# NOTE: we should probably be using seeds.rb instead of migrations for initializing data.
+class UpdateWaterControlMetadataField < ActiveRecord::Migration[5.1]
+  def up
+    water_control = MetadataField.find_by(name: "water_control")
+    if water_control
+      water_control.update(is_required: 1)
+    end
+  end
+
+  def down
+    water_control = MetadataField.find_by(name: "water_control")
+    if water_control
+      water_control.update(is_required: 0)
+    end
+  end
+end

--- a/db/migrate/20191217193112_update_water_control_metadata_field.rb
+++ b/db/migrate/20191217193112_update_water_control_metadata_field.rb
@@ -4,6 +4,8 @@ class UpdateWaterControlMetadataField < ActiveRecord::Migration[5.1]
   def up
     water_control = MetadataField.find_by(name: "water_control")
     if water_control
+      # default_for_new_host_genome should already equal 1.
+      # See AddNewHostGenomeDefaultToMetadataFields.
       water_control.update(is_required: 1)
     end
   end

--- a/spec/models/metadata_field_spec.rb
+++ b/spec/models/metadata_field_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+# This spec was created well after MetadataField, for the boolean? method.
+describe MetadataField, type: :model do
+  let(:options) { '["Yes", "No"]' }
+
+  it 'not be boolean if not force_options' do
+    expect(create(:metadata_field, force_options: 0, options: options).boolean?).to_not be
+  end
+
+  it 'not be boolean if nil or zero options or more than two' do
+    expect(create(:metadata_field, force_options: 1, options: '[]').boolean?).to_not be
+    expect(create(:metadata_field, force_options: 1, options: nil).boolean?).to_not be
+    expect(create(:metadata_field, force_options: 1, options: '[1,2,3]').boolean?).to_not be
+  end
+
+  it 'not be boolean if wrong order' do
+    expect(create(:metadata_field, force_options: 1, options: '["No", "Yes"]').boolean?).to_not be
+  end
+
+  it 'be boolean if force_options and two options' do
+    expect(create(:metadata_field, force_options: 1, options: options).boolean?).to be
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/test/controllers/metadata_validate_new_samples_test.rb
+++ b/test/controllers/metadata_validate_new_samples_test.rb
@@ -206,15 +206,17 @@ class MetadataValudateNewSamplesTest < ActionDispatch::IntegrationTest
     assert_equal 0, @response.parsed_body['issues']['warnings'].length
   end
 
+  # NOTE: is_required is defined in test/fixtures/metadata_fields.yml, not in
+  # migrations as in prod. Another reason to use seeds.rb.
   test 'required fields' do
     sign_in @user
 
     post validate_csv_for_new_samples_metadata_url, params: {
       metadata: {
-        headers: ['sample_name', 'host_genome', 'sample_type', 'nucleotide_type'],
+        headers: ['sample_name', 'host_genome', 'sample_type', 'nucleotide_type', 'water_control'],
         rows: [
-          ['Test Sample', 'Human', 'Whole Blood', 'DNA'],
-          ['Test Sample 2', 'Human', '', ''],
+          ['Test Sample', 'Human', 'Whole Blood', 'DNA', 'Yes'],
+          ['Test Sample 2', 'Human', '', '', ''],
         ],
       },
       samples: [
@@ -235,7 +237,7 @@ class MetadataValudateNewSamplesTest < ActionDispatch::IntegrationTest
     # Error should throw if row is missing required metadata.
     assert @response.parsed_body['issues']['errors'][0]['isGroup']
     assert_equal ErrorAggregator::ERRORS[:row_missing_required_metadata][:title].call(1, nil), @response.parsed_body['issues']['errors'][0]['caption']
-    assert_equal [[2, "Test Sample 2", "Nucleotide Type, Sample Type"]], @response.parsed_body['issues']['errors'][0]['rows']
+    assert_equal [[2, "Test Sample 2", "Nucleotide Type, Water Control, Sample Type"]], @response.parsed_body['issues']['errors'][0]['rows']
 
     assert_equal 0, @response.parsed_body['issues']['warnings'].length
   end

--- a/test/controllers/metadata_validate_new_samples_test.rb
+++ b/test/controllers/metadata_validate_new_samples_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # Tests MetadataController validate_csv_for_new_samples endpoint
-class MetadataValudateNewSamplesTest < ActionDispatch::IntegrationTest
+class MetadataValidateNewSamplesTest < ActionDispatch::IntegrationTest
   include ErrorHelper
 
   HEADERS_1 = ['sample_name', 'host_genome', 'sample_type', 'blood_fed'].freeze

--- a/test/fixtures/host_genomes.yml
+++ b/test/fixtures/host_genomes.yml
@@ -3,15 +3,15 @@ one:
 
 two:
   name: Human
-  metadata_fields: [collection_date, sample_type, water_control, sex, age, admission_date, nucleotide_type]
+  metadata_fields: [collection_date, sample_type, sex, age, admission_date, nucleotide_type, water_control]
 
 human:
   name: Human
-  metadata_fields: [collection_date, sample_type, water_control, sex, age, admission_date, nucleotide_type, core_field]
+  metadata_fields: [collection_date, sample_type, sex, age, admission_date, nucleotide_type, core_field, water_control]
 
 mosquito:
   name: Mosquito
-  metadata_fields: [collection_date, sample_type, water_control, sex, reported_sex, blood_fed]
+  metadata_fields: [collection_date, sample_type, sex, reported_sex, blood_fed, water_control]
 
 tick:
   name: Tick

--- a/test/fixtures/host_genomes.yml
+++ b/test/fixtures/host_genomes.yml
@@ -3,15 +3,15 @@ one:
 
 two:
   name: Human
-  metadata_fields: [collection_date, sample_type, sex, age, admission_date, nucleotide_type]
+  metadata_fields: [collection_date, sample_type, water_control, sex, age, admission_date, nucleotide_type]
 
 human:
   name: Human
-  metadata_fields: [collection_date, sample_type, sex, age, admission_date, nucleotide_type, core_field]
+  metadata_fields: [collection_date, sample_type, water_control, sex, age, admission_date, nucleotide_type, core_field]
 
 mosquito:
   name: Mosquito
-  metadata_fields: [collection_date, sample_type, sex, reported_sex, blood_fed]
+  metadata_fields: [collection_date, sample_type, water_control, sex, reported_sex, blood_fed]
 
 tick:
   name: Tick

--- a/test/fixtures/metadata_fields.yml
+++ b/test/fixtures/metadata_fields.yml
@@ -12,6 +12,13 @@ nucleotide_type:
   force_options: 1
   options: "[\"DNA\", \"RNA\"]"
 
+water_control:
+  name: "water_control"
+  display_name: "Water Control"
+  base_type: 0
+  is_required: 1
+  is_core: 1
+
 collection_date:
   name: "collection_date"
   display_name: "Collection Date"

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -32,4 +32,10 @@ admin_project:
 metadata_validation_project:
   name: Metadata Project
   users: [admin_one]
-  metadata_fields: [sample_type, nucleotide_type, water_control, collection_date, age, admission_date, blood_fed, reported_sex, sex]
+  metadata_fields: [sample_type, nucleotide_type, collection_date, age, admission_date, blood_fed, reported_sex, sex]
+
+# This was added later to test water_control specifically.
+metadata_validation_project_with_water_control:
+  name: Metadata Project With Water Control
+  users: [admin_one]
+  metadata_fields: [sample_type, nucleotide_type, water_control]

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -32,4 +32,4 @@ admin_project:
 metadata_validation_project:
   name: Metadata Project
   users: [admin_one]
-  metadata_fields: [sample_type, nucleotide_type, collection_date, age, admission_date, blood_fed, reported_sex, sex]
+  metadata_fields: [sample_type, nucleotide_type, water_control, collection_date, age, admission_date, blood_fed, reported_sex, sex]


### PR DESCRIPTION
# Description

This updates: 
* water_control metadata field in database
* unit test of required fields
* CSS of metadata form

![image](https://user-images.githubusercontent.com/28797/71044159-bf75f600-20e5-11ea-898b-fa99106ca575.png)


# Notes

* also adds some validation according to existing docs
* refactored existing integration tests a bit
* question @MarkAZhang : for a metadata field to be applicable for a sample, must it be an attribute of the project AND the host genome? or either project OR host genome? this should be added to the docs
* question @MarkAZhang : what determines the rendered order of the metadata fields as columns?
* existing samples and projects will not be affected; they will not have water_control required
* dictionary auto updates

![image](https://user-images.githubusercontent.com/28797/71044716-4e374280-20e7-11ea-9349-3cd3de192fab.png)

* and so does metadata edit
![image](https://user-images.githubusercontent.com/28797/71044718-50010600-20e7-11ea-9be1-3450beadb205.png)

* and so does CSV download

![image](https://user-images.githubusercontent.com/28797/71045111-a4f14c00-20e8-11ea-9013-ae56eec02792.png)

# Tests

## unit tests
* migrate
* rails t

## new project
* open metadata upload screen in new project
* see new column

## old project
* open in old project
* do not see old column