### PR TITLE
Fix warning for ERCC only hosts

### DIFF
--- a/app/assets/src/components/common/HostOrganismSearchBox.jsx
+++ b/app/assets/src/components/common/HostOrganismSearchBox.jsx
@@ -50,7 +50,13 @@ class HostOrganismSearchBox extends React.Component {
     if (query.length && get([0, "name"], sortedHostGenomes) !== query) {
       results.noMatch = {
         name: "Use Plain Text (No Match)",
-        results: [{ title: query, name: query }],
+        results: [
+          {
+            title: query,
+            name: query,
+            description: "Host will not be subtracted",
+          },
+        ],
       };
     }
     return results;

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -16,10 +16,14 @@ import cs from "./host_organism_message.scss";
 export default class HostOrganismMessage extends React.Component {
   // By design, host names are case insensitive, so we don't
   // get duplicates.
-  hasMatch = host =>
-    map(hg => hg.name.toLowerCase(), this.props.hostGenomes).includes(
+  hasMatch = host => {
+    const filtered = this.props.hostGenomes.filter(
+      hg => this.isERCC(hg.name) || !hg.ercc_only
+    );
+    return map(hg => hg.name.toLowerCase(), filtered).includes(
       host.toLowerCase()
     );
+  };
 
   renderOneHost(host, count) {
     return (

--- a/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/HostOrganismMessage.jsx
@@ -18,7 +18,7 @@ export default class HostOrganismMessage extends React.Component {
   // get duplicates.
   hasMatch = host => {
     const filtered = this.props.hostGenomes.filter(
-      hg => this.isERCC(hg.name) || !hg.ercc_only
+      hg => this.isERCC(hg.name) || !(hg.ercc_only || hg["ercc_only?"])
     );
     return map(hg => hg.name.toLowerCase(), filtered).includes(
       host.toLowerCase()

--- a/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
+++ b/app/assets/src/components/views/playgrounds/PlaygroundComponents.jsx
@@ -55,10 +55,16 @@ export default class PlaygroundComponents extends React.Component {
           hostGenomes={[{ name: "Human", id: 1 }]}
           samples={[{ host_genome_id: 2, host_genome_name: "none" }]}
         />,
+        // one no match ERCC only
+        <HostOrganismMessage
+          key="7"
+          hostGenomes={[{ name: "Ferret", id: 1, ercc_only: true }]}
+          samples={[{ host_genome_id: 1, host_genome_name: "Ferret" }]}
+        />,
         // ERCC only
         <HostOrganismMessage
           key="3"
-          hostGenomes={[{ name: "ERCC Only", id: 7 }]}
+          hostGenomes={[{ name: "ERCC Only", id: 7, ercc_only: true }]}
           samples={[{ host_genome_id: 7, host_genome_name: "ERCC Only" }]}
         />,
         // many

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -71,7 +71,7 @@ module SamplesHelper
     # options for new samples until the team gets a chance to review this policy
     # in light of the data. See also showAsOption.
     # See https://jira.czi.team/browse/IDSEQ-2193.
-    HostGenome.all.select { |h| h.user.nil? }.map { |h| h.slice('name', 'id') }
+    HostGenome.all.select { |h| h.user.nil? }.map { |h| h.slice('name', 'id', 'ercc_only?') }
   end
 
   def get_summary_stats(job_stats_hash, pipeline_run)


### PR DESCRIPTION
# Description

This fixes a bug introduced in #3035 . We must now explicitly filter out ercc only hosts from the set of "good" hosts to decide the warning message. 

![image](https://user-images.githubusercontent.com/28797/74176931-893c8a80-4bed-11ea-8f4a-538a6d82a915.png)


# Notes

* I also took the opportunity to add the "no host subtracted" message in the dropdown, on suggestion from @oliviabholmes 

# Tests

* load playground, see expected for Ferret
* try upload flow, see expected for Ferret 
* see "no host subtracted" for plain text