### PR TITLE
Accept "host_organism" as synonym for "host_genome"

### DIFF
--- a/app/assets/src/components/common/MetadataCSVUpload.jsx
+++ b/app/assets/src/components/common/MetadataCSVUpload.jsx
@@ -102,6 +102,7 @@ class MetadataCSVUpload extends React.Component {
       metadata: processCSVMetadata(csv),
       issues: serverResponse.issues,
       validatingCSV: false,
+      newHostGenomes: serverResponse.newHostGenomes,
     });
   };
 

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -111,8 +111,18 @@ class MetadataUpload extends React.Component {
   };
 
   // MetadataCSVUpload validates metadata before calling onMetadataChangeCSV.
-  onMetadataChangeCSV = ({ metadata, issues, validatingCSV }) => {
-    this.props.onMetadataChange({ metadata, issues, wasManual: false });
+  onMetadataChangeCSV = ({
+    metadata,
+    issues,
+    validatingCSV,
+    newHostGenomes,
+  }) => {
+    this.props.onMetadataChange({
+      metadata,
+      issues,
+      wasManual: false,
+      newHostGenomes,
+    });
     this.setState({
       issues,
       validatingCSV,

--- a/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/SampleUploadFlow.jsx
@@ -58,6 +58,13 @@ class SampleUploadFlow extends React.Component {
 
   handleUploadMetadata = ({ metadata, issues, newHostGenomes }) => {
     const updatedHostGenomes = this.props.hostGenomes.concat(newHostGenomes);
+    // See HOST_GENOME_SYNONYMS in MetadataField
+    const hostGenomeSynonyms = [
+      "host_genome",
+      "Host Genome",
+      "host_organism",
+      "Host Organism",
+    ];
 
     // Populate host_genome_id in sample using metadata.
     const newSamples = this.state.samples.map(sample => {
@@ -67,8 +74,10 @@ class SampleUploadFlow extends React.Component {
           get("Sample Name", row) === sample.name,
         metadata.rows
       );
-      const hostGenomeName =
-        get("host_genome", metadataRow) || get("Host Genome", metadataRow);
+      const hostGenomeName = hostGenomeSynonyms.reduce(
+        (match, name) => metadataRow[name] || match,
+        null
+      );
       const hostGenomeId = find(
         // Lowercase to allow for 'human' to match 'Human'. The same logic
         // is replicated in MetadataHelper.

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -18,6 +18,7 @@ class UploadMetadataStep extends React.Component {
     metadata: null,
     issues: null,
     wasManual: false,
+    newHostGenomes: [],
   };
 
   setShowInstructions = showInstructions => {
@@ -26,11 +27,12 @@ class UploadMetadataStep extends React.Component {
     });
   };
 
-  handleMetadataChange = ({ metadata, issues, wasManual }) => {
+  handleMetadataChange = ({ metadata, issues, wasManual, newHostGenomes }) => {
     this.setState({
       metadata,
       issues,
       wasManual,
+      newHostGenomes,
     });
 
     const metadataValid = metadata && !(issues && issues.errors.length > 0);

--- a/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadMetadataStep.jsx
@@ -71,7 +71,7 @@ class UploadMetadataStep extends React.Component {
       this.props.onUploadMetadata({
         metadata: this.state.metadata,
         issues: this.state.issues,
-        newHostGenomes: result.newHostGenomes,
+        newHostGenomes: this.state.newHostGenomes,
       });
     }
     logAnalyticsEvent("UploadMetadataStep_continue-button_clicked", {

--- a/app/assets/src/components/views/SampleUploadFlow/host_organism_message.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/host_organism_message.scss
@@ -3,6 +3,8 @@
 @import "~styles/themes/typography";
 
 .listContainer {
+  margin: $space-s 0;
+
   background-color: $info-bg;
 
   &.warn {

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -389,8 +389,10 @@ module MetadataHelper
                        hg = HostGenome.find_by(name: name) # case insensitive
                        unless hg
                          hg = HostGenome.new(name: name, user: current_user)
-                         new_host_genomes << hg
                        end
+                       # Return all found or created host genomes until this is resolved:
+                       # https://jira.czi.team/browse/IDSEQ-2193.
+                       new_host_genomes << hg
                        hg.valid? && hg
                      end
                    else

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -56,6 +56,8 @@ module MetadataHelper
     # downloading it from a stand-alone upload instruction page such as /cli_user_instructions.
     # The CLI also directs users to /metadata/metadata_template_csv when asking for metadata during new sample upload,
     # and we should include the host genome column here as well.
+    # NOTE: In Feb 2020, Host Genome was renamed in the UI to Host Organism.
+    # Both names are equivalent in CSV upload.
     include_host_genome = project.nil? || samples_are_new
 
     # If project is nil, use global default and required fields.
@@ -80,7 +82,7 @@ module MetadataHelper
     # TODO(jsheu): Remove legacy field and swap in collection_location_v2.
     fields = fields.reject { |f| f.name == "collection_location" }
 
-    field_names = ["Sample Name"] + (include_host_genome ? ["Host Genome"] : []) + fields.pluck(:display_name)
+    field_names = ["Sample Name"] + (include_host_genome ? ["Host Organism"] : []) + fields.pluck(:display_name)
 
     host_genomes_by_name = HostGenome.all.includes(:metadata_fields).reject { |x| x.metadata_fields.empty? }.index_by(&:name)
 

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -465,7 +465,7 @@ module SamplesHelper
       end
 
       fields.each do |key, value|
-        next if ["Sample Name", "Host Genome", "sample_name", "host_genome"].include?(key)
+        next if MetadataField::RESERVED_NAMES.include?(key)
 
         status = sample.ensure_metadata_field_for_key(key)
 

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -5,6 +5,20 @@ class MetadataField < ApplicationRecord
 
   validate :metadata_field_subsets
 
+  # As of Feb 2020, we renamed "Host Genome" in the UI to better reflect its
+  # purpose as "Host Organism". For backwards compatibility, especially for CSV
+  # uploads, we treat both as synonyms.
+  HOST_GENOME_SYNONYMS = [
+    "host_genome",
+    "Host Genome",
+    "host_organism",
+    "Host Organism",
+  ].freeze
+  # We can't let a user create their own sample_name custom metadata column
+  SAMPLE_NAME_SYNONYMS = ["sample_name", "Sample Name"].freeze
+  RESERVED_NAMES = HOST_GENOME_SYNONYMS | SAMPLE_NAME_SYNONYMS
+  validates :name, exclusion: { in: RESERVED_NAMES }
+
   STRING_TYPE = 0
   NUMBER_TYPE = 1
   DATE_TYPE = 2

--- a/spec/models/metadata_field_spec.rb
+++ b/spec/models/metadata_field_spec.rb
@@ -21,4 +21,9 @@ describe MetadataField, type: :model do
   it 'be boolean if force_options and two options' do
     expect(create(:metadata_field, force_options: 1, options: options).boolean?).to be
   end
+
+  it 'will not create a reserved name' do
+    expect { create(:metadata_field, name: 'sample_name') }.to raise_error(ActiveRecord::RecordInvalid)
+    expect { create(:metadata_field, name: 'my_name') }.to_not raise_error
+  end
 end

--- a/test/controllers/metadata_validate_new_samples_test.rb
+++ b/test/controllers/metadata_validate_new_samples_test.rb
@@ -6,7 +6,6 @@ class MetadataValidateNewSamplesTest < ActionDispatch::IntegrationTest
 
   HEADERS_1 = ['sample_name', 'host_genome', 'sample_type', 'blood_fed'].freeze
   HEADERS_2 = ['sample_name', 'host_genome', 'sample_type', 'nucleotide_type'].freeze
-  HEADERS_3 = ['sample_name', 'host_organism', 'sample_type', 'nucleotide_type'].freeze
   ROW_1 = ['Test Sample', 'Mosquito', 'Whole Blood', 'Blood Fed'].freeze
   ROW_2 = ['Test Sample 2', 'Mosquito', 'Whole Blood', 'Partially Blood Fed'].freeze
   ROW_3 = ['Test Sample', 'Human', 'Whole Blood', 'DNA'].freeze

--- a/test/controllers/metadata_validate_new_samples_test.rb
+++ b/test/controllers/metadata_validate_new_samples_test.rb
@@ -6,6 +6,7 @@ class MetadataValidateNewSamplesTest < ActionDispatch::IntegrationTest
 
   HEADERS_1 = ['sample_name', 'host_genome', 'sample_type', 'blood_fed'].freeze
   HEADERS_2 = ['sample_name', 'host_genome', 'sample_type', 'nucleotide_type'].freeze
+  HEADERS_3 = ['sample_name', 'host_organism', 'sample_type', 'nucleotide_type'].freeze
   ROW_1 = ['Test Sample', 'Mosquito', 'Whole Blood', 'Blood Fed'].freeze
   ROW_2 = ['Test Sample 2', 'Mosquito', 'Whole Blood', 'Partially Blood Fed'].freeze
   ROW_3 = ['Test Sample', 'Human', 'Whole Blood', 'DNA'].freeze
@@ -70,6 +71,50 @@ class MetadataValidateNewSamplesTest < ActionDispatch::IntegrationTest
         },
         {
           name: "Test Sample 2",
+          project_id: @metadata_validation_project.id,
+        },
+      ],
+    }, as: :json
+
+    assert_response :success
+
+    assert_equal 0, @response.parsed_body['issues']['errors'].length
+    assert_equal 0, @response.parsed_body['issues']['warnings'].length
+  end
+
+  test 'basic with alternate names (host organism)' do
+    sign_in @user
+
+    post validate_csv_for_new_samples_metadata_url, params: {
+      metadata: {
+        headers: ['sample_name', 'host_organism', 'Sample Type', 'Blood Fed'],
+        rows: [
+          ROW_1,
+        ],
+      },
+      samples: [
+        {
+          name: "Test Sample",
+          project_id: @metadata_validation_project.id,
+        },
+      ],
+    }, as: :json
+
+    assert_response :success
+
+    assert_equal 0, @response.parsed_body['issues']['errors'].length
+    assert_equal 0, @response.parsed_body['issues']['warnings'].length
+
+    post validate_csv_for_new_samples_metadata_url, params: {
+      metadata: {
+        headers: ['sample_name', 'Host Organism', 'Sample Type', 'Blood Fed'],
+        rows: [
+          ROW_1,
+        ],
+      },
+      samples: [
+        {
+          name: "Test Sample",
           project_id: @metadata_validation_project.id,
         },
       ],


### PR DESCRIPTION
# Description

We are renaming "Host Genome" in the UI to better reflect its purpose as "Host Organism". For backwards compatibility, especially for CSV uploads, we treat both as synonyms.

# Notes

This also fixes an issue on using the same plain text host again in another upload.

# Tests

* new rspec test
* new rails t test
* all existing metadata tests
* try uploading a CSV that has "host_organism" but no "host_genome"
* try uploading a CSV that has only "host_genome"
* try normal upload flow
* verify no reserved names in current prod database

![image](https://user-images.githubusercontent.com/28797/73988639-20f15e80-48f8-11ea-8a19-c2cc19c0b16d.png)
