### PR TITLE
Ensure collection date metadata for humans returned as month-only.

### DIFF
--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -85,7 +85,7 @@ class PhyloTreesController < ApplicationController
 
     nodes = {}
     # populate metadata for sample nodes
-    metadata_by_sample_id = Metadatum.by_sample_ids(@phylo_tree.pipeline_runs.pluck(:sample_id).uniq)
+    metadata_by_sample_id = Metadatum.by_sample_ids(@phylo_tree.pipeline_runs.pluck(:sample_id).uniq, use_raw_date_strings: true)
     @phylo_tree.pipeline_runs
                .joins(:sample, sample: [:project, :host_genome])
                .select("pipeline_runs.id, samples.id as sample_id," \
@@ -278,7 +278,7 @@ class PhyloTreesController < ApplicationController
     # because the taxon_counts table is large.
     taxon_counts = TaxonCount.where(pipeline_run_id: pipeline_run_ids).where(tax_id: taxid).index_by { |tc| "#{tc.pipeline_run_id},#{tc.count_type}" }
 
-    metadata_by_sample_id = Metadatum.by_sample_ids(samples_projects.pluck("sample_id"))
+    metadata_by_sample_id = Metadatum.by_sample_ids(samples_projects.pluck("sample_id"), use_raw_date_strings: true)
 
     samples_projects.each do |sp|
       sp["taxid_reads"] ||= {}

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -346,7 +346,7 @@ module SamplesHelper
   end
 
   def format_samples_basic(samples)
-    metadata_by_sample_id = Metadatum.by_sample_ids(samples.map(&:id))
+    metadata_by_sample_id = Metadatum.by_sample_ids(samples.map(&:id), use_raw_date_strings: true)
     return samples.map do |sample|
       {
         name: sample.name,
@@ -369,7 +369,7 @@ module SamplesHelper
     report_ready_pipeline_run_ids = report_ready_multiget(pipeline_run_ids)
     pipeline_run_stages_by_pipeline_run_id = dependent_records_multiget(PipelineRunStage, :pipeline_run_id, pipeline_run_ids)
     output_states_by_pipeline_run_id = dependent_records_multiget(OutputState, :pipeline_run_id, pipeline_run_ids)
-    metadata_by_sample_id = Metadatum.by_sample_ids(sample_ids)
+    metadata_by_sample_id = Metadatum.by_sample_ids(sample_ids, use_raw_date_strings: true)
 
     # Massage data into the right format
     samples.includes(:pipeline_runs, :host_genome, :project, :input_files, :user).each_with_index do |sample|

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -325,10 +325,7 @@ class Metadatum < ApplicationRecord
           sample_metadata.map do |m|
             # When fetching metadata for a human sample for displaying on the front-end, we want 2001-01 for dates, not 2001-01-01.
             # date_validated_value is a Date object and will show the day when converted to a string. We use the original raw_value string instead.
-            Rails.logger.info("#{m.metadata_field.base_type} #{MetadataField::DATE_TYPE}")
-
             if m.metadata_field.base_type == MetadataField::DATE_TYPE && use_raw_date_strings
-              Rails.logger.info("GOT IT #{m.raw_value}")
               [m.key.to_sym, m.raw_value]
             else
               [m.key.to_sym, m.validated_value]

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -313,12 +313,28 @@ class Metadatum < ApplicationRecord
     end
   end
 
-  def self.by_sample_ids(sample_ids)
+  # use_raw_date_strings is used to show 2001-01 instead of 2001-01-01 for human samples.
+  # when use_raw_date_string is used, date-type metadata will be returned as strings instead of Date objects.
+  def self.by_sample_ids(sample_ids, use_raw_date_strings: false)
     includes(:metadata_field, :location)
       .where(sample_id: sample_ids)
       .group_by(&:sample_id)
       .map do |sample_id, sample_metadata|
-        [sample_id, Hash[sample_metadata.map { |m| [m.key.to_sym, m.validated_value] }]]
+        [
+          sample_id,
+          sample_metadata.map do |m|
+            # When fetching metadata for a human sample for displaying on the front-end, we want 2001-01 for dates, not 2001-01-01.
+            # date_validated_value is a Date object and will show the day when converted to a string. We use the original raw_value string instead.
+            Rails.logger.info("#{m.metadata_field.base_type} #{MetadataField::DATE_TYPE}")
+
+            if m.metadata_field.base_type == MetadataField::DATE_TYPE && use_raw_date_strings
+              Rails.logger.info("GOT IT #{m.raw_value}")
+              [m.key.to_sym, m.raw_value]
+            else
+              [m.key.to_sym, m.validated_value]
+            end
+          end.to_h,
+        ]
       end.to_h
   end
 end

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -361,6 +361,45 @@ RSpec.describe SamplesController, type: :controller do
                                               ])
       end
     end
+
+    describe "#index" do
+      it "returns basic samples with correctly formatted date" do
+        project = create(:project, users: [@joe])
+        create(:sample, name: "Mosquito Sample", project: project, user: @joe, host_genome_name: "Mosquito", metadata_fields: { collection_date: "2019-01-01" })
+
+        get :index, params: { project_id: project.id, basic: true }
+        json_response = JSON.parse(response.body)
+        print(json_response)
+        expect(json_response.length).to eq(1)
+        expect(json_response).to include_json([
+                                                {
+                                                  "name" => "Mosquito Sample",
+                                                  "metadata" => {
+                                                    "collection_date" => "2019-01-01",
+                                                  },
+                                                },
+
+                                              ])
+      end
+
+      it "for human samples, truncates date metadata to month" do
+        project = create(:project, users: [@joe])
+        create(:sample, name: "Human Sample", project: project, user: @joe, host_genome_name: "Human", metadata_fields: { collection_date: "2019-01" })
+
+        get :index, params: { project_id: project.id, basic: true }
+        json_response = JSON.parse(response.body)
+        print(json_response)
+        expect(json_response.length).to eq(1)
+        expect(json_response).to include_json([
+                                                {
+                                                  "name" => "Human Sample",
+                                                  "metadata" => {
+                                                    "collection_date" => "2019-01",
+                                                  },
+                                                },
+                                              ])
+      end
+    end
   end
 
   describe "POST #uploaded_by_current_user" do


### PR DESCRIPTION
# Description

Before:
![Screen Shot 2020-01-13 at 3 49 05 PM](https://user-images.githubusercontent.com/837004/72301866-0c81b500-361d-11ea-9739-b5ae608fd09b.png)

After:
![image](https://user-images.githubusercontent.com/837004/72301864-08559780-361d-11ea-8283-6e3d79fe2730.png)

# Notes

* Previously, the metadata was returned as a Date, which was then coerced into a string when returned as JSON. However, when Dates are coerced to strings, the day is always included.
* `Metadatum.by_sample_ids` now returns strings instead of Dates, which can be unexpected. I gated this behavior on a flag `use_raw_date_strings`. Every place where this function is currently used then passes the metadata back to the front-end, but conceivably the function could have other uses in the future.

# Tests

* Updated tests.
* Verified that the front-end receives the expected data.