### PR TITLE
Update hardcoded references to 2019-09-17 index

### DIFF
--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -25,7 +25,7 @@ class PipelineRunStage < ApplicationRecord
   DAG_NAME_EXPERIMENTAL = "experimental".freeze
 
   # Older alignment configs might not have an s3_nt_info_db_path field, so use a reasonable default in this case.
-  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/2019-09-17/nt_info.sqlite3".freeze
+  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/2020-02-03/nt_info.sqlite3".freeze
 
   STAGE_INFO = {
     1 => {

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -25,7 +25,7 @@ class PipelineRunStage < ApplicationRecord
   DAG_NAME_EXPERIMENTAL = "experimental".freeze
 
   # Older alignment configs might not have an s3_nt_info_db_path field, so use a reasonable default in this case.
-  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/2020-02-03/nt_info.sqlite3".freeze
+  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/#{AlignmentConfig::DEFAULT_NAME}/nt_info.sqlite3".freeze
 
   STAGE_INFO = {
     1 => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Shared variables using Docker x- extension and YAML merging syntax.
 
 x-web-variables: &web-variables
-  ? ALIGNMENT_CONFIG_DEFAULT_NAME=2019-09-17
+  ? ALIGNMENT_CONFIG_DEFAULT_NAME=2020-02-03
   ? SAMPLES_BUCKET_NAME=idseq-samples-development
   ? ES_ADDRESS=http://elasticsearch:9200
   ? AIRBRAKE_PROJECT_ID


### PR DESCRIPTION
### Description
- I found 2 hardcoded references to "2019-09-17". They're not very important but I'll add a note about them to the index update guide.

### Notes
- The docker-compose.yml default gets overwritten as long as the env variables are loaded from Parameter Store.
- DEFAULT_S3_NT_INFO_DB_PATH looks like an edge case based on the comment.