### PR TITLE
Specify explicit ordering of queues for Resque workers.

### DIFF
--- a/balances.json
+++ b/balances.json
@@ -3,6 +3,5 @@
   "project": "idseq",
   "env": "staging",
   "name": "web",
-  "region": "us-west-2",
-  "resque_queues": "data_migration,precache_report_info,q03_pipeline_run,transfer_basespace_files,generate_bulk_download,*"
+  "region": "us-west-2"
 }

--- a/balances.json
+++ b/balances.json
@@ -3,5 +3,6 @@
   "project": "idseq",
   "env": "staging",
   "name": "web",
-  "region": "us-west-2"
+  "region": "us-west-2",
+  "resque_queues": "data_migration,precache_report_info,q03_pipeline_run,transfer_basespace_files,generate_bulk_download,*"
 }

--- a/czecs-resque.json
+++ b/czecs-resque.json
@@ -31,7 +31,7 @@
         },
         {
           "name": "QUEUE",
-          "value": "*"
+          "value": "{{ .Values.resque_queues }}"
         },
         {
           "name": "COUNT",

--- a/czecs-resque.json
+++ b/czecs-resque.json
@@ -31,7 +31,7 @@
         },
         {
           "name": "QUEUE",
-          "value": "{{ .Values.resque_queues }}"
+          "value": "data_migration,q03_pipeline_run,transfer_basespace_files,generate_bulk_download,precache_report_info,*"
         },
         {
           "name": "COUNT",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,7 @@ services:
       <<: *web-variables
       <<: *aws-variables
       <<: *travis-variables
-    command: bundle exec "QUEUE=q03_pipeline_run,precache_report_info,transfer_basespace_files,* COUNT=5 rake resque:workers"
+    command: bundle exec "COUNT=5 rake resque:workers"
   resque_result_monitor:
     image: chanzuckerberg/idseq-web:compose
     volumes:


### PR DESCRIPTION
# Description

Verified in sandbox environment that queue of Resque workers is set correctly.

![Screen Shot 2020-01-21 at 3 49 07 PM](https://user-images.githubusercontent.com/837004/72853369-0cf5fd80-3c66-11ea-9edc-d1a88d18a6df.png)


# Notes

* Prior to this change, the priority of the queues was determined by alphabetical order. (that's the behavior of `*`). With this change, we move bulk download to be lowest priority.
