### PR TITLE
[Heatmap Client Filtering] Add client filtering flag to cache path

### DIFF
--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -8,6 +8,9 @@ class VisualizationsController < ApplicationController
     expires_in: 30.days,
     cache_path: proc do |c|
       sorted_params = c.request.params.to_h.sort.to_h
+      if current_user.allowed_feature?("heatmap_filter_fe")
+        sorted_params[:heatmap_filter_fe] = true
+      end
       sorted_params.to_query
     end
   )


### PR DESCRIPTION
# Description

* Server-side heatmap and client side heatmap would generate the same cache path, leading to cache conflicts
* This change makes the cache paths unique

# Tests

* Run a heatmap with both the flag enable and disabled and verify that it generates two different paths
