### PR TITLE
Fix visual bug with StatusLabel.

### DIFF
--- a/app/assets/src/components/ui/labels/StatusLabel.jsx
+++ b/app/assets/src/components/ui/labels/StatusLabel.jsx
@@ -34,7 +34,7 @@ class StatusLabel extends React.Component {
 StatusLabel.propTypes = {
   className: PropTypes.string,
   status: PropTypes.node,
-  type: PropTypes.oneOf(["success", "warn", "error", "default", "info"]),
+  type: PropTypes.oneOf(["success", "warning", "error", "default", "info"]),
   tooltipText: PropTypes.string,
   inline: PropTypes.bool,
 };

--- a/app/assets/src/components/views/bulk_download/BulkDownloadList.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadList.jsx
@@ -44,7 +44,7 @@ const STATUS_DISPLAY = {
 // In this case, the bulk download task will have status = success and also have an error message.
 const getStatusType = bulkDownload => {
   if (bulkDownload.status === "success" && bulkDownload.error_message) {
-    return "warn";
+    return "warning";
   }
   return STATUS_TYPES[bulkDownload.status];
 };


### PR DESCRIPTION
# Description

Before:

![Screen Shot 2020-01-21 at 11 10 21 AM](https://user-images.githubusercontent.com/837004/72834981-bb864800-3c3e-11ea-8cb5-41ab55ba1040.png)

After:

![Screen Shot 2020-01-21 at 11 10 28 AM](https://user-images.githubusercontent.com/837004/72834987-be813880-3c3e-11ea-8bf6-170e0b779796.png)

# Notes

* I don't think we need a release fix for this, since we are not launching until after this will get pushed to prod.
* The string "warning" is what is in the CSS file. The sample view, which also uses StatusLabel, already passes "warning" correctly, even though the prop type was wrong.