### PR TITLE
Fix bug with overactive logging in bulk download.

### DIFF
--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -449,10 +449,12 @@ class BulkDownload < ApplicationRecord
         failed_sample_ids << pipeline_run.sample.id
       end
 
-      if Time.now.to_f - last_progress_time > progress_update_delay
+      cur_time = Time.now.to_f
+      if cur_time - last_progress_time > progress_update_delay
         progress = (index + 1).to_f / pipeline_runs.length
         update(progress: progress)
         Rails.logger.info(format("Updated progress. %3.1f complete.", progress))
+        last_progress_time = cur_time
       end
     end
 


### PR DESCRIPTION
# Description

We had a mechanism to prevent too many updates to bulk download progress by specifying a minimum delay. However, we forgot to reset `last_progress_time`, which caused updates every after file once the delay is reached the first time. This fixes the bug.

# Tests

* Verify that bulk downloads now behave as expected regarding logging.
