### PR TITLE
[Bug] [Report page] Allow contig downloads for nr

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -473,7 +473,9 @@ class ReportTable extends React.Component {
 
     const validTaxId =
       rowData.taxId < INVALID_CALL_BASE_TAXID || rowData.taxId > 0;
-    const contigVizEnabled = !!keys(getOr({}, "nt.contigs", rowData)).length;
+    const contigVizEnabled =
+      !!keys(getOr({}, "nt.contigs", rowData)).length ||
+      !!keys(getOr({}, "nr.contigs", rowData)).length;
     const coverageVizEnabled =
       alignVizAvailable && validTaxId && getOr(0, "nt.count", rowData) > 0;
     const phyloTreeEnabled =


### PR DESCRIPTION
# Description

Previously, the contigs download button on the new report page was only enabled if the taxon had contigs in NT (see https://jira.czi.team/browse/IDSEQ-1975). This change enables contigs to be downloaded if the taxon has contigs in NR as well.

![image](https://user-images.githubusercontent.com/53838890/71859357-6de8d780-30a3-11ea-81c6-e16ab5a6bbc1.png)


# Tests

* Verified that taxons that should have the option to download contigs have the button enabled.