### PR TITLE
Replace references to "tissue" with "sample type"

### DIFF
--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -240,11 +240,7 @@ class Samples extends React.Component {
       this.handleProjectSelection(result.id);
     } else if (result.category == "Sample") {
       this.applySuggestFilter(result, "sampleIdsParams", "sample_ids");
-    } else if (
-      result.category == "Sample Type" ||
-      result.category == "Tissue"
-    ) {
-      // Tissue is legacy. Check both to be safe.
+    } else if (result.category == "Tissue") {
       this.applySuggestFilter(result, "selectedTissueFilters", "id");
     } else if (result.category == "Host") {
       this.applySuggestFilter(result, "selectedHostIndices", "id");

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -240,7 +240,11 @@ class Samples extends React.Component {
       this.handleProjectSelection(result.id);
     } else if (result.category == "Sample") {
       this.applySuggestFilter(result, "sampleIdsParams", "sample_ids");
-    } else if (result.category == "Tissue") {
+    } else if (
+      result.category == "Sample Type" ||
+      result.category == "Tissue"
+    ) {
+      // Tissue is legacy. Check both to be safe.
       this.applySuggestFilter(result, "selectedTissueFilters", "id");
     } else if (result.category == "Host") {
       this.applySuggestFilter(result, "selectedHostIndices", "id");

--- a/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
@@ -207,7 +207,7 @@ class DiscoveryFilters extends React.Component {
             onChange={this.handleChange.bind(this, "tissueSelected")}
             selected={tissue && tissue.length ? tissueSelected : null}
             options={tissue}
-            label="Tissue"
+            label="Sample Type"
           />
           {this.renderTags("tissue")}
         </div>

--- a/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryHeader.jsx
@@ -20,7 +20,7 @@ class DiscoveryHeader extends React.Component {
     // category "Sample": key: "sample", value: sample_ids[0], text: title
     // category "Location": key: "location", value: id, text: title
     // category "Host": key: "host", value: id, text: title
-    // category "Tissue": key: "tissue", value: id, text: title
+    // category "Sample Type": key: "tissue", value: id, text: title
     // TODO(jsheu): Replace location "v1"
     let category = result.category;
     if (category !== "locationV2") category = category.toLowerCase();

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/DiscoverySidebar.jsx
@@ -351,7 +351,7 @@ export default class DiscoverySidebar extends React.Component {
               {this.buildMetadataRows("host")}
             </div>
             <div className={cs.hasBackground}>
-              <span className={cs.rowLabel}>Tissue</span>
+              <span className={cs.rowLabel}>Sample Type</span>
               {this.buildMetadataRows("tissue")}
             </div>
             <div className={cs.hasBackground}>

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -685,7 +685,7 @@ class DiscoveryView extends React.Component {
 
         if (results.length) {
           suggestions[category] = {
-            name: category === "locationV2" ? "location" : capitalize(category),
+            name: this.getName(category),
             results,
           };
         }
@@ -693,6 +693,17 @@ class DiscoveryView extends React.Component {
     });
 
     return suggestions;
+  };
+
+  getName = category => {
+    if (category === "locationV2") {
+      return "location";
+    } else if (category === "tissue") {
+      // It's too hard to rename all JS so we just rename here
+      return "Sample Type";
+    } else {
+      return capitalize(category);
+    }
   };
 
   getServerSideSuggestions = async query => {

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -710,6 +710,7 @@ class DiscoveryView extends React.Component {
     const { domain } = this.props;
 
     let results = await getSearchSuggestions({
+      // NOTE: backend also supports "tissue", "location", "host" and more
       categories: ["sample", "project", "taxon"],
       query,
       domain,

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -54,7 +54,7 @@ class PhyloTreeCreation extends React.Component {
     this.projectSamplesHeaders = {
       name: "Name",
       host: "Host",
-      tissue: "Tissue",
+      tissue: "Sample Type",
       location: "Location",
       date: "Date",
       reads: "Read Count\n(NT | NR)",
@@ -64,7 +64,7 @@ class PhyloTreeCreation extends React.Component {
       name: "Name",
       project: "Project",
       host: "Host",
-      tissue: "Tissue",
+      tissue: "Sample Type",
       location: "Location",
       date: "Date",
       reads: "Read Count\n(NT | NR)",

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -363,12 +363,8 @@ class SamplesController < ApplicationController
     # Not permission-dependent
     results = {}
 
-    # Keep "tissue" for legacy compatibility. It's too hard to rename all JS
-    # instances to "sample_type"
-    categories = categories.map { |c| c == "tissue" ? "sample_type" : c }
-
     # Need users
-    if !categories || ["project", "sample", "location", "sample_type", "uploader"].any? { |i| categories.include? i }
+    if !categories || ["project", "sample", "location", "tissue", "uploader"].any? { |i| categories.include? i }
       # Admin-only for now: needs permissions scoping
       users = current_user.admin ? prefix_match(User, "name", query, {}) : []
     end
@@ -396,7 +392,7 @@ class SamplesController < ApplicationController
     end
 
     # Permission-dependent
-    if !categories || ["sample", "location", "sample_type", "taxon"].any? { |i| categories.include? i }
+    if !categories || ["sample", "location", "tissue", "taxon"].any? { |i| categories.include? i }
       constrained_samples = samples_by_domain(domain)
       constrained_samples = filter_samples(constrained_samples, params)
       constrained_sample_ids = constrained_samples.pluck(:id)
@@ -442,13 +438,15 @@ class SamplesController < ApplicationController
       end
     end
 
-    if !categories || categories.include?("sample_type")
+    if !categories || categories.include?("tissue")
       sample_types = prefix_match(Metadatum, "string_validated_value", query, sample_id: constrained_sample_ids).where(key: "sample_type")
       unless sample_types.empty?
-        results["Sample Type"] = {
-          "name" => "Sample Type",
+        # Keep "tissue" for legacy compatibility. It's too hard to rename all JS
+        # instances to "sample_type".
+        results["Tissue"] = {
+          "name" => "Tissue",
           "results" => sample_types.pluck(:string_validated_value).uniq.map do |val|
-            { "category" => "Sample Type", "title" => val, "id" => val }
+            { "category" => "Tissue", "title" => val, "id" => val }
           end,
         }
       end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -72,7 +72,9 @@ class SamplesController < ApplicationController
     name_search_query = params[:search]
     filter_query = params[:filter]
     page = params[:page]
-    sample_type_query = params[:sample_type].split(',') if params[:sample_type].present?
+    # Keep "tissue" for legacy compatibility. It's too hard to rename all JS
+    # instances to "sample_type".
+    sample_type_query = params[:tissue].split(',') if params[:tissue].present?
     host_query = params[:host].split(',') if params[:host].present?
     samples_query = params[:ids].split(',') if params[:ids].present?
     sort = params[:sort_by]
@@ -132,7 +134,9 @@ class SamplesController < ApplicationController
         samples: @samples_formatted,
         # Number of samples in the current query.
         count: @samples_count,
-        sample_types: @sample_types,
+        # Keep "tissue" for legacy compatibility. It's too hard to rename all JS
+        # instances to "sample_type"
+        tissues: @sample_types,
         host_genomes: @host_genomes,
         # Total number of samples in the project
         count_project: @count_project,
@@ -301,7 +305,9 @@ class SamplesController < ApplicationController
           { dimension: "time", values: times },
           { dimension: "time_bins", values: time_bins },
           { dimension: "host", values: hosts },
-          { dimension: "sample_type", values: sample_types },
+          # Keep "tissue" for legacy compatibility. It's too hard to rename all JS
+          # instances to "sample_type"
+          { dimension: "tissue", values: sample_types },
         ]
       end
     end
@@ -356,6 +362,10 @@ class SamplesController < ApplicationController
     # Generate structure required by CategorySearchBox
     # Not permission-dependent
     results = {}
+
+    # Keep "tissue" for legacy compatibility. It's too hard to rename all JS
+    # instances to "sample_type"
+    categories = categories.map { |c| c == "tissue" ? "sample_type" : c }
 
     # Need users
     if !categories || ["project", "sample", "location", "sample_type", "uploader"].any? { |i| categories.include? i }

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -187,7 +187,7 @@ module SamplesHelper
     location_v2 = params[:locationV2]
     taxon = params[:taxon]
     time = params[:time]
-    tissue = params[:tissue]
+    sample_type = params[:sample_type]
     visibility = params[:visibility]
     project_id = params[:projectId]
     search_string = params[:search]
@@ -199,7 +199,7 @@ module SamplesHelper
     samples = filter_by_metadata_key(samples, "collection_location", location) if location.present?
     samples = filter_by_metadata_key(samples, "collection_location_v2", location_v2) if location_v2.present?
     samples = filter_by_time(samples, Date.parse(time[0]), Date.parse(time[1])) if time.present?
-    samples = filter_by_metadata_key(samples, "sample_type", tissue) if tissue.present?
+    samples = filter_by_metadata_key(samples, "sample_type", sample_type) if sample_type.present?
     samples = filter_by_visibility(samples, visibility) if visibility.present?
     samples = filter_by_search_string(samples, search_string) if search_string.present?
     samples = filter_by_sample_ids(samples, requested_sample_ids) if requested_sample_ids.present?

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -187,7 +187,9 @@ module SamplesHelper
     location_v2 = params[:locationV2]
     taxon = params[:taxon]
     time = params[:time]
-    sample_type = params[:sample_type]
+    # Keep "tissue" for legacy compatibility. It's too hard to rename all JS
+    # instances to "sample_type"
+    sample_type = params[:tissue]
     visibility = params[:visibility]
     project_id = params[:projectId]
     search_string = params[:search]

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 WebMock.allow_net_connect!
 
 RSpec.describe ProjectsController, type: :controller do
+  KLEBSIELLA_TAX_ID = 2
+
   create_users
 
   # Admin specific behavior
@@ -574,7 +576,6 @@ RSpec.describe ProjectsController, type: :controller do
             expected_projects = []
             create(:project, users: [@user])
             create(:project, :with_sample, users: [@user])
-            KLEBSIELLA_TAX_ID = 2
             create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsormidium", nt: 10, tax_id: 1 }], job_status: "CHECKED" }] }])
             create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 0, tax_id: KLEBSIELLA_TAX_ID }], job_status: "CHECKED" }] }])
             expected_projects << create(:project, users: [@user], samples_data: [{ pipeline_runs_data: [{ taxon_counts_data: [{ taxon_name: "klebsiella", nt: 10, tax_id: KLEBSIELLA_TAX_ID }], job_status: "CHECKED" }] }])


### PR DESCRIPTION
# Description

The UI still shows "tissue" in places although it actually shows "sample type". And the code is full of "tissue" identifiers. This PR corrects the UI, and updates all ruby code, but not all JS, which proved to be too time consuming.  

![whole mosquito](https://user-images.githubusercontent.com/28797/71132312-f9113480-21ab-11ea-8ea4-d35511f9d9fa.png)

![METADATA](https://user-images.githubusercontent.com/28797/71132324-fca4bb80-21ab-11ea-9a13-8a4fe14a678d.png)

![LOCATION V](https://user-images.githubusercontent.com/28797/71132330-00384280-21ac-11ea-8b5d-1d52aec5388b.png)


# Notes

* The "locationV2" has some similar special cases
* The way that names are remapped to camelCase from ruby to JS makes it really difficult to search and replace. 
* The lack of standardization or documentation on data structures makes for reading a lot of code.


# Tests
## specific unit tests that search by sample type
Unit test projects controller
Unit test samples controller

## all unit tests
rails t
rspec

## search suggestions
override get server search suggestions to test that code path
and hit endpoint http://localhost:3000/search_suggestions?categories[]=sample&categories[]=project&categories[]=tissue&query=abdomen&domain=my_data

## manual test data discovery, both samples and projects views
left filter nav
search box
right stats sidebar