### PR TITLE
Change sample row click behavior

### DIFF
--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -657,6 +657,7 @@ class DiscoveryView extends React.Component {
     );
   };
 
+  // TODO (gdingle): fix me
   handleSampleSelected = ({ sample, currentEvent }) => {
     openUrl(`/samples/${sample.id}`, currentEvent);
   };
@@ -1210,18 +1211,19 @@ class DiscoveryView extends React.Component {
         <Divider style="medium" />
         <div className={cs.mainContainer}>
           <div className={cs.leftPane}>
-            {showFilters && dimensions && (
-              <DiscoveryFilters
-                {...mapValues(
-                  dim => dim.values,
-                  keyBy("dimension", dimensions)
-                )}
-                {...filters}
-                domain={domain}
-                onFilterChange={this.handleFilterChange}
-                allowedFeatures={allowedFeatures}
-              />
-            )}
+            {showFilters &&
+              dimensions && (
+                <DiscoveryFilters
+                  {...mapValues(
+                    dim => dim.values,
+                    keyBy("dimension", dimensions)
+                  )}
+                  {...filters}
+                  domain={domain}
+                  onFilterChange={this.handleFilterChange}
+                  allowedFeatures={allowedFeatures}
+                />
+              )}
           </div>
           <div className={cs.centerPane}>
             {currentDisplay === "map" &&

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -657,7 +657,6 @@ class DiscoveryView extends React.Component {
     );
   };
 
-  // TODO (gdingle): fix me
   handleSampleSelected = ({ sample, currentEvent }) => {
     openUrl(`/samples/${sample.id}`, currentEvent);
   };
@@ -1037,7 +1036,6 @@ class DiscoveryView extends React.Component {
                 onMapLevelChange={this.handleMapLevelChange}
                 onMapMarkerClick={this.handleMapMarkerClick}
                 onMapTooltipTitleClick={this.handleMapTooltipTitleClick}
-                onSampleSelected={this.handleSampleSelected}
                 onSelectedSamplesUpdate={this.handleSelectedSamplesUpdate}
                 projectId={projectId}
                 ref={samplesView => (this.samplesView = samplesView)}

--- a/app/assets/src/components/views/discovery/TableRenderers.jsx
+++ b/app/assets/src/components/views/discovery/TableRenderers.jsx
@@ -3,6 +3,8 @@ import React from "react";
 import cx from "classnames";
 import moment from "moment";
 
+import { logAnalyticsEvent } from "~/api/analytics";
+import { openUrl } from "~utils/links";
 import BasicPopup from "~/components/BasicPopup";
 import SamplePublicIcon from "~ui/icons/SamplePublicIcon";
 import SamplePrivateIcon from "~ui/icons/SamplePrivateIcon";
@@ -106,7 +108,16 @@ class TableRenderers extends React.Component {
         )}
         <div className={cs.sampleRightPane}>
           {sample ? (
-            <div className={cs.sampleNameAndStatus}>
+            <div
+              className={cs.sampleNameAndStatus}
+              onClick={event => {
+                openUrl(`/samples/${sample.id}`, event);
+                logAnalyticsEvent("TableRenderers_sample-name_clicked", {
+                  sampleId: sample.id,
+                  sampleName: sample.name,
+                });
+              }}
+            >
               <BasicPopup
                 trigger={<div className={cs.sampleName}>{sample.name}</div>}
                 content={sample.name}

--- a/app/assets/src/components/views/discovery/TableRenderers.jsx
+++ b/app/assets/src/components/views/discovery/TableRenderers.jsx
@@ -106,18 +106,19 @@ class TableRenderers extends React.Component {
               ))}
           </div>
         )}
-        <div className={cs.sampleRightPane}>
+        <div
+          className={cs.sampleRightPane}
+          onClick={event => {
+            event.stopPropagation(); // prevent handleRowClick
+            openUrl(`/samples/${sample.id}`, event);
+            logAnalyticsEvent("TableRenderers_sample-name_clicked", {
+              sampleId: sample.id,
+              sampleName: sample.name,
+            });
+          }}
+        >
           {sample ? (
-            <div
-              className={cs.sampleNameAndStatus}
-              onClick={event => {
-                openUrl(`/samples/${sample.id}`, event);
-                logAnalyticsEvent("TableRenderers_sample-name_clicked", {
-                  sampleId: sample.id,
-                  sampleName: sample.name,
-                });
-              }}
-            >
+            <div className={cs.sampleNameAndStatus}>
               <BasicPopup
                 trigger={<div className={cs.sampleName}>{sample.name}</div>}
                 content={sample.name}

--- a/app/assets/src/components/views/discovery/discovery_api.js
+++ b/app/assets/src/components/views/discovery/discovery_api.js
@@ -52,6 +52,7 @@ const getDiscoveryStats = async ({ domain, filters, projectId, search }) => {
 const processRawSample = sample => {
   const row = {
     sample: {
+      id: sample.id,
       name: sample.name,
       project: get("derived_sample_output.project_name", sample.details),
       publicAccess: !!sample.public,

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -496,6 +496,7 @@ class SamplesView extends React.Component {
   };
 
   handleRowClick = ({ event, rowData }) => {
+    // TODO (gdingle): change me to select checkbox
     const { onSampleSelected, samples } = this.props;
     const sample = samples.get(rowData.id);
     onSampleSelected && onSampleSelected({ sample, currentEvent: event });

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -496,10 +496,14 @@ class SamplesView extends React.Component {
   };
 
   handleRowClick = ({ event, rowData }) => {
-    // TODO (gdingle): change me to select checkbox
-    const { onSampleSelected, samples } = this.props;
+    const { onSampleSelected, samples, selectedSampleIds } = this.props;
     const sample = samples.get(rowData.id);
-    onSampleSelected && onSampleSelected({ sample, currentEvent: event });
+    if (onSampleSelected) {
+      onSampleSelected({ sample, currentEvent: event });
+    } else {
+      // Default to selecting the row
+      this.handleSelectRow(sample.id, !selectedSampleIds.has(sample.id));
+    }
     logAnalyticsEvent("SamplesView_row_clicked", {
       sampleId: sample.id,
       sampleName: sample.name,


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/28797/72464823-e0844200-378a-11ea-9556-cb804385faea.png)

The current behavior is seriously annoying me and others because missing a checkbox opens the sample page and resets all checkboxes. The screenshot above shows the new target area. The rest of the row now selects the checkbox, which is easy to undo if unintentional. 

# Notes

* I did not try to fix the current bug where click drag selecting text causes `handleRowClick` to fire
* The meaning of our row click stats will change

# Tests

* Click on new target area, see sample page open
* Click on row, see checkbox