### PR TITLE
Hide 'sample will become public on' for public projects

### DIFF
--- a/app/assets/src/components/views/samples/ProjectSettingsModal/ProjectSettingsModal.jsx
+++ b/app/assets/src/components/views/samples/ProjectSettingsModal/ProjectSettingsModal.jsx
@@ -106,10 +106,12 @@ class ProjectSettingsModal extends React.Component {
                     </span>
                   </div>
                 )}
-                <div className={cs.note}>
-                  Next project sample will become public on{" "}
-                  {nextPublicSampleDate}.
-                </div>
+                {nextPublicSampleDate && (
+                  <div className={cs.note}>
+                    Next project sample will become public on{" "}
+                    {nextPublicSampleDate}.
+                  </div>
+                )}
               </div>
               <Divider />
               <div className={cs.userManagementFormContainer}>


### PR DESCRIPTION
# Description

While looking at IDSEQ-2225, I noticed that public projects still display the `Next project sample will become public on` message in the project settings modal, but with no date displayed.

![image](https://user-images.githubusercontent.com/53838890/73983381-2bf1c200-48eb-11ea-95d6-a0503d1e56c3.png)

Discussed with @happyimadesignr and agreed that hiding the message for public projects would be much less confusing!
![image](https://user-images.githubusercontent.com/53838890/73983420-488dfa00-48eb-11ea-850d-495d5f524196.png)

