### PR TITLE
Validate bulk downloads field params in controller

### DIFF
--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -30,6 +30,7 @@ class BulkDownloadsController < ApplicationController
   # POST /bulk_downloads
   def create
     create_params = bulk_download_create_params
+
     # Convert sample ids to pipeline run ids.
     begin
       pipeline_run_ids = validate_bulk_download_create_params(create_params, current_user)
@@ -42,10 +43,14 @@ class BulkDownloadsController < ApplicationController
       return
     end
 
+    # Convert params to a hash before passing it into the model.
+    params = create_params[:params]
+    params = params.to_hash if params.present?
+
     # Create and save the bulk download.
     bulk_download = BulkDownload.new(download_type: create_params[:download_type],
                                      pipeline_run_ids: pipeline_run_ids,
-                                     params: create_params[:params],
+                                     params: params,
                                      status: BulkDownload::STATUS_WAITING,
                                      user_id: current_user.id)
 
@@ -66,7 +71,7 @@ class BulkDownloadsController < ApplicationController
     else
       LogUtil.log_err_and_airbrake(
         "BulkDownloadsFailedEvent: Failed to save bulk download for type #{create_params[:download_type]} with #{pipeline_run_ids.length} samples.
-        #{bulk_download.errors.full_messages} #{create_params[:params]}"
+        #{bulk_download.errors.full_messages} #{params}"
       )
       render json: { error: KICKOFF_FAILURE_HUMAN_READABLE }, status: :unprocessable_entity
     end

--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -42,7 +42,6 @@ class BulkDownloadsController < ApplicationController
       return
     end
 
-    # TODO(mark): Additional validations for each download type.
     # Create and save the bulk download.
     bulk_download = BulkDownload.new(download_type: create_params[:download_type],
                                      pipeline_run_ids: pipeline_run_ids,
@@ -65,7 +64,11 @@ class BulkDownloadsController < ApplicationController
         }, status: :internal_server_error
       end
     else
-      render json: bulk_download.errors.full_messages, status: :unprocessable_entity
+      LogUtil.log_err_and_airbrake(
+        "BulkDownloadsFailedEvent: Failed to save bulk download for type #{create_params[:download_type]} with #{pipeline_run_ids.length} samples.
+        #{bulk_download.errors.full_messages} #{create_params[:params]}"
+      )
+      render json: { error: KICKOFF_FAILURE_HUMAN_READABLE }, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/bulk_downloads_helper.rb
+++ b/app/helpers/bulk_downloads_helper.rb
@@ -52,8 +52,9 @@ module BulkDownloadsHelper
       formatted_bulk_download[:log_url] = bulk_download.log_url
     end
 
-    unless bulk_download.params_json.nil?
-      formatted_bulk_download[:params] = JSON.parse(bulk_download.params_json)
+    # params is not included by default, because it's a wrapper variable around params_json.
+    unless bulk_download.params.nil?
+      formatted_bulk_download[:params] = bulk_download.params
     end
 
     if detailed

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -20,62 +20,55 @@ class BulkDownload < ApplicationRecord
 
   before_save :convert_params_to_json
 
-  attr_accessor :params
+  attr_writer :params
 
   validates :status, presence: true, inclusion: { in: [STATUS_WAITING, STATUS_RUNNING, STATUS_ERROR, STATUS_SUCCESS] }
   validate :params_checks
 
-  def params_checks
-    set_params
-    params = self.params
-
-    params_value = lambda do |key|
-      return nil if params.nil?
-      # Each field param should be structured as
-      # { displayName: "FOO", value: "BAR" }
-      # field_params[key] should be ActionController::Parameters object that responds to :keys
-      params[key].respond_to?(:keys) ? params[key]["value"] : nil
+  # This is a wrapper around the params_json field that exposes params_json as a Hash via "params".
+  # You should not ever access params_json or @params directly. Call "params" instead.
+  # If you read and write to params, params_json will be updated automatically when you save.
+  def params
+    # Load params from params_json if necessary.
+    if @params.nil? && params_json
+      @params = JSON.parse(params_json)
     end
-
-    if download_type == BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE
-      errors.add(:params, "background value must be an integer") unless params_value.call("background").is_a? Integer
-    end
-
-    if download_type == BulkDownloadTypesHelper::COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE
-      metric = params_value.call("metric")
-      errors.add(:params, "metrics value is invalid") unless HeatmapHelper::ALL_METRICS.pluck(:value).include?(metric)
-
-      if ["NT.zscore", "NR.zscore"].include?(metric)
-        errors.add(:params, "background value must be an integer") unless params_value.call("background").is_a? Integer
-      end
-    end
-
-    if download_type == BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE
-      taxa_with_reads = params_value.call("taxa_with_reads")
-      errors.add(:params, "taxa_with_reads must be all or an integer") unless taxa_with_reads.is_a?(Integer) || taxa_with_reads == "all"
-
-      if taxa_with_reads == "all"
-        errors.add(:params, "file_format must be .fasta or .fastq") unless [".fasta", ".fastq"].include?(params_value.call("file_format"))
-      end
-    end
-
-    if download_type == BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE
-      taxa_with_contigs = params_value.call("taxa_with_contigs")
-      errors.add(:params, "taxa_with_contigs must be all or an integer") unless taxa_with_contigs.is_a?(Integer) || taxa_with_contigs == "all"
-    end
+    @params
   end
 
   def convert_params_to_json
-    # We need the params in object form during validation.
     # Convert params to JSON right before saving.
     if params
       self.params_json = params.to_json
     end
   end
 
-  def set_params
-    if params_json
-      self.params = JSON.parse(params_json)
+  def params_checks
+    if download_type == BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE
+      errors.add(:params, "background value must be an integer") unless get_param_value("background").is_a? Integer
+    end
+
+    if download_type == BulkDownloadTypesHelper::COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE
+      metric = get_param_value("metric")
+      errors.add(:params, "metrics value is invalid") unless HeatmapHelper::ALL_METRICS.pluck(:value).include?(metric)
+
+      if ["NT.zscore", "NR.zscore"].include?(metric)
+        errors.add(:params, "background value must be an integer") unless get_param_value("background").is_a? Integer
+      end
+    end
+
+    if download_type == BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE
+      taxa_with_reads = get_param_value("taxa_with_reads")
+      errors.add(:params, "taxa_with_reads must be all or an integer") unless taxa_with_reads.is_a?(Integer) || taxa_with_reads == "all"
+
+      if taxa_with_reads == "all"
+        errors.add(:params, "file_format must be .fasta or .fastq") unless [".fasta", ".fastq"].include?(get_param_value("file_format"))
+      end
+    end
+
+    if download_type == BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE
+      taxa_with_contigs = get_param_value("taxa_with_contigs")
+      errors.add(:params, "taxa_with_contigs must be all or an integer") unless taxa_with_contigs.is_a?(Integer) || taxa_with_contigs == "all"
     end
   end
 
@@ -265,13 +258,10 @@ class BulkDownload < ApplicationRecord
   end
 
   def get_param_field(key, field)
-    # If params is nil, try to set it from params_json
-    if params.nil? && params_json.present?
-      self.params = JSON.parse(params_json)
-    end
-    if params.present?
-      return params.dig(key, field)
-    end
+    params.dig(key, field)
+  rescue
+    # If params is nil or malformed, will return nil
+    nil
   end
 
   def get_param_value(key)

--- a/spec/controllers/bulk_downloads_controller_spec.rb
+++ b/spec/controllers/bulk_downloads_controller_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe BulkDownloadsController, type: :controller do
         @sample_two = create(:sample, project: @project_admin,
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
 
-        bulk_download_joe = create(:bulk_download, user: @joe, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "reads_non_host")
+        bulk_download_joe = create(:bulk_download, user: @joe, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "unmapped_reads")
         create(:bulk_download, user: @admin, pipeline_run_ids: [@sample_two.first_pipeline_run.id])
 
         get :index, format: :json
@@ -293,7 +293,7 @@ RSpec.describe BulkDownloadsController, type: :controller do
         expect(bulk_downloads.length).to eq(1)
         expect(bulk_downloads[0]["id"]).to eq(bulk_download_joe.id)
         expect(bulk_downloads[0]["user_id"]).to eq(@joe.id)
-        expect(bulk_downloads[0]["download_type"]).to eq("reads_non_host")
+        expect(bulk_downloads[0]["download_type"]).to eq("unmapped_reads")
         expect(bulk_downloads[0]["num_samples"]).to eq(1)
         # Should not return pipeline runs.
         expect(bulk_downloads[0]["pipeline_runs"]).to eq(nil)
@@ -309,7 +309,7 @@ RSpec.describe BulkDownloadsController, type: :controller do
         @sample_one = create(:sample, project: @project, name: "Joes Sample",
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
 
-        bulk_download_joe = create(:bulk_download, user: @joe, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "reads_non_host")
+        bulk_download_joe = create(:bulk_download, user: @joe, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "unmapped_reads")
 
         get :show, params: { format: "json", id: bulk_download_joe.id }
 
@@ -317,11 +317,11 @@ RSpec.describe BulkDownloadsController, type: :controller do
         json_response = JSON.parse(response.body)
 
         expect(json_response["bulk_download"]["user_id"]).to eq(@joe.id)
-        expect(json_response["bulk_download"]["download_type"]).to eq("reads_non_host")
+        expect(json_response["bulk_download"]["download_type"]).to eq("unmapped_reads")
         expect(json_response["bulk_download"]["num_samples"]).to eq(1)
         expect(json_response["bulk_download"]["pipeline_runs"].length).to eq(1)
         expect(json_response["bulk_download"]["pipeline_runs"][0]["sample_name"]).to eq("Joes Sample")
-        expect(json_response["download_type"]["display_name"]).to eq("Reads (Non-host)")
+        expect(json_response["download_type"]["display_name"]).to eq("Unmapped Reads")
       end
 
       it "should error if the requested bulk download is not viewable" do
@@ -347,7 +347,7 @@ RSpec.describe BulkDownloadsController, type: :controller do
         @sample_one = create(:sample, project: @project, name: "Joes Sample",
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
 
-        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_SUCCESS, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "reads_non_host")
+        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_SUCCESS, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "unmapped_reads")
       end
 
       it "should return url in basic case" do
@@ -481,8 +481,8 @@ RSpec.describe BulkDownloadsController, type: :controller do
         @sample_two = create(:sample, project: @project_admin,
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
 
-        create(:bulk_download, user: @joe, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "reads_non_host")
-        create(:bulk_download, user: @admin, pipeline_run_ids: [@sample_two.first_pipeline_run.id], download_type: "contigs_non_host")
+        create(:bulk_download, user: @joe, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "unmapped_reads")
+        create(:bulk_download, user: @admin, pipeline_run_ids: [@sample_two.first_pipeline_run.id], download_type: "sample_overview")
 
         get :index, format: :json
 
@@ -491,10 +491,10 @@ RSpec.describe BulkDownloadsController, type: :controller do
 
         expect(bulk_downloads.length).to eq(2)
         expect(bulk_downloads[0]["user_id"]).to eq(@joe.id)
-        expect(bulk_downloads[0]["download_type"]).to eq("reads_non_host")
+        expect(bulk_downloads[0]["download_type"]).to eq("unmapped_reads")
         expect(bulk_downloads[0]["num_samples"]).to eq(1)
         expect(bulk_downloads[1]["user_id"]).to eq(@admin.id)
-        expect(bulk_downloads[1]["download_type"]).to eq("contigs_non_host")
+        expect(bulk_downloads[1]["download_type"]).to eq("sample_overview")
         expect(bulk_downloads[1]["num_samples"]).to eq(1)
       end
 
@@ -601,7 +601,7 @@ RSpec.describe BulkDownloadsController, type: :controller do
         @sample_one = create(:sample, project: @project, name: "Joes Sample",
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
 
-        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_RUNNING, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "reads_non_host")
+        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_RUNNING, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "unmapped_reads")
       end
 
       let(:mock_file_size) { 1000 }
@@ -669,7 +669,7 @@ RSpec.describe BulkDownloadsController, type: :controller do
         @sample_one = create(:sample, project: @project, name: "Joes Sample",
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
 
-        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_RUNNING, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "reads_non_host")
+        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_RUNNING, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "unmapped_reads")
       end
 
       it "should properly update bulk download on success" do
@@ -693,7 +693,7 @@ RSpec.describe BulkDownloadsController, type: :controller do
         @sample_one = create(:sample, project: @project, name: "Joes Sample",
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
 
-        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_RUNNING, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "reads_non_host")
+        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_RUNNING, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "unmapped_reads")
       end
 
       it "should properly update bulk download on success" do
@@ -717,7 +717,7 @@ RSpec.describe BulkDownloadsController, type: :controller do
         @sample_one = create(:sample, project: @project, name: "Joes Sample",
                                       pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }])
 
-        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_RUNNING, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "reads_non_host")
+        @bulk_download_joe = create(:bulk_download, user: @joe, status: BulkDownload::STATUS_RUNNING, pipeline_run_ids: [@sample_one.first_pipeline_run.id], download_type: "unmapped_reads")
       end
 
       actions = BulkDownloadsController::UPDATE_WITH_TOKEN_ACTIONS

--- a/spec/factories/bulk_downloads.rb
+++ b/spec/factories/bulk_downloads.rb
@@ -6,6 +6,9 @@ FactoryBot.define do
     before :create do |bulk_download, options|
       if options.params
         bulk_download.params_json = options.params.to_json
+        # This ensures that during validation, the params have keys that are strings, not symbols.
+        # We are inconsistent about whether we use symbols or strings in our Hashes.
+        bulk_download.params = JSON.parse(bulk_download.params_json)
       end
     end
   end

--- a/spec/helpers/bulk_download_helper_spec.rb
+++ b/spec/helpers/bulk_download_helper_spec.rb
@@ -185,4 +185,45 @@ RSpec.describe BulkDownloadsHelper, type: :helper do
       expect(response[:failed_sample_ids]).to eq([])
     end
   end
+
+  describe "#validate_bulk_download_field_params" do
+    it "should pass for bulk downloads without field params" do
+      helper.validate_bulk_download_field_params(
+        nil, BulkDownloadTypesHelper::SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE
+      )
+    end
+
+    it "should pass for valid parameters" do
+      params = ActionController::Parameters.new(taxa_with_reads: ActionController::Parameters.new(value: 1,
+                                                                                                  displayName: "Mock Taxon"))
+
+      helper.validate_bulk_download_field_params(
+        params, BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE
+      )
+    end
+
+    it "should pass for extraneous parameters" do
+      params = ActionController::Parameters.new(taxa_with_reads: ActionController::Parameters.new(value: 1,
+                                                                                                  displayName: "Mock Taxon"),
+                                                extra_param: ActionController::Parameters.new(value: "foo",
+                                                                                              displayName: "bar"))
+
+      helper.validate_bulk_download_field_params(
+        params, BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE
+      )
+    end
+
+    it "should throw error if parameters are invalid" do
+      params = ActionController::Parameters.new(taxa_with_reads: ActionController::Parameters.new( # value should be an integer
+        value: "abc",
+        displayName: "Mock Taxon"
+      ))
+
+      expect do
+        helper.validate_bulk_download_field_params(
+          params, BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE
+        )
+      end.to raise_error(StandardError, BulkDownloadsHelper::KICKOFF_FAILURE_HUMAN_READABLE)
+    end
+  end
 end

--- a/spec/helpers/bulk_download_helper_spec.rb
+++ b/spec/helpers/bulk_download_helper_spec.rb
@@ -185,45 +185,4 @@ RSpec.describe BulkDownloadsHelper, type: :helper do
       expect(response[:failed_sample_ids]).to eq([])
     end
   end
-
-  describe "#validate_bulk_download_field_params" do
-    it "should pass for bulk downloads without field params" do
-      helper.validate_bulk_download_field_params(
-        nil, BulkDownloadTypesHelper::SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE
-      )
-    end
-
-    it "should pass for valid parameters" do
-      params = ActionController::Parameters.new(taxa_with_reads: ActionController::Parameters.new(value: 1,
-                                                                                                  displayName: "Mock Taxon"))
-
-      helper.validate_bulk_download_field_params(
-        params, BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE
-      )
-    end
-
-    it "should pass for extraneous parameters" do
-      params = ActionController::Parameters.new(taxa_with_reads: ActionController::Parameters.new(value: 1,
-                                                                                                  displayName: "Mock Taxon"),
-                                                extra_param: ActionController::Parameters.new(value: "foo",
-                                                                                              displayName: "bar"))
-
-      helper.validate_bulk_download_field_params(
-        params, BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE
-      )
-    end
-
-    it "should throw error if parameters are invalid" do
-      params = ActionController::Parameters.new(taxa_with_reads: ActionController::Parameters.new( # value should be an integer
-        value: "abc",
-        displayName: "Mock Taxon"
-      ))
-
-      expect do
-        helper.validate_bulk_download_field_params(
-          params, BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE
-        )
-      end.to raise_error(StandardError, BulkDownloadsHelper::KICKOFF_FAILURE_HUMAN_READABLE)
-    end
-  end
 end

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -115,10 +115,6 @@ describe BulkDownload, type: :model do
         "--progress-url",
         "https://idseq.net/bulk_downloads/#{@bulk_download.id}/progress/#{@bulk_download.access_token}",
       ]
-      print("\n")
-      print(@bulk_download.bulk_download_ecs_task_command.join(" "))
-      print("\n")
-      print(task_command.join(" "))
 
       expect(@bulk_download.bulk_download_ecs_task_command).to eq(task_command)
     end
@@ -158,9 +154,13 @@ describe BulkDownload, type: :model do
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ], params: {
-                                "file_format" => {
-                                  "value" => ".fasta",
-                                  "displayName" => ".fasta",
+                                "file_format": {
+                                  "value": ".fasta",
+                                  "displayName": ".fasta",
+                                },
+                                "taxa_with_reads": {
+                                  "value": "all",
+                                  "displayName": "All Taxa",
                                 },
                               })
 
@@ -193,9 +193,13 @@ describe BulkDownload, type: :model do
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ], params: {
-                                "file_format" => {
-                                  "value" => ".fastq",
-                                  "displayName" => ".fastq",
+                                "file_format": {
+                                  "value": ".fastq",
+                                  "displayName": ".fastq",
+                                },
+                                "taxa_with_reads": {
+                                  "value": "all",
+                                  "displayName": "All Taxa",
                                 },
                               })
 
@@ -226,11 +230,16 @@ describe BulkDownload, type: :model do
       expect(@bulk_download.bulk_download_ecs_task_command).to eq(task_command)
     end
 
-    it "returns the correct task command for contigs_non_host download type with fasta file format" do
+    it "returns the correct task command for contigs_non_host download type" do
       @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
-                              ])
+                              ], params: {
+                                "taxa_with_contigs": {
+                                  "value": 100,
+                                  "displayName": "Mock Taxon",
+                                },
+                              })
 
       task_command = [
         "python",
@@ -292,9 +301,13 @@ describe BulkDownload, type: :model do
                                 @sample_two.first_pipeline_run.id,
                                 @sample_one.first_pipeline_run.id,
                               ], params: {
-                                "file_format" => {
-                                  "value" => ".fastq",
-                                  "displayName" => ".fastq",
+                                "file_format": {
+                                  "value": ".fastq",
+                                  "displayName": ".fastq",
+                                },
+                                "taxa_with_reads": {
+                                  "value": 100,
+                                  "displayName": "Mock Taxon",
                                 },
                               })
 
@@ -336,9 +349,13 @@ describe BulkDownload, type: :model do
                                 @sample_one.first_pipeline_run.id,
                                 @sample_two.first_pipeline_run.id,
                               ], params: {
-                                "file_format" => {
-                                  "value" => ".fastq",
-                                  "displayName" => ".fastq",
+                                "file_format": {
+                                  "value": ".fastq",
+                                  "displayName": ".fastq",
+                                },
+                                "taxa_with_reads": {
+                                  "value": 100,
+                                  "displayName": "Mock Taxon",
                                 },
                               })
 
@@ -374,9 +391,13 @@ describe BulkDownload, type: :model do
                                 @sample_two.first_pipeline_run.id,
                                 @sample_one.first_pipeline_run.id,
                               ], params: {
-                                "file_format" => {
-                                  "value" => ".fastq",
-                                  "displayName" => ".fastq",
+                                "file_format": {
+                                  "value": ".fastq",
+                                  "displayName": ".fastq",
+                                },
+                                "taxa_with_reads": {
+                                  "value": 100,
+                                  "displayName": "Mock Taxon",
                                 },
                               })
 
@@ -582,9 +603,9 @@ describe BulkDownload, type: :model do
     end
 
     it "correctly generates download file for download type sample_taxon_report" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background" => {
-                                             "value" => mock_background_id,
-                                             "displayName" => "Mock Background",
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background": {
+                                             "value": mock_background_id,
+                                             "displayName": "Mock Background",
                                            })
 
       expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv")
@@ -601,9 +622,9 @@ describe BulkDownload, type: :model do
     end
 
     it "correctly updates the bulk_download status and progress as the sample_taxon_report runs" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background" => {
-                                             "value" => mock_background_id,
-                                             "displayName" => "Mock Background",
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background": {
+                                             "value": mock_background_id,
+                                             "displayName": "Mock Background",
                                            })
 
       expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv")
@@ -661,9 +682,9 @@ describe BulkDownload, type: :model do
     it "correctly generates download file for download type reads_non_host for single taxon" do
       create_taxon_lineage(mock_tax_id)
 
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_reads" => {
-                                             "value" => mock_tax_id,
-                                             "displayName" => "Salmonella enterica",
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_reads": {
+                                             "value": mock_tax_id,
+                                             "displayName": "Salmonella enterica",
                                            })
 
       expect(bulk_download).to receive(:get_taxon_fasta_from_pipeline_run_combined_nt_nr).with(anything, mock_tax_id, mock_tax_level).exactly(2).times.and_return("mock_reads_nonhost_fasta")
@@ -681,9 +702,9 @@ describe BulkDownload, type: :model do
     it "correctly handles empty fastas for download type reads_non_host for single taxon" do
       create_taxon_lineage(mock_tax_id)
 
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_reads" => {
-                                             "value" => mock_tax_id,
-                                             "displayName" => "Salmonella enterica",
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_reads": {
+                                             "value": mock_tax_id,
+                                             "displayName": "Salmonella enterica",
                                            })
 
       expect(bulk_download).to receive(:get_taxon_fasta_from_pipeline_run_combined_nt_nr).with(anything, mock_tax_id, mock_tax_level).exactly(2).times.and_return(nil)
@@ -702,12 +723,12 @@ describe BulkDownload, type: :model do
 
     it "correctly generates download file for download type combined_sample_taxon_results" do
       bulk_download = create_bulk_download(BulkDownloadTypesHelper::COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE,
-                                           "background" => {
-                                             "value" => mock_background_id,
-                                             "displayName" => "Mock Background",
-                                           }, "metric" => {
-                                             "value" => "NT.rpm",
-                                             "displayName" => "NT RPM",
+                                           "background": {
+                                             "value": mock_background_id,
+                                             "displayName": "Mock Background",
+                                           }, "metric": {
+                                             "value": "NT.rpm",
+                                             "displayName": "NT RPM",
                                            })
 
       expect(BulkDownloadsHelper).to receive(:generate_combined_sample_taxon_results_csv).with(
@@ -726,12 +747,12 @@ describe BulkDownload, type: :model do
 
     it "correctly handles individual sample failures for download type combined_sample_taxon_results" do
       bulk_download = create_bulk_download(BulkDownloadTypesHelper::COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE,
-                                           "background" => {
-                                             "value" => mock_background_id,
-                                             "displayName" => "Mock Background",
-                                           }, "metric" => {
-                                             "value" => "NT.rpm",
-                                             "displayName" => "NT RPM",
+                                           "background": {
+                                             "value": mock_background_id,
+                                             "displayName": "Mock Background",
+                                           }, "metric": {
+                                             "value": "NT.rpm",
+                                             "displayName": "NT RPM",
                                            })
 
       expect(BulkDownloadsHelper).to receive(:generate_combined_sample_taxon_results_csv).with(
@@ -750,22 +771,10 @@ describe BulkDownload, type: :model do
       expect(bulk_download.error_message).to eq(BulkDownloadsHelper::FAILED_SAMPLES_ERROR_TEMPLATE % 1)
     end
 
-    it "correctly throws exception if taxa_with_reads param not found for download type reads_non_host for single taxon" do
-      create_taxon_lineage(mock_tax_id)
-
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, {})
-
-      expect do
-        bulk_download.generate_download_file
-      end.to raise_error.with_message(BulkDownloadsHelper::READS_NON_HOST_TAXID_EXPECTED)
-
-      expect(bulk_download.status).to eq(BulkDownload::STATUS_ERROR)
-    end
-
     it "correctly throws exception if taxon count not found for download type reads_non_host for single taxon" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_reads" => {
-                                             "value" => mock_tax_id,
-                                             "displayName" => "Salmonella enterica",
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_reads": {
+                                             "value": mock_tax_id,
+                                             "displayName": "Salmonella enterica",
                                            })
 
       expect do
@@ -776,9 +785,9 @@ describe BulkDownload, type: :model do
     end
 
     it "correctly generates download file for download type contigs_non_host for single taxon" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_contigs" => {
-                                             "value" => mock_tax_id,
-                                             "displayName" => "Salmonella enterica",
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE, "taxa_with_contigs": {
+                                             "value": mock_tax_id,
+                                             "displayName": "Salmonella enterica",
                                            })
       allow_any_instance_of(PipelineRun).to receive(:get_contigs_for_taxid).and_return([object_double(Contig.new, to_fa: "mock_contigs_nonhost_fasta")])
 
@@ -793,9 +802,9 @@ describe BulkDownload, type: :model do
     end
 
     it "correctly handles individual sample failures" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background" => {
-                                             "value" => mock_background_id,
-                                             "displayName" => "Mock Background",
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background": {
+                                             "value": mock_background_id,
+                                             "displayName": "Mock Background",
                                            })
 
       expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv")
@@ -814,9 +823,9 @@ describe BulkDownload, type: :model do
     end
 
     it "correctly handles s3 tar file upload error" do
-      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background" => {
-                                             "value" => mock_background_id,
-                                             "displayName" => "Mock Background",
+      bulk_download = create_bulk_download(BulkDownloadTypesHelper::SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE, "background": {
+                                             "value": mock_background_id,
+                                             "displayName": "Mock Background",
                                            })
 
       expect(PipelineReportService).to receive(:call).with(anything, mock_background_id, csv: true).exactly(1).times.and_return("mock_report_csv")
@@ -1005,9 +1014,9 @@ describe BulkDownload, type: :model do
         pipeline_run_ids: [@sample_one.first_pipeline_run.id],
         download_type: BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE,
         params: {
-          "taxa_with_reads" => {
-            "value" => 100,
-            "displayName" => "Mock Taxon",
+          "taxa_with_reads": {
+            "value": 100,
+            "displayName": "Mock Taxon",
           },
         }
       )
@@ -1022,9 +1031,9 @@ describe BulkDownload, type: :model do
         pipeline_run_ids: [@sample_one.first_pipeline_run.id],
         download_type: BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE,
         params: {
-          "taxa_with_contigs" => {
-            "value" => 200,
-            "displayName" => "Mock Taxon 2",
+          "taxa_with_contigs": {
+            "value": 200,
+            "displayName": "Mock Taxon 2",
           },
         }
       )
@@ -1039,18 +1048,79 @@ describe BulkDownload, type: :model do
         pipeline_run_ids: [@sample_one.first_pipeline_run.id],
         download_type: BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE,
         params: {
-          "taxa_with_contigs" => {
-            "value" => "all",
-            "displayName" => "All Taxon",
+          "taxa_with_contigs": {
+            "value": "all",
+            "displayName": "All Taxon",
           },
-          "file_format" => {
-            "value" => ".fastq",
-            "displayName" => ".fastq",
+          "file_format": {
+            "value": ".fastq",
+            "displayName": ".fastq",
           },
         }
       )
 
       expect(bulk_download.download_display_name).to eq("Contigs (Non-host)")
+    end
+  end
+
+  context "#params_checks validations" do
+    before do
+      @joe = create(:joe)
+      @project = create(:project, users: [@joe], name: "Test Project")
+      @sample_one = create(:sample, project: @project, name: "Test Sample One",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
+    end
+
+    let(:bulk_download) do
+      build(
+        :bulk_download,
+        user: @joe,
+        pipeline_run_ids: [@sample_one.first_pipeline_run.id],
+        download_type: BulkDownloadTypesHelper::READS_NON_HOST_BULK_DOWNLOAD_TYPE
+      )
+    end
+
+    it "should pass for bulk downloads without field params" do
+      bulk_download.download_type = BulkDownloadTypesHelper::SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE
+      expect(bulk_download).to be_valid
+    end
+
+    it "should pass for valid parameters" do
+      bulk_download.params = {
+        "taxa_with_reads" => {
+          "value" => 100,
+          "displayName" => "All Taxon",
+        },
+      }
+
+      expect(bulk_download).to be_valid
+    end
+
+    it "should pass for extraneous parameters" do
+      bulk_download.params = {
+        "taxa_with_reads" => {
+          "value" => 100,
+          "displayName" => "All Taxon",
+        },
+        "extra_params" => {
+          "value" => "foo",
+          "displayName" => "bar",
+        },
+      }
+
+      expect(bulk_download).to be_valid
+    end
+
+    it "should throw error if parameters are invalid" do
+      bulk_download.params = {
+        "taxa_with_reads" => {
+          # value should be an integer or "all"
+          "value" => "abc",
+          "displayName" => "All Taxon",
+        },
+      }
+
+      expect(bulk_download).to_not be_valid
     end
   end
 end


### PR DESCRIPTION
# Description

When creating a bulk download, validation that the params provided by the user are valid.
Only 4 of the bulk downloads require params.
If the user uses the BulkDownloadModal, it should be impossible for them to send an invalid set of parameters, but this provides an extra check on the back-end.

# Tests

* Verify that all bulk downloads can still be created.
* Write helper and controller tests.
