### PR TITLE
IDSEQ-2078 - [Release Fix] Auth0 management client token expiration

### DIFF
--- a/app/helpers/auth0_user_management_helper.rb
+++ b/app/helpers/auth0_user_management_helper.rb
@@ -92,12 +92,15 @@ module Auth0UserManagementHelper
 
   # Set up Auth0 management client for actions like adding users.
   def self.auth0_management_client
-    # See: https://github.com/auth0/ruby-auth0/blob/master/README.md#management-api-v2
-    @auth0_management_client ||= Auth0Client.new(
-      client_id: ENV["AUTH0_MANAGEMENT_CLIENT_ID"],
-      client_secret: ENV["AUTH0_MANAGEMENT_CLIENT_SECRET"],
-      domain: ENV["AUTH0_MANAGEMENT_DOMAIN"],
-      api_version: 2
-    )
+    @auth0_management_client_cache ||= ActiveSupport::Cache::MemoryStore.new(expires_in: 1.hour)
+    @auth0_management_client_cache.fetch('management_client', race_condition_ttl: 10.seconds) do
+      # See: https://github.com/auth0/ruby-auth0/blob/master/README.md#management-api-v2
+      Auth0Client.new(
+        client_id: ENV["AUTH0_MANAGEMENT_CLIENT_ID"],
+        client_secret: ENV["AUTH0_MANAGEMENT_CLIENT_SECRET"],
+        domain: ENV["AUTH0_MANAGEMENT_DOMAIN"],
+        api_version: 2
+      )
+    end
   end
 end


### PR DESCRIPTION
# Description

Auth0 management API tokens expire every 24 hours, and it seems Auth0 Management Client ruby library doesn't handle token refreshes.

This PR is adding an TTL expiration logic to the memoization pattern.

# Tests

* Manual
* Automated tests all-passed