### PR TITLE
[Heatmap] [Bug] Maintain metadata sorting when applying filters

### DIFF
--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -619,10 +619,7 @@ export default class Heatmap {
       ).forEach((label, idx) => {
         label.pos = idx;
       });
-      return;
-    }
-
-    if (this.options.shouldSortColumns) {
+    } else if (this.options.shouldSortColumns) {
       this.sortColumns("asc");
     } else if (this.options.clustering) {
       this.clusterColumns();

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -895,18 +895,6 @@ export default class Heatmap {
       this.columnMetadataSortAsc = true;
     }
 
-    if (this.columnMetadataSortField) {
-      this.columnClustering = null;
-      orderBy(
-        this.columnLabels,
-        label => {
-          return (label.metadata && label.metadata[value]) || "ZZZ";
-        },
-        this.columnMetadataSortAsc ? "asc" : "desc"
-      ).forEach((label, idx) => {
-        label.pos = idx;
-      });
-    }
     this.processData("cluster");
     onColumnMetadataSortChange &&
       onColumnMetadataSortChange(

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -605,7 +605,22 @@ export default class Heatmap {
       this.clusterRows();
     }
 
-    if (this.columnMetadataSortField) return;
+    if (this.columnMetadataSortField) {
+      this.columnClustering = null;
+      orderBy(
+        this.columnLabels,
+        label => {
+          return (
+            (label.metadata && label.metadata[this.columnMetadataSortField]) ||
+            "ZZZ"
+          );
+        },
+        this.columnMetadataSortAsc ? "asc" : "desc"
+      ).forEach((label, idx) => {
+        label.pos = idx;
+      });
+      return;
+    }
 
     if (this.options.shouldSortColumns) {
       this.sortColumns("asc");


### PR DESCRIPTION
# Description

See IDSEQ-2226.

If a heatmap was sorted by a metadata field, that sorting would be lost upon applying a filter (but the sorting icon would remain, which makes it extra confusing). Saved heatmaps that were sorted by a metadata field would also have the same issue. This is because the logic to sort columns by the metadata was only actually applied when a metadata label was clicked, even though the state was being stored properly.

This change moves the logic for sorting/clustering by metadata out of the `handleColumnMetadataLabelClick` and into the more generic `cluster` function (which is called by `handleColumnMetadataLabelClick` anyways), so metadata sorting should not be unexpectedly lost upon:
1) Applying filters
2) Opening a saved heatmap
3) Reloading a heatmap
4) Accessing a heatmap via URL

# Tests

* Verified that sorting by metadata would not be lost when applying filters to the heatmap.
* Verified that adding metadata fields and sorting by different field still works as expected.
