### PR TITLE
[Heatmap Filtering] Send more metric data to enable all client-side threshold filters

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -449,9 +449,6 @@ class SamplesHeatmapView extends React.Component {
     for (let filter of thresholdFilters) {
       // Convert metric name format from "NT_zscore" to "NT.zscore"
       let metric = filter["metric"].split("_").join(".");
-      // TODO(julie): Backend needs to send more metric data to enable all threshold filters on frontend.
-      // ALL_METRICS currently only includes rPM, zscore, and total reads (and is missing %id, L, log(1/e)).
-      // Current placeholder logic returns true for all taxons if the data for a particular metric is not present.
       if (Object.keys(data).includes(metric)) {
         let value = data[metric][taxonDetails["index"]][sampleIndex];
         if (!value) {
@@ -641,7 +638,14 @@ class SamplesHeatmapView extends React.Component {
 
   getControlOptions = () => ({
     // Server side options
-    metrics: this.props.metrics,
+    metrics: [
+      { value: "NT.zscore", text: "NT Z Score" },
+      { value: "NT.rpm", text: "NT rPM" },
+      { value: "NT.r", text: "NT r (total reads)" },
+      { value: "NR.zscore", text: "NR Z Score" },
+      { value: "NR.rpm", text: "NR rPM" },
+      { value: "NR.r", text: "NR r (total reads)" },
+    ],
     categories: this.props.categories || [],
     subcategories: this.props.subcategories || {},
     backgrounds: this.props.backgrounds,

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -48,6 +48,14 @@ const SPECIFICITY_OPTIONS = [
   { text: "All", value: 0 },
   { text: "Specific Only", value: 1 },
 ];
+const METRIC_OPTIONS = [
+  "NT.zscore",
+  "NT.rpm",
+  "NT.r",
+  "NR.zscore",
+  "NR.rpm",
+  "NR.r",
+];
 
 const parseAndCheckInt = (val, defaultVal) => {
   let parsed = parseInt(val);
@@ -638,14 +646,9 @@ class SamplesHeatmapView extends React.Component {
 
   getControlOptions = () => ({
     // Server side options
-    metrics: [
-      { value: "NT.zscore", text: "NT Z Score" },
-      { value: "NT.rpm", text: "NT rPM" },
-      { value: "NT.r", text: "NT r (total reads)" },
-      { value: "NR.zscore", text: "NR Z Score" },
-      { value: "NR.rpm", text: "NR rPM" },
-      { value: "NR.r", text: "NR r (total reads)" },
-    ],
+    metrics: this.props.metrics.filter(metric =>
+      METRIC_OPTIONS.includes(metric.value)
+    ),
     categories: this.props.categories || [],
     subcategories: this.props.subcategories || {},
     backgrounds: this.props.backgrounds,

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -160,7 +160,7 @@ class VisualizationsController < ApplicationController
           { text: "NR rPM", value: "NR_rpm" },
           { text: "NR %id", value: "NR_percentidentity" },
           { text: "NR L (alignment length in bp)", value: "NR_alignmentlength" },
-          { text: "NR log(1/e)", value: "NR_neglogevalue" },
+          { text: "R log(1/e)", value: "NR_neglogevalue" },
         ],
         operators: [">=", "<="],
       },

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -160,7 +160,7 @@ class VisualizationsController < ApplicationController
           { text: "NR rPM", value: "NR_rpm" },
           { text: "NR %id", value: "NR_percentidentity" },
           { text: "NR L (alignment length in bp)", value: "NR_alignmentlength" },
-          { text: "R log(1/e)", value: "NR_neglogevalue" },
+          { text: "NR log(1/e)", value: "NR_neglogevalue" },
         ],
         operators: [">=", "<="],
       },

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -24,6 +24,12 @@ module HeatmapHelper
     { text: "NR rPM", value: "NR.rpm" },
     { text: "NR Z Score", value: "NR.zscore" },
     { text: "NR r (total reads)", value: "NR.r" },
+    { text: "NT %id", value: "NT.percentidentity" },
+    { text: "NT L (alignment length in bp)", value: "NT.alignmentlength" },
+    { text: "NT log(1/e)", value: "NT.neglogevalue" },
+    { text: "NR %id", value: "NR.percentidentity" },
+    { text: "NR L (alignment length in bp)", value: "NR.alignmentlength" },
+    { text: "NR log(1/e)", value: "NR.neglogevalue" },
   ].freeze
 
   # Samples and background are assumed here to be vieweable.

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -29,7 +29,7 @@ module HeatmapHelper
     { text: "NT log(1/e)", value: "NT.neglogevalue" },
     { text: "NR %id", value: "NR.percentidentity" },
     { text: "NR L (alignment length in bp)", value: "NR.alignmentlength" },
-    { text: "NR log(1/e)", value: "NR.neglogevalue" },
+    { text: "R log(1/e)", value: "NR.neglogevalue" },
   ].freeze
 
   # Samples and background are assumed here to be vieweable.


### PR DESCRIPTION
# Description

Currently, some threshold filters aren't functional (%id, L, log(1/e)) with client-side filtering because that data is currently not being returned from the backend. (IDSEQ-2189) This change sends the necessary data to enable all threshold filters to operate on the client-side.

# Tests

* Verified that NT and NR %id, L, log(1/e) threshold filters work with the `heatmap_filter_fe` flag enabled.
