### PR TITLE
Add auto-refreshing to the bulk download list.

### DIFF
--- a/app/assets/src/components/views/bulk_download/bulk_download_list.scss
+++ b/app/assets/src/components/views/bulk_download/bulk_download_list.scss
@@ -29,6 +29,15 @@
   }
 }
 
+.autoUpdateWarning {
+  margin-bottom: $space-xxxs;
+
+  .link {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}
+
 .viewHeader {
   margin-top: $space-xl;
   margin-bottom: $space-xl;

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -150,7 +150,8 @@ class BulkDownload < ApplicationRecord
     command = ["python", "s3_tar_writer.py",
                "--src-urls", *src_urls,
                "--tar-names", *tar_names,
-               "--dest-url", dest_url,]
+               "--dest-url", dest_url,
+               "--progress-delay", PROGRESS_UPDATE_DELAY,]
 
     # The success url is mandatory.
     if success_url

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -106,6 +106,8 @@ describe BulkDownload, type: :model do
         get_expected_tar_name(@project, @sample_two, "original_R2.fastq.gz"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Original Input Files.tar.gz",
+        "--progress-delay",
+        15,
         "--success-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
         "--error-url",
@@ -113,6 +115,10 @@ describe BulkDownload, type: :model do
         "--progress-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/progress/#{@bulk_download.access_token}",
       ]
+      print("\n")
+      print(@bulk_download.bulk_download_ecs_task_command.join(" "))
+      print("\n")
+      print(task_command.join(" "))
 
       expect(@bulk_download.bulk_download_ecs_task_command).to eq(task_command)
     end
@@ -134,6 +140,8 @@ describe BulkDownload, type: :model do
         get_expected_tar_name(@project, @sample_two, "unmapped.fasta"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Unmapped Reads.tar.gz",
+        "--progress-delay",
+        15,
         "--success-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
         "--error-url",
@@ -167,6 +175,8 @@ describe BulkDownload, type: :model do
         get_expected_tar_name(@project, @sample_two, "reads_nh.fasta"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
+        "--progress-delay",
+        15,
         "--success-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
         "--error-url",
@@ -204,6 +214,8 @@ describe BulkDownload, type: :model do
         get_expected_tar_name(@project, @sample_two, "reads_nh_R2.fastq"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
+        "--progress-delay",
+        15,
         "--success-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
         "--error-url",
@@ -231,6 +243,8 @@ describe BulkDownload, type: :model do
         get_expected_tar_name(@project, @sample_two, "contigs_nh.fasta"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Contigs (Non-host).tar.gz",
+        "--progress-delay",
+        15,
         "--success-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
         "--error-url",
@@ -259,6 +273,8 @@ describe BulkDownload, type: :model do
         get_expected_tar_name(@project, @sample_two, "reads_per_gene.star.tab"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Host Gene Counts.tar.gz",
+        "--progress-delay",
+        15,
         "--success-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
         "--error-url",
@@ -297,6 +313,8 @@ describe BulkDownload, type: :model do
         get_expected_tar_name(@project, @sample_two, "reads_nh_R2.fastq"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
+        "--progress-delay",
+        15,
         "--success-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
         "--error-url",
@@ -339,6 +357,8 @@ describe BulkDownload, type: :model do
         get_expected_tar_name(@project, @sample_two, "reads_nh_R2.fastq"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
+        "--progress-delay",
+        15,
         "--success-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
         "--error-url",
@@ -375,6 +395,8 @@ describe BulkDownload, type: :model do
         get_expected_tar_name(@project, @sample_two, "reads_nh_R2.fastq"),
         "--dest-url",
         "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Reads (Non-host).tar.gz",
+        "--progress-delay",
+        15,
         "--success-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
         "--error-url",


### PR DESCRIPTION
# Description

Automatically auto-update the bulk download list for 5 minutes, then show a warning.

![Screen Shot 2020-01-06 at 4 46 18 PM](https://user-images.githubusercontent.com/837004/71859680-a63ce580-30a4-11ea-9f38-778039d81b38.png)

# Notes

* It's not obvious that the user has to refresh the page to see updates, which is why this auto-update feature is added.
* Since the download tasks are limited to only pinging the server every 15 seconds, we only refresh the page every 15 seconds.
