### PR TITLE
[Report Page] Cleanup: move rpm calc and sample default fields

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -62,6 +62,16 @@ class SamplesController < ApplicationController
   MIN_CLI_VERSION = '0.7.3'.freeze
   CLI_DEPRECATION_MSG = "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git` or with sudo + pip2/pip3 depending on your setup to update and try again.".freeze
 
+  SAMPLE_DEFAULT_FIELDS = [
+    :name,
+    :created_at,
+    :updated_at,
+    :project_id,
+    :status,
+    :host_genome_id,
+    :upload_error,
+  ].freeze
+
   # GET /samples
   # GET /samples.json
   def index
@@ -751,23 +761,13 @@ class SamplesController < ApplicationController
   end
 
   def show_v2
-    # TODO: move to fastjson_api serializer
-    default_fields = [
-      :name,
-      :created_at,
-      :updated_at,
-      :project_id,
-      :status,
-      :host_genome_id,
-      :upload_error,
-    ]
     respond_to do |format|
       format.html { render 'show_v2' }
       format.json do
         render json: @sample
           .as_json(
             methods: [],
-            only: default_fields,
+            only: SAMPLE_DEFAULT_FIELDS,
             include: {
               project: {
                 only: [:id, :name],

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -149,7 +149,7 @@ class PipelineReportService
       @timer.split("compute_rpm")
 
       counts_by_tax_level.each_value do |tax_level_taxa|
-        compute_z_scores(tax_level_taxa, adjusted_total_reads)
+        compute_z_scores(tax_level_taxa)
       end
       @timer.split("compute_z_scores")
 
@@ -419,7 +419,7 @@ class PipelineReportService
     return value.clamp(min_z_score, max_z_score)
   end
 
-  def compute_z_scores(taxa_counts, _adjusted_total_reads)
+  def compute_z_scores(taxa_counts)
     taxa_counts.each_value do |taxon_counts|
       nt_z_score = compute_z_score(taxon_counts[:nt][:rpm], taxon_counts[:nt][:bg_mean], taxon_counts[:nt][:bg_stdev]) if taxon_counts[:nt].present?
       nr_z_score = compute_z_score(taxon_counts[:nr][:rpm], taxon_counts[:nr][:bg_mean], taxon_counts[:nr][:bg_stdev]) if taxon_counts[:nr].present?


### PR DESCRIPTION
# Description

Extracting rpm calculation for the report page into its own method to keep logic separated (IDSEQ-2136).

Moving `default_fields` into a constant for readability and reusability (IDSEQ-2120).

# Tests

* Verified that report page is unaffected by these changes.
