### PR TITLE
[IDSEQ-1984] Change taxon search query type to `match` and remove wildcards

### DIFF
--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -32,7 +32,7 @@ module ElasticsearchHelper
         query: {
           match: {
             "#{level}_name": {
-              query: "*#{query}*",
+              query: query,
               fuzziness: "auto",
               operator: "and",
             },

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -27,6 +27,9 @@ module ElasticsearchHelper
     matching_taxa = []
     taxon_ids = []
     tax_levels.each do |level|
+      # ElasticSearch `match` query matching multiple strings in a fuzzy way (supports a few typos based
+      # on the size of the query)according to the operator specified (`and` in this case).
+      # `match` is the query type recommended by ElasticSearch for full-text search.
       search_params = {
         size: ElasticsearchHelper::MAX_SEARCH_RESULTS,
         query: {

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -1,4 +1,9 @@
 module ElasticsearchHelper
+  # Limit maximum number of results for performance
+  # Since we currently might filter by sample and/or project only after the ElasticSearch,
+  # it should be large enough to avoid filtering everything out
+  # TODO(tiago): Eventually, this filtering should be moved to ElasticSearch, at which point we should reduce the max value
+  # (We can also move it to a parameter that clients of this functions can set)
   MAX_SEARCH_RESULTS = 50
 
   def prefix_match(model, field, prefix, condition)

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -49,6 +49,7 @@ module ElasticsearchHelper
       }
       search_response = TaxonLineage.search(search_params)
       search_taxon_ids = search_response.aggregations.distinct_taxa.buckets.pluck(:key)
+
       taxon_data = TaxonLineage
                    .where("#{level}_taxid" => search_taxon_ids)
                    .order(id: :desc)


### PR DESCRIPTION
# Description

* Changes the logic of taxon search to use a query by `match`. This type of query matches multiple strings in a fuzzy way according to the operator specified (`and` in this case). `match` is the query type recommended by ElasticSearch for full-text search.
* Level of fuzziness is automatic computed based on the size of the query string
* Previously, we were using the `query_string` query type. Together with the use of wildcards made the results hard to understand.

# Notes

* Jira: https://jira.czi.team/browse/IDSEQ-1984

# Tests

* Tested search suggestions and for several pathogens and the results seem more logical and easy to understand.
* Query "wuhan mosquito" returns: 
Before:
```
Wuhan tick virus 2
Wuhan ledantevirus
```
Now: 
```
Wuhan Mosquito Virus 9
Wuhan Mosquito Virus 6
Wuhan Mosquito Virus 4
Wuhan mosquito orthophasmavirus 2
Wuhan mosquito orthophasmavirus 1
Wuhan Mosquito Virus 8
```
