### PR TITLE
Add restrictions to privacy-sensitive bulk downloads.

### DIFF
--- a/app/assets/src/components/ui/labels/StatusLabel.jsx
+++ b/app/assets/src/components/ui/labels/StatusLabel.jsx
@@ -8,9 +8,13 @@ import cs from "./status_label.scss";
 
 class StatusLabel extends React.Component {
   render() {
-    const { status, type, className, tooltipText } = this.props;
+    const { status, type, className, tooltipText, inline } = this.props;
     const label = (
-      <div className={cx(className, cs.statusLabel, cs[type])}>{status}</div>
+      <div
+        className={cx(className, cs.statusLabel, inline && cs.inline, cs[type])}
+      >
+        {status}
+      </div>
     );
 
     if (tooltipText) {
@@ -32,6 +36,7 @@ StatusLabel.propTypes = {
   status: PropTypes.node,
   type: PropTypes.oneOf(["success", "warn", "error", "default"]),
   tooltipText: PropTypes.string,
+  inline: PropTypes.bool,
 };
 
 StatusLabel.defaultProps = {

--- a/app/assets/src/components/ui/labels/status_label.scss
+++ b/app/assets/src/components/ui/labels/status_label.scss
@@ -28,4 +28,8 @@
     background-color: $warning-bg;
     color: $warning;
   }
+
+  &.inline {
+    display: inline-block;
+  }
 }

--- a/app/assets/src/components/utils/propTypes.js
+++ b/app/assets/src/components/utils/propTypes.js
@@ -109,6 +109,7 @@ const SampleUploadType = PropTypes.oneOf(["basespace", "local", "remote"]);
 const DownloadType = PropTypes.shape({
   type: PropTypes.string,
   display_name: PropTypes.string,
+  admin_only: PropTypes.bool,
   description: PropTypes.string,
   category: PropTypes.string,
   fields: PropTypes.arrayOf(
@@ -117,6 +118,7 @@ const DownloadType = PropTypes.shape({
       display_name: PropTypes.string,
     })
   ),
+  uploader_only: PropTypes.bool,
 });
 
 const DownloadTypeParam = PropTypes.shape({

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -14,6 +14,7 @@ import {
 import cx from "classnames";
 import memoize from "memoize-one";
 
+import StatusLabel from "~ui/labels/StatusLabel";
 import Dropdown from "~ui/controls/dropdowns/Dropdown";
 import LoadingMessage from "~/components/common/LoadingMessage";
 import RadioButton from "~ui/controls/RadioButton";
@@ -25,6 +26,7 @@ import {
   getHeatmapMetrics,
 } from "~/api";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
+import { UserContext } from "~/components/common/UserContext";
 
 import TaxonContigSelect from "./TaxonContigSelect";
 import cs from "./choose_step.scss";
@@ -388,17 +390,21 @@ class ChooseStep extends React.Component {
   renderDownloadType = downloadType => {
     const { selectedDownloadTypeName, onSelect } = this.props;
     const { allSamplesUploadedByCurrentUser } = this.state;
+    const { admin } = this.context || {};
+
     const selected = selectedDownloadTypeName === downloadType.type;
     let disabled = false;
     let disabledMessage = "";
 
     if (
-      downloadType.type === "host_gene_counts" &&
-      !allSamplesUploadedByCurrentUser
+      downloadType.uploader_only &&
+      !allSamplesUploadedByCurrentUser &&
+      !admin
     ) {
       disabled = true;
-      disabledMessage =
-        "To download host gene counts, you must be the original uploader of all selected samples.";
+      disabledMessage = `To download ${
+        downloadType.display_name
+      }, you must be the original uploader of all selected samples.`;
     }
 
     const downloadTypeElement = (
@@ -417,7 +423,12 @@ class ChooseStep extends React.Component {
           selected={selected}
         />
         <div className={cs.content}>
-          <div className={cs.name}>{downloadType.display_name}</div>
+          <div className={cs.name}>
+            {downloadType.display_name}
+            {downloadType.admin_only && (
+              <StatusLabel inline status="Admin Only" />
+            )}
+          </div>
           <div className={cs.description}>{downloadType.description}</div>
           {downloadType.fields &&
             selected && (
@@ -505,5 +516,7 @@ ChooseStep.propTypes = {
   onContinue: PropTypes.func.isRequired,
   selectedSampleIds: PropTypes.instanceOf(Set),
 };
+
+ChooseStep.contextType = UserContext;
 
 export default ChooseStep;

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -64,6 +64,7 @@ module BulkDownloadTypesHelper
       description: "Host gene count outputs from STAR",
       category: "report",
       execution_type: ECS_EXECUTION_TYPE,
+      admin_only: true,
     },
     {
       type: READS_NON_HOST_BULK_DOWNLOAD_TYPE,
@@ -109,6 +110,7 @@ module BulkDownloadTypesHelper
       description: "Original files you submitted to IDseq",
       category: "raw",
       execution_type: ECS_EXECUTION_TYPE,
+      uploader_only: true,
     },
   ].freeze
 

--- a/app/helpers/bulk_downloads_helper.rb
+++ b/app/helpers/bulk_downloads_helper.rb
@@ -14,6 +14,9 @@ module BulkDownloadsHelper
   SUCCESS_URL_REQUIRED = "Success url required for bulk download.".freeze
   FAILED_SAMPLES_ERROR_TEMPLATE = "%s samples could not be processed. Please contact us for help.".freeze
   UNKNOWN_EXECUTION_TYPE = "Could not find execution type for bulk download".freeze
+  UNKNOWN_DOWNLOAD_TYPE = "Could not find download type for bulk download".freeze
+  ADMIN_ONLY_DOWNLOAD_TYPE = "You must be an admin to initiate this download type.".freeze
+  UPLOADER_ONLY_DOWNLOAD_TYPE = "You must be the uploader of all selected samples to initiate this download type.".freeze
   BULK_DOWNLOAD_GENERATION_FAILED = "Could not generate bulk download".freeze
   READS_NON_HOST_TAXID_EXPECTED = "Expected taxid for reads non-host bulk download".freeze
   READS_NON_HOST_TAXON_LINEAGE_EXPECTED_TEMPLATE = "Unexpected error. Could not find valid taxon lineage for taxid %s".freeze
@@ -63,6 +66,50 @@ module BulkDownloadsHelper
       end
     end
     formatted_bulk_download
+  end
+
+  # Will raise errors if any validation fails.
+  # Returns pipeline_run_ids for the samples in the bulk download.
+  def validate_bulk_download_create_params(create_params, user)
+    sample_ids = create_params[:sample_ids]
+
+    # Max samples check.
+    max_samples_allowed = get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD)
+
+    # Max samples should be string containing an integer, but just in case.
+    if max_samples_allowed.nil?
+      raise KICKOFF_FAILURE_HUMAN_READABLE
+    end
+
+    if sample_ids.length > Integer(max_samples_allowed) && !current_user.admin?
+      raise BulkDownloadsHelper::MAX_SAMPLES_EXCEEDED_ERROR_TEMPLATE % max_samples_allowed
+    end
+
+    # Access control check.
+    viewable_samples = current_power.viewable_samples.where(id: sample_ids)
+    if viewable_samples.length != sample_ids.length
+      raise BulkDownloadsHelper::SAMPLE_NO_PERMISSION_ERROR
+    end
+
+    type_data = BulkDownloadTypesHelper::BULK_DOWNLOAD_TYPE_NAME_TO_DATA[create_params[:download_type]]
+
+    if type_data.nil?
+      raise BulkDownloadsHelper::UNKNOWN_DOWNLOAD_TYPE
+    end
+
+    if type_data[:admin_only] && !user.admin?
+      raise BulkDownloadsHelper::ADMIN_ONLY_DOWNLOAD_TYPE
+    end
+
+    if type_data[:uploader_only] && !user.admin?
+      samples = Sample.where(user: user, id: sample_ids)
+
+      if sample_ids.length != samples.length
+        raise BulkDownloadsHelper::UPLOADER_ONLY_DOWNLOAD_TYPE
+      end
+    end
+
+    get_valid_pipeline_run_ids_for_samples(viewable_samples)
   end
 
   # Generate the metric values matrix.


### PR DESCRIPTION
# Description

* Add concept of admin-only and uploader-only download types.
* host gene counts is admin-only
* original input file is uploader-only
* Added validation in the create endpoint for these concepts.
* Added "admin-only" tag for admin-only downloads, so admins know.

What admins see:
![Screen Shot 2019-12-20 at 6 02 47 PM](https://user-images.githubusercontent.com/837004/71302127-80050f00-235c-11ea-8a8b-ee01d0a6cc6d.png)

What normal users see:
![Screen Shot 2019-12-20 at 6 02 57 PM](https://user-images.githubusercontent.com/837004/71302133-8c896780-235c-11ea-9201-8642c5630ef1.png)

Error messages from back-end validation (when UI is bypassed):

![Screen Shot 2019-12-20 at 6 18 43 PM](https://user-images.githubusercontent.com/837004/71302143-9e6b0a80-235c-11ea-9afc-d3a611b3ab2b.png)

![Screen Shot 2019-12-20 at 6 19 33 PM](https://user-images.githubusercontent.com/837004/71302145-a0cd6480-235c-11ea-87bf-3c7051b2ccf1.png)

# Tests
* Updated non-admin and admin tests.
* Verified manually that UI behaves as expected for non-admin and admin.
