### PR TITLE
Remove host genome default for input

### DIFF
--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -13,7 +13,6 @@ import _fp, {
   sortBy,
   find,
   pickBy,
-  isEqual,
 } from "lodash/fp";
 
 import { logAnalyticsEvent } from "~/api/analytics";
@@ -63,40 +62,11 @@ class MetadataManualInput extends React.Component {
       },
       this.setDefaultWaterControl
     );
-
-    this.setDefaultHostGenomes();
-  }
-
-  componentDidUpdate(prevProps) {
-    const prevSampleNames = map("name", prevProps.samples);
-    const sampleNames = map("name", this.props.samples);
-    if (!isEqual(prevSampleNames, sampleNames)) {
-      this.setDefaultHostGenomes();
-    }
   }
 
   // Need to special case this to avoid a missing required field error.
   setDefaultWaterControl = () => {
     this.applyToAll("water_control", "No");
-  };
-
-  setDefaultHostGenomes = () => {
-    // If samples are new, set all host genomes to Human by default.
-    // Can't use updateHostGenome/updateMetadataField for bulk update.
-    if (this.props.samplesAreNew) {
-      const newHeaders = union(["Host Genome"], this.state.headersToEdit);
-      let newFields = this.state.metadataFieldsToEdit;
-      this.props.samples.forEach(sample => {
-        if (!get([sample.name, "Host Genome"], newFields)) {
-          newFields = set([sample.name, "Host Genome"], "Human", newFields);
-        }
-      });
-      this.setState({
-        headersToEdit: newHeaders,
-        metadataFieldsToEdit: newFields,
-      });
-      this.onMetadataChange(newHeaders, newFields);
-    }
   };
 
   getManualInputColumns = () => {


### PR DESCRIPTION
# Description

As part of the change to more flexible host genome, we decided to remove the human default on upload.

# Tests

Try to upload samples, see blank host genomes, no JS errors.

Try submitting blank, see "host genome required" message.