### PR TITLE
Add file type and improve descriptions for bulk downloads.

### DIFF
--- a/app/assets/src/components/views/bulk_download/BulkDownloadList.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadList.jsx
@@ -131,6 +131,7 @@ class BulkDownloadList extends React.Component {
         label: "",
         width: 190,
         cellRenderer: BulkDownloadTableRenderers.renderStatus,
+        disableSort: true,
       },
     ];
   };

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -425,6 +425,11 @@ class ChooseStep extends React.Component {
         <div className={cs.content}>
           <div className={cs.name}>
             {downloadType.display_name}
+            {downloadType.file_type_display && (
+              <span className={cs.fileType}>
+                &nbsp;({downloadType.file_type_display})
+              </span>
+            )}
             {downloadType.admin_only && (
               <StatusLabel inline status="Admin Only" />
             )}
@@ -480,13 +485,17 @@ class ChooseStep extends React.Component {
   };
 
   render() {
-    const { onContinue } = this.props;
+    const { onContinue, selectedSampleIds } = this.props;
+
+    const numSamples = selectedSampleIds.size;
 
     return (
       <div className={cs.chooseStep}>
         <div className={cs.header}>
           <div className={cs.title}>Choose a Download</div>
-          <div className={cs.tagline}>Learn More</div>
+          <div className={cs.tagline}>
+            {numSamples} sample{numSamples != 1 ? "s" : ""} selected
+          </div>
         </div>
         <div className={cs.downloadTypeContainer}>
           {this.renderDownloadTypes()}

--- a/app/assets/src/components/views/bulk_download/choose_step.scss
+++ b/app/assets/src/components/views/bulk_download/choose_step.scss
@@ -15,8 +15,8 @@
   }
 
   .tagline {
-    @include font-header-xs;
-    color: $primary-light;
+    @include font-body-xs;
+    color: $medium-grey;
   }
 }
 
@@ -28,7 +28,7 @@
 
   .category {
     &:not(:first-child) {
-      margin-top: 40px;
+      margin-top: $space-l;
     }
 
     .title {
@@ -120,6 +120,10 @@
   .description {
     @include font-body-xxs;
     color: $dark-grey;
+  }
+
+  .fileType {
+    color: $medium-grey;
   }
 }
 

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -17,14 +17,16 @@ module BulkDownloadTypesHelper
     {
       type: SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE,
       display_name: "Sample Overviews",
-      description: "Sample metadata and QC metrics",
+      description: "Sample QC metrics (e.g. percent reads passing QC) and other summary statistics",
       category: "report",
       execution_type: RESQUE_EXECUTION_TYPE,
+      # This will be displayed in the bulk-download creation modal.
+      file_type_display: ".csv",
     },
     {
       type: SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE,
       display_name: "Sample Taxon Reports",
-      description: "Metrics (e.g. total reads, rPM) and metadata for each taxon identified in the sample",
+      description: "Computed metrics (e.g. total reads, rPM) and metadata for each taxon identified in the sample",
       category: "report",
       execution_type: RESQUE_EXECUTION_TYPE,
       fields: [
@@ -33,11 +35,12 @@ module BulkDownloadTypesHelper
           type: "background",
         },
       ],
+      file_type_display: ".csv",
     },
     {
       type: COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE,
       display_name: "Combined Sample Taxon Results",
-      description: "The value of a particular metric (e.g. total reads, rPM) for all taxa in all selected samples, in a single data table",
+      description: "The value of a particular metric (e.g. total reads, rPM) for all taxa in all selected samples, combined into a single file",
       category: "report",
       fields: [
         {
@@ -50,13 +53,15 @@ module BulkDownloadTypesHelper
         },
       ],
       execution_type: RESQUE_EXECUTION_TYPE,
+      file_type_display: ".csv",
     },
     {
       type: CONTIG_SUMMARY_REPORT_BULK_DOWNLOAD_TYPE,
       display_name: "Contig Summary Reports",
-      description: "Contig metadata and QC metrics",
+      description: "Contig QC metrics (e.g. read coverage, percent identity) and other summary statistics",
       category: "report",
       execution_type: RESQUE_EXECUTION_TYPE,
+      file_type_display: ".csv",
     },
     {
       type: HOST_GENE_COUNTS_BULK_DOWNLOAD_TYPE,
@@ -65,6 +70,7 @@ module BulkDownloadTypesHelper
       category: "report",
       execution_type: ECS_EXECUTION_TYPE,
       admin_only: true,
+      file_type_display: ".star.tab",
     },
     {
       type: READS_NON_HOST_BULK_DOWNLOAD_TYPE,


### PR DESCRIPTION
# Description

Improve the descriptions and add file types to report bulk downloads. Also replaced "Learn More" with the sample count, as per Jenn's mocks.

![Screen Shot 2020-01-07 at 5 26 11 PM](https://user-images.githubusercontent.com/837004/71942666-d18e0600-3172-11ea-890d-954ad400c3f5.png)

For the file descriptions, I placed more emphasis on Quality Control (QC) which I think users will be interested in. I tried to provide one or two good examples of the kinds of columns they'd find in the download. While not making the description too long.

Also fixed a bug where a column that shouldn't be sortable was sortable (in the bulk download list).

