### PR TITLE
Add user settings and user-facing settings page.

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -383,6 +383,15 @@ const uploadedByCurrentUser = async sampleIds => {
 
 const getHeatmapMetrics = () => get("/visualizations/heatmap_metrics.json");
 
+const getUserSettingMetadataByCategory = () =>
+  get("/user_settings/metadata_by_category");
+
+const updateUserSetting = (key, value) =>
+  postWithCSRF("user_settings/update", {
+    key,
+    value,
+  });
+
 export {
   bulkImportRemoteSamples,
   bulkUploadRemoteSamples,
@@ -414,6 +423,7 @@ export {
   getSummaryContigCounts,
   getTaxonDescriptions,
   getTaxonDistributionForBackground,
+  getUserSettingMetadataByCategory,
   getVisualizations,
   markSampleUploaded,
   saveProjectDescription,
@@ -430,4 +440,5 @@ export {
   getTaxaWithReadsSuggestions,
   getTaxaWithContigsSuggestions,
   uploadedByCurrentUser,
+  updateUserSetting,
 };

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -223,7 +223,7 @@ const UserMenuDropDown = ({
     allowedFeatures.includes("bulk_downloads") &&
       userDropdownItems.push(
         <BareDropdown.Item
-          key="1"
+          key="downloads"
           text={
             <a
               className={cs.option}
@@ -238,9 +238,29 @@ const UserMenuDropDown = ({
         />
       );
 
+    adminUser &&
+      userDropdownItems.push(
+        <BareDropdown.Item
+          key="user_settings"
+          text={
+            <a
+              className={cs.option}
+              href="/user_settings"
+              onClick={() =>
+                logAnalyticsEvent(
+                  "Header_dropdown-user-settings-option_clicked"
+                )
+              }
+            >
+              Settings
+            </a>
+          }
+        />
+      );
+
     userDropdownItems.push(
       <BareDropdown.Item
-        key="2"
+        key="help"
         text={
           <ExternalLink
             className={cs.option}
@@ -254,7 +274,7 @@ const UserMenuDropDown = ({
         }
       />,
       <BareDropdown.Item
-        key="3"
+        key="feedback"
         text={
           <a
             className={cs.option}
@@ -272,7 +292,7 @@ const UserMenuDropDown = ({
     adminUser &&
       userDropdownItems.push(
         <BareDropdown.Item
-          key="4"
+          key="create_user"
           text={
             <a className={cs.option} href="/users/new">
               Create User
@@ -282,9 +302,9 @@ const UserMenuDropDown = ({
       );
 
     userDropdownItems.push(
-      <BareDropdown.Divider key="5" />,
+      <BareDropdown.Divider key="divider_one" />,
       <BareDropdown.Item
-        key="6"
+        key="terms_of_service"
         text={
           <a
             className={cs.option}
@@ -300,7 +320,7 @@ const UserMenuDropDown = ({
         }
       />,
       <BareDropdown.Item
-        key="7"
+        key="privacy_policy"
         text={
           <a
             className={cs.option}
@@ -315,9 +335,9 @@ const UserMenuDropDown = ({
           </a>
         }
       />,
-      <BareDropdown.Divider key="8" />,
+      <BareDropdown.Divider key="divider_two" />,
       <BareDropdown.Item
-        key="9"
+        key="logout"
         text="Logout"
         onClick={withAnalytics(
           signOut,

--- a/app/assets/src/components/views/UserSettingsView.jsx
+++ b/app/assets/src/components/views/UserSettingsView.jsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { set } from "lodash/fp";
+
+import { ViewHeader, NarrowContainer } from "~/components/layout";
+import { getUserSettingMetadataByCategory, updateUserSetting } from "~/api";
+import LoadingMessage from "~/components/common/LoadingMessage";
+import Checkbox from "~ui/controls/Checkbox";
+import { UserContext } from "~/components/common/UserContext";
+
+import cs from "./user_settings_view.scss";
+
+export default class UserSettingsView extends React.Component {
+  state = {
+    userPreferenceMetadata: null,
+    isLoading: true,
+    // User setting values that were modified on this page and not reflected in the UserContext.
+    modifiedUserSettings: {},
+    error: "",
+  };
+
+  async componentDidMount() {
+    try {
+      const userPreferenceMetadata = await getUserSettingMetadataByCategory();
+
+      this.setState({
+        isLoading: false,
+        userPreferenceMetadata,
+      });
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e.error);
+      // Show an error if the update fails.
+      this.setState({
+        isLoading: false,
+        error: "Could not fetch user settings. Please try again later.",
+      });
+    }
+  }
+
+  getUserPreferenceValues = () => {
+    const { userSettings } = this.context || {};
+
+    return {
+      ...userSettings,
+      ...this.state.modifiedUserSettings,
+    };
+  };
+
+  handleUserPreferenceUpdate = async (key, value) => {
+    // Modify the value on the front-end, so that the user gets instant feedback.
+    this.setState({
+      modifiedUserSettings: set(key, value, this.state.modifiedUserSettings),
+    });
+
+    try {
+      await updateUserSetting(key, value);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e.error);
+      // Show an error if the update fails.
+      this.setState({
+        error: "We were unable to save your settings",
+      });
+    }
+  };
+
+  renderUserPreferenceField = field => {
+    const currentValue = this.getUserPreferenceValues()[field.key];
+    if (field.data_type === "boolean") {
+      return (
+        <div className={cs.field}>
+          <Checkbox
+            label={field.description}
+            onChange={(_, isChecked) =>
+              this.handleUserPreferenceUpdate(
+                field.key,
+                isChecked ? "true" : "false"
+              )
+            }
+            checked={currentValue === "true"}
+          />
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  renderCategory = category => {
+    return (
+      <div className={cs.category}>
+        <div className={cs.title}>{category.name}</div>
+        <div className={cs.fields}>
+          {category.settings.map(this.renderUserPreferenceField)}
+        </div>
+      </div>
+    );
+  };
+
+  renderCategories = () => {
+    const { error, userPreferenceMetadata } = this.state;
+
+    if (userPreferenceMetadata && userPreferenceMetadata.length === 0) {
+      return <div className={cs.noResultsMessage}>No user settings found</div>;
+    }
+
+    return (
+      <div>
+        {error && <div className={cs.error}>{error}</div>}
+        {userPreferenceMetadata &&
+          userPreferenceMetadata.map(category => this.renderCategory(category))}
+      </div>
+    );
+  };
+
+  renderLoading = () => {
+    return <LoadingMessage message="Loading Settings..." />;
+  };
+
+  render() {
+    const { isLoading } = this.state;
+
+    return (
+      <div>
+        <NarrowContainer>
+          <ViewHeader className={cs.viewHeader}>
+            <ViewHeader.Content>
+              <ViewHeader.Title label={"User Settings"} />
+            </ViewHeader.Content>
+          </ViewHeader>
+          {isLoading ? this.renderLoading() : this.renderCategories()}
+        </NarrowContainer>
+      </div>
+    );
+  }
+}
+
+UserSettingsView.contextType = UserContext;

--- a/app/assets/src/components/views/user_settings_view.scss
+++ b/app/assets/src/components/views/user_settings_view.scss
@@ -1,0 +1,27 @@
+@import "~styles/themes/elements";
+@import "~styles/themes/typography";
+@import "~styles/themes/colors";
+
+.viewHeader {
+  margin-top: $space-xl;
+  margin-bottom: $space-xl;
+}
+
+.error {
+  color: $error;
+  margin-bottom: $space-s;
+}
+
+.noResultsMessage {
+  color: $medium-grey;
+}
+
+.category {
+  .title {
+    @include font-header-m;
+  }
+
+  .field {
+    padding: $space-s;
+  }
+}

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -1,0 +1,60 @@
+class UserSettingsController < ApplicationController
+  # User settings is currently admin-only because there aren't any user-facing user settings
+  # and it doesn't make sense to show an empty screen.
+  # Remove this condition if you are adding an additional user-facing user setting.
+  before_action :admin_required
+
+  # GET /user_settings/metadata_by_category
+  # Get metadata for user settings that are editable by the user.
+  def metadata_by_category
+    user_setting_metadata = []
+    viewable_keys = current_user.viewable_user_setting_keys
+
+    UserSetting::DISPLAY_CATEGORIES.each do |category|
+      viewable_category_keys = category[:settings] & viewable_keys
+
+      unless viewable_category_keys.empty?
+        user_setting_metadata << {
+          name: category[:name],
+          settings: viewable_category_keys.map do |key|
+            {
+              key: key,
+              description: UserSetting::METADATA[key][:description],
+              data_type: UserSetting::METADATA[key][:data_type],
+            }
+          end,
+        }
+      end
+    end
+
+    render json: user_setting_metadata
+  rescue => e
+    LogUtil.log_backtrace(e)
+    LogUtil.log_err_and_airbrake("UserSettingsMetadataFetchError: Unexpected issue fetching user setting metadata: #{e}")
+    render json: {
+      status: "failure",
+      error: e,
+    }, status: :internal_server_error
+  end
+
+  # POST /user_settings/update
+  def update
+    current_user.save_user_setting(params[:key], params[:value])
+
+    render json: {
+      status: "success",
+      key: params[:key],
+      value: current_user.get_user_setting(params[:key]),
+    }
+  rescue => e
+    LogUtil.log_backtrace(e)
+    LogUtil.log_err_and_airbrake("UserSettingsUpdateError: Unexpected issue updating user settings: #{e}")
+    render json: {
+      status: "failure",
+      error: e,
+    }, status: :unprocessable_entity
+  end
+
+  def index
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,6 +35,7 @@ module ApplicationHelper
       admin: current_user ? current_user.role == 1 : false,
       allowedFeatures: current_user && current_user.allowed_feature_list,
       maxSamplesBulkDownload: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD),
+      userSettings: current_user && current_user.viewable_user_settings,
     }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ApplicationRecord
   has_many :phylo_trees, dependent: :destroy
   has_many :backgrounds, dependent: :destroy
   has_many :bulk_downloads, dependent: :destroy
+  has_many :user_settings, dependent: :destroy
 
   validates :email, presence: true
   validates :name, presence: true, format: {
@@ -119,6 +120,46 @@ class User < ApplicationRecord
 
   def owns_project?(project_id)
     projects.exists?(project_id)
+  end
+
+  def get_user_setting(key)
+    user_setting = user_settings.find_by(key: key)
+
+    return user_setting.value unless user_setting.nil?
+
+    return UserSetting::METADATA[key][:default]
+  end
+
+  def save_user_setting(key, value)
+    user_setting = user_settings.find_or_initialize_by(key: key)
+
+    user_setting.value = value
+    user_setting.save!
+  end
+
+  # Remove any user settings gated on allowed_features that the user doesn't have access to.
+  def viewable_user_setting_keys
+    parsed_allowed_feature_list = allowed_feature_list
+    UserSetting::METADATA.select do |_key, metadata|
+      metadata[:required_allowed_feature].nil? || parsed_allowed_feature_list.include?(metadata[:required_allowed_feature])
+    end.keys
+  end
+
+  def viewable_user_settings
+    # Fetch viewable user settings.
+    existing_user_settings = user_settings
+                             .where(key: viewable_user_setting_keys)
+                             .map { |setting| [setting.key, setting.value] }
+                             .to_h
+
+    # Fill in all missing user settings with the default value.
+    viewable_user_setting_keys.each do |key|
+      if existing_user_settings[key].nil?
+        existing_user_settings[key] = UserSetting::METADATA[key][:default]
+      end
+    end
+
+    existing_user_settings
   end
 
   # Update login trackable fields

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -1,0 +1,47 @@
+class UserSetting < ApplicationRecord
+  belongs_to :user
+  validate :user_setting_checks
+
+  # An example user setting
+  EXAMPLE_USER_SETTING = "example_user_setting".freeze
+
+  # value must be "true" or "false".
+  DATA_TYPE_BOOLEAN = "boolean".freeze
+
+  # Stores metadata for various user settings.
+  # data_type - specifies the type of data that is being stored. You can perform validations on the data in user_setting_checks.
+  # required_allowed_feature - the setting will only be visible if an allowed feature is true.
+  METADATA = {
+    EXAMPLE_USER_SETTING => {
+      default: "true",
+      description: "An example user setting. User settings can handle any persistent user-specific configurations.",
+      data_type: DATA_TYPE_BOOLEAN,
+    },
+  }.freeze
+
+  # Governs how the settings will be displayed in the User Settings page on the front-end.
+  # Only include user settings that you want the user to be able to modify.
+  # Specifies both the order of categories as well as the order of settings within categories.
+  DISPLAY_CATEGORIES = [
+    {
+      name: "Example Category",
+      settings: [
+        EXAMPLE_USER_SETTING,
+      ],
+    },
+  ].freeze
+
+  def user_setting_checks
+    # Verify that the key is listed above.
+    unless METADATA.keys.include?(key)
+      errors.add(:key, "invalid (#{key})")
+      return
+    end
+
+    # Validation for various data types.
+    data_type = METADATA[key][:data_type]
+    if data_type == DATA_TYPE_BOOLEAN
+      errors.add(:value, "must be true or false for boolean data type (#{value} given)") unless ["true", "false"].include?(value)
+    end
+  end
+end

--- a/app/views/user_settings/index.html.erb
+++ b/app/views/user_settings/index.html.erb
@@ -1,0 +1,6 @@
+<div id="UserSettingsView_page">
+  <%= javascript_tag do %>
+    react_component('UserSettingsView', {}, 'UserSettingsView_page',
+    JSON.parse('<%= raw escape_json(user_context)%>'));
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,10 @@ Rails.application.routes.draw do
   post 'bulk_downloads/:id/error/:access_token', to: 'bulk_downloads#error_with_token', as: :bulk_downloads_error
   post 'bulk_downloads/:id/progress/:access_token', to: 'bulk_downloads#progress_with_token', as: :bulk_downloads_progress
 
+  get 'user_settings/metadata_by_category', to: 'user_settings#metadata_by_category'
+  post 'user_settings/update', to: 'user_settings#update'
+  get 'user_settings', to: 'user_settings#index'
+
   resources :host_genomes
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]
 

--- a/db/migrate/20191218014846_create_user_settings.rb
+++ b/db/migrate/20191218014846_create_user_settings.rb
@@ -1,0 +1,10 @@
+class CreateUserSettings < ActiveRecord::Migration[5.1]
+  def change
+    create_table :user_settings do |t| # A table of user settings. Each user + setting combination is a separate row.
+      t.references :user, foreign_key: true
+      t.string :key, comment: "The name of the user setting, e.g. receives_bulk_download_success_emails"
+      t.string :value, comment: "The value of the user setting, e.g. true. The schema of this value (e.g. boolean, number) is determined by the hard-coded data type associated with the key."
+      t.index ["user_id", "key"], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_216_200_333) do
+ActiveRecord::Schema.define(version: 20_191_218_220_321) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -553,6 +553,14 @@ ActiveRecord::Schema.define(version: 20_191_216_200_333) do
     t.integer "top_n"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "user_settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "user_id"
+    t.string "key", comment: "The name of the user setting, e.g. receives_bulk_download_success_emails"
+    t.string "value", comment: "The value of the user setting, e.g. true. The schema of this value (e.g. boolean, number) is determined by the hard-coded data type associated with the key."
+    t.index ["user_id", "key"], name: "index_user_settings_on_user_id_and_key", unique: true
+    t.index ["user_id"], name: "index_user_settings_on_user_id"
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/spec/controllers/user_settings_controller_spec.rb
+++ b/spec/controllers/user_settings_controller_spec.rb
@@ -1,0 +1,182 @@
+require 'rails_helper'
+
+RSpec.describe UserSettingsController, type: :controller do
+  create_users
+
+  let(:mock_user_setting) { "mock_user_setting" }
+  let(:mock_user_setting_description) { "mock_user_setting_description" }
+  let(:mock_user_setting_two) { "mock_user_setting_two" }
+  let(:mock_user_setting_description_two) { "mock_user_setting_description_two" }
+  let(:mock_user_setting_three) { "mock_user_setting_three" }
+
+  def stub_mock_user_setting_metadata(additional_settings = {})
+    user_settings = {
+      mock_user_setting => {
+        default: "true",
+        description: mock_user_setting_description,
+        data_type: UserSetting::DATA_TYPE_BOOLEAN,
+      },
+      mock_user_setting_two => {
+        default: "true",
+        description: mock_user_setting_description_two,
+        data_type: UserSetting::DATA_TYPE_BOOLEAN,
+      },
+    }.merge!(additional_settings)
+
+    stub_const("UserSetting::METADATA", user_settings)
+  end
+
+  def stub_mock_display_categories(additional_settings = [])
+    stub_const("UserSetting::DISPLAY_CATEGORIES",
+               [
+                 name: "Example Category",
+                 settings: [
+                   mock_user_setting,
+                   mock_user_setting_two,
+                 ] + additional_settings,
+               ])
+  end
+
+  # Admin specific behavior
+  context "Admin user" do
+    # create_users
+    before do
+      sign_in @admin
+    end
+
+    describe "GET metadata_by_category" do
+      it "returns viewable display categories" do
+        stub_mock_user_setting_metadata()
+        stub_mock_display_categories()
+
+        get :metadata_by_category, params: { format: "json" }
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(1)
+        expect(json_response[0]["name"]).to eq("Example Category")
+        expect(json_response[0]["settings"].length).to eq(2)
+        expect(json_response[0]["settings"][0]["key"]).to eq(mock_user_setting)
+        expect(json_response[0]["settings"][0]["description"]).to eq(mock_user_setting_description)
+        expect(json_response[0]["settings"][0]["data_type"]).to eq(UserSetting::DATA_TYPE_BOOLEAN)
+        expect(json_response[0]["settings"][1]["key"]).to eq(mock_user_setting_two)
+        expect(json_response[0]["settings"][1]["description"]).to eq(mock_user_setting_description_two)
+        expect(json_response[0]["settings"][1]["data_type"]).to eq(UserSetting::DATA_TYPE_BOOLEAN)
+      end
+
+      it "does not return user settings that aren't specified in display_categories" do
+        # Add an additional user setting that isn't in the display categories.
+        stub_mock_user_setting_metadata(mock_user_setting_three => {
+                                          default: "true",
+                                          description: mock_user_setting_description,
+                                          data_type: UserSetting::DATA_TYPE_BOOLEAN,
+                                        })
+        stub_mock_display_categories()
+
+        get :metadata_by_category, params: { format: "json" }
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(1)
+        expect(json_response[0]["name"]).to eq("Example Category")
+        expect(json_response[0]["settings"].length).to eq(2)
+      end
+
+      it "does not return user settings with required_allowed_features that the user doesn't have" do
+        mock_user_setting_three = "mock_user_setting_three"
+
+        stub_mock_user_setting_metadata(mock_user_setting_three => {
+                                          default: "true",
+                                          description: mock_user_setting_description,
+                                          data_type: UserSetting::DATA_TYPE_BOOLEAN,
+                                          required_allowed_feature: "mock_allowed_feature",
+                                        })
+        stub_mock_display_categories([mock_user_setting_three])
+
+        get :metadata_by_category, params: { format: "json" }
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(1)
+        expect(json_response[0]["name"]).to eq("Example Category")
+        expect(json_response[0]["settings"].length).to eq(2)
+      end
+
+      it "does return user settings with required_allowed_features that the user has" do
+        stub_mock_user_setting_metadata(mock_user_setting_three => {
+                                          default: "true",
+                                          description: mock_user_setting_description,
+                                          data_type: UserSetting::DATA_TYPE_BOOLEAN,
+                                          required_allowed_feature: "mock_allowed_feature",
+                                        })
+        stub_mock_display_categories([mock_user_setting_three])
+
+        @admin.add_allowed_feature("mock_allowed_feature")
+
+        get :metadata_by_category, params: { format: "json" }
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(1)
+        expect(json_response[0]["name"]).to eq("Example Category")
+        expect(json_response[0]["settings"].length).to eq(3)
+      end
+    end
+
+    describe "GET update" do
+      it "updates user setting" do
+        stub_mock_user_setting_metadata()
+        stub_mock_display_categories()
+
+        post :update, params: { format: "json", key: mock_user_setting, value: "true" }
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["status"]).to eq("success")
+        expect(json_response["key"]).to eq(mock_user_setting)
+        expect(json_response["value"]).to eq("true")
+      end
+
+      it "throws error if value is invalid for boolean data type" do
+        stub_mock_user_setting_metadata()
+        stub_mock_display_categories()
+
+        post :update, params: { format: "json", key: mock_user_setting, value: "mock_bad_value" }
+
+        expect(response).to have_http_status :unprocessable_entity
+        json_response = JSON.parse(response.body)
+        expect(json_response["status"]).to eq("failure")
+      end
+
+      it "throws error if value is invalid for key that isn't present in metadata" do
+        stub_mock_user_setting_metadata()
+        stub_mock_display_categories()
+
+        post :update, params: { format: "json", key: "mock_bad_key", value: "true" }
+
+        expect(response).to have_http_status :unprocessable_entity
+        json_response = JSON.parse(response.body)
+        expect(json_response["status"]).to eq("failure")
+      end
+    end
+  end
+
+  context "Joe user" do
+    before do
+      sign_in @joe
+    end
+
+    describe "GET metadata_by_category" do
+      it "should not be accessible to non-admins" do
+        stub_mock_user_setting_metadata()
+        stub_mock_display_categories()
+
+        get :metadata_by_category, params: { format: "json" }
+        expect(controller).not_to receive(:metadata_by_category)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "GET update" do
+      it "should not be accessible to non-admins" do
+        stub_mock_user_setting_metadata()
+        stub_mock_display_categories()
+
+        post :update, params: { format: "json", key: mock_user_setting, value: "true" }
+        expect(controller).not_to receive(:update)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

Add user preferences.

Currently gated on bulk downloads because that's the only user preference.

Includes a page for users to modify their preferences. Includes validation for the "boolean" data type. 

User preferences page
![Screen Shot 2019-12-18 at 2 36 03 PM](https://user-images.githubusercontent.com/837004/71129675-d0d20780-21a4-11ea-8b7d-e757c9ae0411.png)

Dropdown menu (once bulk downloads is enabled)
![Screen Shot 2019-12-18 at 2 35 49 PM](https://user-images.githubusercontent.com/837004/71129678-d29bcb00-21a4-11ea-9af9-88ed341e4838.png)

When no user preferences can be found (shouldn't happen because this feature is gated on bulk downloads)
![Screen Shot 2019-12-18 at 2 26 06 PM](https://user-images.githubusercontent.com/837004/71129682-d4fe2500-21a4-11ea-81c9-9b9e1138a527.png)

Error message if something goes wrong.
![Screen Shot 2019-12-18 at 2 22 45 PM](https://user-images.githubusercontent.com/837004/71129687-d62f5200-21a4-11ea-9d53-bf5f0974b5f2.png)

# Notes
Some notable design decisions:
* Instead of having a JSON object for all preferences or having a single row with different preferences as columns, we store preference name/preference value/user pairs in each row. This allows you to add new preferences without database schema changes. It also allows for future queries where you need all users with a certain preference (which would be hard with a JSON object)
* We hard-code the metadata for the different user preferences instead of storing them in a UserPreferencesField table. Since the code will depend on certain user preferences being a certain way, it seems correct to put the metadata for these preferences in code. For example, if the code expects a certain user preference to be a boolean, but the data type is stored in the database, then there's no way to guarantee that this is the case.
* Right now, the "value" column of the database is a "string". If you need specific behavior for certain user preferences, you will need to add a "data_type" and write the validation for it.
* If a user doesn't have anything set for a particular user preference, the default value will be used.
* Still need to write tests. Wanted to get a round of feedback on the table schema first (in case any of the above is controversial)
