### PR TITLE
cache report only if pipeline run is complete and successful

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -814,7 +814,7 @@ class SamplesController < ApplicationController
     background_id = get_background_id(@sample, params[:background])
 
     if pipeline_run
-      # Don't cache the response until all results for the pipeline run have been loaded
+      # Don't cache the response until all results for the pipeline run are available
       # so the displayed pipeline run status and report hover actions will be updated correctly.
       skip_cache = !pipeline_run.complete_and_successful? || params[:skip_cache] || false
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -814,9 +814,9 @@ class SamplesController < ApplicationController
     background_id = get_background_id(@sample, params[:background])
 
     if pipeline_run
-      # Don't cache the response until the pipeline run is report-ready
-      # so the displayed pipeline run status will be updated correctly.
-      skip_cache = !pipeline_run.report_ready? || params[:skip_cache] || false
+      # Don't cache the response until all results for the pipeline run have been loaded
+      # so the displayed pipeline run status and report hover actions will be updated correctly.
+      skip_cache = !pipeline_run.complete_and_successful? || params[:skip_cache] || false
 
       report_info_params = pipeline_run.report_info_params
       # If the pipeline_version wasn't passed in from the client-side,

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -297,7 +297,7 @@ class PipelineRun < ApplicationRecord
     # once a pipeline run is successful and all results are available.
     #   (1) "results_finalized == FINALIZED_SUCCESS" means all results destined for the DB
     #       have successfully been loaded from S3.
-    #   (2) "finalized == STATUS_CHECKED" means all Batch jobs have completed successfully.
+    #   (2) "job_status == STATUS_CHECKED" means all Batch jobs have completed successfully.
     #       This is important because certain outputs (e.g. coverage viz) are never loaded to
     #       the DB. Instead they are fetched at the time a report is viewed. We can only be
     #       certain that generation of those outputs is complete if the last Batch job has succeeded.

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -301,7 +301,7 @@ class PipelineRun < ApplicationRecord
     #       This is important because certain outputs (e.g. coverage viz) are never loaded to
     #       the DB. Instead they are fetched at the time a report is viewed. We can only be
     #       certain that generation of those outputs is complete if the last Batch job has succeeded.
-    pipeline_run.results_finalized == FINALIZED_SUCCESS && pipeline_run.finalized == STATUS_CHECKED
+    results_finalized == FINALIZED_SUCCESS && job_status == STATUS_CHECKED
   end
 
   def failed?


### PR DESCRIPTION
# Description
**Problem**: When a user accesses a report before the Experimental stage of the pipeline run is complete, then the report will be cached. This is problematic because now all users will see the incomplete state of the report (e.g. coverage viz disabled, taxon fasta disabled) even after the results of the Experimental stage become available, because the report is retrieved from the cache. 
**Solution**: Cache reports only once all stages have completed and all results have been loaded.

# Tests
Tested locally that the `complete_and_successful?` method behaves as expected. Will verify caching behavior once this code is in staging
