### PR TITLE
Fix double counting of failed src urls in bulk downloads.

### DIFF
--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -124,7 +124,8 @@ class BulkDownloadsController < ApplicationController
 
     if params[:error_type] == "FailedSrcUrlError"
       LogUtil.log_err_and_airbrake("BulkDownloadFailedSrcUrlError (id #{@bulk_download.id}): The following paths failed to process: #{params[:error_data]}")
-      update_params[:error_message] = FAILED_SAMPLES_ERROR_TEMPLATE % params[:error_data].length
+      sample_count = SamplesHelper.get_sample_count_from_sample_paths(params[:error_data])
+      update_params[:error_message] = FAILED_SAMPLES_ERROR_TEMPLATE % sample_count
     end
 
     @bulk_download.update(update_params)

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -15,6 +15,10 @@ module SamplesHelper
   # Limit the number of objects we scan in a bucket to avoid timeouts and memory issues.
   S3_OBJECT_LIMIT = 10_000
 
+  # Sample files stored in S3 have paths like s3://idseq-samples-prod/samples/{project_id}/{sample_id}/{path_to_file}
+  # This regex extracts the sample_id from sample S3 paths.
+  SAMPLE_PATH_ID_MATCHER = %r{\A.*samples\/\d*\/(\d*)\/.*\z}
+
   def generate_sample_list_csv(formatted_samples)
     attributes = %w[sample_name uploader upload_date overall_job_status runtime_seconds
                     total_reads nonhost_reads nonhost_reads_percent total_ercc_reads subsampled_fraction
@@ -640,6 +644,19 @@ module SamplesHelper
       taxon["sample_count_contigs"] = pipeline_runs_by_taxid[taxon["taxid"]].uniq.length
     end
     taxon_list
+  end
+
+  def self.get_sample_count_from_sample_paths(urls)
+    sample_ids = Set.new
+
+    urls.each do |url|
+      if (matches = SAMPLE_PATH_ID_MATCHER.match(url))
+        sample_id = matches[1]
+        sample_ids.add(sample_id)
+      end
+    end
+
+    sample_ids.size
   end
 
   private

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -480,6 +480,10 @@ class PipelineRun < ApplicationRecord
 
   # buffer can be a file or an array.
   def write_contig_mapping_table_csv(buffer)
+    # If there are no contigs, return an empty file.
+    if contigs.empty?
+      return
+    end
     nt_m8_map = get_m8_mapping(CONTIG_NT_TOP_M8)
     nr_m8_map = get_m8_mapping(CONTIG_NR_TOP_M8)
     header_row = ['contig_name', 'read_count', 'contig_length', 'contig_coverage']


### PR DESCRIPTION
# Description

Previously, we were counting the number of failed files. But some samples can generate more than one file.
We now extract the sample id from the file path and count the unique sample ids.

Also ensure that the contig_summary_report generates an empty csv when there are no contigs. (as opposed to generating just the headers) This makes it a little easier to identify when the file has no contents (from the file size).

# Tests

* Updated tests.
