### PR TITLE
[IDSEQ-2099] Update deploy/shell scripts to include `sandbox` env

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -59,7 +59,7 @@ def notify_slack(env, image, stage)
   end
 end
 
-#notify_slack(env, image, "start")
+notify_slack(env, image, "start")
 begin
   os = RbConfig::CONFIG['host_os'] =~ /darwin/ ? 'darwin' : 'linux'
   system!("curl -L https://github.com/chanzuckerberg/czecs/releases/download/v0.1.1/czecs_0.1.1_#{os}_amd64.tar.gz | tar xz -C /tmp czecs")
@@ -73,9 +73,9 @@ begin
     system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
     system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor #{cluster} idseq-#{env}-resque-result-monitor czecs-resque.json")
   end
-  # notify_slack(env, image, "end")
+  notify_slack(env, image, "end")
 rescue Exception  # Even on abort/SystemExit
-  #notify_slack(env, image, "failure")
+  notify_slack(env, image, "failure")
   raise
 ensure
   system!("rm -f /tmp/czecs")

--- a/bin/deploy
+++ b/bin/deploy
@@ -65,10 +65,8 @@ begin
   system!("curl -L https://github.com/chanzuckerberg/czecs/releases/download/v0.1.1/czecs_0.1.1_#{os}_amd64.tar.gz | tar xz -C /tmp czecs")
   task_definition_arn = `/tmp/czecs register --quiet -f balances.json --set tag=#{image} --set env=#{env} czecs.json`.strip
   $?.exitstatus == 0 || abort("\n== Could not register task ==\n")
-
   puts 'running migrations'
-  system!("/tmp/czecs task -f balances.json --timeout 0 --set taskDefinitionArn=#{task_definition_arn} --set cluster=idseq-#{cluster}-ecs czecs-task-migrate.json")
-
+  system!("/tmp/czecs task -f balances.json --timeout 0 --set taskDefinitionArn=#{task_definition_arn} --set cluster=#{cluster} czecs-task-migrate.json")
   system!("/tmp/czecs upgrade --task-definition-arn #{task_definition_arn} #{cluster} idseq-#{env}-web")
   system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers #{cluster} idseq-#{env}-resque czecs-resque.json")
   system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")

--- a/bin/deploy
+++ b/bin/deploy
@@ -13,7 +13,12 @@ end
 
 env = ARGV.shift
 image = ARGV.shift
-cluster = env  # Yes, the cluster name is exactly env, no prefix/postfix
+cluster = if env == "sandbox"
+            "idseq-#{env}-ecs"
+          else
+            # TODO(2020-01-23): Rename staging/prod clusters to same format (IDSEQ-2155).
+            env
+          end
 
 if !env || !image
   puts 'Usage: ./bin/deploy ENV IMAGE_TAG'
@@ -60,12 +65,14 @@ begin
   system!("curl -L https://github.com/chanzuckerberg/czecs/releases/download/v0.1.1/czecs_0.1.1_#{os}_amd64.tar.gz | tar xz -C /tmp czecs")
   task_definition_arn = `/tmp/czecs register --quiet -f balances.json --set tag=#{image} --set env=#{env} czecs.json`.strip
   $?.exitstatus == 0 || abort("\n== Could not register task ==\n")
+
   puts 'running migrations'
   system!("/tmp/czecs task -f balances.json --timeout 0 --set taskDefinitionArn=#{task_definition_arn} --set cluster=idseq-#{cluster}-ecs czecs-task-migrate.json")
-  system!("/tmp/czecs upgrade --task-definition-arn #{task_definition_arn} idseq-#{cluster}-ecs idseq-#{env}-web")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers idseq-#{cluster}-ecs idseq-#{env}-resque czecs-resque.json")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor idseq-#{cluster}-ecs idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor idseq-#{cluster}-ecs idseq-#{env}-resque-result-monitor czecs-resque.json")
+
+  system!("/tmp/czecs upgrade --task-definition-arn #{task_definition_arn} #{cluster} idseq-#{env}-web")
+  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers #{cluster} idseq-#{env}-resque czecs-resque.json")
+  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
+  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor #{cluster} idseq-#{env}-resque-result-monitor czecs-resque.json")
   # notify_slack(env, image, "end")
 rescue Exception  # Even on abort/SystemExit
   #notify_slack(env, image, "failure")

--- a/bin/deploy
+++ b/bin/deploy
@@ -16,7 +16,7 @@ image = ARGV.shift
 cluster = if env == "sandbox"
             "idseq-#{env}-ecs"
           else
-            # TODO(2020-01-23): Rename staging/prod clusters to same format (IDSEQ-2155).
+            # TODO(2020-01-23): Rename staging/prod clusters to new format (IDSEQ-2155).
             env
           end
 
@@ -69,8 +69,10 @@ begin
   system!("/tmp/czecs task -f balances.json --timeout 0 --set taskDefinitionArn=#{task_definition_arn} --set cluster=#{cluster} czecs-task-migrate.json")
   system!("/tmp/czecs upgrade --task-definition-arn #{task_definition_arn} #{cluster} idseq-#{env}-web")
   system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers #{cluster} idseq-#{env}-resque czecs-resque.json")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor #{cluster} idseq-#{env}-resque-result-monitor czecs-resque.json")
+  unless env == "sandbox"
+    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
+    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor #{cluster} idseq-#{env}-resque-result-monitor czecs-resque.json")
+  end
   # notify_slack(env, image, "end")
 rescue Exception  # Even on abort/SystemExit
   #notify_slack(env, image, "failure")

--- a/bin/deploy
+++ b/bin/deploy
@@ -54,21 +54,21 @@ def notify_slack(env, image, stage)
   end
 end
 
-notify_slack(env, image, "start")
+#notify_slack(env, image, "start")
 begin
   os = RbConfig::CONFIG['host_os'] =~ /darwin/ ? 'darwin' : 'linux'
   system!("curl -L https://github.com/chanzuckerberg/czecs/releases/download/v0.1.1/czecs_0.1.1_#{os}_amd64.tar.gz | tar xz -C /tmp czecs")
   task_definition_arn = `/tmp/czecs register --quiet -f balances.json --set tag=#{image} --set env=#{env} czecs.json`.strip
   $?.exitstatus == 0 || abort("\n== Could not register task ==\n")
   puts 'running migrations'
-  system!("/tmp/czecs task -f balances.json --timeout 0 --set taskDefinitionArn=#{task_definition_arn} --set cluster=#{cluster} czecs-task-migrate.json")
-  system!("/tmp/czecs upgrade --task-definition-arn #{task_definition_arn} #{cluster} idseq-#{env}-web")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers #{cluster} idseq-#{env}-resque czecs-resque.json")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor #{cluster} idseq-#{env}-resque-result-monitor czecs-resque.json")
-  notify_slack(env, image, "end")
+  system!("/tmp/czecs task -f balances.json --timeout 0 --set taskDefinitionArn=#{task_definition_arn} --set cluster=idseq-#{cluster}-ecs czecs-task-migrate.json")
+  system!("/tmp/czecs upgrade --task-definition-arn #{task_definition_arn} idseq-#{cluster}-ecs idseq-#{env}-web")
+  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers idseq-#{cluster}-ecs idseq-#{env}-resque czecs-resque.json")
+  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor idseq-#{cluster}-ecs idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
+  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor idseq-#{cluster}-ecs idseq-#{env}-resque-result-monitor czecs-resque.json")
+  # notify_slack(env, image, "end")
 rescue Exception  # Even on abort/SystemExit
-  notify_slack(env, image, "failure")
+  #notify_slack(env, image, "failure")
   raise
 ensure
   system!("rm -f /tmp/czecs")

--- a/bin/shell
+++ b/bin/shell
@@ -16,19 +16,22 @@ end
 
 ecs_client = Aws::ECS::Client.new(region: 'us-west-2')
 ec2_client = Aws::EC2::Client.new(region: 'us-west-2')
-service = "idseq-sandbox-web"
+cluster = if env == "sandbox"
+            "idseq-#{env}-ecs"
+          else
+            # TODO(2020-01-23): Rename staging/prod clusters to same format (IDSEQ-2155).
+            env
+          end
+service = "idseq-#{env}-web"
 
-resp = ecs_client.describe_services(cluster: env, services: [service])
-service = resp.services.first
+task = ecs_client.list_tasks(cluster: cluster, service_name: service).task_arns.first
 
-task = ecs_client.list_tasks(cluster: env, service_name: "idseq-sandbox-web").task_arns.first
-
-tasks = ecs_client.describe_tasks(cluster: env, tasks: [task])
-instances = ecs_client.describe_container_instances(cluster: env,
+tasks = ecs_client.describe_tasks(cluster: cluster, tasks: [task])
+instances = ecs_client.describe_container_instances(cluster: cluster,
                                                     container_instances: [tasks.tasks[0].container_instance_arn])
 
 resp = ec2_client.describe_instances(instance_ids: [instances.container_instances[0].ec2_instance_id])
 
 private_ip = resp.reservations.first.instances.first.private_ip_address
 
-exec %(ssh -t #{private_ip} "sudo docker exec -it \\`sudo docker ps | grep ecs-idseq-sandbox-web | head -1 | awk '{print \\$NF}'\\` bin/entrypoint.sh #{command} ")
+exec %(ssh -t #{private_ip} "sudo docker exec -it \\`sudo docker ps | grep ecs-#{service} | head -1 | awk '{print \\$NF}'\\` bin/entrypoint.sh #{command} ")

--- a/bin/shell
+++ b/bin/shell
@@ -16,12 +16,12 @@ end
 
 ecs_client = Aws::ECS::Client.new(region: 'us-west-2')
 ec2_client = Aws::EC2::Client.new(region: 'us-west-2')
-service = "idseq-#{env}-web"
+service = "idseq-sandbox-web"
 
 resp = ecs_client.describe_services(cluster: env, services: [service])
 service = resp.services.first
 
-task = ecs_client.list_tasks(cluster: env, service_name: "idseq-#{env}-web").task_arns.first
+task = ecs_client.list_tasks(cluster: env, service_name: "idseq-sandbox-web").task_arns.first
 
 tasks = ecs_client.describe_tasks(cluster: env, tasks: [task])
 instances = ecs_client.describe_container_instances(cluster: env,
@@ -31,4 +31,4 @@ resp = ec2_client.describe_instances(instance_ids: [instances.container_instance
 
 private_ip = resp.reservations.first.instances.first.private_ip_address
 
-exec %(ssh -t #{private_ip} "sudo docker exec -it \\`sudo docker ps | grep ecs-idseq-#{env}-web | head -1 | awk '{print \\$NF}'\\` bin/entrypoint.sh #{command} ")
+exec %(ssh -t #{private_ip} "sudo docker exec -it \\`sudo docker ps | grep ecs-idseq-sandbox-web | head -1 | awk '{print \\$NF}'\\` bin/entrypoint.sh #{command} ")

--- a/bin/shell
+++ b/bin/shell
@@ -19,7 +19,7 @@ ec2_client = Aws::EC2::Client.new(region: 'us-west-2')
 cluster = if env == "sandbox"
             "idseq-#{env}-ecs"
           else
-            # TODO(2020-01-23): Rename staging/prod clusters to same format (IDSEQ-2155).
+            # TODO(2020-01-23): Rename staging/prod clusters to new format (IDSEQ-2155).
             env
           end
 service = "idseq-#{env}-web"


### PR DESCRIPTION
### Description
- This makes the deploy/shell scripts work with the new `sandbox` env.

### Notes
- The new sandbox ECS cluster follows the name format `idseq-sandbox-ecs` instead of just `staging` or `prod`. It looks like the new format is standardized by the shared-infra module (https://github.com/chanzuckerberg/shared-infra/blob/master/terraform/modules/ecs-cluster/main.tf#L2) and probably allows for more specific resource naming.
- This script update will unblock people who want to deploy/shell into `sandbox` with the current configuration.
- I think we should later rename the `staging` and `prod` clusters to follow the new format to be consistent. Broke off into this ticket: https://jira.czi.team/browse/IDSEQ-2155

### Tests
- Ran `bin/deploy sandbox` and `bin/shell sandbox` successfully. Also tried with staging to make sure the other format still works.