### PR TITLE
[Heatmap filtering] Skip filter clauses in query if client-filtering enabled

### DIFF
--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -194,22 +194,20 @@ module HeatmapHelper
   )
     categories_map = ReportHelper::CATEGORIES_TAXID_BY_NAME
     categories_clause = ""
+    read_specificity_clause = ""
+    phage_clause = ""
+
     unless client_filtering_enabled
       if categories.present?
         categories_clause = " AND superkingdom_taxid IN (#{categories.map { |category| categories_map[category] }.compact.join(',')})"
       elsif include_phage
         categories_clause = " AND superkingdom_taxid = #{categories_map['Viruses']}"
       end
-    end
 
-    read_specificity_clause = ""
-    unless client_filtering_enabled
       if read_specificity
         read_specificity_clause = " AND taxon_counts.tax_id > 0"
       end
-    end
 
-    unless client_filtering_enabled
       if !include_phage && categories.present?
         phage_clause = " AND is_phage != 1"
       elsif include_phage && categories.blank?

--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -197,6 +197,12 @@ module HeatmapHelper
     read_specificity_clause = ""
     phage_clause = ""
 
+    # If client-side filtering is enabled on the heatmap, then skip the filters in the query.
+    # This enables consistent behavior for users viewing saved heatmaps with the client-side filtering flag enabled,
+    # so that they will not only be filtering on an already-filtered subset of the data.
+    # The filters are skipped in the query rather than modifying the client's request paramaters since
+    # saved visualizations are tied to visualization ids, and saved parameters are then pulled from the
+    # Visualizations table on the server-side.
     unless client_filtering_enabled
       if categories.present?
         categories_clause = " AND superkingdom_taxid IN (#{categories.map { |category| categories_map[category] }.compact.join(',')})"


### PR DESCRIPTION
# Description

If the user has client-side filtering for the heatmap enabled, don't apply those filters to the query when the server is fetching data.

This allows saved heatmaps to behave as expected when the client-side filtering flag is enabled, rather than applying the filters to an already filtered set of data.

# Tests

* Verified that saved heatmaps behave as expected both when the `heatmap_frontend_fe` flag is enabled and disabled.
