### PR TITLE
Add admin options for bulk downloads

### DIFF
--- a/app/assets/src/components/views/bulk_download/BulkDownloadDetailsModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadDetailsModal.jsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 import { getBulkDownload } from "~/api/bulk_downloads";
 import Modal from "~ui/containers/Modal";
 import LoadingMessage from "~/components/common/LoadingMessage";
+import { UserContext } from "~/components/common/UserContext";
+import ExternalLink from "~/components/ui/controls/ExternalLink";
 
 import cs from "./bulk_download_details_modal.scss";
 import BulkDownloadSummary from "./BulkDownloadSummary";
@@ -43,6 +45,7 @@ class BulkDownloadDetailsModal extends React.Component {
 
   renderDetails = () => {
     const { bulkDownloadDetails, downloadType } = this.state;
+    const { admin } = this.context || {};
 
     if (bulkDownloadDetails === null) {
       return (
@@ -53,20 +56,39 @@ class BulkDownloadDetailsModal extends React.Component {
     }
 
     return (
-      <div className={cs.details}>
-        <BulkDownloadSummary
-          downloadType={downloadType}
-          downloadSummary={this.getDownloadSummary(bulkDownloadDetails)}
-        />
-        <div className={cs.samplesHeader}>Samples in this download</div>
-        <div className={cs.samplesList}>
-          {bulkDownloadDetails.pipeline_runs.map(pipelineRun => (
-            <div key={pipelineRun.id} className={cs.sampleName}>
-              {pipelineRun.sample_name}
-            </div>
-          ))}
+      <React.Fragment>
+        {admin && (
+          <div className={cs.adminDetails}>
+            ID: {bulkDownloadDetails.id}, run in:{" "}
+            {bulkDownloadDetails.execution_type}
+            {bulkDownloadDetails.log_url && (
+              <span>
+                ,{" "}
+                <ExternalLink
+                  className={cs.logUrl}
+                  href={bulkDownloadDetails.log_url}
+                >
+                  log url
+                </ExternalLink>
+              </span>
+            )}
+          </div>
+        )}
+        <div className={cs.details}>
+          <BulkDownloadSummary
+            downloadType={downloadType}
+            downloadSummary={this.getDownloadSummary(bulkDownloadDetails)}
+          />
+          <div className={cs.samplesHeader}>Samples in this download</div>
+          <div className={cs.samplesList}>
+            {bulkDownloadDetails.pipeline_runs.map(pipelineRun => (
+              <div key={pipelineRun.id} className={cs.sampleName}>
+                {pipelineRun.sample_name}
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      </React.Fragment>
     );
   };
 
@@ -88,5 +110,7 @@ BulkDownloadDetailsModal.propTypes = {
     id: PropTypes.number,
   }),
 };
+
+BulkDownloadDetailsModal.contextType = UserContext;
 
 export default BulkDownloadDetailsModal;

--- a/app/assets/src/components/views/bulk_download/BulkDownloadList.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadList.jsx
@@ -11,39 +11,11 @@ import TableRenderers from "~/components/views/discovery/TableRenderers";
 import BlankScreenMessage from "~/components/common/BlankScreenMessage";
 import { Table } from "~/components/visualizations/table";
 import { openUrl } from "~utils/links";
+import { UserContext } from "~/components/common/UserContext";
 
 import BulkDownloadTableRenderers from "./BulkDownloadTableRenderers";
 import BulkDownloadDetailsModal from "./BulkDownloadDetailsModal";
 import cs from "./bulk_download_list.scss";
-
-const TABLE_COLUMNS = [
-  {
-    dataKey: "download_name",
-    label: "Download",
-    width: 500,
-    flexGrow: 1,
-    headerClassName: cs.downloadNameHeader,
-    cellRenderer: BulkDownloadTableRenderers.renderDownload,
-  },
-  {
-    dataKey: "created_at",
-    label: "Created On",
-    width: 200,
-    cellRenderer: TableRenderers.renderDateWithElapsed,
-  },
-  {
-    dataKey: "file_size",
-    label: "File Size",
-    width: 200,
-    className: cs.lightCell,
-  },
-  {
-    dataKey: "status",
-    label: "",
-    width: 190,
-    cellRenderer: BulkDownloadTableRenderers.renderStatus,
-  },
-];
 
 const STATUS_TYPES = {
   waiting: "default",
@@ -98,6 +70,40 @@ class BulkDownloadList extends React.Component {
       bulkDownloads: this.processBulkDownloads(bulkDownloads),
     });
   }
+
+  getTableColumns = () => {
+    const { admin } = this.context || {};
+
+    return [
+      {
+        dataKey: "download_name",
+        label: "Download",
+        width: 500,
+        flexGrow: 1,
+        headerClassName: cs.downloadNameHeader,
+        cellRenderer: cellData =>
+          BulkDownloadTableRenderers.renderDownload(cellData, admin),
+      },
+      {
+        dataKey: "created_at",
+        label: "Created On",
+        width: 200,
+        cellRenderer: TableRenderers.renderDateWithElapsed,
+      },
+      {
+        dataKey: "file_size",
+        label: "File Size",
+        width: 200,
+        className: cs.lightCell,
+      },
+      {
+        dataKey: "status",
+        label: "",
+        width: 190,
+        cellRenderer: BulkDownloadTableRenderers.renderStatus,
+      },
+    ];
+  };
 
   processBulkDownloads = bulkDownloads =>
     bulkDownloads.map(bulkDownload => ({
@@ -180,7 +186,7 @@ class BulkDownloadList extends React.Component {
           rowClassName={cs.tableRow}
           headerClassName={cs.tableHeader}
           className={cs.table}
-          columns={TABLE_COLUMNS}
+          columns={this.getTableColumns()}
           data={this.state.bulkDownloads}
           defaultRowHeight={70}
           sortable
@@ -222,5 +228,7 @@ class BulkDownloadList extends React.Component {
     );
   }
 }
+
+BulkDownloadList.contextType = UserContext;
 
 export default BulkDownloadList;

--- a/app/assets/src/components/views/bulk_download/BulkDownloadTableRenderers.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadTableRenderers.jsx
@@ -8,7 +8,7 @@ import LoadingBar from "~ui/controls/LoadingBar";
 import cs from "./bulk_download_table_renderers.scss";
 
 export default class BulkDownloadTableRenderers extends React.Component {
-  static renderDownload = ({ rowData }) => {
+  static renderDownload = ({ rowData }, admin = false) => {
     if (!rowData) {
       return null;
     }
@@ -26,8 +26,15 @@ export default class BulkDownloadTableRenderers extends React.Component {
               tooltipText={rowData.tooltipText}
             />
           </div>
-          <div className={cs.sampleCount} onClick={rowData.onStatusClick}>
-            {rowData.num_samples} Sample{rowData.num_samples === 1 ? "" : "s"}
+          <div className={cs.metadata}>
+            <span className={cs.detailsLink} onClick={rowData.onStatusClick}>
+              {rowData.num_samples} Sample{rowData.num_samples === 1 ? "" : "s"}
+            </span>
+            {admin && (
+              <React.Fragment>
+                | <span className={cs.userName}>{rowData.user_name}</span>
+              </React.Fragment>
+            )}
           </div>
         </div>
       </div>

--- a/app/assets/src/components/views/bulk_download/bulk_download_details_modal.scss
+++ b/app/assets/src/components/views/bulk_download/bulk_download_details_modal.scss
@@ -1,4 +1,5 @@
 @import "~styles/themes/typography";
+@import "~styles/themes/colors";
 @import "~styles/themes/elements";
 
 .title {
@@ -7,6 +8,19 @@
 
 .loadingContainer {
   margin-top: $space-m;
+}
+
+.adminDetails {
+  margin-bottom: $space-l;
+  color: $medium-grey;
+
+  .logUrl {
+    text-decoration: underline;
+
+    &:hover {
+      color: $black;
+    }
+  }
 }
 
 .details {

--- a/app/assets/src/components/views/bulk_download/bulk_download_table_renderers.scss
+++ b/app/assets/src/components/views/bulk_download/bulk_download_table_renderers.scss
@@ -27,13 +27,21 @@
       margin-left: $space-xxs;
     }
 
-    .sampleCount {
+    .metadata {
       @include font-body-xxs;
       color: $medium-grey;
-      cursor: pointer;
 
-      &:hover {
-        color: $black;
+      .detailsLink {
+        cursor: pointer;
+        margin-right: 10px;
+
+        &:hover {
+          color: $black;
+        }
+      }
+
+      .userName {
+        margin-left: 10px;
       }
     }
   }

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -473,14 +473,15 @@ class SamplesView extends React.Component {
   };
 
   handleBulkDownloadModalOpen = () => {
-    const { maxSamplesBulkDownload } = this.context || {};
+    const { maxSamplesBulkDownload, admin } = this.context || {};
     if (!maxSamplesBulkDownload) {
       this.setState({
         bulkDownloadButtonTempTooltip:
           "Unexpected issue. Please contact us for help.",
       });
     } else if (
-      this.props.selectedSampleIds.size > parseInt(maxSamplesBulkDownload)
+      this.props.selectedSampleIds.size > parseInt(maxSamplesBulkDownload) &&
+      !admin
     ) {
       this.setState({
         bulkDownloadButtonTempTooltip: `No more than ${maxSamplesBulkDownload} samples allowed in one download.`,

--- a/app/helpers/bulk_downloads_helper.rb
+++ b/app/helpers/bulk_downloads_helper.rb
@@ -39,11 +39,16 @@ module BulkDownloadsHelper
     return pipeline_runs.map(&:id)
   end
 
-  def format_bulk_download(bulk_download, with_pipeline_runs = false)
+  def format_bulk_download(bulk_download, with_pipeline_runs: false, admin: false)
     formatted_bulk_download = bulk_download.as_json(except: [:access_token])
     formatted_bulk_download[:num_samples] = bulk_download.pipeline_runs.length
     formatted_bulk_download[:download_name] = bulk_download.download_display_name
     formatted_bulk_download[:file_size] = ActiveSupport::NumberHelper.number_to_human_size(bulk_download.output_file_size)
+    if admin
+      formatted_bulk_download[:user_name] = bulk_download.user.name
+      formatted_bulk_download[:execution_type] = bulk_download.execution_type
+      formatted_bulk_download[:log_url] = bulk_download.log_url
+    end
 
     unless bulk_download.params_json.nil?
       formatted_bulk_download[:params] = JSON.parse(bulk_download.params_json)

--- a/app/lib/aws_util.rb
+++ b/app/lib/aws_util.rb
@@ -1,6 +1,9 @@
 class AwsUtil
+  # This is currently used to generate log urls for admins. We assume deployment in us-west-2 region.
+  AWS_REGION = "us-west-2".freeze
+
   def self.get_cloudwatch_url(log_group, log_stream)
-    "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2" \
+    "https://#{AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=#{AWS_REGION}" \
       "#logEventViewer:group=#{log_group};stream=#{log_stream}"
   end
 end

--- a/app/lib/aws_util.rb
+++ b/app/lib/aws_util.rb
@@ -1,0 +1,6 @@
+class AwsUtil
+  def self.get_cloudwatch_url(log_group, log_stream)
+    "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2" \
+      "#logEventViewer:group=#{log_group};stream=#{log_stream}"
+  end
+end

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -207,8 +207,7 @@ class PipelineRunStage < ApplicationRecord
 
   def log_url
     return nil unless job_log_id
-    "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2" \
-      "#logEventViewer:group=/aws/batch/job;stream=#{job_log_id}"
+    AwsUtil.get_cloudwatch_url("/aws/batch/job", job_log_id)
   end
 
   ########### STAGE SPECIFIC FUNCTIONS BELOW ############

--- a/app/views/bulk_downloads/index.html.erb
+++ b/app/views/bulk_downloads/index.html.erb
@@ -1,3 +1,3 @@
 <%= javascript_tag do %>
-  react_component('BulkDownloadList', {}, 'page_content');
+  react_component('BulkDownloadList', {}, 'page_content', JSON.parse('<%= raw escape_json(user_context) %>'));
 <% end %>


### PR DESCRIPTION
# Description

Add the following options for admins:
* Admins are exempt from the max sample limit.
* Admins can see bulk downloads from all users.
* Admins can see the name of the bulk download owner.

<img width="1398" alt="Screen Shot 2019-12-18 at 9 06 25 PM" src="https://user-images.githubusercontent.com/837004/71149628-09dd9c80-21e4-11ea-9007-1e12b250397c.png">

* Admins can see the id of the bulk download, the execution type, and a log url for ecs downloads. 

<img width="737" alt="Screen Shot 2019-12-18 at 10 16 54 PM" src="https://user-images.githubusercontent.com/837004/71149665-24177a80-21e4-11ea-9532-5a48fbedb128.png">

These options will make it easier for admins to address issues around bulk downloads.

# Tests

* Added tests for admin privileges. There are already existing tests to check that normal users don't have these privileges.
* Verify that the UI still behaves as before for normal users, but admin users can get around the max sample limit and see additional fields in bulk download details modal.
