### PR TITLE
Always use execute option for bulk download fargate tasks.

### DIFF
--- a/spec/controllers/basespace_controller_spec.rb
+++ b/spec/controllers/basespace_controller_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe BasespaceController, type: :controller do
 
       before do
         allow(HttpHelper).to receive(:post_json).and_return("access_token" => access_token)
-        allow(ENV).to receive(:[]).with("BASESPACE_OAUTH_REDIRECT_URI").and_return("MOCK_URI")
-        allow(ENV).to receive(:[]).with("BASESPACE_CLIENT_ID").and_return("MOCK_ID")
-        allow(ENV).to receive(:[]).with("BASESPACE_CLIENT_SECRET").and_return("MOCK_SECRET")
+        stub_const('ENV', ENV.to_hash.merge("BASESPACE_OAUTH_REDIRECT_URI" => "MOCK_URI",
+                                            "BASESPACE_CLIENT_ID" => "MOCK_ID",
+                                            "BASESPACE_CLIENT_SECRET" => "MOCK_SECRET"))
       end
 
       it "renders the oauth template" do

--- a/spec/controllers/bulk_downloads_controller_spec.rb
+++ b/spec/controllers/bulk_downloads_controller_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe BulkDownloadsController, type: :controller do
     describe "POST #create" do
       before do
         AppConfigHelper.set_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD, 100)
-        allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
-        allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
+        stub_const('ENV', ENV.to_hash.merge("SERVER_DOMAIN" => "https://idseq-net",
+                                            "SAMPLES_BUCKET_NAME" => "idseq-samples-prod"))
       end
 
       def get_expected_tar_name(project, sample, suffix)
@@ -31,15 +31,8 @@ RSpec.describe BulkDownloadsController, type: :controller do
         @sample_two = create(:sample, project: @project, name: "Test Sample Two",
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
 
-        mock_task_command = ["python", "mock_command.py"]
-
-        # s3_tar_writer_command is tested extensively in the model_spec.
-        expect_any_instance_of(BulkDownload).to receive(:s3_tar_writer_command).and_return(
-          mock_task_command
-        )
-
         expect(Open3).to receive(:capture3)
-          .with("aegea", "ecs", "run", a_string_starting_with("--command=#{mock_task_command.join(' ')}"), any_args)
+          .with("aegea", "ecs", "run", a_string_starting_with("--execute"), any_args)
           .exactly(1).times.and_return(
             [JSON.generate("taskArn": "ABC"), "", instance_double(Process::Status, exitstatus: 0)]
           )
@@ -74,9 +67,6 @@ RSpec.describe BulkDownloadsController, type: :controller do
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
         @sample_two = create(:sample, project: @project, name: "Test Sample Two",
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
-
-        allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
-        allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
 
         expect(Open3).to receive(:capture3).exactly(1).times.and_return(
           ["", "", instance_double(Process::Status, exitstatus: 1)]
@@ -506,8 +496,8 @@ RSpec.describe BulkDownloadsController, type: :controller do
     describe "POST #create" do
       before do
         AppConfigHelper.set_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD, 100)
-        allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
-        allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
+        stub_const('ENV', ENV.to_hash.merge("SERVER_DOMAIN" => "https://idseq-net",
+                                            "SAMPLES_BUCKET_NAME" => "idseq-samples-prod"))
       end
 
       it "should ignore max samples limit if admin" do

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -8,12 +8,12 @@ describe BulkDownload, type: :model do
     end
 
     it "returns correct success url for prod" do
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
+      stub_const('ENV', ENV.to_hash.merge("SERVER_DOMAIN" => "https://idseq.net"))
       expect(@bulk_download.success_url).to eq("https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}")
     end
 
     it "returns correct success url for staging" do
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://staging.idseq.net")
+      stub_const('ENV', ENV.to_hash.merge("SERVER_DOMAIN" => "https://staging.idseq.net"))
       expect(@bulk_download.success_url).to eq("https://staging.idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}")
     end
 
@@ -29,12 +29,12 @@ describe BulkDownload, type: :model do
     end
 
     it "returns correct error url for prod" do
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
+      stub_const('ENV', ENV.to_hash.merge("SERVER_DOMAIN" => "https://idseq.net"))
       expect(@bulk_download.error_url).to eq("https://idseq.net/bulk_downloads/#{@bulk_download.id}/error/#{@bulk_download.access_token}")
     end
 
     it "returns correct error url for staging" do
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://staging.idseq.net")
+      stub_const('ENV', ENV.to_hash.merge("SERVER_DOMAIN" => "https://staging.idseq.net"))
       expect(@bulk_download.error_url).to eq("https://staging.idseq.net/bulk_downloads/#{@bulk_download.id}/error/#{@bulk_download.access_token}")
     end
 
@@ -52,12 +52,12 @@ describe BulkDownload, type: :model do
     end
 
     it "returns correct progress url for prod" do
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
+      stub_const('ENV', ENV.to_hash.merge("SERVER_DOMAIN" => "https://idseq.net"))
       expect(@bulk_download.progress_url).to eq("https://idseq.net/bulk_downloads/#{@bulk_download.id}/progress/#{@bulk_download.access_token}")
     end
 
     it "returns correct progress url for staging" do
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://staging.idseq.net")
+      stub_const('ENV', ENV.to_hash.merge("SERVER_DOMAIN" => "https://staging.idseq.net"))
       expect(@bulk_download.progress_url).to eq("https://staging.idseq.net/bulk_downloads/#{@bulk_download.id}/progress/#{@bulk_download.access_token}")
     end
 
@@ -80,6 +80,9 @@ describe BulkDownload, type: :model do
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
       @sample_two = create(:sample, project: @project, name: "Test Sample Two",
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+
+      stub_const('ENV', ENV.to_hash.merge("SERVER_DOMAIN" => "https://idseq.net",
+                                          "SAMPLES_BUCKET_NAME" => "idseq-samples-prod"))
     end
 
     it "returns the correct task command for original_input_file download type" do
@@ -87,8 +90,6 @@ describe BulkDownload, type: :model do
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ])
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
 
       task_command = [
         "python",
@@ -121,9 +122,6 @@ describe BulkDownload, type: :model do
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ])
-
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
 
       task_command = [
         "python",
@@ -158,9 +156,6 @@ describe BulkDownload, type: :model do
                                 },
                               })
 
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
-
       task_command = [
         "python",
         "s3_tar_writer.py",
@@ -194,9 +189,6 @@ describe BulkDownload, type: :model do
                                 },
                               })
 
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
-
       task_command = [
         "python",
         "s3_tar_writer.py",
@@ -228,9 +220,6 @@ describe BulkDownload, type: :model do
                                 @sample_two.first_pipeline_run.id,
                               ])
 
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
-
       task_command = [
         "python",
         "s3_tar_writer.py",
@@ -258,9 +247,6 @@ describe BulkDownload, type: :model do
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ])
-
-      allow(ENV).to receive(:[]).with("SERVER_DOMAIN").and_return("https://idseq.net")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
 
       task_command = [
         "python",
@@ -291,29 +277,11 @@ describe BulkDownload, type: :model do
       @bulk_download = create(:bulk_download, user: @joe)
     end
 
-    let(:mock_shell_command) { "MOCK\\ SHELL\\ COMMAND" }
     let(:mock_executable_file_path) { "/tmp/mock_path" }
 
     it "returns the correct aegea ecs submit command" do
       allow(Rails).to receive(:env).and_return("prod")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
-
-      task_command = [
-        "aegea", "ecs", "run", "--command=#{mock_shell_command}",
-        "--task-role", "idseq-downloads-prod",
-        "--task-name", BulkDownload::ECS_TASK_NAME,
-        "--ecr-image", "idseq-s3-tar-writer:latest",
-        "--fargate-cpu", "4096",
-        "--fargate-memory", "8192",
-        "--cluster", "idseq-fargate-tasks-prod",
-      ]
-
-      expect(@bulk_download.aegea_ecs_submit_command(shell_command: mock_shell_command)).to eq(task_command)
-    end
-
-    it "uses executable file path correctly" do
-      allow(Rails).to receive(:env).and_return("prod")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
+      stub_const('ENV', ENV.to_hash.merge("SAMPLES_BUCKET_NAME" => "idseq-samples-prod"))
 
       task_command = [
         "aegea", "ecs", "run", "--execute=#{mock_executable_file_path}",
@@ -332,55 +300,56 @@ describe BulkDownload, type: :model do
     it "allows override of ecr image via AppConfig" do
       AppConfigHelper.set_app_config(AppConfig::S3_TAR_WRITER_SERVICE_ECR_IMAGE, "idseq-s3-tar-writer:v1.0")
       allow(Rails).to receive(:env).and_return("prod")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-prod")
+      stub_const('ENV', ENV.to_hash.merge("SAMPLES_BUCKET_NAME" => "idseq-samples-prod"))
 
       task_command = [
-        "aegea", "ecs", "run", "--command=#{mock_shell_command}",
+        "aegea", "ecs", "run", "--execute=#{mock_executable_file_path}",
         "--task-role", "idseq-downloads-prod",
         "--task-name", BulkDownload::ECS_TASK_NAME,
         "--ecr-image", "idseq-s3-tar-writer:v1.0",
         "--fargate-cpu", "4096",
         "--fargate-memory", "8192",
         "--cluster", "idseq-fargate-tasks-prod",
+        "--staging-s3-bucket", "aegea-ecs-execute-prod",
       ]
 
-      expect(@bulk_download.aegea_ecs_submit_command(shell_command: mock_shell_command)).to eq(task_command)
+      expect(@bulk_download.aegea_ecs_submit_command(executable_file_path: mock_executable_file_path)).to eq(task_command)
     end
 
     it "outputs correct command in staging" do
-      AppConfigHelper.set_app_config(AppConfig::S3_TAR_WRITER_SERVICE_ECR_IMAGE, "idseq-s3-tar-writer:v1.0")
       allow(Rails).to receive(:env).and_return("staging")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-staging")
+      stub_const('ENV', ENV.to_hash.merge("SAMPLES_BUCKET_NAME" => "idseq-samples-staging"))
 
       task_command = [
-        "aegea", "ecs", "run", "--command=#{mock_shell_command}",
+        "aegea", "ecs", "run", "--execute=#{mock_executable_file_path}",
         "--task-role", "idseq-downloads-staging",
         "--task-name", BulkDownload::ECS_TASK_NAME,
-        "--ecr-image", "idseq-s3-tar-writer:v1.0",
+        "--ecr-image", "idseq-s3-tar-writer:latest",
         "--fargate-cpu", "4096",
         "--fargate-memory", "8192",
         "--cluster", "idseq-fargate-tasks-staging",
+        "--staging-s3-bucket", "aegea-ecs-execute-staging",
       ]
 
-      expect(@bulk_download.aegea_ecs_submit_command(shell_command: mock_shell_command)).to eq(task_command)
+      expect(@bulk_download.aegea_ecs_submit_command(executable_file_path: mock_executable_file_path)).to eq(task_command)
     end
 
     it "outputs correct command in development" do
-      AppConfigHelper.set_app_config(AppConfig::S3_TAR_WRITER_SERVICE_ECR_IMAGE, "idseq-s3-tar-writer:v1.0")
       allow(Rails).to receive(:env).and_return("development")
-      allow(ENV).to receive(:[]).with("SAMPLES_BUCKET_NAME").and_return("idseq-samples-development")
+      stub_const('ENV', ENV.to_hash.merge("SAMPLES_BUCKET_NAME" => "idseq-samples-development"))
 
       task_command = [
-        "aegea", "ecs", "run", "--command=#{mock_shell_command}",
+        "aegea", "ecs", "run", "--execute=#{mock_executable_file_path}",
         "--task-role", "idseq-downloads-development",
         "--task-name", BulkDownload::ECS_TASK_NAME,
-        "--ecr-image", "idseq-s3-tar-writer:v1.0",
+        "--ecr-image", "idseq-s3-tar-writer:latest",
         "--fargate-cpu", "4096",
         "--fargate-memory", "8192",
         "--cluster", "idseq-fargate-tasks-staging",
+        "--staging-s3-bucket", "aegea-ecs-execute-staging",
       ]
 
-      expect(@bulk_download.aegea_ecs_submit_command(shell_command: mock_shell_command)).to eq(task_command)
+      expect(@bulk_download.aegea_ecs_submit_command(executable_file_path: mock_executable_file_path)).to eq(task_command)
     end
   end
 
@@ -390,30 +359,10 @@ describe BulkDownload, type: :model do
       @bulk_download = create(:bulk_download, user: @joe)
     end
 
-    let(:mock_shell_command) { "SHELL COMMAND" }
     let(:mock_aegea_ecs_submit_command) { "AEGEA ECS SUBMIT COMMAND" }
     let(:mock_task_arn) { "ABC" }
 
     it "runs correctly in basic case" do
-      expect(@bulk_download).to receive(:aegea_ecs_submit_command).exactly(1).times.with(hash_including(shell_command: Shellwords.escape(mock_shell_command))).and_return(
-        [mock_aegea_ecs_submit_command]
-      )
-
-      expect(Open3).to receive(:capture3).exactly(1).times.with(mock_aegea_ecs_submit_command).and_return(
-        [JSON.generate("taskArn": mock_task_arn), "", instance_double(Process::Status, exitstatus: 0)]
-      )
-
-      @bulk_download.kickoff_ecs_task([mock_shell_command])
-
-      expect(@bulk_download.ecs_task_arn).to eq(mock_task_arn)
-      expect(@bulk_download.status).to eq(BulkDownload::STATUS_RUNNING)
-    end
-
-    it "uses executable when number of pipeline runs is over threshold" do
-      # stub pipeline runs length to be larger than the min threshold.
-      expect(@bulk_download).to receive(:pipeline_runs).exactly(1).times.and_return(
-        double("Fake pipeline runs array", length: BulkDownload::EXECUTABLE_MIN_THRESHOLD)
-      )
       expect(@bulk_download).to receive(:aegea_ecs_submit_command).exactly(1).times.with(hash_including(executable_file_path: anything)).and_return(
         [mock_aegea_ecs_submit_command]
       )
@@ -424,7 +373,7 @@ describe BulkDownload, type: :model do
 
       expect_any_instance_of(Tempfile).to receive(:unlink).exactly(1).times
 
-      @bulk_download.kickoff_ecs_task([mock_shell_command])
+      @bulk_download.kickoff_ecs_task(["SHELL_COMMAND"])
 
       expect(@bulk_download.ecs_task_arn).to eq(mock_task_arn)
       expect(@bulk_download.status).to eq(BulkDownload::STATUS_RUNNING)


### PR DESCRIPTION
# Description

Previously, we would directly send the command to run in the docker container (which was a long command starting with `python s3_tar_writer.py --src-urls`) using the `--command` option of `aegea ecs run`.

ECS has a limit of 8192 characters for "container overrides" which includes (but is not limited to) the command. Whenever the command gets long enough that we exceed this limit, we need to switch to using `--execute` instead.

What `--execute` does is temporarily download your command as a file to s3, then have the docker container fetch this file and execute it. aegea handles all of this.

This change stops using `--command` or `--execute` depending on the number of samples and uses `--execute` in all cases.

Even though `--execute` is more complex than `--command`, it is difficult to determine when to switch between `--command` or `--execute`. Previously, the condition was to use `--execute` when there were more than 100 samples being downloaded. This seemed reasonable at the time, given how long the commands for 100 samples were. However, the format for the commands then changed (we made the dest tar paths, which are part of the command, longer), which caused downloads of as little as 40 samples to fail because their command was too long. 

In order to eliminate the possibility for bugs due to exceeding the container override limit, we're just using `--execute` in all cases.

# Notes

* Also switched to a new way of stubbing `ENV` variables in rspec. The issue with the old way was that if some code tried to fetch an `ENV` variable that you didn't explicitly mock, an error would be thrown.

# Tests

* Updated tests and verified that they pass.
* Verified that bulk downloads still work.
