### PR TITLE
Fix water control default not being applied

### DIFF
--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -249,6 +249,7 @@ class MetadataManualInput extends React.Component {
   isHostGenomeIdValidForField = (hostGenomeId, field) =>
     // Special-case 'Host Genome' (the field that lets you change the Host Genome)
     field === "Host Genome" ||
+    this.props.projectMetadataFields[field].is_required ||
     includes(
       hostGenomeId,
       get([field, "host_genome_ids"], this.props.projectMetadataFields)
@@ -301,7 +302,8 @@ class MetadataManualInput extends React.Component {
 
           // Only show a MetadataInput if this metadata field matches the sample's host genome.
           if (this.isHostGenomeIdValidForField(sampleHostGenomeId, column)) {
-            const hostGenome = this.getSampleHostGenome(sample);
+            // host is unknown on initial load
+            const hostGenome = this.getSampleHostGenome(sample) || {};
             return (
               <div>
                 <MetadataInput

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -249,7 +249,7 @@ class MetadataManualInput extends React.Component {
   isHostGenomeIdValidForField = (hostGenomeId, field) =>
     // Special-case 'Host Genome' (the field that lets you change the Host Genome)
     field === "Host Genome" ||
-    this.props.projectMetadataFields[field].is_required ||
+    get([field, "is_required"], this.props.projectMetadataFields) ||
     includes(
       hostGenomeId,
       get([field, "host_genome_ids"], this.props.projectMetadataFields)

--- a/app/assets/src/components/common/metadata_manual_input.scss
+++ b/app/assets/src/components/common/metadata_manual_input.scss
@@ -57,6 +57,7 @@ $metadata-input-extra-width: 225;
     .input {
       margin: $space-xxs $space-m $space-xxs 0;
       width: $metadata-input-width + 0px;
+      vertical-align: top; // for host genome to align to others
 
       &.extraWidth {
         width: $metadata-input-extra-width + 0px;


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/28797/73216725-5ed9d000-410b-11ea-8a62-722c05d4f205.png)

Making the host genome default blank caused the water control default apply all to no longer work, because there was logic to depend on a valid host genome in the "apply all" method. That logic would seem to be relevant only when there is a mix of fields available depending on the selected host genomes. It's not clear to me what the consequences would be of setting a value in JS for a field that is not available for a certain sample. I would expect it to be ignored by the backend on submission. 

In any case, the simple workaround here is to skip the logic for required fields which by definition are available for all samples. 

# Notes

* There was a CSS issue I noticed for the first time -- not sure how it could be related -- but I fixed it. 

# Tests

* upload samples, fill out form, except water control
* see progress to review step, no more water control required error