### PR TITLE
[Release fix] Fix prop with wrong name in ChooseStep (IDSEQ-2178)

### DIFF
--- a/app/assets/src/components/views/bulk_download/ChooseStep.jsx
+++ b/app/assets/src/components/views/bulk_download/ChooseStep.jsx
@@ -316,11 +316,7 @@ class ChooseStep extends React.Component {
   };
 
   renderDownloadType = downloadType => {
-    const {
-      selectedDownloadTypeName,
-      onSelect,
-      selectedSampleIds,
-    } = this.props;
+    const { selectedDownloadTypeName, onSelect, validSampleIds } = this.props;
     const { allSamplesUploadedByCurrentUser } = this.state;
     const { admin, appConfig } = this.context || {};
 
@@ -340,7 +336,7 @@ class ChooseStep extends React.Component {
     } else if (
       downloadType.type === "original_input_file" &&
       appConfig.maxSamplesBulkDownloadOriginalFiles &&
-      selectedSampleIds.size > appConfig.maxSamplesBulkDownloadOriginalFiles &&
+      validSampleIds.size > appConfig.maxSamplesBulkDownloadOriginalFiles &&
       !admin
     ) {
       disabled = true;


### PR DESCRIPTION
# Description

Fix prop with the wrong name in `ChooseStep`; `selectedSampleIds` was renamed to `validSampleIds`

# Tests

* Tested by selecting samples in a project and selecting the "Original Input File" download type to hit that branching statement

The original error:
<img width="624" alt="Screen Shot 2020-01-29 at 3 52 15 PM" src="https://user-images.githubusercontent.com/24234461/73407907-60dc9400-42af-11ea-8962-ae6ad377e89f.png">
