### PR TITLE
[Release Fix] Check if savedParams exist before updating its thresholdFilters

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -221,17 +221,22 @@ class SamplesHeatmapView extends React.Component {
     // See also parseUrlParams().
     // TODO: should remove this when the Visualization table is cleaned up.
     let savedParams = this.props.savedParamValues;
-    savedParams.thresholdFilters = map(
-      threshold => ({
-        metricDisplay: get(
-          "text",
-          find(["value", threshold.metric], this.props.thresholdFilters.targets)
-        ),
-        ...threshold,
-      }),
-      savedParams.thresholdFilters
-    );
-    return savedParams;
+    if (savedParams && savedParams.thresholdFilters) {
+      savedParams.thresholdFilters = map(
+        threshold => ({
+          metricDisplay: get(
+            "text",
+            find(
+              ["value", threshold.metric],
+              this.props.thresholdFilters.targets
+            )
+          ),
+          ...threshold,
+        }),
+        savedParams.thresholdFilters
+      );
+      return savedParams;
+    }
   };
 
   getUrlParams = () => {


### PR DESCRIPTION
# Description

Related to [this](https://github.com/chanzuckerberg/idseq-web/pull/3065) change, I failed to check if `savedParams` and `savedParams.thresholdFilters` exists before updating the values to include `metricDisplay` for backwards compatibility, which would cause heatmaps to crash if there were no `savedParams`. This fix adds in those checks to avoid the undefined error.

# Tests

* Opened a heatmap that was previously crashing and verified that it no longer crashes.
