### PR TITLE
[Report page] Fix margins so genus and species columns are aligned

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/report_table.scss
+++ b/app/assets/src/components/views/SampleViewV2/report_table.scss
@@ -121,6 +121,8 @@
 .speciesRow {
   .nameCell {
     font-weight: $font-weight-regular;
+    margin-left: $space-s;
+    margin-right: $space-xxxs;
   }
 }
 
@@ -152,12 +154,6 @@
     .hoverActions {
       display: inline-block;
     }
-  }
-}
-
-.speciesRow {
-  .nameCell {
-    margin-left: $space-s;
   }
 }
 


### PR DESCRIPTION
# Description

The numerical columns of the genus and species rows would not be aligned on narrower screens (species row numbers pushed slightly to the right due to not correcting for an extra margin).

**Before:**
![image](https://user-images.githubusercontent.com/53838890/72112290-07a5c400-32f2-11ea-88bd-dc869998c6b7.png)

**Fixed:**
![image](https://user-images.githubusercontent.com/53838890/72112297-0b394b00-32f2-11ea-8c68-79752eb70ea1.png)


# Notes

Consolidated redundant class declarations.

# Tests

* Verified that the columns are now properly aligned.
