### PR TITLE
[Public] Update header text + enable taxon descriptions

### DIFF
--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -142,7 +142,7 @@ class Header extends React.Component {
             {NCOV_PUBLIC_SITE && (
               <a href="/">
                 <div className={cs.publicNcovHomeLink}>
-                  Coronavirus Public Data
+                  Novel Coronavirus Public Data
                 </div>
               </a>
             )}

--- a/app/controllers/backgrounds_controller.rb
+++ b/app/controllers/backgrounds_controller.rb
@@ -5,7 +5,7 @@ class BackgroundsController < ApplicationController
   before_action :set_background, only: [:show, :edit, :update, :destroy, :show_taxon_dist]
 
   # Endpoints made public for public ncov page.
-  PUBLIC_NCOV_ENDPOINTS = [:index].freeze
+  PUBLIC_NCOV_ENDPOINTS = [:index, :show_taxon_dist].freeze
 
   skip_before_action :authenticate_user!, only: PUBLIC_NCOV_ENDPOINTS
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,7 @@ PUBLIC_ENDPOINTS = [:landing, :sign_up, :maintenance].freeze
 
 # Endpoints made public for public ncov page.
 PUBLIC_NCOV_ENDPOINTS = [
-  :public, :index,
+  :public, :index, :taxon_descriptions,
 ].freeze
 
 class HomeController < ApplicationController


### PR DESCRIPTION
### Description
- Update the header to "Novel Coronavirus" and enable the Wikipedia taxon descriptions.

### Tests
- Tested locally.