### PR TITLE
Change AppConfig value column to text.

### DIFF
--- a/db/migrate/20200207200038_change_app_config_value_to_text.rb
+++ b/db/migrate/20200207200038_change_app_config_value_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeAppConfigValueToText < ActiveRecord::Migration[5.1]
+  def change
+    change_column :app_configs, :value, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_115_021_328) do
+ActiveRecord::Schema.define(version: 20_200_207_200_038) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 20_200_115_021_328) do
 
   create_table "app_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "key"
-    t.string "value"
+    t.text "value"
     t.index ["key"], name: "index_app_configs_on_key", unique: true
   end
 


### PR DESCRIPTION
# Description

The AppConfig's value column is currently type `string`, which only allows strings of up to 255 characters. This prohibits us from storing larger JSON values.

This PR changes the type to `text`.

# Tests

* Tested that longer JSON values which previously couldn't be assigned can now be assigned.
