### PR TITLE
add config

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,8 @@ class ActiveSupport::TestCase
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
+  # Rollback database after tests
+  self.use_transactional_tests = true
 
   def access_sample_with_background(background, sample)
     get "/samples/#{sample.id}?background_id=#{background.id}"


### PR DESCRIPTION
# Description

This will allow us to run `rails t` then `rspec` without interference. 

# Notes

Option appears to be enabled already in our `rspec` config.

# Tests

