### PR TITLE
Make sample open in new tab from heatmap

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -5,7 +5,7 @@ import { size, map, keyBy, isEmpty } from "lodash/fp";
 
 import { withAnalytics, logAnalyticsEvent } from "~/api/analytics";
 import { DataTooltip } from "~ui/containers";
-import { openUrl } from "~utils/links";
+import { openUrlInNewTab } from "~utils/links";
 import Heatmap from "~/components/visualizations/heatmap/Heatmap";
 import { getTooltipStyle } from "~/components/utils/tooltip";
 import MetadataLegend from "~/components/common/Heatmap/MetadataLegend";
@@ -350,7 +350,7 @@ class SamplesHeatmapVis extends React.Component {
     // Disable cell click if spacebar is pressed to pan the heatmap.
     if (!this.state.spacePressed) {
       const sampleId = this.props.sampleIds[cell.columnIndex];
-      openUrl(`/samples/${sampleId}`, currentEvent);
+      openUrlInNewTab(`/samples/${sampleId}`, currentEvent);
       logAnalyticsEvent("SamplesHeatmapVis_cell_clicked", {
         sampleId,
       });


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/28797/72466014-001c6a00-378d-11ea-8c14-7d3f54c4d4c3.png)

The current behavior was annoying because of the "are you sure you want to leave?" message. That is not triggered when opening in a new tab. Also, it seems like a user would typically want to compare the sample info with the heatmap and not go back and reload the entire heatmap. 

# Tests

* click on a square and see new tab without message