### PR TITLE
Disable non host alignment retry

### DIFF
--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -193,7 +193,10 @@ class PipelineRunStage < ApplicationRecord
 
     # note failed attempt and retry
     add_failed_job
-    unless count_failed_tries <= MAX_RETRIES
+    # Disable retrying for non host alignment
+    #  It is best if such a retry needs to happen for it to happen many hours
+    #  later after a different set of instances are running.
+    unless count_failed_tries <= MAX_RETRIES || dag_name == DAG_NAME_ALIGNMENT
       LogUtil.log_err_and_airbrake("Job #{job_id} for pipeline run #{id} was killed #{MAX_RETRIES} times.")
       save
       return


### PR DESCRIPTION
# Description

This disables the stage-level retry for non host alignment. This is one of two fixes ([the other fix](https://github.com/chanzuckerberg/idseq-dag/pull/243)) for a bug with rapsearch. Both fixes will fix the bug independently but both together will make the system more resilient.

The issue is that rapsearch generates intermediate files. Our current system does not clean these files. If rapsearch fails for whatever reason the intermediate files from that run will remain on the instance it ran on. If the retry is run on the same instance these incomplete intermediate break the subsequent run. At times of low volume when there are few instances this is actually not so unlikely.

Based on a conversation with @boris-dimitrov It is best if such a retry needs to happen for it to happen many hours later after a different set of instances are running. So I am disabling this retry specifically for non host alignment and I added a comment with this explanation.

# Tests

This is a fairly small change. I will run a pipeline locally to ensure it still works.