### PR TITLE
[Bug] [Report page] Handle case when total_reads is nil

### DIFF
--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -73,13 +73,13 @@ class PipelineReportService
     # taxon_counts (is report_ready), or if its results are finalized without errors.
     # Otherwise just return the metadata, which includes statuses and error messages to display.
     # TODO(julie): refactor + clarify pipeline run statuses (JIRA: https://jira.czi.team/browse/IDSEQ-1890)
-    unless @pipeline_run && (@pipeline_run.report_ready? || (@pipeline_run.finalized? && !@pipeline_run.failed?))
+    unless @pipeline_run && (@pipeline_run.report_ready? || (@pipeline_run.finalized? && !@pipeline_run.failed?)) && @pipeline_run.total_reads
       return JSON.dump(
         metadata: metadata
       )
     end
 
-    adjusted_total_reads = (@pipeline_run.total_reads.to_i - @pipeline_run.total_ercc_reads.to_i) * @pipeline_run.subsample_fraction.to_i
+    adjusted_total_reads = (@pipeline_run.total_reads - @pipeline_run.total_ercc_reads.to_i) * @pipeline_run.subsample_fraction
     @timer.split("initialize_and_adjust_reads")
 
     if @parallel


### PR DESCRIPTION
# Description

Check that pipeline_run.total_reads is not nil to prevent an [error](https://chanzuckerberg.airbrake.io/projects/158403/groups/2651997048859801072/notices/2651997033413937079) during the `adjusted_total_reads` calculation.

# Notes

Also removed a redundant variable declaration (`@pipeline_run_id = @pipeline_run.id`) and replaced variables accordingly.

# Tests

* Verified that the report will not throw an error if pipeline_run.total_reads is nil.