### PR TITLE
[Heatmap Client Filtering] Add label to mark the heatmap client filtering beta

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapHeader.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapHeader.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { ViewHeader } from "~/components/layout";
 import BasicPopup from "~/components/BasicPopup";
+import StatusLabel from "~ui/labels/StatusLabel";
 import { SaveButton, ShareButton } from "~ui/controls/buttons";
 import { DownloadButtonDropdown } from "~ui/controls/dropdowns";
 import { withAnalytics, logAnalyticsEvent } from "~/api/analytics";
+import { UserContext } from "~/components/common/UserContext";
+import { ViewHeader } from "~/components/layout";
 
 import cs from "./samples_heatmap_view.scss";
 
@@ -40,11 +42,23 @@ export default class SamplesHeatmapHeader extends React.Component {
 
   render() {
     const { sampleIds } = this.props;
+    const { allowedFeatures } = this.context || {};
 
     return (
       <ViewHeader className={cs.viewHeader}>
         <ViewHeader.Content>
-          <ViewHeader.Pretitle>Heatmap</ViewHeader.Pretitle>
+          <ViewHeader.Pretitle>
+            <React.Fragment>
+              Heatmap
+              {allowedFeatures.includes("heatmap_filter_fe") && (
+                <StatusLabel
+                  status="Beta - Client Filtering"
+                  type="info"
+                  inline={true}
+                />
+              )}
+            </React.Fragment>
+          </ViewHeader.Pretitle>
           <ViewHeader.Title
             label={`Comparing ${sampleIds ? sampleIds.length : ""} Samples`}
           />
@@ -101,3 +115,5 @@ SamplesHeatmapHeader.propTypes = {
   onShareClick: PropTypes.func.isRequired,
   onSaveClick: PropTypes.func.isRequired,
 };
+
+SamplesHeatmapHeader.contextType = UserContext;

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -26,6 +26,7 @@ import { getSampleMetadataFields } from "~/api/metadata";
 import { logAnalyticsEvent, withAnalytics } from "~/api/analytics";
 import SamplesHeatmapVis from "~/components/views/compare/SamplesHeatmapVis";
 import SortIcon from "~ui/icons/SortIcon";
+import { UserContext } from "~/components/common/UserContext";
 
 import cs from "./samples_heatmap_view.scss";
 import SamplesHeatmapControls from "./SamplesHeatmapControls";
@@ -399,6 +400,8 @@ class SamplesHeatmapView extends React.Component {
   }
 
   filterTaxa() {
+    const { allowedFeatures } = this.context || {};
+
     let {
       taxonFilterState,
       taxonPassesThresholdFilters,
@@ -407,7 +410,7 @@ class SamplesHeatmapView extends React.Component {
     let taxonDetails = {},
       taxonIds = new Set(),
       filteredData = {};
-    if (this.props.allowedFeatures.includes("heatmap_filter_fe")) {
+    if (allowedFeatures.includes("heatmap_filter_fe")) {
       allTaxonIds.forEach(taxonId => {
         let taxon = allTaxonDetails[taxonId];
         if (!taxonIds.has(taxonId) && this.taxonPassesSelectedFilters(taxon)) {
@@ -736,7 +739,9 @@ class SamplesHeatmapView extends React.Component {
   });
 
   handleSelectedOptionsChange = newOptions => {
-    if (this.props.allowedFeatures.includes("heatmap_filter_fe")) {
+    const { allowedFeatures } = this.context || {};
+
+    if (allowedFeatures.includes("heatmap_filter_fe")) {
       const frontendFilters = [
         "species",
         "categories",
@@ -915,7 +920,6 @@ class SamplesHeatmapView extends React.Component {
 }
 
 SamplesHeatmapView.propTypes = {
-  allowedFeatures: PropTypes.array,
   backgrounds: PropTypes.array,
   categories: PropTypes.array,
   metrics: PropTypes.array,
@@ -927,5 +931,7 @@ SamplesHeatmapView.propTypes = {
   thresholdFilters: PropTypes.object,
   heatmapTs: PropTypes.number,
 };
+
+SamplesHeatmapView.contextType = UserContext;
 
 export default SamplesHeatmapView;


### PR DESCRIPTION
# Description

* Add label to identify a heatmap has being client filtering
* Change the feature flag passing to use context

# Notes

<img width="741" alt="Screen Shot 2020-02-06 at 3 18 22 PM" src="https://user-images.githubusercontent.com/37312125/73987072-2351b980-48f4-11ea-938d-c0374d785f04.png">

# Tests

* Open heatmap with a user *with* a heatmap client filtering enabled and *see the label*
* Open heatmap with a user *without* a heatmap client filtering flag and see *no  label*