### PR TITLE
Add a Rake task to export DAGs

### DIFF
--- a/lib/tasks/export_dags.rake
+++ b/lib/tasks/export_dags.rake
@@ -7,7 +7,8 @@ task :export_dags, [:sample_id] => :environment do |_, args|
       puts "Exported #{dag_name}.json"
     end
 
-    def aegea_batch_submit_command(*) end
+    def aegea_batch_submit_command(*)
+    end
 
     def extract_dag
       send(job_command_func)

--- a/lib/tasks/export_dags.rake
+++ b/lib/tasks/export_dags.rake
@@ -16,7 +16,7 @@ task :export_dags, [:sample_id] => :environment do |_, args|
   end
 
   if args.sample_id?
-    Sample.where(id: args.sample_id).first.pipeline_runs.each do |pipeline_run|
+    Sample.find_by(id: args.sample_id).pipeline_runs.each do |pipeline_run|
       PipelineRunStage::STAGE_INFO.each do |step_number, stage_info|
         puts "Exporting DAG #{step_number} for pipeline run #{pipeline_run.id} (sample #{pipeline_run.sample.id})"
         exporter = DAGExporter.new(

--- a/lib/tasks/export_dags.rake
+++ b/lib/tasks/export_dags.rake
@@ -1,0 +1,34 @@
+task :export_dags, [:sample_id] => :environment do |t, args|
+  class DAGExporter < PipelineRunStage
+    def upload_dag_json_and_return_job_command(dag_json, *)
+      File.open("#{dag_name}.json", "w") do |f|
+        f.write(dag_json)
+      end
+      puts "Exported #{dag_name}.json"
+    end
+
+    def aegea_batch_submit_command(*)
+    end
+
+    def extract_dag()
+      send(job_command_func)
+    end
+  end
+
+  if args.sample_id?
+    Sample.where(id: args.sample_id).first.pipeline_runs.each do |pipeline_run|
+      PipelineRunStage::STAGE_INFO.each do |step_number, stage_info|
+        puts "Exporting DAG #{step_number} for pipeline run #{pipeline_run.id} (sample #{pipeline_run.sample.id})"
+        exporter = DAGExporter.new(
+          step_number: step_number,
+          name: stage_info[:name],
+          job_command_func: stage_info[:job_command_func],
+          pipeline_run: pipeline_run
+        )
+        exporter.extract_dag()
+      end
+    end
+  else
+    puts "Usage: rake export_dags[12345] (where 12345 is the sample ID)"
+  end
+end

--- a/lib/tasks/export_dags.rake
+++ b/lib/tasks/export_dags.rake
@@ -1,4 +1,4 @@
-task :export_dags, [:sample_id] => :environment do |t, args|
+task :export_dags, [:sample_id] => :environment do |_, args|
   class DAGExporter < PipelineRunStage
     def upload_dag_json_and_return_job_command(dag_json, *)
       File.open("#{dag_name}.json", "w") do |f|
@@ -7,10 +7,9 @@ task :export_dags, [:sample_id] => :environment do |t, args|
       puts "Exported #{dag_name}.json"
     end
 
-    def aegea_batch_submit_command(*)
-    end
+    def aegea_batch_submit_command(*) end
 
-    def extract_dag()
+    def extract_dag
       send(job_command_func)
     end
   end
@@ -25,10 +24,10 @@ task :export_dags, [:sample_id] => :environment do |t, args|
           job_command_func: stage_info[:job_command_func],
           pipeline_run: pipeline_run
         )
-        exporter.extract_dag()
+        exporter.extract_dag
       end
     end
   else
-    puts "Usage: rake export_dags[12345] (where 12345 is the sample ID)"
+    puts 'Usage: rake export_dags[12345] (where 12345 is the sample ID)'
   end
 end


### PR DESCRIPTION
# Description

This is part of the work to separate pipeline/workflow logic from idseq-web.

When cutting over to the new pipeline infra, this task will be run to export the workflow definitions using a recent representative sample, then we will update https://github.com/chanzuckerberg/idseq-web/blob/master/app/models/pipeline_run_stage.rb#L215-L344 to dispatch workflows/pipelines by executing Step Functions with the given parameters/attributes (replacing the current approach of constructing the DAG and launching a Batch job).