### PR TITLE
Fix branch version tagging potential issue

### DIFF
--- a/bin/deploy_automation/_shared_functions.sh
+++ b/bin/deploy_automation/_shared_functions.sh
@@ -105,9 +105,9 @@ _git_fetch_and_cleanup() {
   # fetch from remote origin
   git fetch origin
 
-  # remove any dangling version tags not present in the remote origin
+  # remove any dangling version tags not present in remote origin
   # (this could happen if a previous run failed to push tags to remote)
-  git tag -d $(
+  declare dangling_tags; dangling_tags=$(
     grep -vxFf  \
       <(git ls-remote --tags origin | cut -f 2 | sed -E 's/^refs\/tags\///') \
       <(git tag -l \
@@ -115,4 +115,8 @@ _git_fetch_and_cleanup() {
       ) \
       || [[ $? == 1 ]]
   )
+  if [ ! -z "$dangling_tags" ]; then
+    _trace "Found some dangling version tags not present in remote origin. Removing..."
+    git tag -d "$dangling_tags"
+  fi
 }

--- a/bin/deploy_automation/_shared_functions.sh
+++ b/bin/deploy_automation/_shared_functions.sh
@@ -76,7 +76,7 @@ _bump_version_string() {
   declare from_version="$1"
   declare field="$2" # 1: major, 2: minor, 3: patch
   echo "${from_version}.0.0.0" | \
-    awk -v i="$field" -F. '{$i = $i + 1} 1' | \
+    awk -v i="$field" -F. '{$i = $i + 1; for(j=i+1;j<=NF;j++){$j="0";}} 1' | \
     sed 's/ /./g' | \
     cut -d. -f1-3
 }

--- a/bin/deploy_automation/automated_release_cycle.sh
+++ b/bin/deploy_automation/automated_release_cycle.sh
@@ -21,7 +21,6 @@ source "$SCRIPT_DIR/_shared_functions.sh"
 
 
 main() {
-  
   # Ensure current branch is not prod or staging
   # This command will set prod and staging HEADs to other commits,
   # and we want to be in a different branch to prevent any issues.
@@ -36,15 +35,9 @@ main() {
   _log "**** STARTING NEW RELEASE CYCLE ****"
   "$SCRIPT_DIR/start_release_cycle.sh"
 
-  declare staging_tag; staging_tag="$(_get_latest_tag "$STAGING_ENV")"
-  declare prod_tag; prod_tag="$(_get_latest_tag "$PROD_ENV")"
-
-  declare msg;
-  msg="**** READY FOR DEPLOYMENT ****${LF}"
-  msg+="${YELLOW}PLEASE EXECUTE THE FOLLOWING COMMANDS${LF}"
-  msg+="./bin/deploy_automation/deploy_tag.sh staging '${staging_tag}'${LF}"
-  msg+="./bin/deploy_automation/deploy_tag.sh prod '${prod_tag}'"
-  _log "$msg"
+  _log "**** READY FOR DEPLOYMENT ****"
+  _log "New tags: ${YELLOW}" \
+       "$(_get_latest_tag "$PROD_ENV")    $(_get_latest_tag "$STAGING_ENV")"
 }
 
 main "$@"

--- a/bin/deploy_automation/automated_release_cycle.sh
+++ b/bin/deploy_automation/automated_release_cycle.sh
@@ -21,6 +21,8 @@ source "$SCRIPT_DIR/_shared_functions.sh"
 
 
 main() {
+  _git_fetch_and_cleanup
+
   # Ensure current branch is not prod or staging
   # This command will set prod and staging HEADs to other commits,
   # and we want to be in a different branch to prevent any issues.
@@ -28,16 +30,58 @@ main() {
 
   _log "**** CHECKING TAG VERSIONS FOR RELEASE/HOT FIXES ****"
   "$SCRIPT_DIR/patch_branch_version_tags.sh"
+  _trace ""
+
+  _log "**** CHECKING RELEASE CYCLE STATE ****"
+  declare current_release_state; current_release_state=$(__check_release_state)
+  _log "Current release cycle state: $current_release_state"
+  _trace ""
 
   _log "**** CLOSING RELEASE CYCLE ****"
-  "$SCRIPT_DIR/close_release_cycle.sh"
+  if [ "$current_release_state" != "closed" ]; then
+    "$SCRIPT_DIR/close_release_cycle.sh"
+  else
+    _log "${YELLOW}WARNING: Current release cycle seems to be already closed. Skipping this step."
+  fi
+  _trace ""
 
   _log "**** STARTING NEW RELEASE CYCLE ****"
   "$SCRIPT_DIR/start_release_cycle.sh"
+  _trace ""
 
   _log "**** READY FOR DEPLOYMENT ****"
   _log "New tags: ${YELLOW}" \
        "$(_get_latest_tag "$PROD_ENV")    $(_get_latest_tag "$STAGING_ENV")"
 }
+
+__check_release_state() {
+  declare current_prod_version; current_prod_version=$(_get_latest_version "${PROD_ENV}")
+  declare current_staging_version; current_staging_version=$(_get_latest_version "${STAGING_ENV}")
+  declare checklist_json; checklist_json=$(_fetch_current_release_checklist_from_github)
+  declare highest_version; highest_version=$(sort -rV <( printf "%s\n" "$current_prod_version" "$current_staging_version" ) | head -n 1)
+  declare latest_staging_tag; latest_staging_tag=$(_get_latest_tag "${STAGING_ENV}")
+  declare latest_staging_tag_commit; latest_staging_tag_commit=$(_get_latest_commit "origin/${STAGING_BRANCH}")
+  declare latest_staging_commit; latest_staging_commit=$(_get_latest_commit "origin/${STAGING_BRANCH}")
+
+  _trace "current_prod_version=$current_prod_version"
+  _trace "current_staging_version=$current_staging_version"
+  _trace "highest_version=$highest_version"
+  _trace "latest_staging_tag=$latest_staging_tag ($latest_staging_tag_commit)"
+  _trace "latest_staging_commit=$latest_staging_commit"
+  _trace "checklist_json=$(jq -c <<<"$checklist_json" | cut -c 1-40)"
+
+  if [ "$checklist_json" == "null" ] \
+     && [ ! -z "$current_staging_version" ] \
+     && [ "$current_staging_version" == "$current_prod_version" ] \
+     && [ "$latest_staging_tag_commit" == "$latest_staging_commit" ]; then
+    echo "closed"
+  elif [ "$checklist_json" != "null" ] && \
+       [ "$current_staging_version" == "$highest_version" ]; then
+    echo "open"
+  else
+    echo "unknown"
+  fi
+}
+
 
 main "$@"

--- a/bin/deploy_automation/close_release_cycle.sh
+++ b/bin/deploy_automation/close_release_cycle.sh
@@ -54,6 +54,7 @@ main() {
 
   # deploy instructions
   _log "Release cycle $staging_tag_version successfully closed."
+       "Please deploy ${tag} ($(git log -n1 "${tag}" --format=%h)) to ${prod}"
 }
 
 main "$@"

--- a/bin/deploy_automation/close_release_cycle.sh
+++ b/bin/deploy_automation/close_release_cycle.sh
@@ -30,12 +30,14 @@ main() {
 
   # Verify if there is at least one item in the check list
   if ! ( grep -qE '^\s*\*\s*\[[xX ]+\]' <<< "$checklist_body" ); then
-    _exit_with_err_msg "INVALID STATE: Couldn't find any items in the release checklist. Please check $checklist_html_url"
+    _exit_with_err_msg "INVALID STATE: Couldn't find any items in the release checklist." \
+                       "Please check $checklist_html_url and restart the process"
   fi
 
   # Verify if there are unchecked items left
   if ( grep -qE '^\s*\*\s*\[[^xX]\]' <<< "$checklist_body" ); then
-    _exit_with_err_msg "INVALID STATE: There are unchecked items in the release checklist. Please check $checklist_html_url"
+    _exit_with_err_msg "INVALID STATE: There are unchecked items in the release checklist." \
+                       "Please check $checklist_html_url and restart the process"
   fi
 
   # Create a new tag for `prod` pointing to HEAD of `staging`
@@ -53,8 +55,8 @@ main() {
   git push --atomic -f origin "${tag}" "${PROD_BRANCH}"
 
   # deploy instructions
-  _log "Release cycle $staging_tag_version successfully closed."
-       "Please deploy ${tag} ($(git log -n1 "${tag}" --format=%h)) to ${prod}"
+  _log "Release cycle $staging_tag_version successfully closed." \
+       "Please deploy ${tag} ($(git log -n1 "${tag}" --format=%h)) to ${PROD_ENV}"
 }
 
 main "$@"

--- a/bin/deploy_automation/deploy_rev.sh
+++ b/bin/deploy_automation/deploy_rev.sh
@@ -19,12 +19,12 @@ main() {
   _log "Starting deployment of $git_rev (sha-$sha) to $env"
 
   _log "Checking if docker image $docker_image is available"
-  if ! __retry 10 60 __docker_tag_exists "${DOCKER_REPOSITORY_NAME}" "sha-$sha"; then
+  if ! __retry 15 60 __docker_tag_exists "${DOCKER_REPOSITORY_NAME}" "sha-$sha"; then
     _exit_with_err_msg "Couldn't find image ${docker_image} in docker hub"
   fi
 
   _log "Checking if Github commit ${sha} in a valid state"
-  if ! __retry 10 60 __check_commit_state "${sha}" "$env"; then
+  if ! __retry 15 60 __check_commit_state "${sha}" "$env"; then
     _exit_with_err_msg "Commit ${sha} is in an invalid state. Aborting deployment. More details at $GITHUB_REPOSITORY_URL/commits/${env}"
   fi
 

--- a/bin/deploy_automation/make_release_checklist.sh
+++ b/bin/deploy_automation/make_release_checklist.sh
@@ -7,7 +7,7 @@ source "$SCRIPT_DIR/_shared_functions.sh"
 # Compare staging to prod and create a draft pull request in github
 # with commits that are only in staging
 main() {
-  git fetch --all
+  _git_fetch_and_cleanup
 
   # make sure release checklist doesn't exist yet
   _assert_no_release_checklist

--- a/bin/deploy_automation/patch_branch_version_tags.sh
+++ b/bin/deploy_automation/patch_branch_version_tags.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/_shared_functions.sh"
 # If there are additional commits, create a new tag for that environment and bump the
 # patch version (ex: v0.24_staging_... -> v0.24.1_staging_...)
 main() {
-  git fetch --all
+  _git_fetch_and_cleanup
 
   __patch_version_tag "$STAGING_BRANCH" "$STAGING_ENV" "Release fix"
   __patch_version_tag "$PROD_BRANCH" "$PROD_ENV" "Hot fix"

--- a/bin/deploy_automation/start_release_cycle.sh
+++ b/bin/deploy_automation/start_release_cycle.sh
@@ -34,6 +34,13 @@ main() {
     _exit_with_err_msg "$msg"
   fi
 
+  # check if there is any commit in master
+  declare commit_count; commit_count=$(git rev-list "origin/$STAGING_BRANCH".."origin/$MASTER_BRANCH" | wc -l)
+  if [ "$commit_count" -eq "0" ]; then
+    _exit_with_err_msg "origin/${MASTER_BRANCH} doesn't seem to have any additional commits after origin/${STAGING_BRANCH}." \
+                       "Cannot start a new release cycle."
+  fi
+ 
   # Bump tag version
   declare next_version; next_version=$(_bump_version_string "$staging_tag_version" 2)
   _log "Bumping $STAGING_BRANCH from version $staging_tag_version to $next_version"
@@ -55,7 +62,8 @@ main() {
   "$SCRIPT_DIR/make_release_checklist.sh"
 
   # deploy instructions
-  _log "Release cycle ready. Please deploy ${tag} ($(git log -n1 "${tag}" --format=%h)) to ${STAGING_ENV}"
+  _log "Release cycle ready." \
+       "Please deploy ${tag} ($(git log -n1 "${tag}" --format=%h)) to ${STAGING_ENV}"
 }
 
 main "$@"

--- a/bin/deploy_automation/update_release_checklist.sh
+++ b/bin/deploy_automation/update_release_checklist.sh
@@ -7,7 +7,7 @@ source "$SCRIPT_DIR/_shared_functions.sh"
 # Updates the release checklist with all release fixes that have been created since
 # the beginning of the current version
 main() {
-  git fetch --all
+  _git_fetch_and_cleanup
 
   declare checklist_json; checklist_json=$(_get_current_release_checklist_json)
   declare checklist_html_url; checklist_html_url=$(jq -er .html_url <<< "$checklist_json")


### PR DESCRIPTION
# Description

Fix a potential issue in `patch_branch_version_tags.sh` where failing to push tags to origin would create an inconsistent state if the command were re-executed.

Also adding some extra release cycle state detection to resume from error conditions.

# Tests

* Manual
