### PR TITLE
[Report Page] Clean up TODOs for pipeline report service

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -995,13 +995,7 @@ export default class SampleViewV2 extends React.Component {
     } = this.state;
     // reportReady is true if the pipeline run hasn't failed and is report-ready
     // (might still be running Experimental, but at least taxon_counts has been loaded).
-    // pipelineRunReportAvailable was renamed to reportReady, but we check both in case the old variable
-    // name was cached.
-    // TODO(julie): remove pipelineRunReportAvailable during cleanup.
-    if (
-      reportMetadata.reportReady ||
-      reportMetadata.pipelineRunReportAvailable
-    ) {
+    if (reportMetadata.reportReady) {
       return (
         <div className={cs.reportViewContainer}>
           <div className={cs.reportFilters}>


### PR DESCRIPTION
# Description

Addressing the cleanup tasks in IDSEQ-2137, IDSEQ-2139, IDSEQ-2138, and IDSEQ-2128:
* Removing some of the TODO comments in `pipeline_report_service.rb` that will not be done or have already been addressed.
* Removing some of the TODO comments and deprecated variables in `SampleViewV2`
* Separating the logic for adding children species to a genus out of `compute_aggregate_scores` and into its own function for a more logical flow
* Moving `required_columns` into a constant

# Tests

* Verified that the sample report page still loads properly after these changes.
