### PR TITLE
Limit number of "additional samples" in phylo tree creation

### DIFF
--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -148,7 +148,7 @@ class PhyloTreesController < ApplicationController
 
     # Retrieve pipeline runs that contain the specified taxid.
     eligible_pipeline_runs = current_power.pipeline_runs.top_completed_runs
-    pipeline_run_ids_with_taxid = TaxonByterange.where(taxid: taxid).limit(ELIGIBLE_PIPELINE_RUNS_LIMIT).pluck(:pipeline_run_id)
+    pipeline_run_ids_with_taxid = TaxonByterange.where(taxid: taxid).order(id: :desc).limit(ELIGIBLE_PIPELINE_RUNS_LIMIT).pluck(:pipeline_run_id)
     # Always include all project runs
     project_pipeline_run_ids = TaxonByterange.joins(pipeline_run: [{ sample: :project }]).where(taxid: taxid, samples: { project_id: project_id }).pluck(:pipeline_run_id)
     eligible_pipeline_run_ids_with_taxid =

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -32,6 +32,7 @@ class PhyloTreesController < ApplicationController
   before_action :assert_access, only: OTHER_ACTIONS
   before_action :check_access
 
+  # This limit determines how many rows can be displayed in "additional samples".
   # This limit was added because the phylo tree creation was timing out for admins
   # and otherwise the results will grow without bound per user.
   ELIGIBLE_PIPELINE_RUNS_LIMIT = 1000

--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -148,15 +148,15 @@ class PhyloTreesController < ApplicationController
 
     # Retrieve pipeline runs that contain the specified taxid.
     eligible_pipeline_runs = current_power.pipeline_runs.top_completed_runs
-    pipeline_run_ids_with_taxid = TaxonByterange.where(taxid: taxid).order(id: :desc).limit(ELIGIBLE_PIPELINE_RUNS_LIMIT).pluck(:pipeline_run_id)
-    # Always include all project runs
-    project_pipeline_run_ids = TaxonByterange.joins(pipeline_run: [{ sample: :project }]).where(taxid: taxid, samples: { project_id: project_id }).pluck(:pipeline_run_id)
+    pipeline_run_ids_with_taxid = TaxonByterange.where(taxid: taxid)
     eligible_pipeline_run_ids_with_taxid =
-      eligible_pipeline_runs.where(id: pipeline_run_ids_with_taxid | project_pipeline_run_ids)
-                            .order(id: :desc).pluck(:id)
+      eligible_pipeline_runs.where(id: pipeline_run_ids_with_taxid)
+                            .order(id: :desc).limit(ELIGIBLE_PIPELINE_RUNS_LIMIT).pluck(:pipeline_run_id).pluck(:id)
+    # Always include all project runs
+    project_pipeline_run_ids_with_taxid = TaxonByterange.joins(pipeline_run: [{ sample: :project }]).where(taxid: taxid, samples: { project_id: project_id }).pluck(:pipeline_run_id)
 
     # Retrieve information for displaying the tree's sample list.
-    @samples = sample_details_json(eligible_pipeline_run_ids_with_taxid, taxid)
+    @samples = sample_details_json(Set.new(eligible_pipeline_run_ids_with_taxid | project_pipeline_run_ids_with_taxid, taxid))
 
     # Retrieve information about the taxon
     taxon_lineage = TaxonLineage.where(taxid: taxid).last


### PR DESCRIPTION
# Description

In investigating a pipeline error, I discovered that phylo tree creation was broken for admins in prod. The root cause is a unscalable query. 

# Notes

* I isolated the slow query in the console 
* The SQL query is still really ugly and could be optimized more

```
SELECT `pipeline_runs`.`id`
FROM `pipeline_runs`
WHERE `pipeline_runs`.`sample_id` IN (3412, ...
  AND (id IN
         (SELECT max(id)
          FROM pipeline_runs
          WHERE job_status = 'CHECKED'
            AND sample_id IN
              (SELECT id
               FROM samples)
          GROUP BY sample_id))
  AND `pipeline_runs`.`id` IN (2913, ...
ORDER BY `pipeline_runs`.`id` DESC LIMIT 1000
```

# Tests

* See limit in query log

* Try advancing in localhost, see appropriate data return 

* Confirm 1000 rows in table


![image](https://user-images.githubusercontent.com/28797/74063731-ee9e3a80-49a5-11ea-81ec-3ced3bd86489.png)

![image](https://user-images.githubusercontent.com/28797/74064653-fb239280-49a7-11ea-8981-0370cff777ea.png)



![image](https://user-images.githubusercontent.com/28797/74063732-efcf6780-49a5-11ea-8f1b-1f02a639ff22.png)


