### PR TITLE
[Report page] Display upload errors on report page

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -941,8 +941,12 @@ export default class SampleViewV2 extends React.Component {
     } else {
       // Some kind of error or warning has occurred.
       if (sample) {
-        pipelineRun.known_user_error = knownUserError;
-        pipelineRun.error_message = errorMessage;
+        // If an upload error occurred, the pipeline run might not exist so
+        // only try to set these fields if the pipeline run started.
+        if (pipelineRun) {
+          pipelineRun.known_user_error = knownUserError;
+          pipelineRun.error_message = errorMessage;
+        }
         ({ status, message, linkText, type, link, icon } = sampleErrorInfo(
           sample,
           pipelineRun

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -924,7 +924,10 @@ export default class SampleViewV2 extends React.Component {
       message = "Loading report data.";
       icon = <LoadingIcon className={cs.icon} />;
       type = "inProgress";
-    } else if (pipelineRunStatus === "WAITING" && !sample.upload_error) {
+    } else if (
+      pipelineRunStatus === "WAITING" &&
+      (sample && !sample.upload_error)
+    ) {
       status = "IN PROGRESS";
       message = jobStatus;
       icon = <LoadingIcon className={cs.icon} />;

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -924,7 +924,7 @@ export default class SampleViewV2 extends React.Component {
       message = "Loading report data.";
       icon = <LoadingIcon className={cs.icon} />;
       type = "inProgress";
-    } else if (pipelineRunStatus === "WAITING") {
+    } else if (pipelineRunStatus === "WAITING" && !sample.upload_error) {
       status = "IN PROGRESS";
       message = jobStatus;
       icon = <LoadingIcon className={cs.icon} />;

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -758,6 +758,7 @@ class SamplesController < ApplicationController
       :project_id,
       :status,
       :host_genome_id,
+      :upload_error,
     ]
     respond_to do |format|
       format.html { render 'show_v2' }


### PR DESCRIPTION
# Description

Pass a sample's upload_errors (if any) to the report page so that they can be displayed accordingly, particularly in the case of a stalled upload.

![image](https://user-images.githubusercontent.com/53838890/71852984-00cb4700-308f-11ea-9646-ab7da26e79ed.png)

# Tests

* Verified that a stalled upload will display "It looks like it is taking a long time to upload your sample file" on the report page rather than "Waiting to start or receive files."
