### PR TITLE
Add ability to disable pipeline processing after sample upload.

### DIFF
--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -42,6 +42,7 @@ export const bulkUploadLocalWithMetadata = async ({
       "input_files_attributes",
       "name",
       "project_id",
+      "do_not_process",
     ]),
     samples
   );

--- a/app/assets/src/components/ui/controls/terms_agreement.scss
+++ b/app/assets/src/components/ui/controls/terms_agreement.scss
@@ -1,8 +1,9 @@
 @import "~styles/themes/colors";
+@import "~styles/themes/elements";
 
 .termsAgreement {
-  margin-top: 30px;
-  margin-bottom: 30px;
+  margin-top: $space-l;
+  margin-bottom: $space-l;
 
   // Global because Checkbox does not use CSS modules
   :global(.label) {

--- a/app/assets/src/components/ui/labels/StatusLabel.jsx
+++ b/app/assets/src/components/ui/labels/StatusLabel.jsx
@@ -34,7 +34,7 @@ class StatusLabel extends React.Component {
 StatusLabel.propTypes = {
   className: PropTypes.string,
   status: PropTypes.node,
-  type: PropTypes.oneOf(["success", "warn", "error", "default"]),
+  type: PropTypes.oneOf(["success", "warn", "error", "default", "info"]),
   tooltipText: PropTypes.string,
   inline: PropTypes.bool,
 };

--- a/app/assets/src/components/ui/labels/status_label.scss
+++ b/app/assets/src/components/ui/labels/status_label.scss
@@ -24,6 +24,11 @@
     color: $error;
   }
 
+  &.info {
+    background-color: $info-bg;
+    color: $info;
+  }
+
   &.warning {
     background-color: $warning-bg;
     color: $warning;

--- a/app/assets/src/components/utils/sample.js
+++ b/app/assets/src/components/utils/sample.js
@@ -79,8 +79,7 @@ export const joinServerError = response => {
 export const sampleErrorInfo = (sample, pipelineRun) => {
   let status, message, linkText, type, link, pipelineVersionUrlParam;
   switch (
-    sample.upload_error ||
-    (pipelineRun && pipelineRun.known_user_error)
+    sample.upload_error || (pipelineRun && pipelineRun.known_user_error)
   ) {
     case "BASESPACE_UPLOAD_FAILED":
       status = "SAMPLE FAILED";
@@ -112,9 +111,17 @@ export const sampleErrorInfo = (sample, pipelineRun) => {
       type = "warning";
       link = "mailto:help@idseq.net";
       break;
+    case "DO_NOT_PROCESS":
+      status = "PROCESSING SKIPPED";
+      message =
+        "Sample processing has been skipped due to user selection during upload.";
+      type = "info";
+      break;
     case "FAULTY_INPUT":
       status = "COMPLETE - ISSUE";
-      message = `Sorry, something was wrong with your input file. ${pipelineRun.error_message}.`;
+      message = `Sorry, something was wrong with your input file. ${
+        pipelineRun.error_message
+      }.`;
       linkText = "Please check your file format and reupload your file.";
       type = "warning";
       link = "/samples/upload";

--- a/app/assets/src/components/views/SampleUploadFlow/UploadProgressModal.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadProgressModal.jsx
@@ -114,11 +114,23 @@ export default class UploadProgressModal extends React.Component {
     }));
   };
 
+  // Add any flags selected by the user in the Review Step.
+  addFlagsToSamples = samples => {
+    const { skipSampleProcessing } = this.props;
+
+    return samples.map(sample => ({
+      ...sample,
+      do_not_process: skipSampleProcessing,
+    }));
+  };
+
   initiateUploadLocal = () => {
     const { samples, metadata } = this.props;
 
+    const samplesToUpload = this.addFlagsToSamples(samples);
+
     bulkUploadLocalWithMetadata({
-      samples,
+      samples: samplesToUpload,
       metadata,
       callbacks: {
         onCreateSamplesError: (errors, erroredSampleNames) => {
@@ -177,6 +189,8 @@ export default class UploadProgressModal extends React.Component {
       bulkUploadFnName = "bulkUploadBasespace";
       samplesToUpload = map(pick(BASESPACE_SAMPLE_FIELDS), samplesToUpload);
     }
+
+    samplesToUpload = this.addFlagsToSamples(samplesToUpload);
 
     let response;
 
@@ -498,4 +512,5 @@ UploadProgressModal.propTypes = {
   onUploadComplete: PropTypes.func.isRequired,
   uploadType: PropTypes.string.isRequired,
   project: PropTypes.Project,
+  skipSampleProcessing: PropTypes.bool,
 };

--- a/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/sample_upload_flow.scss
@@ -1,5 +1,6 @@
 @import "~styles/themes/colors";
 @import "~styles/themes/typography";
+@import "~styles/themes/elements";
 
 .sampleUploadFlow {
   .inner {
@@ -417,5 +418,16 @@
 
   .loadingIcon {
     margin-right: 5px;
+  }
+
+  .skipSampleProcessingOption {
+    margin-top: $space-l;
+
+    // Global because Checkbox does not use CSS modules
+    :global(.label) {
+      font-size: 12px;
+      line-height: 20px;
+      margin-left: 10px;
+    }
   }
 }

--- a/app/assets/src/components/views/SampleView/sample_view.scss
+++ b/app/assets/src/components/views/SampleView/sample_view.scss
@@ -160,6 +160,15 @@
           font-size: 20px;
         }
       }
+
+      &.info {
+        background-color: $info-bg;
+        color: $info;
+
+        .icon {
+          fill: $info;
+        }
+      }
     }
 
     .message {

--- a/app/assets/src/components/views/SampleViewV2/sample_view_v2.scss
+++ b/app/assets/src/components/views/SampleViewV2/sample_view_v2.scss
@@ -131,6 +131,15 @@
           font-size: 20px;
         }
       }
+
+      &.info {
+        background-color: $info-bg;
+        color: $info;
+
+        .icon {
+          fill: $info;
+        }
+      }
     }
 
     .message {

--- a/app/assets/src/components/views/UserSettingsView.jsx
+++ b/app/assets/src/components/views/UserSettingsView.jsx
@@ -72,12 +72,9 @@ export default class UserSettingsView extends React.Component {
           <Checkbox
             label={field.description}
             onChange={(_, isChecked) =>
-              this.handleUserPreferenceUpdate(
-                field.key,
-                isChecked ? "true" : "false"
-              )
+              this.handleUserPreferenceUpdate(field.key, isChecked)
             }
-            checked={currentValue === "true"}
+            checked={currentValue}
           />
         </div>
       );

--- a/app/assets/src/components/views/discovery/TableRenderers.jsx
+++ b/app/assets/src/components/views/discovery/TableRenderers.jsx
@@ -21,6 +21,7 @@ const STATUS_TYPE = {
   "host filtering": "default",
   alignment: "default",
   waiting: "default",
+  skipped: "info",
 };
 
 class TableRenderers extends React.Component {

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1455,7 +1455,7 @@ class SamplesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def samples_params
-    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name, :basespace_dataset_id, :basespace_access_token, :skip_cache,
+    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name, :basespace_dataset_id, :basespace_access_token, :skip_cache, :do_not_process,
                                          input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts],])
     new_params[:samples] if new_params
   end
@@ -1465,7 +1465,7 @@ class SamplesController < ApplicationController
                         :s3_star_index_path, :s3_bowtie2_index_path,
                         :host_genome_id, :host_genome_name,
                         :sample_notes, :search, :subsample, :max_input_fragments,
-                        :basespace_dataset_id, :basespace_access_token, :client,
+                        :basespace_dataset_id, :basespace_access_token, :client, :do_not_process,
                         input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts],]
     permitted_params.concat([:pipeline_branch, :dag_vars, :s3_preload_result_path, :alignment_config_name, :subsample]) if current_user.admin?
     params.require(:sample).permit(*permitted_params)

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -379,8 +379,13 @@ module SamplesHelper
       top_pipeline_run = top_pipeline_run_by_sample_id[sample.id]
       job_stats_hash = top_pipeline_run ? job_stats_by_pipeline_run_id[top_pipeline_run.id] : {}
       job_info[:derived_sample_output] = sample_derived_data(sample, top_pipeline_run, job_stats_hash)
-
-      job_info[:run_info] = if sample.upload_error && sample.upload_error != Sample::UPLOAD_ERROR_LOCAL_UPLOAD_STALLED
+      job_info[:run_info] = if sample.upload_error && sample.upload_error == Sample::DO_NOT_PROCESS
+                              {
+                                result_status_description: 'SKIPPED',
+                                finalized: 0,
+                                report_ready: 0,
+                              }
+                            elsif sample.upload_error && sample.upload_error != Sample::UPLOAD_ERROR_LOCAL_UPLOAD_STALLED
                               {
                                 result_status_description: 'FAILED',
                                 finalized: 0,

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -36,6 +36,7 @@ class Sample < ApplicationRecord
   UPLOAD_ERROR_S3_UPLOAD_FAILED = "S3_UPLOAD_FAILED".freeze
   UPLOAD_ERROR_LOCAL_UPLOAD_STALLED = "LOCAL_UPLOAD_STALLED".freeze
   UPLOAD_ERROR_LOCAL_UPLOAD_FAILED = "LOCAL_UPLOAD_FAILED".freeze
+  DO_NOT_PROCESS = "DO_NOT_PROCESS".freeze
 
   TOTAL_READS_JSON = "total_reads.json".freeze
   LOG_BASENAME = 'log.txt'.freeze
@@ -716,6 +717,11 @@ class Sample < ApplicationRecord
   def kickoff_pipeline
     # only kickoff pipeline when no active pipeline_run running
     return unless pipeline_runs.in_progress.empty?
+
+    if do_not_process
+      update(status: STATUS_CHECKED, upload_error: Sample::DO_NOT_PROCESS)
+      return
+    end
 
     pr = PipelineRun.new
     pr.sample = self

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -141,7 +141,7 @@ class User < ApplicationRecord
     user_setting.save!
   end
 
-  # Remove any user settings gated on allowed_features that the user doesn't have access to.
+  # Remove any user settings gated on allowed_features that the user doesn't have access to due to allowed_feature flags.
   def viewable_user_setting_keys
     parsed_allowed_feature_list = allowed_feature_list
     UserSetting::METADATA.select do |_key, metadata|
@@ -149,6 +149,7 @@ class User < ApplicationRecord
     end.keys
   end
 
+  # Get all viewable user settings, excluding any that are guarded on feature flags.
   def viewable_user_settings
     # Fetch viewable user settings.
     existing_user_settings = user_settings

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -1,11 +1,19 @@
 class UserSetting < ApplicationRecord
   belongs_to :user
+
+  attr_writer :value
+
   validate :user_setting_checks
+
+  before_save :serialize_value
 
   # An example user setting
   EXAMPLE_USER_SETTING = "example_user_setting".freeze
+  # Show the option to skip sample processing at the end of the sample upload flow.
+  SHOW_SKIP_PROCESSING_OPTION = "show_skip_processing_option".freeze
 
-  # value must be "true" or "false".
+  # value must be "true" or "false". Can be string or boolean.
+  # Booleans will be stored in the database as a serialized string.
   DATA_TYPE_BOOLEAN = "boolean".freeze
 
   # Stores metadata for various user settings.
@@ -13,8 +21,13 @@ class UserSetting < ApplicationRecord
   # required_allowed_feature - the setting will only be visible if an allowed feature is true.
   METADATA = {
     EXAMPLE_USER_SETTING => {
-      default: "true",
+      default: true,
       description: "An example user setting. User settings can handle any persistent user-specific configurations.",
+      data_type: DATA_TYPE_BOOLEAN,
+    },
+    SHOW_SKIP_PROCESSING_OPTION => {
+      default: false,
+      description: "Show the option to skip sample processing at the end of the sample upload flow.",
       data_type: DATA_TYPE_BOOLEAN,
     },
   }.freeze
@@ -27,9 +40,20 @@ class UserSetting < ApplicationRecord
       name: "Example Category",
       settings: [
         EXAMPLE_USER_SETTING,
+        SHOW_SKIP_PROCESSING_OPTION,
       ],
     },
   ].freeze
+
+  # Call this function to get the value for a user setting.
+  # This automatically converted the serialized value in the database to the appropriate data type
+  # (e.g. converts strings to booleans for boolean data types)
+  def value
+    if @value.nil? && serialized_value
+      @value = deserialized_value
+    end
+    @value
+  end
 
   def user_setting_checks
     # Verify that the key is listed above.
@@ -41,7 +65,26 @@ class UserSetting < ApplicationRecord
     # Validation for various data types.
     data_type = METADATA[key][:data_type]
     if data_type == DATA_TYPE_BOOLEAN
-      errors.add(:value, "must be true or false for boolean data type (#{value} given)") unless ["true", "false"].include?(value)
+      # We accept both the string and boolean forms of true and false.
+      errors.add(:value, "must be true or false for boolean data type (#{value} given)") unless [true, false, "true", "false"].include?(value)
     end
+  end
+
+  private
+
+  # Serialize the value to be stored in the database.
+  def serialize_value
+    unless value.nil?
+      self.serialized_value = String(value)
+    end
+  end
+
+  # Deserialize the serialized_value stored in the database.
+  def deserialized_value
+    # Convert boolean strings to booleans.
+    if METADATA[key] && METADATA[key][:data_type] == DATA_TYPE_BOOLEAN
+      return serialized_value == "true"
+    end
+    return serialized_value
   end
 end

--- a/db/migrate/20200114013138_add_do_not_process_to_sample.rb
+++ b/db/migrate/20200114013138_add_do_not_process_to_sample.rb
@@ -1,0 +1,5 @@
+class AddDoNotProcessToSample < ActiveRecord::Migration[5.1]
+  def change
+    add_column :samples, :do_not_process, :boolean, null: false, default: false, comment: "If true, sample will skip pipeline processing."
+  end
+end

--- a/db/migrate/20200115021328_remove_serialized_value_in_user_settings.rb
+++ b/db/migrate/20200115021328_remove_serialized_value_in_user_settings.rb
@@ -1,0 +1,8 @@
+class RemoveSerializedValueInUserSettings < ActiveRecord::Migration[5.1]
+  def change
+    change_table :user_settings, bulk: true do |t|
+      t.remove :value
+      t.string :serialized_value, comment: "The serialized value of the user setting. The schema of this value (e.g. boolean, number) is determined by the hard-coded data type associated with the key."
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_109_023_047) do
+ActiveRecord::Schema.define(version: 20_200_115_021_328) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -391,6 +391,7 @@ ActiveRecord::Schema.define(version: 20_200_109_023_047) do
     t.integer "uploaded_from_basespace", limit: 1, default: 0
     t.string "basespace_access_token"
     t.string "upload_error"
+    t.boolean "do_not_process", default: false, null: false, comment: "If true, sample will skip pipeline processing."
     t.index ["host_genome_id"], name: "samples_host_genome_id_fk"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
     t.index ["user_id"], name: "index_samples_on_user_id"
@@ -558,7 +559,7 @@ ActiveRecord::Schema.define(version: 20_200_109_023_047) do
   create_table "user_settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "user_id"
     t.string "key", comment: "The name of the user setting, e.g. receives_bulk_download_success_emails"
-    t.string "value", comment: "The value of the user setting, e.g. true. The schema of this value (e.g. boolean, number) is determined by the hard-coded data type associated with the key."
+    t.string "serialized_value", comment: "The serialized value of the user setting. The schema of this value (e.g. boolean, number) is determined by the hard-coded data type associated with the key."
     t.index ["user_id", "key"], name: "index_user_settings_on_user_id_and_key", unique: true
     t.index ["user_id"], name: "index_user_settings_on_user_id"
   end

--- a/spec/controllers/user_settings_controller_spec.rb
+++ b/spec/controllers/user_settings_controller_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe UserSettingsController, type: :controller do
   def stub_mock_user_setting_metadata(additional_settings = {})
     user_settings = {
       mock_user_setting => {
-        default: "true",
+        default: true,
         description: mock_user_setting_description,
         data_type: UserSetting::DATA_TYPE_BOOLEAN,
       },
       mock_user_setting_two => {
-        default: "true",
+        default: true,
         description: mock_user_setting_description_two,
         data_type: UserSetting::DATA_TYPE_BOOLEAN,
       },
@@ -120,12 +120,12 @@ RSpec.describe UserSettingsController, type: :controller do
         stub_mock_user_setting_metadata()
         stub_mock_display_categories()
 
-        post :update, params: { format: "json", key: mock_user_setting, value: "true" }
+        post :update, params: { format: "json", key: mock_user_setting, value: true }
 
         json_response = JSON.parse(response.body)
         expect(json_response["status"]).to eq("success")
         expect(json_response["key"]).to eq(mock_user_setting)
-        expect(json_response["value"]).to eq("true")
+        expect(json_response["value"]).to eq(true)
       end
 
       it "throws error if value is invalid for boolean data type" do
@@ -143,7 +143,7 @@ RSpec.describe UserSettingsController, type: :controller do
         stub_mock_user_setting_metadata()
         stub_mock_display_categories()
 
-        post :update, params: { format: "json", key: "mock_bad_key", value: "true" }
+        post :update, params: { format: "json", key: "mock_bad_key", value: true }
 
         expect(response).to have_http_status :unprocessable_entity
         json_response = JSON.parse(response.body)

--- a/spec/factories/user_settings.rb
+++ b/spec/factories/user_settings.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :user_setting do
+  end
+end

--- a/spec/models/user_setting_spec.rb
+++ b/spec/models/user_setting_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe UserSetting, type: :model do
+  context "saving and serializing values" do
+    before do
+      @joe = create(:joe)
+      stub_const("UserSetting::METADATA",
+                 "example_user_setting" => {
+                   default: true,
+                   description: "An example user setting. User settings can handle any persistent user-specific configurations.",
+                   data_type: UserSetting::DATA_TYPE_BOOLEAN,
+                 })
+    end
+
+    it "should serialize boolean value correctly" do
+      user_setting = create(:user_setting, key: "example_user_setting", value: true, user: @joe)
+
+      expect(user_setting.value).to eq(true)
+      expect(user_setting.serialized_value).to eq("true")
+    end
+
+    it "should deserialize boolean value correctly" do
+      user_setting = create(:user_setting, key: "example_user_setting", serialized_value: "false", user: @joe)
+
+      expect(user_setting.value).to eq(false)
+      expect(user_setting.serialized_value).to eq("false")
+    end
+  end
+end


### PR DESCRIPTION
# Description

Add a checkbox during the review step of sample uploading.

<img width="1262" alt="Screen Shot 2020-01-16 at 1 51 02 PM" src="https://user-images.githubusercontent.com/837004/72565798-7db4a880-3867-11ea-8925-1ee4e76a6c29.png">

This checkbox is gated by a user setting. The user will only see this option if the setting is set to true.

If the checkbox is selected, the sample will skip processing and show a special blue message to indicate that processing was skipped.

<img width="563" alt="Screen Shot 2020-01-16 at 1 52 28 PM" src="https://user-images.githubusercontent.com/837004/72565818-86a57a00-3867-11ea-95e7-0bb988876035.png">

<img width="1342" alt="Screen Shot 2020-01-16 at 1 52 41 PM" src="https://user-images.githubusercontent.com/837004/72565824-8907d400-3867-11ea-9216-41c155f9d0b7.png">

# Notes

* Also updated how UserSettings are parsed so that "value" is returned as a boolean instead of a string (but the value is stored in the database as a string)

# Tests

* Verified that the user setting guards the feature properly.
* Verified that for all three upload types, the checkbox prevents the sample from kicking off a pipeline run. Verified that it works for multiple samples.
* Updated tests.
