### PR TITLE
touch NT and NR before deleting LRU references

### DIFF
--- a/app/lib/dags/experimental.json.jbuilder
+++ b/app/lib/dags/experimental.json.jbuilder
@@ -92,6 +92,7 @@ json.steps do
     module: "idseq_dag.steps.generate_alignment_viz",
     additional_files: {
       nt_loc_db: attr[:nt_loc_db],
+      nt_db: attr[:nt_db],
     },
     additional_attributes: {
       nt_db: attr[:nt_db],

--- a/app/lib/dags/postprocess.json.jbuilder
+++ b/app/lib/dags/postprocess.json.jbuilder
@@ -100,6 +100,7 @@ json.steps do
     additional_files: {
       lineage_db: attr[:lineage_db],
       loc_db: attr[:nt_loc_db],
+      db: attr[:nt_db],
     },
     additional_attributes: {
       db: attr[:nt_db],
@@ -115,6 +116,7 @@ json.steps do
     additional_files: {
       lineage_db: attr[:lineage_db],
       loc_db: attr[:nr_loc_db],
+      db: attr[:nr_db],
     },
     additional_attributes: {
       db: attr[:nr_db],


### PR DESCRIPTION
Listing the huge NT and NR databases as "additional_files" makes sure the DAG engine prefetches them like all other big files, but more importantly, ensure they are not deleted by the LRU reference caching policy at the start of the postprocessing or experimental stages that use them.

This is a companion to https://github.com/chanzuckerberg/idseq-dag/pull/240 and the two can go out in any order.

For more details see https://jira.czi.team/browse/IDSEQ-1866