### PR TITLE
[Report page] Load less data for report page samples dropdown

### DIFF
--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -189,6 +189,7 @@ const getSamples = ({
   filters,
   listAllIds,
   sampleIds,
+  basic,
 } = {}) =>
   get("/samples/index_v2.json", {
     params: {
@@ -198,6 +199,7 @@ const getSamples = ({
       limit,
       offset,
       listAllIds,
+      basic, // if true, then don't include extra details (ex: metadata) for each sample
       // &sampleIds=[1,2] instead of default &sampleIds[]=1&sampleIds[]=2 format.
       sampleIds: JSON.stringify(sampleIds),
       ...filters,

--- a/app/assets/src/api/index.js
+++ b/app/assets/src/api/index.js
@@ -189,7 +189,7 @@ const getSamples = ({
   filters,
   listAllIds,
   sampleIds,
-  basic,
+  basic = false,
 } = {}) =>
   get("/samples/index_v2.json", {
     params: {

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -194,8 +194,10 @@ export default class SampleViewV2 extends React.Component {
     const { project } = this.state;
 
     if (project) {
+      // only really need sample names and ids, so request the basic version without extra details
       const projectSamples = await getSamples({
         projectId: project.id,
+        basic: true,
       });
 
       this.setState({ projectSamples: projectSamples.samples });

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -180,9 +180,9 @@ class SamplesController < ApplicationController
       methods: [:private_until]
     )
 
+    basic = ActiveModel::Type::Boolean.new.cast(params[:basic])
     # If basic requested, then don't include extra details (ex: metadata) for each sample.
-    # params[:basic] becomes a string, so cast it into a boolean for this check.
-    unless ActiveModel::Type::Boolean.new.cast(params[:basic])
+    unless basic
       samples_visibility = get_visibility(limited_samples)
       # format_samples loads a lot of information about samples
       # There are many ways we can refactor: multiple endpoints for client to ask for the information

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -181,7 +181,8 @@ class SamplesController < ApplicationController
     )
 
     # If basic requested, then don't include extra details (ex: metadata) for each sample.
-    if params[:basic].blank?
+    # params[:basic] becomes a string, so cast it into a boolean for this check.
+    unless ActiveModel::Type::Boolean.new.cast(params[:basic])
       samples_visibility = get_visibility(limited_samples)
       # format_samples loads a lot of information about samples
       # There are many ways we can refactor: multiple endpoints for client to ask for the information

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -179,15 +179,18 @@ class SamplesController < ApplicationController
       only: [:id, :name, :host_genome_id, :project_id, :created_at, :public],
       methods: [:private_until]
     )
-    samples_visibility = get_visibility(limited_samples)
 
-    # format_samples loads a lot of information about samples
-    # There are many ways we can refactor: multiple endpoints for client to ask for the information
-    # they actually need or at least a configurable function to get only certain data
-    details_json = format_samples(limited_samples).as_json()
-    limited_samples_json.zip(details_json, samples_visibility).map do |sample, details, visibility|
-      sample[:public] = visibility
-      sample[:details] = details
+    # If basic requested, then don't include extra details (ex: metadata) for each sample.
+    if params[:basic].blank?
+      samples_visibility = get_visibility(limited_samples)
+      # format_samples loads a lot of information about samples
+      # There are many ways we can refactor: multiple endpoints for client to ask for the information
+      # they actually need or at least a configurable function to get only certain data
+      details_json = format_samples(limited_samples).as_json()
+      limited_samples_json.zip(details_json, samples_visibility).map do |sample, details, visibility|
+        sample[:public] = visibility
+        sample[:details] = details
+      end
     end
 
     results = { samples: limited_samples_json }


### PR DESCRIPTION
# Description

See IDSEQ-2123.

The current samples index action used to list all the project samples in a sample's dropdown on the report page (see picture below) fetches a lot more extra data (sample's metadata, pipeline run info, etc) when all that's necessary for the dropdown are the samples' names and ids.

![image](https://user-images.githubusercontent.com/53838890/74203014-06362700-4c23-11ea-9f05-0f0c6a8c1d76.png)

This change adds param `basic` to `index_v2` which will skip sending all the extra sample details.

# Notes

Some rough comparisons for response size and time (just eyeballing locally by looking at the network tab and refreshing a few times):

* Project with 1 sample:
  * Before: 4.8KB, ~500-600ms
  * After: 3.0KB, ~100-250ms
* Project with 15 samples (Medical Detectives):
  * Before: 7.4KB, ~550-700ms
  * After: 3.2KB, ~100-250ms
* Project with 309 samples:
  * Before: 17.9KB, ~900ms-1.64s
  * After: 4.1KB, ~200-350ms

# Tests

* Loaded various sample reports and verified that the data loaded in for `projectSamples` was reduced and loaded in more quickly.
