### PR TITLE
Fix bug where water control was showing in review step.

### DIFF
--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -13,6 +13,7 @@ import _fp, {
   orderBy,
   find,
   pickBy,
+  has,
 } from "lodash/fp";
 
 import { logAnalyticsEvent } from "~/api/analytics";
@@ -66,7 +67,9 @@ class MetadataManualInput extends React.Component {
 
   // Need to special case this to avoid a missing required field error.
   setDefaultWaterControl = () => {
-    this.applyToAll("water_control", "No");
+    if (has("water_control", this.props.projectMetadataFields)) {
+      this.applyToAll("water_control", "No");
+    }
   };
 
   getManualInputColumns = () => {

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -56,17 +56,44 @@ class MetadataUpload extends React.Component {
         getAllSampleTypes(),
       ]
     );
+    this.setState({
+      projectMetadataFields: this.processProjectMetadataFields(
+        projectMetadataFields
+      ),
+      hostGenomes,
+      sampleTypes,
+    });
+  }
+
+  async componentDidUpdate(prevProps) {
+    if (prevProps.project.id !== this.props.project.id) {
+      // Set the projectMetadataFields to null while fetching the new fields.
+      // This forces the MetadataManualInput to re-mount which is necessary for correct behavior.
+      this.setState({
+        projectMetadataFields: null,
+      });
+
+      const projectMetadataFields = await getProjectMetadataFields(
+        this.props.project.id
+      );
+
+      this.setState({
+        projectMetadataFields: this.processProjectMetadataFields(
+          projectMetadataFields
+        ),
+      });
+    }
+  }
+
+  processProjectMetadataFields = projectMetadataFields => {
     const sorted = sortBy(
       metadataField =>
         this.ordering[metadataField.key] || Number.MAX_SAFE_INTEGER,
       projectMetadataFields
     );
-    this.setState({
-      projectMetadataFields: keyBy("key", sorted),
-      hostGenomes,
-      sampleTypes,
-    });
-  }
+
+    return keyBy("key", sorted);
+  };
 
   handleTabChange = tab => {
     this.setState({ currentTab: tab, issues: null });


### PR DESCRIPTION
# Description

Fixes bug where "water_control" shows up in the Review Step, even for projects without water_control.
This was being caused by `setDefaultWaterControl` being called even when water_control wasn't in the projectMetadataFields. ReviewStep simply displays whatever is in the metadata object that is passed to it, and assumes that the previous steps only put valid things into the metadata object.

Also fix a (previously undetected) bug where if you GO BACK to step 1 and pick a different project, step 2 (select metadata) will not refresh the project metadata fields. An edge case, but it's now fixed.

# Tests

* Verified that water_control no longer shows up.
* Verified that when you return to step 1 and switch projects, the metadata fields are as expected. 
