### PR TITLE
IDSEQ-2231 Fix bugs with sample metadata upload when steps are repeated.

### DIFF
--- a/app/assets/src/components/ui/controls/Input.jsx
+++ b/app/assets/src/components/ui/controls/Input.jsx
@@ -14,12 +14,16 @@ class Input extends React.Component {
   };
 
   render() {
-    let { className, disableAutocomplete, ...props } = this.props;
+    let { className, disableAutocomplete, value, ...props } = this.props;
     className = "idseq-ui " + className;
     return (
       <SemanticInput
-        className={className}
         {...props}
+        className={className}
+        // If undefined is passed to SemanticInput, the previous value of the input will continue to
+        // be displayed instead of an empty string.
+        // Therefore, we force an empty string to be passed.
+        value={value || ""}
         onChange={this.handleChange}
         // Chrome ignores autocomplete="off" on purpose, so use a non-standard
         // label. See: https://stackoverflow.com/questions/15738259/disabling-chrome-autofill

--- a/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchPopBox.jsx
@@ -14,6 +14,7 @@ class LiveSearchPopBox extends React.Component {
       isLoading: false,
       results: [],
       // the current value of the search input
+      // Cannot be undefined or null. Must be a string.
       inputValue: this.props.initialValue,
     };
 
@@ -26,7 +27,7 @@ class LiveSearchPopBox extends React.Component {
     if (props.value !== state.prevValue) {
       return {
         prevValue: props.value,
-        inputValue: props.value,
+        inputValue: props.value || "",
       };
     }
     return null;

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -128,13 +128,6 @@ class SampleUploadFlow extends React.Component {
     });
   };
 
-  getSamplesForMetadataValidation = () => {
-    return this.state.samples.map(sample => ({
-      name: sample.name,
-      project_id: sample.project_id,
-    }));
-  };
-
   // SLIGHT HACK: Keep steps mounted, so user can return to them if needed.
   // The internal state of some steps is difficult to recover if they are unmounted.
   renderSteps = () => {
@@ -152,7 +145,7 @@ class SampleUploadFlow extends React.Component {
         {this.state.samples && (
           <UploadMetadataStep
             onUploadMetadata={this.handleUploadMetadata}
-            samples={this.getSamplesForMetadataValidation()}
+            samples={this.state.samples}
             project={this.state.project}
             visible={this.state.currentStep === "uploadMetadata"}
             onDirty={this.metadataChanged}


### PR DESCRIPTION
# Description

This was a combination of a couple of bugs:
Some of the metadata input fields don't behave well when they are passed different props (but not unmounted). 
* In particular, `<LiveSearchPopBox>` doesn't behave well when `undefined` is passed in. It was actually throwing an error. This made it seem as if the Host Genome and Sample Type were pre-populated, when in actuality the metadata value was `undefined`. Since the error was being thrown, it was also not possible to modify these metadata values once you get in this state.
* The Collection Date metadata input was also not being reset properly, but for a different reason. The reason here is that if you pass `undefined` into SemanticInput, it assumes you are making the component uncontrolled and keeps the previous value that was displayed. This again makes it seem as if the field was "pre-populated" when in fact the metadata value was undefined.

Also, the metadata wasn't being properly updated when you go to step 2, return to step 1, change the samples, then go to step 2 again. If the user immediately clicks "Continue" without editing any metadata, they may get unexpected errors. (editing any input field will cause the metadata to be synced)
* Fixed this for MetadataManualInput as a whole.
* water_control also wasn't being updated properly in this situation. It was only called the first time you enter step 2. This has been fixed. An `overrideExistingValues` option was added to `applyToAll`, so that we could set water control to "No" only for NEW samples.

When re-entering step 2, this is what it now looks like:
![Screen Shot 2020-02-05 at 3 17 15 PM](https://user-images.githubusercontent.com/837004/73894735-3e5bf500-4832-11ea-88dc-3b3d95b622c6.png)


# Tests

* Verified that when you "go back" to step 2, clicking Continue immediately shows reasonable validation errors. Also, none of the metadata fields are incorrectly "pre-populated".
* Verified that if you set "Yes" to water-control and later "go back" to step 2, it won't get set to "No" (i.e. `overrideExistingValues` is working properly)
* Verified that the Upload Metadata Modal still works properly.
* Verified that uploading metadata via CSV still works properly.
* Verified that after completing these steps, you can still complete the sample upload flow properly.
* Verified both when the `host_genome_free_text` and `sample_type_free_text` allowed feature flags are on and off.
* Verified both when projects have and don't have the `water_control` metadata field.