### PR TITLE
Sample type controller

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -92,6 +92,8 @@ const createSample = (
 
 const getAllHostGenomes = () => get("/host_genomes.json");
 
+const getAllSampleTypes = () => get("/sample_types.json");
+
 // TODO(mark): Remove this method once we launch the new sample upload flow.
 const bulkUploadRemoteSamples = samples =>
   postWithCSRF(`/samples/bulk_upload.json`, {
@@ -401,6 +403,7 @@ export {
   deleteSample,
   getAlignmentData,
   getAllHostGenomes,
+  getAllSampleTypes,
   getContigsSequencesByByteranges,
   getCoverageVizData,
   getCoverageVizSummary,

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -9,7 +9,7 @@ import MetadataCSVLocationsMenu, {
 import PropTypes from "~/components/utils/propTypes";
 import AlertIcon from "~ui/icons/AlertIcon";
 import Tabs from "~/components/ui/controls/Tabs";
-import { getAllHostGenomes } from "~/api";
+import { getAllHostGenomes, getAllSampleTypes } from "~/api";
 import { getProjectMetadataFields } from "~/api/metadata";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import LoadingIcon from "~ui/icons/LoadingIcon";
@@ -30,18 +30,23 @@ class MetadataUpload extends React.Component {
     },
     projectMetadataFields: null,
     hostGenomes: [],
+    sampleTypes: [],
     validatingCSV: false,
     CSVLocationWarnings: {},
   };
 
   async componentDidMount() {
-    const [projectMetadataFields, hostGenomes] = await Promise.all([
-      getProjectMetadataFields(this.props.project.id),
-      getAllHostGenomes(),
-    ]);
+    const [projectMetadataFields, hostGenomes, sampleTypes] = await Promise.all(
+      [
+        getProjectMetadataFields(this.props.project.id),
+        getAllHostGenomes(),
+        getAllSampleTypes(),
+      ]
+    );
     this.setState({
       projectMetadataFields: keyBy("key", projectMetadataFields),
       hostGenomes,
+      sampleTypes,
     });
   }
 

--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -1,0 +1,10 @@
+class SampleTypesController < ApplicationController
+  # GET /sample_types.json
+  def index
+    @sample_types = SampleType.all
+
+    respond_to do |format|
+      format.json { render json: @sample_types }
+    end
+  end
+end

--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -1,10 +1,8 @@
 class SampleTypesController < ApplicationController
   # GET /sample_types.json
   def index
-    @sample_types = SampleType.all
-
     respond_to do |format|
-      format.json { render json: @sample_types }
+      format.json { render json: SampleType.all }
     end
   end
 end

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -1,4 +1,5 @@
-# From https://docs.google.com/spreadsheets/d/1_hPkQe5LI0Zw_C0Ls4HVCEDsc_FNNVOaU_aAfoaiZRE/
+# From "Sample Type Groupings" at
+# https://docs.google.com/spreadsheets/d/1_hPkQe5LI0Zw_C0Ls4HVCEDsc_FNNVOaU_aAfoaiZRE/
 # Each sample type represents a canonical, mutually-exclusive type supported by IDseq.
 class SampleType < ApplicationRecord
   validates :name, :group, presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,7 @@ Rails.application.routes.draw do
   get 'user_settings', to: 'user_settings#index'
 
   resources :host_genomes
+  resources :sample_types
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]
 
   resources :benchmarks, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,7 @@ Rails.application.routes.draw do
   post 'user_settings/update', to: 'user_settings#update'
   get 'user_settings', to: 'user_settings#index'
 
-  get 'sample_types', to: 'sample_types#index'
+  get 'sample_types.json', to: 'sample_types#index'
 
   resources :host_genomes
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,8 +147,9 @@ Rails.application.routes.draw do
   post 'user_settings/update', to: 'user_settings#update'
   get 'user_settings', to: 'user_settings#index'
 
+  get 'sample_types', to: 'sample_types#index'
+
   resources :host_genomes
-  resources :sample_types
   resources :users, only: [:create, :new, :edit, :update, :destroy, :index]
 
   resources :benchmarks, only: [:index]

--- a/db/migrate/20200108180542_create_sample_types.rb
+++ b/db/migrate/20200108180542_create_sample_types.rb
@@ -14,7 +14,8 @@ class CreateSampleTypes < ActiveRecord::Migration[5.1]
     populate_sample_types!
   end
 
-  # From https://docs.google.com/spreadsheets/d/1_hPkQe5LI0Zw_C0Ls4HVCEDsc_FNNVOaU_aAfoaiZRE/
+  # From "Sample Type Groupings" at
+  # https://docs.google.com/spreadsheets/d/1_hPkQe5LI0Zw_C0Ls4HVCEDsc_FNNVOaU_aAfoaiZRE/
   def populate_sample_types!
     initial_data = {
       'Systemic Inflammation': [

--- a/spec/factories/sample_types.rb
+++ b/spec/factories/sample_types.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :sample_type do
-  end
-end

--- a/spec/models/sample_type_spec.rb
+++ b/spec/models/sample_type_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe SampleType, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
# Description

This adds a sample type controller and hooks it up to the `MetadataUpload` component.

# Notes

This PR will be followed by another that uses the sample type info to show suggestions in `MetadataUpload`.

# Tests

Try uploading 
See no errors
See expected response json

```
[
  {
    "id": 59,
    "name": "Plasma",
    "group": "Systemic Inflammation",
    "insect_only": false,
    "human_only": false,
    "created_at": "2020-01-08T12:12:29.000-08:00",
    "updated_at": "2020-01-08T12:12:29.000-08:00"
  },
...
]
```