### PR TITLE
Add separate sample limit for original input files download type.

### DIFF
--- a/app/assets/src/components/common/UserContext.jsx
+++ b/app/assets/src/components/common/UserContext.jsx
@@ -3,6 +3,8 @@ import React from "react";
 export const UserContext = React.createContext({
   admin: false,
   allowedFeatures: new Set(),
+  appConfig: {},
+  userSettings: {},
 });
 // Name to show in DevTools
 UserContext.displayName = "UserContext";

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -305,7 +305,7 @@ class ChooseStep extends React.Component {
       selectedSampleIds,
     } = this.props;
     const { allSamplesUploadedByCurrentUser } = this.state;
-    const { admin, maxSamplesBulkDownloadOriginalFiles } = this.context || {};
+    const { admin, appConfig } = this.context || {};
 
     const selected = selectedDownloadTypeName === downloadType.type;
     let disabled = false;
@@ -322,12 +322,14 @@ class ChooseStep extends React.Component {
       }, you must be the original uploader of all selected samples.`;
     } else if (
       downloadType.type === "original_input_file" &&
-      maxSamplesBulkDownloadOriginalFiles &&
-      selectedSampleIds.size > maxSamplesBulkDownloadOriginalFiles &&
+      appConfig.maxSamplesBulkDownloadOriginalFiles &&
+      selectedSampleIds.size > appConfig.maxSamplesBulkDownloadOriginalFiles &&
       !admin
     ) {
       disabled = true;
-      disabledMessage = `No more than ${maxSamplesBulkDownloadOriginalFiles} samples
+      disabledMessage = `No more than ${
+        appConfig.maxSamplesBulkDownloadOriginalFiles
+      } samples
         allowed for ${downloadType.display_name} downloads`;
     }
 

--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -299,9 +299,13 @@ class ChooseStep extends React.Component {
   };
 
   renderDownloadType = downloadType => {
-    const { selectedDownloadTypeName, onSelect } = this.props;
+    const {
+      selectedDownloadTypeName,
+      onSelect,
+      selectedSampleIds,
+    } = this.props;
     const { allSamplesUploadedByCurrentUser } = this.state;
-    const { admin } = this.context || {};
+    const { admin, maxSamplesBulkDownloadOriginalFiles } = this.context || {};
 
     const selected = selectedDownloadTypeName === downloadType.type;
     let disabled = false;
@@ -316,6 +320,15 @@ class ChooseStep extends React.Component {
       disabledMessage = `To download ${
         downloadType.display_name
       }, you must be the original uploader of all selected samples.`;
+    } else if (
+      downloadType.type === "original_input_file" &&
+      maxSamplesBulkDownloadOriginalFiles &&
+      selectedSampleIds.size > maxSamplesBulkDownloadOriginalFiles &&
+      !admin
+    ) {
+      disabled = true;
+      disabledMessage = `No more than ${maxSamplesBulkDownloadOriginalFiles} samples
+        allowed for ${downloadType.display_name} downloads`;
     }
 
     const downloadTypeElement = (

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -473,18 +473,20 @@ class SamplesView extends React.Component {
   };
 
   handleBulkDownloadModalOpen = () => {
-    const { maxSamplesBulkDownload, admin } = this.context || {};
-    if (!maxSamplesBulkDownload) {
+    const { appConfig, admin } = this.context || {};
+    if (!appConfig.maxSamplesBulkDownload) {
       this.setState({
         bulkDownloadButtonTempTooltip:
           "Unexpected issue. Please contact us for help.",
       });
     } else if (
-      this.props.selectedSampleIds.size > maxSamplesBulkDownload &&
+      this.props.selectedSampleIds.size > appConfig.maxSamplesBulkDownload &&
       !admin
     ) {
       this.setState({
-        bulkDownloadButtonTempTooltip: `No more than ${maxSamplesBulkDownload} samples allowed in one download.`,
+        bulkDownloadButtonTempTooltip: `No more than ${
+          appConfig.maxSamplesBulkDownload
+        } samples allowed in one download.`,
       });
     } else {
       this.setState({ bulkDownloadModalOpen: true });

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -480,7 +480,7 @@ class SamplesView extends React.Component {
           "Unexpected issue. Please contact us for help.",
       });
     } else if (
-      this.props.selectedSampleIds.size > parseInt(maxSamplesBulkDownload) &&
+      this.props.selectedSampleIds.size > maxSamplesBulkDownload &&
       !admin
     ) {
       this.setState({

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -483,6 +483,9 @@ class SamplesView extends React.Component {
       this.props.selectedSampleIds.size > appConfig.maxSamplesBulkDownload &&
       !admin
     ) {
+      // There is a separate max sample limit for the original input file download type.
+      // This is checked in BulkDownloadModal, and the original input file option is disabled if there
+      // are too many samples.
       this.setState({
         bulkDownloadButtonTempTooltip: `No more than ${
           appConfig.maxSamplesBulkDownload

--- a/app/helpers/app_config_helper.rb
+++ b/app/helpers/app_config_helper.rb
@@ -28,7 +28,9 @@ module AppConfigHelper
     default_value
   end
 
+  # Return all app configs that should be sent to the front-end React application.
   def configs_for_context
+    # Fetch all app configs in one query.
     app_configs = AppConfig
                   .where(key: [
                            AppConfig::MAX_SAMPLES_BULK_DOWNLOAD,

--- a/app/helpers/app_config_helper.rb
+++ b/app/helpers/app_config_helper.rb
@@ -27,4 +27,19 @@ module AppConfigHelper
     end
     default_value
   end
+
+  def configs_for_context
+    app_configs = AppConfig
+                  .where(key: [
+                           AppConfig::MAX_SAMPLES_BULK_DOWNLOAD,
+                           AppConfig::MAX_SAMPLES_BULK_DOWNLOAD_ORIGINAL_FILES,
+                         ])
+                  .map { |app_config| [app_config.key, app_config.value] }
+                  .to_h
+
+    {
+      maxSamplesBulkDownload: app_configs[AppConfig::MAX_SAMPLES_BULK_DOWNLOAD].to_i,
+      maxSamplesBulkDownloadOriginalFiles: app_configs[AppConfig::MAX_SAMPLES_BULK_DOWNLOAD_ORIGINAL_FILES].to_i,
+    }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,8 +34,11 @@ module ApplicationHelper
     {
       admin: current_user ? current_user.role == 1 : false,
       allowedFeatures: current_user && current_user.allowed_feature_list,
-      maxSamplesBulkDownload: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD).to_i,
-      maxSamplesBulkDownloadOriginalFiles: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD_ORIGINAL_FILES).to_i,
+      # TODO(mark): Fetch all app configs in one request.
+      appConfig: {
+        maxSamplesBulkDownload: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD).to_i,
+        maxSamplesBulkDownloadOriginalFiles: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD_ORIGINAL_FILES).to_i,
+      },
       userSettings: current_user && current_user.viewable_user_settings,
     }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,11 +34,7 @@ module ApplicationHelper
     {
       admin: current_user ? current_user.role == 1 : false,
       allowedFeatures: current_user && current_user.allowed_feature_list,
-      # TODO(mark): Fetch all app configs in one request.
-      appConfig: {
-        maxSamplesBulkDownload: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD).to_i,
-        maxSamplesBulkDownloadOriginalFiles: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD_ORIGINAL_FILES).to_i,
-      },
+      appConfig: AppConfigHelper.configs_for_context(),
       userSettings: current_user && current_user.viewable_user_settings,
     }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,8 @@ module ApplicationHelper
     {
       admin: current_user ? current_user.role == 1 : false,
       allowedFeatures: current_user && current_user.allowed_feature_list,
-      maxSamplesBulkDownload: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD),
+      maxSamplesBulkDownload: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD).to_i,
+      maxSamplesBulkDownloadOriginalFiles: get_app_config(AppConfig::MAX_SAMPLES_BULK_DOWNLOAD_ORIGINAL_FILES).to_i,
       userSettings: current_user && current_user.viewable_user_settings,
     }
   end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -12,6 +12,9 @@ class AppConfig < ApplicationRecord
   USE_AUTH0_FOR_NEW_USERS = 'use_auth0_for_new_users'.freeze
   # The maximum number of samples that can be part of one bulk download.
   MAX_SAMPLES_BULK_DOWNLOAD = 'max_samples_bulk_download'.freeze
+  # The maximum number of samples that can be part of an original input files bulk download.
+  # Original input file downloads are significantly bigger and slower than other downloads, so a separate limit is needed.
+  MAX_SAMPLES_BULK_DOWNLOAD_ORIGINAL_FILES = 'max_samples_bulk_download_original_files'.freeze
   # When this is "1", the announcement banner on the top of the site header will be enabled.
   # Other conditions may check a time constraint.
   SHOW_ANNOUNCEMENT_BANNER = 'show_announcement_banner'.freeze

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -369,7 +369,6 @@ RSpec.describe SamplesController, type: :controller do
 
         get :index, params: { project_id: project.id, basic: true }
         json_response = JSON.parse(response.body)
-        print(json_response)
         expect(json_response.length).to eq(1)
         expect(json_response).to include_json([
                                                 {
@@ -388,7 +387,6 @@ RSpec.describe SamplesController, type: :controller do
 
         get :index, params: { project_id: project.id, basic: true }
         json_response = JSON.parse(response.body)
-        print(json_response)
         expect(json_response.length).to eq(1)
         expect(json_response).to include_json([
                                                 {


### PR DESCRIPTION
# Description

Add a separate sample limit for original input files download type.

Show warning via hover tooltip if user exceeds limit. Same pattern as when user isn't the original uploader of the samples.

![Screen Shot 2020-01-17 at 5 37 33 PM](https://user-images.githubusercontent.com/837004/72656588-31de2e00-3951-11ea-81d9-b3d3556524b0.png)

# Tests

* Manually test that upload behaves as expected. Other download types are not affected by new sample limit.
* Update tests.
