### PR TITLE
[Report page] [Bug] Make species names lowercase

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/report_table.scss
+++ b/app/assets/src/components/views/SampleViewV2/report_table.scss
@@ -91,7 +91,6 @@
 
   .taxonContainer {
     .taxonName {
-      text-transform: capitalize;
       white-space: normal;
       &:hover {
         cursor: pointer;
@@ -118,15 +117,15 @@
   }
 }
 
+.taxonContainer::first-letter {
+  text-transform: uppercase;
+}
+
 .speciesRow {
   .nameCell {
     font-weight: $font-weight-regular;
     margin-left: $space-s;
     margin-right: $space-xxxs;
-
-    .taxonName {
-      text-transform: none;
-    }
   }
 }
 

--- a/app/assets/src/components/views/SampleViewV2/report_table.scss
+++ b/app/assets/src/components/views/SampleViewV2/report_table.scss
@@ -123,6 +123,10 @@
     font-weight: $font-weight-regular;
     margin-left: $space-s;
     margin-right: $space-xxxs;
+
+    .taxonName {
+      text-transform: none;
+    }
   }
 }
 


### PR DESCRIPTION
# Description

As per IDSEQ-2074, genus names should be uppercase and species names should be lowercase, but all taxon names were capitalized on the new report page.
![image](https://user-images.githubusercontent.com/53838890/72368881-c0358400-36b3-11ea-88eb-3d215a070673.png)

# Notes
`text-transform: capitalize` is applied on taxonNames by default to ensure genus rows are capitalized properly, which is then overridden with `text-transform: none` for species rows.

# Tests

* Verified that species names are in lowercase.