### PR TITLE
[Report Page] Fix bugs related to categories

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -332,11 +332,12 @@ export default class SampleViewV2 extends React.Component {
 
     // taxon's category was selected and its subcategories were not excluded
     if (
-      categories.has(row.category) &&
-      !some(
-        subcategory => subcategories.has(subcategory),
-        row.subcategories || []
-      )
+      (categories.has(row.category) &&
+        !some(
+          subcategory => subcategories.has(subcategory),
+          row.subcategories || []
+        )) ||
+      (categories.has("uncategorized") && row.category === null)
     ) {
       return true;
     }
@@ -1029,19 +1030,20 @@ export default class SampleViewV2 extends React.Component {
               />
             </div>
           )}
-          {view == "tree" && (
-            <div>
-              <TaxonTreeVis
-                lineage={lineageData}
-                metric={selectedOptions.metric}
-                nameType={selectedOptions.nameType}
-                onTaxonClick={this.handleTaxonClick}
-                sample={sample}
-                taxa={filteredReportData}
-                useReportV2Format={true}
-              />
-            </div>
-          )}
+          {view == "tree" &&
+            filteredReportData.length > 0 && (
+              <div>
+                <TaxonTreeVis
+                  lineage={lineageData}
+                  metric={selectedOptions.metric}
+                  nameType={selectedOptions.nameType}
+                  onTaxonClick={this.handleTaxonClick}
+                  sample={sample}
+                  taxa={filteredReportData}
+                  useReportV2Format={true}
+                />
+              </div>
+            )}
         </div>
       );
     } else {


### PR DESCRIPTION
# Description

Fixing https://jira.czi.team/browse/IDSEQ-1950 and https://jira.czi.team/browse/IDSEQ-1951:

* Taxon tree will no longer crash if no taxons pass the selected filters (the tree will no longer be rendered unless there are taxons).
![image](https://user-images.githubusercontent.com/53838890/71136060-662ac700-21b8-11ea-8c1f-4a6acb9cac03.png)

* Uncagtegorized taxons will now show up if you select that filter.
![image](https://user-images.githubusercontent.com/53838890/71136043-58754180-21b8-11ea-8224-7c7a94bde417.png)

# Tests

* Applied filters until no taxons passed, selected taxon tree view, verified that page did not crash.
* Applied the "uncategorized" category filter and verified that the results matched that of the legacy page.
