### PR TITLE
IDSEQ-2024 Change bulk download output_file_size to bigint

### DIFF
--- a/db/migrate/20200109023047_change_output_file_size_to_big_int.rb
+++ b/db/migrate/20200109023047_change_output_file_size_to_big_int.rb
@@ -1,0 +1,5 @@
+class ChangeOutputFileSizeToBigInt < ActiveRecord::Migration[5.1]
+  def change
+    change_column :bulk_downloads, :output_file_size, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_218_220_321) do
+ActiveRecord::Schema.define(version: 20_200_109_023_047) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -94,7 +94,7 @@ ActiveRecord::Schema.define(version: 20_191_218_220_321) do
     t.string "access_token"
     t.float "progress"
     t.string "ecs_task_arn", comment: "The ecs task arn for this bulk download if applicable"
-    t.integer "output_file_size", comment: "The file size of the generated output file. Can be nil while the file is being generated."
+    t.bigint "output_file_size", comment: "The file size of the generated output file. Can be nil while the file is being generated."
     t.index ["user_id"], name: "index_bulk_downloads_on_user_id"
   end
 


### PR DESCRIPTION
# Description

File sizes were too big for integer.

# Notes
The bulk download table is currently small so this migration should be fast.

# Tests

* Verified that the migration doesn't erase existing data.
* Verify that a large file size works after the migration.
