### PR TITLE
[Bug] [Report page] Fix report page crash when opening sample details sidebar

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -811,7 +811,7 @@ export default class SampleViewV2 extends React.Component {
     } else if (sidebarMode === "sampleDetails") {
       return {
         sampleId: sample.id,
-        pipelineVersion: pipelineRun.pipeline_version,
+        pipelineVersion: pipelineRun ? pipelineRun.pipeline_version : null,
         onMetadataUpdate: this.handleMetadataUpdate,
       };
     }


### PR DESCRIPTION
# Description

If the sample is just starting and has not yet received a pipeline run, the new report page would crash if "Sample Details" is clicked.

This adds a check to ensure that `pipelineRun` is not accessed before it exists.

# Tests

* Found a sample still "Waiting to Start or Receive Files" and verified that clicking the Sample Details button opens the sidebar without crashing.
