### PR TITLE
[Heatmap filters] [Bug] Fix undefined threshold filters on old saved heatmaps

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -70,7 +70,7 @@ class SamplesHeatmapView extends React.Component {
     this.urlParams = this.parseUrlParams();
     // URL params have precedence
     this.urlParams = {
-      ...props.savedParamValues,
+      ...this.parseSavedParams(),
       ...this.urlParams,
     };
 
@@ -212,6 +212,22 @@ class SamplesHeatmapView extends React.Component {
       urlParams.metadataSortAsc = urlParams.metadataSortAsc === "true";
     }
     return urlParams;
+  };
+
+  parseSavedParams = () => {
+    // If the saved threshold object doesn't have metricDisplay, add it. For backwards compatibility.
+    let savedParams = this.props.savedParamValues;
+    savedParams.thresholdFilters = map(
+      threshold => ({
+        metricDisplay: get(
+          "text",
+          find(["value", threshold.metric], this.props.thresholdFilters.targets)
+        ),
+        ...threshold,
+      }),
+      savedParams.thresholdFilters
+    );
+    return savedParams;
   };
 
   getUrlParams = () => {

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -191,6 +191,8 @@ class SamplesHeatmapView extends React.Component {
     }
     if (typeof urlParams.thresholdFilters === "string") {
       // If the saved threshold object doesn't have metricDisplay, add it. For backwards compatibility.
+      // See also parseSavedParams().
+      // TODO: should remove this when the Visualization table is cleaned up.
       urlParams.thresholdFilters = map(
         threshold => ({
           metricDisplay: get(
@@ -216,6 +218,8 @@ class SamplesHeatmapView extends React.Component {
 
   parseSavedParams = () => {
     // If the saved threshold object doesn't have metricDisplay, add it. For backwards compatibility.
+    // See also parseUrlParams().
+    // TODO: should remove this when the Visualization table is cleaned up.
     let savedParams = this.props.savedParamValues;
     savedParams.thresholdFilters = map(
       threshold => ({


### PR DESCRIPTION
# Description

See IDSEQ-2245.

Some older saved visualizations have the `thresholdFilters` saved in a different format (missing `metricDisplay`, which is used for displaying the `thresholdFilterTag`), which results in the threshold filters appearing as `undefined`.

This is actually [handled](https://github.com/chanzuckerberg/idseq-web/blob/4795743af2dc952f13f5cf899db282867cd24f7e/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx#L193) for most URLs, but because saved visualizations have a shortened URL that don't include all the selected options, `savedParams` need to be handled as well.

# Tests

* Loaded an old saved heatmap and verified that the threshold filters showed up as expected.
