### PR TITLE
[IDSEQ-1452 - Data Discovery] Fix bug of having to click twice to select all rows

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryDataLayer.js
+++ b/app/assets/src/components/views/discovery/DiscoveryDataLayer.js
@@ -24,7 +24,16 @@ class ObjectCollection {
 class ObjectCollectionView {
   constructor(
     collection,
-    { conditions = {}, pageSize = 50, onViewChange = null }
+    {
+      // conditions: Extra conditions to use for this view.
+      // These will be sent to the apiFunction of the corresponding collection when requesting new data.
+      conditions = {},
+      // pageSize: Size of the page for this view.
+      pageSize = 50,
+      // callbacks to notify the client when changes occur
+      // onViewChange: triggered when the view finishes loading new object ids (the full list of ids in the view)
+      onViewChange = null,
+    }
   ) {
     this._orderedIds = null;
     this._loading = true;
@@ -118,6 +127,10 @@ class ObjectCollectionView {
         this._collection.entries[sample.id] = sample;
       });
 
+      // NOTE(tiago): we currently load the ids of ALL objects in the view. This allows using a simple solution to
+      // handle the select all options.
+      // It currently works with minimal performance impact, but might need to review in the future, as the number
+      // of objects in these views increases
       if (fetchedObjectIds) {
         this._orderedIds = fetchedObjectIds;
         this._onViewChange && this._onViewChange();

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -122,6 +122,7 @@ class DiscoveryView extends React.Component {
         sampleActiveColumns: undefined,
         sampleDimensions: [],
         search: null,
+        selectableSampleIds: [],
         selectedSampleIds: new Set(),
         showFilters: true,
         showStats: true,
@@ -132,7 +133,10 @@ class DiscoveryView extends React.Component {
     );
     this.dataLayer = new DiscoveryDataLayer(this.props.domain);
     const conditions = this.getConditions();
-    this.samples = this.dataLayer.samples.createView({ conditions });
+    this.samples = this.dataLayer.samples.createView({
+      conditions,
+      onViewChange: this.refreshSampleData,
+    });
     this.projects = this.dataLayer.projects.createView({
       conditions,
       onViewChange: this.refreshProjectData,
@@ -389,6 +393,12 @@ class DiscoveryView extends React.Component {
   refreshProjectData = () => {
     this.refreshProject();
     this.refreshProjectStats();
+  };
+
+  refreshSampleData = () => {
+    this.setState({
+      selectableSampleIds: this.samples.getIds(),
+    });
   };
 
   refreshFilteredDimensions = async () => {
@@ -962,6 +972,7 @@ class DiscoveryView extends React.Component {
       mapLocationData,
       mapPreviewedLocationId,
       sampleActiveColumns,
+      selectableSampleIds,
       selectedSampleIds,
       projectId,
     } = this.state;
@@ -1030,7 +1041,7 @@ class DiscoveryView extends React.Component {
                 projectId={projectId}
                 ref={samplesView => (this.samplesView = samplesView)}
                 samples={samples}
-                selectableIds={samples.getIds()}
+                selectableIds={selectableSampleIds}
                 selectedSampleIds={selectedSampleIds}
               />
             </div>
@@ -1199,19 +1210,18 @@ class DiscoveryView extends React.Component {
         <Divider style="medium" />
         <div className={cs.mainContainer}>
           <div className={cs.leftPane}>
-            {showFilters &&
-              dimensions && (
-                <DiscoveryFilters
-                  {...mapValues(
-                    dim => dim.values,
-                    keyBy("dimension", dimensions)
-                  )}
-                  {...filters}
-                  domain={domain}
-                  onFilterChange={this.handleFilterChange}
-                  allowedFeatures={allowedFeatures}
-                />
-              )}
+            {showFilters && dimensions && (
+              <DiscoveryFilters
+                {...mapValues(
+                  dim => dim.values,
+                  keyBy("dimension", dimensions)
+                )}
+                {...filters}
+                domain={domain}
+                onFilterChange={this.handleFilterChange}
+                allowedFeatures={allowedFeatures}
+              />
+            )}
           </div>
           <div className={cs.centerPane}>
             {currentDisplay === "map" &&


### PR DESCRIPTION
## Description

* The samples view was not being re-rendered once the all the ids for a specific view (in this case sample view) were fetched. Thus the first click on the select all checkbox would not work properly.
* Fixed by using the callback for view changes and forcing the re-render through a state variable.
* Jira: https://jira.czi.team/browse/IDSEQ-1452 
* Also added a few more comments to discovery data layer parameters.

## Example

![Jan-10-2020 09-17-10](https://user-images.githubusercontent.com/37312125/72172443-032cea00-338a-11ea-8d0b-a1b1a37bd5fe.gif)

## Tests

* Open a samples view
* Click select all checkbox
* Verify that all 