### PR TITLE
Add custom boolean toggle control for water control metadata

### DIFF
--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -60,11 +60,13 @@ class MetadataInput extends React.Component {
     const { warning } = this.state;
 
     if (metadataType.isBoolean) {
+      const onLabel = metadataType.options[0];
+      const offLabel = metadataType.options[1];
       return (
         <Toggle
-          initialChecked={false}
-          onLabel={metadataType.options[0]}
-          offLabel={metadataType.options[1]}
+          initialChecked={value === onLabel ? true : false}
+          onLabel={onLabel}
+          offLabel={offLabel}
           onChange={label => onChange(metadataType.key, label, true)}
         />
       );

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -10,6 +10,7 @@ import GeoSearchInputBox, {
   getLocationWarning,
 } from "~/components/ui/controls/GeoSearchInputBox";
 import AlertIcon from "~ui/icons/AlertIcon";
+import Toggle from "~ui/controls/Toggle";
 
 import cs from "./metadata_input.scss";
 
@@ -58,7 +59,16 @@ class MetadataInput extends React.Component {
     } = this.props;
     const { warning } = this.state;
 
-    if (isArray(metadataType.options)) {
+    if (metadataType.isBoolean) {
+      return (
+        <Toggle
+          initialChecked={false}
+          onLabel={metadataType.options[0]}
+          offLabel={metadataType.options[1]}
+          onChange={label => onChange(metadataType.key, label, true)}
+        />
+      );
+    } else if (isArray(metadataType.options)) {
       const options = metadataType.options.map(option => ({
         text: option,
         value: option,
@@ -144,6 +154,7 @@ MetadataInput.propTypes = {
     key: PropTypes.string,
     dataType: PropTypes.oneOf(["number", "string", "date", "location"]),
     options: PropTypes.arrayOf(PropTypes.string),
+    isBoolean: PropTypes.bool,
   }),
   // Third optional parameter signals to the parent whether to immediately save. false means "wait for onSave to fire".
   // This is useful for the text input, where the parent wants to save onBlur, not onChange.

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -68,6 +68,7 @@ class MetadataInput extends React.Component {
           onLabel={onLabel}
           offLabel={offLabel}
           onChange={label => onChange(metadataType.key, label, true)}
+          className={className}
         />
       );
     } else if (isArray(metadataType.options)) {

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import cx from "classnames";
-import _fp, { filter, keyBy, concat, find } from "lodash/fp";
+import _fp, { filter, keyBy, concat, find, sortBy } from "lodash/fp";
 
 import MetadataCSVUpload from "~/components/common/MetadataCSVUpload";
 import MetadataCSVLocationsMenu, {
@@ -34,13 +34,28 @@ class MetadataUpload extends React.Component {
     CSVLocationWarnings: {},
   };
 
+  // Define the order in which metadata fields should be render in the upload
+  // grid. The order was defined by the perceived affinity of fields.
+  ordering = {
+    host_genome: 1, // currently, this is not a MetadataField technically
+    sample_type: 2,
+    nucleotide_type: 3,
+    water_control: 4,
+    collection_date: 5, // legacy
+    collection_location_v2: 6,
+  };
+
   async componentDidMount() {
     const [projectMetadataFields, hostGenomes] = await Promise.all([
       getProjectMetadataFields(this.props.project.id),
       getAllHostGenomes(),
     ]);
+    const sorted = sortBy(
+      metadataField => this.ordering[metadataField.key],
+      projectMetadataFields
+    );
     this.setState({
-      projectMetadataFields: keyBy("key", projectMetadataFields),
+      projectMetadataFields: keyBy("key", sorted),
       hostGenomes,
     });
   }

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -36,6 +36,7 @@ class MetadataUpload extends React.Component {
 
   // Define the order in which metadata fields should be render in the upload
   // grid. The order was defined by the perceived affinity of fields.
+  // Any field not defined will appear after in the pre-existing order.
   ordering = {
     host_genome: 1, // currently, this is not a MetadataField technically
     sample_type: 2,

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -51,7 +51,8 @@ class MetadataUpload extends React.Component {
       getAllHostGenomes(),
     ]);
     const sorted = sortBy(
-      metadataField => this.ordering[metadataField.key],
+      metadataField =>
+        this.ordering[metadataField.key] || Number.MAX_SAFE_INTEGER,
       projectMetadataFields
     );
     this.setState({

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -42,8 +42,9 @@ class MetadataUpload extends React.Component {
     sample_type: 2,
     nucleotide_type: 3,
     water_control: 4,
-    collection_date: 5, // legacy
-    collection_location_v2: 6,
+    collection_date: 5,
+    collection_location: 6, // legacy, code for both cases to be safe
+    collection_location_v2: 7,
   };
 
   async componentDidMount() {

--- a/app/assets/src/components/ui/controls/Toggle.jsx
+++ b/app/assets/src/components/ui/controls/Toggle.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Radio } from "semantic-ui-react";
+import PropTypes from "prop-types";
+
+// TODO (gdingle):
+// import cs from './toggle.scss'
+
+/**
+ * Extension of semantic-ui radio toggle that shows on/off labels. The current
+ * label is sent to the onChange handler. The current state can be overriden
+ * by passing in new props.
+ */
+class Toggle extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  // For "apply all" to work, it needs to override local state
+  static getDerivedStateFromProps(props, state) {
+    if (props.initialChecked !== state.prevInitialChecked) {
+      return {
+        prevInitialChecked: props.initialChecked,
+        checked: props.initialChecked,
+      };
+    } else {
+      return {
+        prevInitialChecked: props.initialChecked,
+        checked: state.checked,
+      };
+    }
+  }
+
+  render() {
+    const { onLabel, offLabel, onChange } = this.props;
+    return (
+      <div>
+        <Radio
+          toggle
+          checked={this.state.checked}
+          label={this.state.checked ? onLabel : offLabel}
+          onChange={(_, inputProps) => {
+            const checked = inputProps.checked;
+            this.setState({ checked: checked });
+            onChange && onChange(checked ? onLabel : offLabel);
+          }}
+          className={this.props.className}
+        />
+      </div>
+    );
+  }
+}
+
+Toggle.propTypes = {
+  className: PropTypes.string,
+  onChange: PropTypes.func,
+  onLabel: PropTypes.string.isRequired,
+  offLabel: PropTypes.string.isRequired,
+  initialChecked: PropTypes.bool.isRequired,
+};
+
+Toggle.defaultProps = {
+  onLabel: "On",
+  offLabel: "Off",
+  initialChecked: false,
+};
+
+export default Toggle;

--- a/app/assets/src/components/ui/controls/Toggle.jsx
+++ b/app/assets/src/components/ui/controls/Toggle.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Radio } from "semantic-ui-react";
 import PropTypes from "prop-types";
+import cx from "classnames";
 
-// TODO (gdingle):
-// import cs from './toggle.scss'
+import cs from "./toggle.scss";
 
 /**
  * Extension of semantic-ui radio toggle that shows on/off labels. The current
@@ -43,7 +43,7 @@ class Toggle extends React.PureComponent {
           this.setState({ checked: checked });
           onChange && onChange(checked ? onLabel : offLabel);
         }}
-        className={this.props.className}
+        className={cx(this.props.className, cs.toggle)}
       />
     );
   }

--- a/app/assets/src/components/ui/controls/Toggle.jsx
+++ b/app/assets/src/components/ui/controls/Toggle.jsx
@@ -34,19 +34,17 @@ class Toggle extends React.PureComponent {
   render() {
     const { onLabel, offLabel, onChange } = this.props;
     return (
-      <div>
-        <Radio
-          toggle
-          checked={this.state.checked}
-          label={this.state.checked ? onLabel : offLabel}
-          onChange={(_, inputProps) => {
-            const checked = inputProps.checked;
-            this.setState({ checked: checked });
-            onChange && onChange(checked ? onLabel : offLabel);
-          }}
-          className={this.props.className}
-        />
-      </div>
+      <Radio
+        toggle
+        checked={this.state.checked}
+        label={this.state.checked ? onLabel : offLabel}
+        onChange={(_, inputProps) => {
+          const checked = inputProps.checked;
+          this.setState({ checked: checked });
+          onChange && onChange(checked ? onLabel : offLabel);
+        }}
+        className={this.props.className}
+      />
     );
   }
 }

--- a/app/assets/src/components/ui/controls/toggle.scss
+++ b/app/assets/src/components/ui/controls/toggle.scss
@@ -6,3 +6,16 @@
 .toggle label:after {
   transform: scale(1) !important;
 }
+
+// Repeat classname to increase specificity and override semantic-ui !important.
+.toggle.toggle.toggle input:checked ~ label:before {
+  background-color: transparent !important; // override semantic-ui
+  // TODO (gdingle): change to idseq color
+  border: 2px solid #2185d0 !important;
+}
+
+.toggle.toggle.toggle input:indeterminate ~ label:before {
+  background-color: transparent !important; // override semantic-ui
+  // TODO (gdingle): change to idseq color
+  border: 2px solid gray !important;
+}

--- a/app/assets/src/components/ui/controls/toggle.scss
+++ b/app/assets/src/components/ui/controls/toggle.scss
@@ -11,7 +11,7 @@
 .toggle.toggle.toggle input:checked ~ label:before {
   background-color: transparent !important; // override semantic-ui
   // TODO (gdingle): change to idseq color
-  border: 2px solid #2185d0;
+  border: 2px solid blue;
   height: 2rem;
   line-height: 2rem;
   width: 4rem;
@@ -28,4 +28,14 @@
 
 .toggle.toggle.toggle label:after {
   top: 3px; // vertically align the circle in the height of the container
+}
+
+.toggle.toggle.toggle input:checked ~ label:after {
+  // TODO (gdingle): change to idseq color
+  background-color: blue;
+}
+
+.toggle.toggle.toggle input:indeterminate ~ label:after {
+  // TODO (gdingle): change to idseq color
+  background-color: gray;
 }

--- a/app/assets/src/components/ui/controls/toggle.scss
+++ b/app/assets/src/components/ui/controls/toggle.scss
@@ -7,35 +7,56 @@
   transform: scale(1) !important;
 }
 
+.toggle.toggle.toggle label:before {
+  height: 2rem;
+  line-height: 2rem;
+  width: 68px;
+}
+
+// This aligns the text in the container above.
+.toggle.toggle.toggle label {
+  // padding-top: 0;
+  // padding-left: 0;
+}
+
+.toggle.toggle.toggle input:checked ~ label {
+  // padding-left: 0.5rem;
+}
+
+.toggle.toggle.toggle input:indeterminate ~ label {
+  // padding-left: 3.5rem;
+}
+
 // Repeat classname to increase specificity and override semantic-ui !important.
 .toggle.toggle.toggle input:checked ~ label:before {
   background-color: transparent !important; // override semantic-ui
   // TODO (gdingle): change to idseq color
   border: 2px solid blue;
-  height: 2rem;
-  line-height: 2rem;
-  width: 4rem;
+  padding-left: 0.5rem;
 }
 
 .toggle.toggle.toggle input:indeterminate ~ label:before {
   background-color: transparent !important; // override semantic-ui
   // TODO (gdingle): change to idseq color
   border: 2px solid gray;
-  height: 2rem;
-  line-height: 2rem;
-  width: 4rem;
 }
 
 .toggle.toggle.toggle label:after {
   top: 3px; // vertically align the circle in the height of the container
+  height: 1.5rem;
+  width: 1.5rem;
 }
 
 .toggle.toggle.toggle input:checked ~ label:after {
   // TODO (gdingle): change to idseq color
   background-color: blue;
+  left: calc(
+    68px - 4px - 1.5rem
+  ); // inner width of toggle minus inner padding minus width of
 }
 
 .toggle.toggle.toggle input:indeterminate ~ label:after {
   // TODO (gdingle): change to idseq color
   background-color: gray;
+  left: 4px; // should be same as 'top' above
 }

--- a/app/assets/src/components/ui/controls/toggle.scss
+++ b/app/assets/src/components/ui/controls/toggle.scss
@@ -11,11 +11,21 @@
 .toggle.toggle.toggle input:checked ~ label:before {
   background-color: transparent !important; // override semantic-ui
   // TODO (gdingle): change to idseq color
-  border: 2px solid #2185d0 !important;
+  border: 2px solid #2185d0;
+  height: 2rem;
+  line-height: 2rem;
+  width: 4rem;
 }
 
 .toggle.toggle.toggle input:indeterminate ~ label:before {
   background-color: transparent !important; // override semantic-ui
   // TODO (gdingle): change to idseq color
-  border: 2px solid gray !important;
+  border: 2px solid gray;
+  height: 2rem;
+  line-height: 2rem;
+  width: 4rem;
+}
+
+.toggle.toggle.toggle label:after {
+  top: 3px; // vertically align the circle in the height of the container
 }

--- a/app/assets/src/components/ui/controls/toggle.scss
+++ b/app/assets/src/components/ui/controls/toggle.scss
@@ -1,3 +1,5 @@
+@import "~styles/themes/colors";
+
 // For unknown reasons, semantic-ui is adding the rule
 //  [type=radio]:not(:checked)+label:after { transform: scale(0); }
 // which has the effect of hiding the circle part of the toggle when off.
@@ -8,55 +10,53 @@
 }
 
 .toggle.toggle.toggle label:before {
-  height: 2rem;
-  line-height: 2rem;
+  height: 28px;
+  line-height: 28px;
   width: 68px;
 }
 
-// This aligns the text in the container above.
 .toggle.toggle.toggle label {
-  // padding-top: 0;
-  // padding-left: 0;
+  padding-top: 5px; // vertical align text
+  min-width: 58px; // enough space for text
 }
 
+// Place text to the left
 .toggle.toggle.toggle input:checked ~ label {
-  // padding-left: 0.5rem;
+  padding-left: 17px;
+  padding-right: 17px;
 }
 
+// Place text to the right
 .toggle.toggle.toggle input:indeterminate ~ label {
-  // padding-left: 3.5rem;
+  padding-left: 34px;
 }
 
 // Repeat classname to increase specificity and override semantic-ui !important.
 .toggle.toggle.toggle input:checked ~ label:before {
   background-color: transparent !important; // override semantic-ui
-  // TODO (gdingle): change to idseq color
-  border: 2px solid blue;
-  padding-left: 0.5rem;
+  border: 1px solid $primary-light;
+  padding-left: 4px;
 }
 
 .toggle.toggle.toggle input:indeterminate ~ label:before {
   background-color: transparent !important; // override semantic-ui
-  // TODO (gdingle): change to idseq color
-  border: 2px solid gray;
+  border: 1px solid $light-grey;
 }
 
 .toggle.toggle.toggle label:after {
-  top: 3px; // vertically align the circle in the height of the container
-  height: 1.5rem;
-  width: 1.5rem;
+  top: 5px; // vertically align the circle in the height of the container
+  height: 18px;
+  width: 18px;
 }
 
 .toggle.toggle.toggle input:checked ~ label:after {
-  // TODO (gdingle): change to idseq color
-  background-color: blue;
+  background-color: $primary-light;
   left: calc(
-    68px - 4px - 1.5rem
-  ); // inner width of toggle minus inner padding minus width of
+    68px - 6px - 18px
+  ); // inner width of toggle minus inner padding minus width of circle
 }
 
 .toggle.toggle.toggle input:indeterminate ~ label:after {
-  // TODO (gdingle): change to idseq color
-  background-color: gray;
-  left: 4px; // should be same as 'top' above
+  background-color: $lightest-grey;
+  left: 6px; // should be same as 'top' above plus one
 }

--- a/app/assets/src/components/ui/controls/toggle.scss
+++ b/app/assets/src/components/ui/controls/toggle.scss
@@ -14,6 +14,8 @@
 }
 
 .toggle.toggle.toggle label:before {
+  margin-left: 0px; // remove 4px margin
+  margin-right: 0px; // remove 4px margin
   height: 28px;
   line-height: 28px;
   width: 68px;
@@ -21,6 +23,7 @@
 
 .toggle.toggle.toggle label {
   padding-top: 6px; // vertical align text
+  min-height: 34px;
   min-width: 58px; // enough space for text
   font-size: $font-size-small;
 }
@@ -29,7 +32,6 @@
 .toggle.toggle.toggle input:checked ~ label {
   padding-left: 17px;
   padding-right: 17px;
-  color: $dark-grey !important;
 }
 
 // Place text to the right
@@ -53,16 +55,19 @@
   top: 5px; // vertically align the circle in the height of the container
   height: 18px;
   width: 18px;
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+  transition-duration: 0.2s, 0.2s; // down from 0.3s
 }
 
 .toggle.toggle.toggle input:checked ~ label:after {
   background-color: $primary-light;
   left: calc(
-    68px - 6px - 18px
+    68px - 9px - 18px
   ); // inner width of toggle minus inner padding minus width of circle
 }
 
 .toggle.toggle.toggle input:indeterminate ~ label:after {
   background-color: $lightest-grey;
-  left: 6px; // should be same as 'top' above plus one
+  left: 2px;
 }

--- a/app/assets/src/components/ui/controls/toggle.scss
+++ b/app/assets/src/components/ui/controls/toggle.scss
@@ -1,11 +1,15 @@
 @import "~styles/themes/colors";
+@import "~styles/themes/typography";
+
+// NOTE: Classname .toggle is repeated here as .toggle.toggle.toggle to increase
+// specificity and always override semantic-ui.
 
 // For unknown reasons, semantic-ui is adding the rule
 //  [type=radio]:not(:checked)+label:after { transform: scale(0); }
 // which has the effect of hiding the circle part of the toggle when off.
 // The circle is always visible on the official example page at:
 // https://react.semantic-ui.com/modules/checkbox/#types-toggle
-.toggle label:after {
+.toggle.toggle.toggle label:after {
   transform: scale(1) !important;
 }
 
@@ -16,22 +20,24 @@
 }
 
 .toggle.toggle.toggle label {
-  padding-top: 5px; // vertical align text
+  padding-top: 6px; // vertical align text
   min-width: 58px; // enough space for text
+  font-size: $font-size-small;
 }
 
 // Place text to the left
 .toggle.toggle.toggle input:checked ~ label {
   padding-left: 17px;
   padding-right: 17px;
+  color: $dark-grey !important;
 }
 
 // Place text to the right
 .toggle.toggle.toggle input:indeterminate ~ label {
   padding-left: 34px;
+  color: $dark-grey !important;
 }
 
-// Repeat classname to increase specificity and override semantic-ui !important.
 .toggle.toggle.toggle input:checked ~ label:before {
   background-color: transparent !important; // override semantic-ui
   border: 1px solid $primary-light;

--- a/app/assets/src/components/ui/controls/toggle.scss
+++ b/app/assets/src/components/ui/controls/toggle.scss
@@ -1,0 +1,8 @@
+// For unknown reasons, semantic-ui is adding the rule
+//  [type=radio]:not(:checked)+label:after { transform: scale(0); }
+// which has the effect of hiding the circle part of the toggle when off.
+// The circle is always visible on the official example page at:
+// https://react.semantic-ui.com/modules/checkbox/#types-toggle
+.toggle label:after {
+  transform: scale(1) !important;
+}

--- a/app/assets/src/components/ui/controls/toggle.scss.js
+++ b/app/assets/src/components/ui/controls/toggle.scss.js
@@ -1,1 +1,0 @@
-// TODO (gdingle):

--- a/app/assets/src/components/ui/controls/toggle.scss.js
+++ b/app/assets/src/components/ui/controls/toggle.scss.js
@@ -1,0 +1,1 @@
+// TODO (gdingle):

--- a/app/assets/src/components/views/playgrounds/PlaygroundControls.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundControls.jsx
@@ -1,18 +1,20 @@
-import CompareButton from "../../ui/controls/buttons/CompareButton";
-import DownloadButton from "../../ui/controls/buttons/DownloadButton";
-import Dropdown from "../../ui/controls/dropdowns/Dropdown";
-import ButtonDropdown from "../../ui/controls/dropdowns/ButtonDropdown";
-import BetaLabel from "../../ui/labels/BetaLabel";
-import DownloadButtonDropdown from "../../ui/controls/dropdowns/DownloadButtonDropdown";
-import MultipleDropdown from "../../ui/controls/dropdowns/MultipleDropdown";
-import ThresholdFilterDropdown from "../../ui/controls/dropdowns/ThresholdFilterDropdown";
-import PrimaryButton from "../../ui/controls/buttons/PrimaryButton";
 import PropTypes from "prop-types";
 import React from "react";
-import SecondaryButton from "../../ui/controls/buttons/SecondaryButton";
-import Slider from "../../ui/controls/Slider";
-import Checkbox from "../../ui/controls/Checkbox";
-import MultipleNestedDropdown from "../../ui/controls/dropdowns/MultipleNestedDropdown";
+
+import CompareButton from "~ui/controls/buttons/CompareButton";
+import DownloadButton from "~ui/controls/buttons/DownloadButton";
+import Dropdown from "~ui/controls/dropdowns/Dropdown";
+import ButtonDropdown from "~ui/controls/dropdowns/ButtonDropdown";
+import BetaLabel from "~ui/labels/BetaLabel";
+import DownloadButtonDropdown from "~ui/controls/dropdowns/DownloadButtonDropdown";
+import MultipleDropdown from "~ui/controls/dropdowns/MultipleDropdown";
+import ThresholdFilterDropdown from "~ui/controls/dropdowns/ThresholdFilterDropdown";
+import PrimaryButton from "~ui/controls/buttons/PrimaryButton";
+import SecondaryButton from "~ui/controls/buttons/SecondaryButton";
+import Slider from "~ui/controls/Slider";
+import Checkbox from "~ui/controls/Checkbox";
+import MultipleNestedDropdown from "~ui/controls/dropdowns/MultipleNestedDropdown";
+import Toggle from "~ui/controls/Toggle";
 
 class PlaygroundControls extends React.Component {
   constructor(props) {
@@ -163,8 +165,6 @@ class PlaygroundControls extends React.Component {
             components={[
               <DownloadButton
                 key={0}
-                fluid
-                options={this.dropdownOptions}
                 text="Download"
                 onClick={option =>
                   this.setState({ event: "DropdownButton:Clicked", option })
@@ -172,9 +172,7 @@ class PlaygroundControls extends React.Component {
               />,
               <DownloadButton
                 key={1}
-                fluid
                 disabled
-                options={this.dropdownOptions}
                 text="Download"
                 onClick={option =>
                   this.setState({ event: "DropdownButton:Clicked", option })
@@ -188,19 +186,15 @@ class PlaygroundControls extends React.Component {
             components={[
               <DownloadButtonDropdown
                 key={0}
-                fluid
                 options={this.dropdownOptions}
-                text="Download"
                 onClick={option =>
                   this.setState({ event: "DropdownButton:Clicked", option })
                 }
               />,
               <DownloadButtonDropdown
                 key={1}
-                fluid
                 disabled
                 options={this.dropdownOptions}
-                text="Download"
                 onClick={option =>
                   this.setState({ event: "DropdownButton:Clicked", option })
                 }
@@ -348,6 +342,24 @@ class PlaygroundControls extends React.Component {
                 label="Checkbox"
                 onChange={() => this.setState({ event: "Checkbox:Change" })}
                 value={1}
+              />,
+            ]}
+          />
+          <ComponentCard
+            title="Toggle"
+            width={3}
+            components={[
+              <Toggle
+                key={1}
+                onLabel="Yes"
+                offLabel="No"
+                initialChecked={true}
+              />,
+              <Toggle
+                key={2}
+                onLabel="Yes"
+                offLabel="No"
+                initialChecked={false}
               />,
             ]}
           />

--- a/app/assets/src/components/views/playgrounds/PlaygroundControls.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundControls.jsx
@@ -42,327 +42,262 @@ class PlaygroundControls extends React.Component {
     return (
       <div className="playground">
         <div className="playground-grid">
-          <ComponentCard
-            title="Primary Button"
-            width={3}
-            components={[
-              <PrimaryButton
-                key={0}
-                text="Submit"
-                onClick={() => this.setState({ event: "PrimaryButton:Click" })}
-              />,
-              <PrimaryButton
-                key={1}
-                text="Submit"
-                disabled
-                onClick={() => this.setState({ event: "PrimaryButton:Click" })}
-              />,
-              <PrimaryButton
-                key={1}
-                label={<BetaLabel />}
-                text="Submit"
-                onClick={() => this.setState({ event: "PrimaryButton:Click" })}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Secondary Button"
-            width={3}
-            components={[
-              <SecondaryButton
-                key={0}
-                text="Submit"
-                onClick={() =>
-                  this.setState({ event: "SecondaryButton:Click" })
-                }
-              />,
-              <SecondaryButton
-                key={1}
-                text="Submit"
-                disabled
-                onClick={() =>
-                  this.setState({ event: "SecondaryButton:Click" })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Icon Button"
-            width={3}
-            components={[
-              <CompareButton
-                key={0}
-                onClick={() => this.setState({ event: "CompareButton:Click" })}
-              />,
-              <CompareButton
-                key={1}
-                disabled
-                onClick={() =>
-                  this.setState({
-                    event: "CompareButton:Click: should not show up!",
-                  })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Button Dropdown"
-            width={3}
-            components={[
-              <ButtonDropdown
-                primary
-                key={0}
-                fluid
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-              <ButtonDropdown
-                primary
-                key={1}
-                fluid
-                disabled
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Change", option })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Secondary Button Dropdown"
-            width={3}
-            components={[
-              <ButtonDropdown
-                secondary
-                key={0}
-                fluid
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-              <ButtonDropdown
-                secondary
-                key={1}
-                fluid
-                disabled
-                options={this.dropdownOptions}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Change", option })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Download Button"
-            width={3}
-            components={[
-              <DownloadButton
-                key={0}
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-              <DownloadButton
-                key={1}
-                disabled
-                text="Download"
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Download Dropdown Button"
-            width={4}
-            components={[
-              <DownloadButtonDropdown
-                key={0}
-                options={this.dropdownOptions}
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-              <DownloadButtonDropdown
-                key={1}
-                disabled
-                options={this.dropdownOptions}
-                onClick={option =>
-                  this.setState({ event: "DropdownButton:Clicked", option })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Threshold Filter Dropdown"
-            width={5}
-            components={[
-              <ThresholdFilterDropdown
-                key={0}
-                options={this.thresholdOptions}
-                onApply={vars => {
-                  this.setState({
-                    event: "ThresholdFilterDropdown:Apply",
-                    vars,
-                  });
-                }}
-              />,
-              <ThresholdFilterDropdown
-                key={1}
-                options={this.thresholdOptions}
-                disabled
-                onApply={vars => {
-                  this.setState({
-                    event: "ThresholdFilterDropdown:Apply",
-                    vars,
-                  });
-                }}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Dropdown"
-            width={4}
-            components={[
-              <Dropdown
-                key={0}
-                fluid
-                rounded
-                options={this.dropdownOptions}
-                label="Option"
-                onChange={() => this.setState({ event: "Dropdown:Change" })}
-              />,
-              <Dropdown
-                key={1}
-                fluid
-                disabled
-                rounded
-                options={this.dropdownOptions}
-                label="Option"
-                onChange={() => this.setState({ event: "Dropdown:Change" })}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Multiple Option Dropdown"
-            width={4}
-            components={[
-              <MultipleDropdown
-                key={0}
-                fluid
-                rounded
-                search
-                options={this.dropdownOptions}
-                label="Options"
-                onChange={() =>
-                  this.setState({ event: "MultipleDropdown:Change" })
-                }
-              />,
-              <MultipleDropdown
-                key={1}
-                fluid
-                rounded
-                disabled
-                options={this.dropdownOptions}
-                label="Options"
-                onChange={() =>
-                  this.setState({ event: "MultipleDropdown:Change" })
-                }
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Multiple Nested Dropdown"
-            width={4}
-            components={[
-              <MultipleNestedDropdown
-                key={0}
-                fluid
-                rounded
-                options={this.dropdownOptions}
-                label="Options"
-                onChange={(a, b) => {
-                  this.setState({ event: "MultipleDropdown:Change" });
-                }}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Slider"
-            width={4}
-            components={[
-              <Slider
-                key={0}
-                options={this.dropdownOptions}
-                label="Slider: "
-                onChange={() => this.setState({ event: "Slider:Change" })}
-                onAfterChange={() =>
-                  this.setState({ event: "Slider:onAfterChange" })
-                }
-                min={0}
-                max={100}
-                value={20}
-              />,
-              <Slider
-                key={1}
-                disabled
-                options={this.dropdownOptions}
-                label="Slider: "
-                onChange={() => this.setState({ event: "Slider:Change" })}
-                onAfterChange={() =>
-                  this.setState({ event: "Slider:onAfterChange" })
-                }
-                min={0}
-                max={100}
-                value={20}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Checkbox"
-            width={4}
-            components={[
-              <Checkbox
-                key={0}
-                label="Checkbox"
-                onChange={() => this.setState({ event: "Checkbox:Change" })}
-                value={0}
-                checked={true}
-              />,
-              <Checkbox
-                key={1}
-                label="Checkbox"
-                onChange={() => this.setState({ event: "Checkbox:Change" })}
-                value={1}
-              />,
-            ]}
-          />
-          <ComponentCard
-            title="Toggle"
-            width={3}
-            components={[
-              <Toggle
-                key={1}
-                onLabel="Yes"
-                offLabel="No"
-                initialChecked={true}
-              />,
-              <Toggle
-                key={2}
-                onLabel="Yes"
-                offLabel="No"
-                initialChecked={false}
-              />,
-            ]}
-          />
+          <ComponentCard title="Primary Button" width={3}>
+            <PrimaryButton
+              key={0}
+              text="Submit"
+              onClick={() => this.setState({ event: "PrimaryButton:Click" })}
+            />
+            <PrimaryButton
+              key={1}
+              text="Submit"
+              disabled
+              onClick={() => this.setState({ event: "PrimaryButton:Click" })}
+            />
+            <PrimaryButton
+              key={1}
+              label={<BetaLabel />}
+              text="Submit"
+              onClick={() => this.setState({ event: "PrimaryButton:Click" })}
+            />
+          </ComponentCard>
+          <ComponentCard title="Secondary Button" width={3}>
+            <SecondaryButton
+              key={0}
+              text="Submit"
+              onClick={() => this.setState({ event: "SecondaryButton:Click" })}
+            />
+            <SecondaryButton
+              key={1}
+              text="Submit"
+              disabled
+              onClick={() => this.setState({ event: "SecondaryButton:Click" })}
+            />
+          </ComponentCard>
+          <ComponentCard title="Icon Button" width={3}>
+            <CompareButton
+              key={0}
+              onClick={() => this.setState({ event: "CompareButton:Click" })}
+            />
+            <CompareButton
+              key={1}
+              disabled
+              onClick={() =>
+                this.setState({
+                  event: "CompareButton:Click: should not show up!",
+                })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Button Dropdown" width={3}>
+            <ButtonDropdown
+              primary
+              key={0}
+              fluid
+              options={this.dropdownOptions}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+            <ButtonDropdown
+              primary
+              key={1}
+              fluid
+              disabled
+              options={this.dropdownOptions}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Change", option })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Secondary Button Dropdown" width={3}>
+            <ButtonDropdown
+              secondary
+              key={0}
+              fluid
+              options={this.dropdownOptions}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+            <ButtonDropdown
+              secondary
+              key={1}
+              fluid
+              disabled
+              options={this.dropdownOptions}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Change", option })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Download Button" width={3}>
+            <DownloadButton
+              key={0}
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+            <DownloadButton
+              key={1}
+              disabled
+              text="Download"
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Download Dropdown Button" width={4}>
+            <DownloadButtonDropdown
+              key={0}
+              options={this.dropdownOptions}
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+            <DownloadButtonDropdown
+              key={1}
+              disabled
+              options={this.dropdownOptions}
+              onClick={option =>
+                this.setState({ event: "DropdownButton:Clicked", option })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Threshold Filter Dropdown" width={5}>
+            <ThresholdFilterDropdown
+              key={0}
+              options={this.thresholdOptions}
+              onApply={vars => {
+                this.setState({
+                  event: "ThresholdFilterDropdown:Apply",
+                  vars,
+                });
+              }}
+            />
+            <ThresholdFilterDropdown
+              key={1}
+              options={this.thresholdOptions}
+              disabled
+              onApply={vars => {
+                this.setState({
+                  event: "ThresholdFilterDropdown:Apply",
+                  vars,
+                });
+              }}
+            />
+          </ComponentCard>
+          <ComponentCard title="Dropdown" width={4}>
+            <Dropdown
+              key={0}
+              fluid
+              rounded
+              options={this.dropdownOptions}
+              label="Option"
+              onChange={() => this.setState({ event: "Dropdown:Change" })}
+            />
+            <Dropdown
+              key={1}
+              fluid
+              disabled
+              rounded
+              options={this.dropdownOptions}
+              label="Option"
+              onChange={() => this.setState({ event: "Dropdown:Change" })}
+            />
+          </ComponentCard>
+          <ComponentCard title="Multiple Option Dropdown" width={4}>
+            <MultipleDropdown
+              key={0}
+              fluid
+              rounded
+              search
+              options={this.dropdownOptions}
+              label="Options"
+              onChange={() =>
+                this.setState({ event: "MultipleDropdown:Change" })
+              }
+            />
+            <MultipleDropdown
+              key={1}
+              fluid
+              rounded
+              disabled
+              options={this.dropdownOptions}
+              label="Options"
+              onChange={() =>
+                this.setState({ event: "MultipleDropdown:Change" })
+              }
+            />
+          </ComponentCard>
+          <ComponentCard title="Multiple Nested Dropdown" width={4}>
+            <MultipleNestedDropdown
+              key={0}
+              fluid
+              rounded
+              options={this.dropdownOptions}
+              label="Options"
+              onChange={(a, b) => {
+                this.setState({ event: "MultipleDropdown:Change" });
+              }}
+            />
+          </ComponentCard>
+          <ComponentCard title="Slider" width={4}>
+            <Slider
+              key={0}
+              options={this.dropdownOptions}
+              label="Slider: "
+              onChange={() => this.setState({ event: "Slider:Change" })}
+              onAfterChange={() =>
+                this.setState({ event: "Slider:onAfterChange" })
+              }
+              min={0}
+              max={100}
+              value={20}
+            />
+            <Slider
+              key={1}
+              disabled
+              options={this.dropdownOptions}
+              label="Slider: "
+              onChange={() => this.setState({ event: "Slider:Change" })}
+              onAfterChange={() =>
+                this.setState({ event: "Slider:onAfterChange" })
+              }
+              min={0}
+              max={100}
+              value={20}
+            />
+          </ComponentCard>
+          <ComponentCard title="Checkbox" width={4}>
+            <Checkbox
+              key={0}
+              label="Checkbox"
+              onChange={() => this.setState({ event: "Checkbox:Change" })}
+              value={0}
+              checked={true}
+            />
+            <Checkbox
+              key={1}
+              label="Checkbox"
+              onChange={() => this.setState({ event: "Checkbox:Change" })}
+              value={1}
+            />
+          </ComponentCard>
+          <ComponentCard title="Toggle" width={3}>
+            <Toggle key={1} onLabel="Yes" offLabel="No" initialChecked={true} />
+            <Toggle
+              key={2}
+              onLabel="Yes"
+              offLabel="No"
+              initialChecked={false}
+            />
+          </ComponentCard>
         </div>
         <div className="playground-console">
           <span className="playground-console-label">Last Event:</span>
@@ -377,14 +312,14 @@ PlaygroundControls.propTypes = {
   thresholdFilters: PropTypes.object,
 };
 
-const ComponentCard = ({ title, components, width }) => {
+const ComponentCard = ({ title, width, children }) => {
   return (
     <div
       className="component-card"
       style={{ gridColumn: `auto / span ${width}` }}
     >
       <div className="title">{title}</div>
-      {components.map((component, idx) => (
+      {React.Children.map(children, (component, idx) => (
         <div key={idx} className="component">
           {component}
         </div>
@@ -394,7 +329,7 @@ const ComponentCard = ({ title, components, width }) => {
 };
 
 ComponentCard.propTypes = {
-  components: PropTypes.arrayOf(PropTypes.node),
+  children: PropTypes.node,
   title: PropTypes.string,
   width: PropTypes.number,
 };

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -170,10 +170,15 @@ class MetadataField < ApplicationRecord
   end
 
   # If the field has exactly two forced options, it is effectively a boolean.
+  # For now, we only support Yes/No, in that order.
   def boolean?
     return false unless options && force_options == 1
 
-    return JSON.parse(options).length == 2
+    parsed = JSON.parse(options)
+
+    return false unless parsed.length == 2
+
+    return parsed[0] == "Yes" && parsed[1] == "No"
   end
 
   private

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -14,6 +14,7 @@ class MetadataField < ApplicationRecord
     NUMBER_TYPE,
     DATE_TYPE,
     LOCATION_TYPE,
+    # see also boolean? method
   ], }
 
   # NOTE: not sure why these columns were not created as booleans
@@ -124,6 +125,7 @@ class MetadataField < ApplicationRecord
       is_required: is_required,
       examples: examples && JSON.parse(examples),
       default_for_new_host_genome: default_for_new_host_genome,
+      isBoolean: boolean?,
     }
   end
 
@@ -165,6 +167,13 @@ class MetadataField < ApplicationRecord
       return "location"
     end
     ""
+  end
+
+  # If the field has exactly two forced options, it is effectively a boolean.
+  def boolean?
+    return false unless options && force_options == 1
+
+    return JSON.parse(options).length == 2
   end
 
   private

--- a/spec/models/metadata_field_spec.rb
+++ b/spec/models/metadata_field_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# TODO: (gdingle): change this to yes/no only
+
 # This spec was created well after MetadataField, for the boolean? method.
 describe MetadataField, type: :model do
   it 'not be boolean if not force_options' do

--- a/spec/models/metadata_field_spec.rb
+++ b/spec/models/metadata_field_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-# TODO: (gdingle): change this to yes/no only
-
 # This spec was created well after MetadataField, for the boolean? method.
 describe MetadataField, type: :model do
+  let(:options) { '["Yes", "No"]' }
+
   it 'not be boolean if not force_options' do
-    expect(create(:metadata_field, force_options: 0, options: '[1,0]').boolean?).to_not be
+    expect(create(:metadata_field, force_options: 0, options: options).boolean?).to_not be
   end
 
   it 'not be boolean if nil or zero options or more than two' do
@@ -14,7 +14,11 @@ describe MetadataField, type: :model do
     expect(create(:metadata_field, force_options: 1, options: '[1,2,3]').boolean?).to_not be
   end
 
+  it 'not be boolean if wrong order' do
+    expect(create(:metadata_field, force_options: 1, options: '["No", "Yes"]').boolean?).to_not be
+  end
+
   it 'be boolean if force_options and two options' do
-    expect(create(:metadata_field, force_options: 1, options: '[1,0]').boolean?).to be
+    expect(create(:metadata_field, force_options: 1, options: options).boolean?).to be
   end
 end

--- a/spec/models/metadata_field_spec.rb
+++ b/spec/models/metadata_field_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+# This spec was created well after MetadataField, for the boolean? method.
+describe MetadataField, type: :model do
+  it 'not be boolean if not force_options' do
+    expect(create(:metadata_field, force_options: 0, options: '[1,0]').boolean?).to_not be
+  end
+
+  it 'not be boolean if nil or zero options or more than two' do
+    expect(create(:metadata_field, force_options: 1, options: '[]').boolean?).to_not be
+    expect(create(:metadata_field, force_options: 1, options: nil).boolean?).to_not be
+    expect(create(:metadata_field, force_options: 1, options: '[1,2,3]').boolean?).to_not be
+  end
+
+  it 'be boolean if force_options and two options' do
+    expect(create(:metadata_field, force_options: 1, options: '[1,0]').boolean?).to be
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/test/controllers/metadata_validate_new_samples_test.rb
+++ b/test/controllers/metadata_validate_new_samples_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # Tests MetadataController validate_csv_for_new_samples endpoint
-class MetadataValudateNewSamplesTest < ActionDispatch::IntegrationTest
+class MetadataValidateNewSamplesTest < ActionDispatch::IntegrationTest
   include ErrorHelper
 
   HEADERS_1 = ['sample_name', 'host_genome', 'sample_type', 'blood_fed'].freeze


### PR DESCRIPTION
# Description

Following the mocks https://chanzuckerberg.invisionapp.com/share/A6V572ZSBU5#/screens/396544827/comments, this adds a custom control based on semantic UI `Checkbox`. Rendering the control is determined by the new `boolean?` method of `MetadataField`. Currently, only fields that have options "Yes" and "No" are considered boolean.

![image](https://user-images.githubusercontent.com/28797/71937097-2e33f580-3160-11ea-95fd-eff2a240b604.png)

![image](https://user-images.githubusercontent.com/28797/71860117-80184500-30a6-11ea-9928-e059b24f8574.png)

I also added an ordering of fields based on the design. 

# Notes

* please ignore the snyk warning because I'm going to merge this branch into another branch, not master
* there was a semantic ui CSS bug such that the default `Checkbox` with toggle is not rendering the circle when unselected
* `force_options` does not seem to do anything in the upload flow. All fields that have options are "forced" by the UI controls.
* only other yes/no field I saw in the codebase was "antibiotics applied"
* I refactored the playground to use `children` as that is more idiomatic

# Tests

* new rspec test of `boolean?`
* load playground, see both states of toggle, see click behavior
* load upload flow, check apply all works
