### PR TITLE
New host organism info message on review step

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { keys, countBy, groupBy } from "lodash/fp";
+import { keys, countBy, groupBy, mapValues, keyBy, map } from "lodash/fp";
 
 const MATCH = "MATCH";
 const NO_MATCH = "NO_MATCH";
@@ -11,12 +11,14 @@ const NO_MATCH = "NO_MATCH";
  */
 export default class HostOrganismMessage extends React.Component {
   static propTypes = {
-    allHostOrganisms: PropTypes.arrayOf(PropTypes.string).isRequired,
-    selectedHostOrganisms: PropTypes.arrayOf(PropTypes.string).isRequired,
+    samples: PropTypes.arrayOf(
+      PropTypes.shape({ host_genome_id: PropTypes.number })
+    ).isRequired,
+    hostGenomes: PropTypes.arrayOf(PropTypes.HostGenome).isRequired,
   };
 
   hasMatch(host) {
-    return this.props.allHostOrganisms.includes(host);
+    return map("name", this.props.hostGenomes).includes(host);
   }
 
   renderOneHost(host) {
@@ -32,11 +34,18 @@ export default class HostOrganismMessage extends React.Component {
       keys(uniqHosts)
     );
     // TODO (gdingle): more display after final designs
-    return <div>{JSON.stringify(grouped)}</div>;
+    // TODO (gdingle): need to get the counts back from uniqHosts
+    return JSON.stringify(grouped);
+  }
+
+  // TODO (gdingle): need to think about new plain text hosts
+  getSelectedHostOrganisms() {
+    const idToName = mapValues("name", keyBy("id", this.props.hostGenomes));
+    return this.props.samples.map(sample => idToName[sample.host_genome_id]);
   }
 
   render() {
-    const uniqHosts = countBy(this.props.selectedHostOrganisms);
+    const uniqHosts = countBy(null, this.getSelectedHostOrganisms());
     const length = keys(uniqHosts).length;
     if (length === 0) {
       return null;

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -34,10 +34,12 @@ export default class HostOrganismMessage extends React.Component {
     // TODO (gdingle): strong classname
     return (
       <span>
-        For the
-        <strong>{count} samples</strong>
-        that you indicated as a
-        <strong>{host}</strong> Host Organism,
+        {" "}
+        For the{" "}
+        <strong>
+          {count} sample{count > 1 ? "s" : ""}
+        </strong>{" "}
+        that you indicated as a <strong>{host}</strong> Host Organism,{" "}
         {this.hasMatch(host) ? (
           <span>
             we will subtract out a <strong>{host}</strong> genome.

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -1,9 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { keys, countBy, groupBy, mapValues, keyBy, map } from "lodash/fp";
+import { keys, countBy, mapValues, keyBy, map } from "lodash/fp";
 
-const MATCH = "MATCH";
-const NO_MATCH = "NO_MATCH";
+import cs from "./host_organism_message.scss";
 
 /**
  * Shows a message depending on whether the selected host matches a
@@ -25,7 +24,7 @@ export default class HostOrganismMessage extends React.Component {
   renderOneHost(host, count) {
     // TODO (gdingle): global style
     return (
-      <div style={{ margin: "10px" }}>
+      <div className={cs.messageContainer}>
         We will be subtracting a host during data processing.
         {this.renderTextLine(host, count)}
       </div>
@@ -54,22 +53,14 @@ export default class HostOrganismMessage extends React.Component {
   }
 
   renderManyHosts(uniqHosts) {
-    // TODO (gdingle): condense NO_MATCH into one line?
-    // const grouped = groupBy(
-    //   host => (this.hasMatch(host) ? MATCH : NO_MATCH),
-    //   keys(uniqHosts)
-    // );
-    // grouped.MATCH
-    // grouped.NO_MATCH
-
     return (
       // TODO (gdingle): global style
-      <div style={{ margin: "10px" }}>
+      <div className={cs.messageContainer}>
         We will be subtracting a host during data processing. Based on your
         selections for Host Organism, we will be subtracting the following
         hosts:
         {keys(uniqHosts).map(host => (
-          <div key={host} style={{ margin: "10px" }}>
+          <div key={host} className={cs.messageLine}>
             {this.renderTextLine(host, uniqHosts[host])}
           </div>
         ))}
@@ -77,7 +68,6 @@ export default class HostOrganismMessage extends React.Component {
     );
   }
 
-  // TODO (gdingle): need to think about new plain text hosts
   getSelectedHostOrganisms() {
     const idToName = mapValues("name", keyBy("id", this.props.hostGenomes));
     return this.props.samples.map(sample => idToName[sample.host_genome_id]);

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -14,6 +14,7 @@ export default class HostOrganismMessage extends React.Component {
     samples: PropTypes.arrayOf(
       PropTypes.shape({ host_genome_id: PropTypes.number })
     ).isRequired,
+    // TODO (gdingle): Failed prop type: Property `hostGenomes` of component `HostOrganismMessage` has invalid PropType notation inside arrayOf.
     hostGenomes: PropTypes.arrayOf(PropTypes.HostGenome).isRequired,
   };
 
@@ -22,8 +23,9 @@ export default class HostOrganismMessage extends React.Component {
   }
 
   renderOneHost(host, count) {
+    // TODO (gdingle): global style
     return (
-      <div>
+      <div style={{ margin: "10px" }}>
         We will be subtracting a host during data processing.
         {this.renderTextLine(host, count)}
       </div>
@@ -61,12 +63,17 @@ export default class HostOrganismMessage extends React.Component {
     // grouped.NO_MATCH
 
     return (
-      <div>
+      // TODO (gdingle): global style
+      <div style={{ margin: "10px" }}>
         We will be subtracting a host during data processing. Based on your
         selections for Host Organism, we will be subtracting the following
         hosts:
         {map(
-          (host, count) => <div>{this.renderTextLine(host, count)}</div>,
+          (count, host) => (
+            <div key={host} style={{ margin: "10px" }}>
+              {this.renderTextLine(host, count)}
+            </div>
+          ),
           uniqHosts
         )}
       </div>

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -13,7 +13,6 @@ export default class HostOrganismMessage extends React.Component {
     samples: PropTypes.arrayOf(
       PropTypes.shape({ host_genome_id: PropTypes.number })
     ).isRequired,
-    // TODO (gdingle): Failed prop type: Property `hostGenomes` of component `HostOrganismMessage` has invalid PropType notation inside arrayOf.
     hostGenomes: PropTypes.arrayOf(PropTypes.HostGenome).isRequired,
   };
 
@@ -22,7 +21,6 @@ export default class HostOrganismMessage extends React.Component {
   }
 
   renderOneHost(host, count) {
-    // TODO (gdingle): global style
     return (
       <div className={cs.messageContainer}>
         We will be subtracting a host during data processing.
@@ -32,7 +30,6 @@ export default class HostOrganismMessage extends React.Component {
   }
 
   renderTextLine(host, count) {
-    // TODO (gdingle): strong classname
     return (
       <span>
         {" "}
@@ -54,7 +51,6 @@ export default class HostOrganismMessage extends React.Component {
 
   renderManyHosts(uniqHosts) {
     return (
-      // TODO (gdingle): global style
       <div className={cs.messageContainer}>
         We will be subtracting a host during data processing. Based on your
         selections for Host Organism, we will be subtracting the following

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { keys, countBy, groupBy } from "lodash/fp";
 
+const MATCH = "MATCH";
 const NO_MATCH = "NO_MATCH";
 
 /**
@@ -14,36 +15,28 @@ export default class HostOrganismMessage extends React.Component {
     selectedHostOrganisms: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
+  hasMatch(host) {
+    return this.props.allHostOrganisms.includes(host);
+  }
+
   renderOneHost(host) {
-    if (this.props.allHostOrganisms.includes(host)) {
+    if (this.hasMatch(host)) {
       return "one host, match";
     }
     return "one host, no match";
   }
 
-  renderManyHost(uniqHosts) {
-    const getMatchingHost = uniqHost =>
-      this.props.allHostOrganisms.includes(uniqHost) ? uniqHost : NO_MATCH;
-    const grouped = groupBy(getMatchingHost, keys(uniqHosts));
-    return (
-      <div>
-        {keys(grouped).map(key => {
-          const count = uniqHosts[key];
-          if (key === NO_MATCH) {
-            return count + " hosts, NO_MATCH";
-          } else {
-            // TODO (gdingle): need to do frequency counts!!!
-            return count + " matches of host" + key;
-          }
-        })}
-      </div>
+  renderManyHosts(uniqHosts) {
+    const grouped = groupBy(
+      host => (this.hasMatch(host) ? MATCH : NO_MATCH),
+      keys(uniqHosts)
     );
+    // TODO (gdingle): more display after final designs
+    return <div>{JSON.stringify(grouped)}</div>;
   }
 
   render() {
-    const { selectedHostOrganisms } = this.props;
-    // TODO (gdingle): need to do frequency counts here!!!
-    const uniqHosts = countBy(selectedHostOrganisms);
+    const uniqHosts = countBy(this.props.selectedHostOrganisms);
     const length = keys(uniqHosts).length;
     if (length === 0) {
       return null;
@@ -51,6 +44,6 @@ export default class HostOrganismMessage extends React.Component {
     if (length === 1) {
       return this.renderOneHost(keys(uniqHosts)[0]);
     }
-    return this.renderManyHost(uniqHosts);
+    return this.renderManyHosts(uniqHosts);
   }
 }

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { keys, countBy, groupBy } from "lodash/fp";
+
+const NO_MATCH = "NO_MATCH";
+
+/**
+ * Shows a message depending on whether the selected host matches a
+ * IDseq-supported host.
+ */
+export default class HostOrganismMessage extends React.Component {
+  static propTypes = {
+    allHostOrganisms: PropTypes.arrayOf(PropTypes.string).isRequired,
+    selectedHostOrganisms: PropTypes.arrayOf(PropTypes.string).isRequired,
+  };
+
+  renderOneHost(host) {
+    if (this.props.allHostOrganisms.includes(host)) {
+      return "one host, match";
+    }
+    return "one host, no match";
+  }
+
+  renderManyHost(uniqHosts) {
+    const getMatchingHost = uniqHost =>
+      this.props.allHostOrganisms.includes(uniqHost) ? uniqHost : NO_MATCH;
+    const grouped = groupBy(getMatchingHost, keys(uniqHosts));
+    return (
+      <div>
+        {keys(grouped).map(key => {
+          const count = uniqHosts[key];
+          if (key === NO_MATCH) {
+            return count + " hosts, NO_MATCH";
+          } else {
+            // TODO (gdingle): need to do frequency counts!!!
+            return count + " matches of host" + key;
+          }
+        })}
+      </div>
+    );
+  }
+
+  render() {
+    const { selectedHostOrganisms } = this.props;
+    // TODO (gdingle): need to do frequency counts here!!!
+    const uniqHosts = countBy(selectedHostOrganisms);
+    const length = keys(uniqHosts).length;
+    if (length === 0) {
+      return null;
+    }
+    if (length === 1) {
+      return this.renderOneHost(keys(uniqHosts)[0]);
+    }
+    return this.renderManyHost(uniqHosts);
+  }
+}

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -68,14 +68,11 @@ export default class HostOrganismMessage extends React.Component {
         We will be subtracting a host during data processing. Based on your
         selections for Host Organism, we will be subtracting the following
         hosts:
-        {map(
-          (count, host) => (
-            <div key={host} style={{ margin: "10px" }}>
-              {this.renderTextLine(host, count)}
-            </div>
-          ),
-          uniqHosts
-        )}
+        {keys(uniqHosts).map(host => (
+          <div key={host} style={{ margin: "10px" }}>
+            {this.renderTextLine(host, uniqHosts[host])}
+          </div>
+        ))}
       </div>
     );
   }

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -21,21 +21,54 @@ export default class HostOrganismMessage extends React.Component {
     return map("name", this.props.hostGenomes).includes(host);
   }
 
-  renderOneHost(host) {
-    if (this.hasMatch(host)) {
-      return "one host, match";
-    }
-    return "one host, no match";
+  renderOneHost(host, count) {
+    return (
+      <div>
+        We will be subtracting a host during data processing.
+        {this.renderTextLine(host, count)}
+      </div>
+    );
+  }
+
+  renderTextLine(host, count) {
+    // TODO (gdingle): strong classname
+    return (
+      <span>
+        For the
+        <strong>{count} samples</strong>
+        that you indicated as a
+        <strong>{host}</strong> Host Organism,
+        {this.hasMatch(host) ? (
+          <span>
+            we will subtract out a <strong>{host}</strong> genome.
+          </span>
+        ) : (
+          <span>we will only remove ERCCs.</span>
+        )}
+      </span>
+    );
   }
 
   renderManyHosts(uniqHosts) {
-    const grouped = groupBy(
-      host => (this.hasMatch(host) ? MATCH : NO_MATCH),
-      keys(uniqHosts)
+    // TODO (gdingle): condense NO_MATCH into one line?
+    // const grouped = groupBy(
+    //   host => (this.hasMatch(host) ? MATCH : NO_MATCH),
+    //   keys(uniqHosts)
+    // );
+    // grouped.MATCH
+    // grouped.NO_MATCH
+
+    return (
+      <div>
+        We will be subtracting a host during data processing. Based on your
+        selections for Host Organism, we will be subtracting the following
+        hosts:
+        {map(
+          (host, count) => <div>{this.renderTextLine(host, count)}</div>,
+          uniqHosts
+        )}
+      </div>
     );
-    // TODO (gdingle): more display after final designs
-    // TODO (gdingle): need to get the counts back from uniqHosts
-    return JSON.stringify(grouped);
   }
 
   // TODO (gdingle): need to think about new plain text hosts
@@ -51,7 +84,8 @@ export default class HostOrganismMessage extends React.Component {
       return null;
     }
     if (length === 1) {
-      return this.renderOneHost(keys(uniqHosts)[0]);
+      const host = keys(uniqHosts)[0];
+      return this.renderOneHost(host, uniqHosts[host]);
     }
     return this.renderManyHosts(uniqHosts);
   }

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -194,6 +194,7 @@ class ReviewStep extends React.Component {
       samples,
       metadata,
       project,
+      hostGenomes,
     } = this.props;
 
     const shouldTruncateDescription =
@@ -312,10 +313,7 @@ class ReviewStep extends React.Component {
           </div>
         </div>
         <div className={cs.controls}>
-          <HostOrganismMessage
-            allHostOrganisms={["a", "b"]}
-            selectedHostOrganisms={["b"]}
-          />
+          <HostOrganismMessage hostGenomes={hostGenomes} samples={samples} />
           <TermsAgreement
             checked={this.state.consentChecked}
             onChange={() =>

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -14,12 +14,13 @@ import {
 import { getProjectMetadataFields } from "~/api/metadata";
 import DataTable from "~/components/visualizations/table/DataTable";
 import PropTypes from "~/components/utils/propTypes";
+import { formatFileSize } from "~/components/utils/format";
+import { UserContext } from "~/components/common/UserContext";
 import PrimaryButton from "~/components/ui/controls/buttons/PrimaryButton";
 import TermsAgreement from "~ui/controls/TermsAgreement";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import PublicProjectIcon from "~ui/icons/PublicProjectIcon";
 import PrivateProjectIcon from "~ui/icons/PrivateProjectIcon";
-import { formatFileSize } from "~/components/utils/format";
 
 import cs from "./sample_upload_flow.scss";
 import UploadProgressModal from "./UploadProgressModal";
@@ -199,7 +200,6 @@ class ReviewStep extends React.Component {
 
     const shouldTruncateDescription =
       project.description && this.countNewLines(project.description) > 5;
-
     return (
       <div
         className={cx(
@@ -313,7 +313,9 @@ class ReviewStep extends React.Component {
           </div>
         </div>
         <div className={cs.controls}>
-          <HostOrganismMessage hostGenomes={hostGenomes} samples={samples} />
+          {this.context.admin && (
+            <HostOrganismMessage hostGenomes={hostGenomes} samples={samples} />
+          )}
           <TermsAgreement
             checked={this.state.consentChecked}
             onChange={() =>
@@ -390,5 +392,7 @@ ReviewStep.propTypes = {
   onStepSelect: PropTypes.func,
   onUploadComplete: PropTypes.func.isRequired,
 };
+
+ReviewStep.contextType = UserContext;
 
 export default ReviewStep;

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -311,6 +311,7 @@ class ReviewStep extends React.Component {
           </div>
         </div>
         <div className={cs.controls}>
+          TODO (gdingle): hellow
           <TermsAgreement
             checked={this.state.consentChecked}
             onChange={() =>

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -23,6 +23,7 @@ import { formatFileSize } from "~/components/utils/format";
 
 import cs from "./sample_upload_flow.scss";
 import UploadProgressModal from "./UploadProgressModal";
+import HostOrganismMessage from "./HostOrganismMessage";
 
 const processMetadataRows = metadataRows =>
   flow(
@@ -311,7 +312,10 @@ class ReviewStep extends React.Component {
           </div>
         </div>
         <div className={cs.controls}>
-          TODO (gdingle): hellow
+          <HostOrganismMessage
+            allHostOrganisms={["a", "b"]}
+            selectedHostOrganisms={["b"]}
+          />
           <TermsAgreement
             checked={this.state.consentChecked}
             onChange={() =>

--- a/app/assets/src/components/views/SampleUploadFlow/host_organism_message.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/host_organism_message.scss
@@ -1,0 +1,26 @@
+@import "~styles/themes/elements";
+@import "~styles/themes/colors";
+@import "~styles/themes/typography";
+
+.messageContainer {
+  margin: $space-s 0;
+  padding: $space-s;
+  background-color: $info-bg;
+
+  strong {
+    font-weight: $font-weight-bold;
+  }
+}
+
+.messageLine {
+  margin: 0 $space-s;
+  padding: $space-s;
+
+  &:nth-child(1) {
+    margin-top: $space-s;
+  }
+
+  &:nth-child(odd) {
+    background-color: $info-dark;
+  }
+}

--- a/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
@@ -27,10 +27,11 @@ export default class PlaygroundComponents extends React.Component {
     const { currentTab } = this.state;
 
     if (currentTab === TABS[0]) {
-      const hostGenomes = [{ name: "Human", id: 1 }];
-      const samples = [{ host_genome_id: 1 }];
       return (
-        <HostOrganismMessage hostGenomes={hostGenomes} samples={samples} />
+        <HostOrganismMessage
+          hostGenomes={[{ name: "Human", id: 1 }]}
+          samples={{ host_genome_id: 1 }}
+        />
       );
     }
 

--- a/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
@@ -55,11 +55,13 @@ export default class PlaygroundComponents extends React.Component {
 
     if (currentTab === TABS[1]) {
       return (
-        <GeoSearchInputBox
-          className={cs.geoSearchBox}
-          // Calls save on selection
-          onResultSelect={this.handleResultSelected}
-        />
+        <div className={cs.componentFrame}>
+          <GeoSearchInputBox
+            className={cs.geoSearchBox}
+            // Calls save on selection
+            onResultSelect={this.handleResultSelected}
+          />
+        </div>
       );
     }
   };
@@ -73,9 +75,7 @@ export default class PlaygroundComponents extends React.Component {
           value={this.state.currentTab}
           onChange={this.onTabChange}
         />
-        <div className={cs.componentContainer}>
-          <div className={cs.componentFrame}>{this.renderComponent()}</div>
-        </div>
+        <div className={cs.componentContainer}>{this.renderComponent()}</div>
       </NarrowContainer>
     );
   }

--- a/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
@@ -40,9 +40,15 @@ export default class PlaygroundComponents extends React.Component {
           hostGenomes={[{ name: "Human", id: 1 }]}
           samples={[{ host_genome_id: 2 }]}
         />,
-        // many
+        // ERCC only
         <HostOrganismMessage
           key="3"
+          hostGenomes={[{ name: "ERCC Only", id: 7 }]}
+          samples={[{ host_genome_id: 7 }]}
+        />,
+        // many
+        <HostOrganismMessage
+          key="4"
           hostGenomes={[{ name: "Human", id: 1 }, { name: "Mosquito", id: 2 }]}
           samples={[
             { host_genome_id: 1 },

--- a/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
@@ -27,12 +27,26 @@ export default class PlaygroundComponents extends React.Component {
     const { currentTab } = this.state;
 
     if (currentTab === TABS[0]) {
-      return (
+      return [
+        // one match
         <HostOrganismMessage
+          key="1"
           hostGenomes={[{ name: "Human", id: 1 }]}
-          samples={{ host_genome_id: 1 }}
-        />
-      );
+          samples={[{ host_genome_id: 1 }]}
+        />,
+        // one no match
+        <HostOrganismMessage
+          key="2"
+          hostGenomes={[{ name: "Human", id: 1 }]}
+          samples={[{ host_genome_id: 2 }]}
+        />,
+        // many
+        <HostOrganismMessage
+          key="3"
+          hostGenomes={[{ name: "Human", id: 1 }, { name: "Mosquito", id: 2 }]}
+          samples={[{ host_genome_id: 1 }, { host_genome_id: 2 }]}
+        />,
+      ];
     }
 
     if (currentTab === TABS[1]) {

--- a/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
@@ -3,10 +3,11 @@ import React from "react";
 import NarrowContainer from "~/components/layout/NarrowContainer";
 import Tabs from "~/components/ui/controls/Tabs";
 import GeoSearchInputBox from "~ui/controls/GeoSearchInputBox";
+import HostOrganismMessage from "~/components/views/SampleUploadFlow/HostOrganismMessage";
 
 import cs from "./playground_components.scss";
 
-const TABS = ["Geo Search Box"];
+const TABS = ["Host Organism Message", "Geo Search Box"];
 
 export default class PlaygroundComponents extends React.Component {
   state = {
@@ -24,7 +25,16 @@ export default class PlaygroundComponents extends React.Component {
 
   renderComponent = () => {
     const { currentTab } = this.state;
-    if (currentTab === "Geo Search Box") {
+
+    if (currentTab === TABS[0]) {
+      const hostGenomes = [{ name: "Human", id: 1 }];
+      const samples = [{ host_genome_id: 1 }];
+      return (
+        <HostOrganismMessage hostGenomes={hostGenomes} samples={samples} />
+      );
+    }
+
+    if (currentTab === TABS[1]) {
       return (
         <GeoSearchInputBox
           className={cs.geoSearchBox}

--- a/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
@@ -44,7 +44,11 @@ export default class PlaygroundComponents extends React.Component {
         <HostOrganismMessage
           key="3"
           hostGenomes={[{ name: "Human", id: 1 }, { name: "Mosquito", id: 2 }]}
-          samples={[{ host_genome_id: 1 }, { host_genome_id: 2 }]}
+          samples={[
+            { host_genome_id: 1 },
+            { host_genome_id: 2 },
+            { host_genome_id: 3 },
+          ]}
         />,
       ];
     }

--- a/app/assets/src/components/views/samples/MetadataUploadModal/ReviewPage.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/ReviewPage.jsx
@@ -9,7 +9,6 @@ class ReviewPage extends React.Component {
   render() {
     return (
       <div className={cs.tableContainer}>
-        TODO (gdingle): hellow
         <DataTable
           className={cs.metadataTable}
           columns={this.props.metadata.headers}

--- a/app/assets/src/components/views/samples/MetadataUploadModal/ReviewPage.jsx
+++ b/app/assets/src/components/views/samples/MetadataUploadModal/ReviewPage.jsx
@@ -9,6 +9,7 @@ class ReviewPage extends React.Component {
   render() {
     return (
       <div className={cs.tableContainer}>
+        TODO (gdingle): hellow
         <DataTable
           className={cs.metadataTable}
           columns={this.props.metadata.headers}


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/28797/72477746-146c6100-37a5-11ea-9d64-5153fa0f391e.png)

This adds the above message to tell the user how host subtraction works depending on the host. There are 4 states of the message depending on the number of hosts and matching known hosts or explicit ERCC only. I put them all in the playground page. 

![image](https://user-images.githubusercontent.com/28797/72478499-ff90cd00-37a6-11ea-9258-b8cb171581e9.png)

**This feature is admin only while we iterate on it**

# Notes

* This feature is admin only while we iterate on it
* The unknown hosts will only be relevant when we start to allow plain text in host input

# Tests

* test admin only to show the message
* test all states in playground
* test positioning in review step