### PR TITLE
Update Redis version in docker-compose to 5.0.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - MYSQL_DATABASE=idseq_development
     command: ['--character-set-server=utf8', '--collation-server=utf8_unicode_ci']
   redis:
-    image: redis:3.0.5
+    image: redis:5.0.3
     container_name: redis
     ports:
       - '6379:6379'


### PR DESCRIPTION
# Description

Redis is only used for the travis build right now, and should not affect production.

This updates the Redis version since 3.0.5 was causing Travis build failures.

5.0.3 is the version of Redis that we are currently using in production. (set in idseq-infra)