### PR TITLE
IDSEQ-2012 Make name uniqueness validation case-insensitive.

### DIFF
--- a/app/models/background.rb
+++ b/app/models/background.rb
@@ -4,7 +4,7 @@ class Background < ApplicationRecord
   has_many :taxon_summaries, dependent: :destroy
   belongs_to :user, optional: true
   validate :validate_size
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
   after_save :submit_store_summary_job
   attr_accessor :just_updated
 

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -6,7 +6,7 @@ class PhyloTree < ApplicationRecord
   has_and_belongs_to_many :pipeline_runs
   belongs_to :user, counter_cache: true # use .size for cache, use .count to force COUNT query
   belongs_to :project
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
   after_create :create_visualization
 
   STATUS_INITIALIZED = 0

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,7 +11,7 @@ class Project < ApplicationRecord
   has_many :phylo_trees, -> { order(created_at: :desc) }, dependent: :restrict_with_exception
   has_one :background
   has_and_belongs_to_many :metadata_fields
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
   include ReportHelper
 
   before_create :add_default_metadata_fields

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -81,7 +81,7 @@ class Sample < ApplicationRecord
 
   validate :input_files_checks
   after_create :initiate_input_file_upload
-  validates :name, uniqueness: { scope: :project_id }
+  validates :name, uniqueness: { scope: :project_id, case_sensitive: false }
 
   before_save :check_host_genome, :concatenate_input_parts, :check_status
   after_save :set_presigned_url_for_local_upload


### PR DESCRIPTION
# Description

If there is an existing phylo tree with name "Test", and you name your phylo tree "test", the Rails validation will pass, but the database insertion will fail. 

Our SQL tables use `COLLATE=utf8_unicode_ci` which is case-insensitive. (so "Test" is considered equal to "test")

This fixes the Rails validation so that it reflects the database constraint.

# Tests

* Tested manually that validation now behaves as expected.
