### PR TITLE
Fix s3 upload when new host genome enabled and existing host

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -520,11 +520,10 @@ module SamplesHelper
         begin
           # TODO: (gdingle): remove allowedFeatures feature gating.
           # See https://jira.czi.team/browse/IDSEQ-2051
-          hg = if user.allowed_feature?("host_genome_free_text")
-                 HostGenome.find_or_create_by!(name: name, user: user)
-               else
-                 HostGenome.find_by(name: name)
-               end
+          hg = HostGenome.find_by(name: name)
+          if hg.nil? && user.allowed_feature?("host_genome_free_text")
+            hg = HostGenome.create!(name: name, user: user)
+          end
         rescue => e
           errors << e.message
           metadata.delete(sample_attributes[:name])


### PR DESCRIPTION
# Description

This bug was revealed when doing s3 uploads with an existing host, because only then does the server try to find the host by name, and there was a bug in `find_or_create_by`. 

# Tests

* try s3 upload flow
* copy curl command
* try curl from command line until no more error and correct json payload response