### PR TITLE
app/models/ercc_count: make csv asset path relative

### DIFF
--- a/app/models/ercc_count.rb
+++ b/app/models/ercc_count.rb
@@ -2,5 +2,6 @@ require 'csv'
 
 class ErccCount < ApplicationRecord
   belongs_to :pipeline_run
-  BASELINE = CSV.table('app/lib/ercc_data.csv').map(&:to_hash)
+  ercc_csv = File.join(File.dirname(__FILE__), '../lib/ercc_data.csv')
+  BASELINE = CSV.table(ercc_csv).map(&:to_hash)
 end


### PR DESCRIPTION
This is needed when cwd is not the repo root.