### PR TITLE
[Report Page] Fix status for samples complete with insufficient reads

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -910,7 +910,9 @@ export default class SampleViewV2 extends React.Component {
       type = "inProgress";
       if (pipelineRun && pipelineRun.pipeline_version) {
         linkText = "View Pipeline Visualization";
-        link = `/samples/${sample.id}/pipeline_viz/${pipelineRun.pipeline_version}`;
+        link = `/samples/${sample.id}/pipeline_viz/${
+          pipelineRun.pipeline_version
+        }`;
       }
     } else {
       // Some kind of error or warning has occurred.
@@ -964,8 +966,8 @@ export default class SampleViewV2 extends React.Component {
       selectedOptions,
       view,
     } = this.state;
-    // reportReady is true if the pipeline run is report-ready (might still be running Experimental,
-    // but at least taxon_counts has been loaded).
+    // reportReady is true if the pipeline run hasn't failed and is report-ready
+    // (might still be running Experimental, but at least taxon_counts has been loaded).
     // pipelineRunReportAvailable was renamed to reportReady, but we check both in case the old variable
     // name was cached.
     // TODO(julie): remove pipelineRunReportAvailable during cleanup.
@@ -1108,9 +1110,8 @@ export default class SampleViewV2 extends React.Component {
             </UserContext.Consumer>
           </div>
           {currentTab === "Report" && this.renderReport()}
-          {currentTab === "Antimicrobial Resistance" && amrData && (
-            <AMRView amr={amrData} />
-          )}
+          {currentTab === "Antimicrobial Resistance" &&
+            amrData && <AMRView amr={amrData} />}
         </NarrowContainer>
         {sample && (
           <DetailsSidebar

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -69,7 +69,10 @@ class PipelineReportService
 
   def generate
     metadata = get_pipeline_status(@pipeline_run)
-    unless @pipeline_run && (@pipeline_run.finalized? || @pipeline_run.report_ready?)
+    # Only generate the report if the pipeline has initialized and has loaded
+    # taxon_counts (is report_ready), or if its results are finalized without errors.
+    # Otherwise just return the metadata, which includes statuses and error messages to display.
+    unless @pipeline_run && (@pipeline_run.report_ready? || (@pipeline_run.finalized? && !@pipeline_run.failed?))
       return JSON.dump(
         metadata: metadata
       )

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -72,6 +72,7 @@ class PipelineReportService
     # Only generate the report if the pipeline has initialized and has loaded
     # taxon_counts (is report_ready), or if its results are finalized without errors.
     # Otherwise just return the metadata, which includes statuses and error messages to display.
+    # TODO(julie): refactor + clarify pipeline run statuses (JIRA: https://jira.czi.team/browse/IDSEQ-1890)
     unless @pipeline_run && (@pipeline_run.report_ready? || (@pipeline_run.finalized? && !@pipeline_run.failed?))
       return JSON.dump(
         metadata: metadata


### PR DESCRIPTION
# Description

Currently, the PipelineReportService will attempt to compute the report results if the pipeline run results have been finalized even if it failed, which can result in errors (see https://idseq.net/samples/36613 and https://idseq.net/samples/36613/report_v2). Instead, the report should immediately return if an error (such as insufficient reads) has occurred in the pipeline run.

# Tests

* Verified locally that the report page would display the appropriate warning message for a sample with insufficient reads.
* Pasted the new PipelineReportService code into the rails console and verified that `PipelineReportService.call` on the sample listed above generated a report instead running into errors.
