### PR TITLE
Fix bug with capitalized emails in 'new user new project' flow

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -464,7 +464,7 @@ class ProjectsController < ApplicationController
   end
 
   def add_user
-    @user = User.find_by(email: params[:user_email_to_add])
+    @user = User.find_by(email: params[:user_email_to_add].downcase)
     if @user
       UserMailer.added_to_projects_email(@user.id, shared_project_email_arguments).deliver_now unless @project.user_ids.include? @user.id
     else
@@ -548,6 +548,7 @@ class ProjectsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def create_new_user_random_password(name, email)
+    email = email.downcase
     Rails.logger.info("Going to create new user via project sharing: #{email}")
     user_params = { email: email, name: name }
     @user = User.new(user_params)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -464,7 +464,8 @@ class ProjectsController < ApplicationController
   end
 
   def add_user
-    @user = User.find_by(email: params[:user_email_to_add].downcase)
+    params[:user_email_to_add].downcase!
+    @user = User.find_by(email: params[:user_email_to_add])
     if @user
       UserMailer.added_to_projects_email(@user.id, shared_project_email_arguments).deliver_now unless @project.user_ids.include? @user.id
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,9 @@ class UsersController < ApplicationController
   # POST /users.json
   def create
     new_user_params = user_params.to_h.symbolize_keys
+    if new_user_params.key?(:email)
+      new_user_params[:email] = new_user_params[:email].downcase
+    end
     send_activation = new_user_params.delete(:send_activation)
     new_user(new_user_params)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,9 +18,7 @@ class UsersController < ApplicationController
   # POST /users.json
   def create
     new_user_params = user_params.to_h.symbolize_keys
-    if new_user_params.key?(:email)
-      new_user_params[:email] = new_user_params[:email].downcase
-    end
+    new_user_params[:email].downcase!
     send_activation = new_user_params.delete(:send_activation)
     new_user(new_user_params)
 


### PR DESCRIPTION
### Description
- There was a bug with capitalized emails in the 'new user new project' flow: https://chanzuckerberg.airbrake.io/projects/158403/groups/2658385090763832215
- The main problem is that Auth0 automatically lowercases (or strips case-sensitivity) emails, so we need to be consistent with them.
- We made a product decision to automatically lowercase as well and have the same behavior. This was favored over generating error messages that would add user friction.

### Tests
- Tested adding a new user on a new project with a capitalized email successfully.
- Tested adding a new user via the admin form successfully.