### PR TITLE
[Data Discovery] Bug fix: Constrain project search by domain and make samples search consistent

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -74,7 +74,7 @@ class ProjectsController < ApplicationController
         # we use includes because we need data from both associations to return aggregate data for the project
         projects = projects.includes(:users).includes(:samples)
         projects = projects.where(id: project_id) if project_id
-        projects = projects.db_search(search) if search
+        projects = projects.search_by_name(search) if search
         if [:host, :location, :locationV2, :taxon, :time, :tissue, :visibility].any? { |key| params.key? key }
           projects = projects.where(samples: { id: filter_samples(current_power.samples, params) })
         end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -68,16 +68,8 @@ class ProjectsController < ApplicationController
 
         list_all_project_ids = ActiveModel::Type::Boolean.new.cast(params[:listAllIds])
 
-        projects = case domain
-                   when "my_data"
-                     current_user.projects
-                   when "public"
-                     Project.public_projects
-                   when "updatable"
-                     current_power.updatable_projects
-                   else
-                     current_power.projects
-                   end
+        projects = current_power.projects_by_domain(domain)
+
         # including these early ensures that users and samples are joined in the same order, making rails assign deterministic aliases
         # we use includes because we need data from both associations to return aggregate data for the project
         projects = projects.includes(:users).includes(:samples)

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -370,7 +370,7 @@ class SamplesController < ApplicationController
     end
 
     if !categories || categories.include?("project")
-      projects = prefix_match(Project, "name", query, id: current_power.projects.pluck(:id))
+      projects = current_power.projects_by_domain(domain).db_search(query)
       unless projects.empty?
         results["Project"] = {
           "name" => "Project",

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -370,7 +370,7 @@ class SamplesController < ApplicationController
     end
 
     if !categories || categories.include?("project")
-      projects = current_power.projects_by_domain(domain).db_search(query)
+      projects = current_power.projects_by_domain(domain).search_by_name(query)
       unless projects.empty?
         results["Project"] = {
           "name" => "Project",

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -415,7 +415,7 @@ class SamplesController < ApplicationController
     end
 
     if !categories || categories.include?("sample")
-      samples = prefix_match(Sample, "name", query, id: constrained_sample_ids)
+      samples = constrained_samples.db_search(query)
       unless samples.empty?
         results["Sample"] = {
           "name" => "Sample",

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -415,7 +415,7 @@ class SamplesController < ApplicationController
     end
 
     if !categories || categories.include?("sample")
-      samples = constrained_samples.db_search(query)
+      samples = constrained_samples.search_by_name(query)
       unless samples.empty?
         results["Sample"] = {
           "name" => "Sample",

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -728,7 +728,7 @@ module SamplesHelper
   end
 
   def filter_by_search_string(samples, search_string)
-    samples.search(search_string)
+    samples.search_by_name(search_string)
   end
 
   def filter_by_sample_ids(samples, requested_sample_ids)

--- a/app/models/power.rb
+++ b/app/models/power.rb
@@ -73,4 +73,17 @@ class Power
   power :viewable_bulk_downloads do
     BulkDownload.viewable(@user)
   end
+
+  power :projects_by_domain do |domain|
+    case domain
+    when "my_data"
+      @user.projects
+    when "public"
+      Project.public_projects
+    when "updatable"
+      updatable_projects
+    else
+      projects
+    end
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -109,10 +109,14 @@ class Project < ApplicationRecord
   end
 
   # search is used by ES
-  def self.db_search(search)
-    if search
-      search = search.strip
-      where("projects.name LIKE :search", search: "%#{search}%")
+  def self.db_search(query)
+    if query
+      tokens = query.scan(/\w+/).map { |t| "%#{t}%" }
+      q = scoped
+      tokens.each do |token|
+        q = q.where("projects.name LIKE :search", search: token.to_s)
+      end
+      q
     else
       scoped
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -109,7 +109,7 @@ class Project < ApplicationRecord
   end
 
   # search is used by ES
-  def self.db_search(query)
+  def self.search_by_name(query)
     if query
       tokens = query.scan(/\w+/).map { |t| "%#{t}%" }
       q = scoped

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -934,4 +934,17 @@ class Sample < ApplicationRecord
   def input_file_s3_paths
     input_files.map { |input_file| "s3://#{ENV['SAMPLES_BUCKET_NAME']}/#{input_file.file_path}" }
   end
+
+  def self.db_search(query)
+    if query
+      tokens = query.scan(/\w+/).map { |t| "%#{t}%" }
+      q = scoped
+      tokens.each do |token|
+        q = q.where("samples.name LIKE :search", search: token.to_s)
+      end
+      q
+    else
+      scoped
+    end
+  end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -935,7 +935,7 @@ class Sample < ApplicationRecord
     input_files.map { |input_file| "s3://#{ENV['SAMPLES_BUCKET_NAME']}/#{input_file.file_path}" }
   end
 
-  def self.db_search(query)
+  def self.search_by_name(query)
     if query
       tokens = query.scan(/\w+/).map { |t| "%#{t}%" }
       q = scoped

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe Project, type: :model do
+  context "#search_by_name" do
+    before do
+      @project_single_match1 = create(:project, name: "Project test single match 1")
+      @project_single_match2 = create(:project, name: "Project test single match 2")
+      @project_partial_match = create(:project, name: "Project test anywhereSinglePartial match")
+      @project_multiple_match = create(:project, name: "Project test single and multiple match")
+      @project_no_match = create(:project, name: "Project test with no match")
+    end
+
+    subject { Project.search_by_name(query) }
+
+    context "with a single word query" do
+      let(:query) { "single" }
+
+      it "returns samples matching single word query" do
+        expect(subject.pluck(:name)).to include(@project_single_match1.name, @project_single_match2.name, @project_multiple_match.name)
+      end
+
+      it "returns samples with partial matches" do
+        expect(subject.pluck(:name)).to include(@project_partial_match.name)
+      end
+
+      it "does not return samples with no matches" do
+        expect(subject.pluck(:name)).to_not include(@project_no_match.name)
+      end
+    end
+
+    context "with a multiple word query" do
+      let(:query) { "single multiple" }
+
+      it "returns only samples matching all tokens in query" do
+        expect(subject.pluck(:name)).to eq([@project_multiple_match.name])
+      end
+    end
+  end
+end

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -231,4 +231,41 @@ describe Sample, type: :model do
       expect(@sample.status_url).to eq("http://localhost:3000/samples/8/pipeline_runs")
     end
   end
+
+  context "#search_by_name" do
+    before do
+      project = create(:project, name: "Test Search Project")
+      @sample_single_match1 = create(:sample, project: project, name: "Sample test single match 1")
+      @sample_single_match2 = create(:sample, project: project, name: "Sample test single match 2")
+      @sample_partial_match = create(:sample, project: project, name: "Sample test anywhereSinglePartial match")
+      @sample_multiple_match = create(:sample, project: project, name: "Sample test single and multiple match")
+      @sample_no_match = create(:sample, project: project, name: "Sample test with no match")
+    end
+
+    subject { Sample.search_by_name(query) }
+
+    context "with a single word query" do
+      let(:query) { "single" }
+
+      it "returns samples matching single word query" do
+        expect(subject.pluck(:name)).to include(@sample_single_match1.name, @sample_single_match2.name, @sample_multiple_match.name)
+      end
+
+      it "returns samples with partial matches" do
+        expect(subject.pluck(:name)).to include(@sample_partial_match.name)
+      end
+
+      it "does not return samples with no matches" do
+        expect(subject.pluck(:name)).to_not include(@sample_no_match.name)
+      end
+    end
+
+    context "with a multiple word query" do
+      let(:query) { "single multiple" }
+
+      it "returns only samples matching all tokens in query" do
+        expect(subject.pluck(:name)).to eq([@sample_multiple_match.name])
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description

* Constrain project search by domain name
* Changed search from `prefix_match` to database like search with multiple tokens (like taxa search)
* Changed samples search to be same type as project and applicable only to name 

# Screenshots

### Projects
* Before:

<img width="535" alt="Screen Shot 2020-01-16 at 11 25 50 PM" src="https://user-images.githubusercontent.com/37312125/72592744-196e0500-38b8-11ea-9f09-9ac2f56fdd36.png">

* After:

<img width="535" alt="Screen Shot 2020-01-16 at 11 25 10 PM" src="https://user-images.githubusercontent.com/37312125/72592749-212da980-38b8-11ea-981d-840719e8dcbd.png">

### Samples

* Before:

<img width="535" alt="Screen Shot 2020-01-16 at 11 49 38 PM" src="https://user-images.githubusercontent.com/37312125/72594854-55579900-38bd-11ea-98e9-82d8216ece19.png">

After:

<img width="535" alt="Screen Shot 2020-01-16 at 11 48 07 PM" src="https://user-images.githubusercontent.com/37312125/72594984-a6678d00-38bd-11ea-9102-50a536969bb5.png">

# Tests
* Unit tests to the search functions
* Search for projects and samples by name in the top search box
* Every string token should match part of the name to be a valid match