### PR TITLE
Handle long sample names in bulk download and fix toolbarIcon onClick.

### DIFF
--- a/app/assets/src/components/views/bulk_download/bulk_download_details_modal.scss
+++ b/app/assets/src/components/views/bulk_download/bulk_download_details_modal.scss
@@ -39,6 +39,7 @@
     .sampleName {
       @include font-body-xs;
       padding: $space-xxxs 0;
+      word-break: break-word;
     }
   }
 }

--- a/app/assets/src/components/views/samples/ToolbarIcon.jsx
+++ b/app/assets/src/components/views/samples/ToolbarIcon.jsx
@@ -23,7 +23,7 @@ class ToolbarIcon extends React.Component {
     const iconWrapper = (
       <div
         className={cx(className, cs.iconWrapper, disabled && cs.disabled)}
-        onClick={onClick}
+        onClick={disabled ? undefined : onClick}
       >
         {icon}
       </div>


### PR DESCRIPTION
# Description

Previously, an overly long sample name would cause a horizontal scrollbar to appear. Not anymore:

<img width="657" alt="Screen Shot 2019-12-31 at 5 20 00 PM" src="https://user-images.githubusercontent.com/837004/71636211-9465c900-2bf2-11ea-8b29-b38b3b2548b9.png">

Also fixed issue where the Download Modal would open when clicked even when the button was disabled (due to 0 samples being selected)

# Notes

* `word-break: break-word` will break up a word into two or more lines only if the word takes up more than one full line. It makes a best effort to NOT break up words (despite the naming). On the other hand, `word-break: break-all` will break words with abandon to fit as many characters into each line as possible.

# Tests

* Verified manually that behavior is as expected.
