### PR TITLE
Add validation to all models, part 1 of 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
         - DB_USERNAME: travis
         - DB_PASSWORD: root
         - SAMPLES_BUCKET_NAME: idseq-samples-development
+        - ALIGNMENT_CONFIG_DEFAULT_NAME: "2020-02-03"
       services:
         - mysql
         - redis
@@ -52,6 +53,7 @@ jobs:
       env:
         - DB_USERNAME: travis
         - DB_PASSWORD: root
+        - ALIGNMENT_CONFIG_DEFAULT_NAME: "2020-02-03"
       services:
         - mysql
         - redis

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1136,6 +1136,8 @@ class SamplesController < ApplicationController
 
     params[:input_files_attributes].reject! { |f| f["source"] == '' }
     params[:alignment_config_name] = AlignmentConfig::DEFAULT_NAME if params[:alignment_config_name].blank?
+    params[:status] = Sample::STATUS_CREATED
+    params[:user] = current_user
 
     @sample = Sample.new(params)
     @sample.project = project if project

--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -53,6 +53,7 @@ module PipelineRunsHelper
       },
     },
   }.freeze
+  ALL_STEP_NAMES = STEP_DESCRIPTIONS.values.map { |stage| stage["steps"].keys }.flatten
 
   PIPELINE_RUN_STILL_RUNNING_ERROR = "PIPELINE_RUN_STILL_RUNNING_ERROR".freeze
   PIPELINE_RUN_FAILED_ERROR = "PIPELINE_RUN_FAILED_ERROR".freeze

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -80,7 +80,7 @@ module SamplesHelper
     # options for new samples until the team gets a chance to review this policy
     # in light of the data. See also showAsOption.
     # See https://jira.czi.team/browse/IDSEQ-2193.
-    HostGenome.all.select { |h| h.user.nil? }.map { |h| h.slice('name', 'id', 'ercc_only?') }
+    HostGenome.all.select(&:show_as_option?).map { |h| h.slice('name', 'id', 'ercc_only?') }
   end
 
   def get_summary_stats(job_stats_hash, pipeline_run)
@@ -570,8 +570,8 @@ module SamplesHelper
 
       # If s3 upload, set "bulk_mode" to true.
       sample.bulk_mode = sample.input_files.map(&:source_type).include?("s3")
-      sample.user = user
       sample.status = Sample::STATUS_CREATED
+      sample.user = user
       if sample.save
         samples << sample
       else

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -80,7 +80,7 @@ module SamplesHelper
     # options for new samples until the team gets a chance to review this policy
     # in light of the data. See also showAsOption.
     # See https://jira.czi.team/browse/IDSEQ-2193.
-    HostGenome.all.select(&:show_as_option?).map { |h| h.slice('name', 'id', 'ercc_only?') }
+    HostGenome.all.select { |h| h.user.nil? }.map { |h| h.slice('name', 'id', 'ercc_only?') }
   end
 
   def get_summary_stats(job_stats_hash, pipeline_run)
@@ -570,8 +570,8 @@ module SamplesHelper
 
       # If s3 upload, set "bulk_mode" to true.
       sample.bulk_mode = sample.input_files.map(&:source_type).include?("s3")
-      sample.status = Sample::STATUS_CREATED
       sample.user = user
+      sample.status = Sample::STATUS_CREATED
       if sample.save
         samples << sample
       else

--- a/app/models/alignment_config.rb
+++ b/app/models/alignment_config.rb
@@ -1,4 +1,5 @@
-# configuration for alignment database for pipelines
+# Configuration for alignment database for pipelines
+# See also create_alignment_config.rake where configs are created.
 class AlignmentConfig < ApplicationRecord
   has_many :pipeline_runs, dependent: :restrict_with_exception
 

--- a/app/models/alignment_config.rb
+++ b/app/models/alignment_config.rb
@@ -2,7 +2,15 @@
 class AlignmentConfig < ApplicationRecord
   has_many :pipeline_runs, dependent: :restrict_with_exception
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, if: :mass_validation_enabled?
+  validates :s3_nt_db_path, presence: true, if: :mass_validation_enabled?
+  validates :s3_nt_loc_db_path, presence: true, if: :mass_validation_enabled?
+  validates :s3_nr_db_path, presence: true, if: :mass_validation_enabled?
+  validates :s3_nr_loc_db_path, presence: true, if: :mass_validation_enabled?
+  validates :s3_lineage_path, presence: true, if: :mass_validation_enabled?
+  validates :s3_accession2taxid_path, presence: true, if: :mass_validation_enabled?
+  validates :s3_deuterostome_db_path, presence: true, if: :mass_validation_enabled?
+  validates :lineage_version, presence: true, numericality: { integer_only: true, greater_than: 0 }, if: :mass_validation_enabled?
 
   # configuration for alignment database for pipelines
   #   set in SSM and loaded via chamber

--- a/app/models/alignment_config.rb
+++ b/app/models/alignment_config.rb
@@ -1,8 +1,12 @@
+# configuration for alignment database for pipelines
 class AlignmentConfig < ApplicationRecord
+  has_many :pipeline_runs, dependent: :restrict_with_exception
+
+  validates :name, presence: true, uniqueness: true
+
   # configuration for alignment database for pipelines
   #   set in SSM and loaded via chamber
   DEFAULT_NAME = ENV["ALIGNMENT_CONFIG_DEFAULT_NAME"]
-  has_many :pipeline_runs, dependent: :restrict_with_exception
 
   # Get the max lineage version from a set of alignment config ids.
   def self.max_lineage_version(alignment_config_ids)

--- a/app/models/alignment_config.rb
+++ b/app/models/alignment_config.rb
@@ -11,7 +11,7 @@ class AlignmentConfig < ApplicationRecord
   validates :s3_lineage_path, presence: true, if: :mass_validation_enabled?
   validates :s3_accession2taxid_path, presence: true, if: :mass_validation_enabled?
   validates :s3_deuterostome_db_path, presence: true, if: :mass_validation_enabled?
-  validates :lineage_version, presence: true, numericality: { integer_only: true, greater_than: 0 }, if: :mass_validation_enabled?
+  validates :lineage_version, presence: true, numericality: { integer_only: true, greater_than: 0 }, if: -> { respond_to?(:lineage_version) && mass_validation_enabled? } # respond_to? for migrations
 
   # configuration for alignment database for pipelines
   #   set in SSM and loaded via chamber

--- a/app/models/amr_count.rb
+++ b/app/models/amr_count.rb
@@ -22,11 +22,15 @@
 #   "Tmt"]
 class AmrCount < ApplicationRecord
   belongs_to :pipeline_run
-
-  validates :gene, presence: true, if: :mass_validation_enabled?
-  validates :allele, presence: true, if: :mass_validation_enabled?
-  validates :drug_family, presence: true, if: :mass_validation_enabled?
-  # AmrCount is designed to handle partial data. See pipeline_run_spec.rb.
+  # AmrCount is designed to handle partial data. See db_load_amr_counts.
+  validates :gene, presence: true, allow_nil: true, if: :mass_validation_enabled?
+  validates :allele, presence: true, allow_nil: true, if: :mass_validation_enabled?
+  validates :drug_family, presence: true, allow_nil: true, if: :mass_validation_enabled?
+  validates :annotation_gene, presence: true, allow_nil: true, if: :mass_validation_enabled?
+  validates :genbank_accession, presence: true, allow_nil: true, if: :mass_validation_enabled?
   validates :coverage, inclusion: 0..100, allow_nil: true, if: :mass_validation_enabled?
   validates :depth, numericality: { greater_than: 0 }, allow_nil: true, if: :mass_validation_enabled?
+  validates :total_reads, numericality: { greater_than: 0, integer_only: true }, allow_nil: true, if: :mass_validation_enabled?
+  validates :dpm, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true, if: :mass_validation_enabled?
+  validates :rpm, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true, if: :mass_validation_enabled?
 end

--- a/app/models/amr_count.rb
+++ b/app/models/amr_count.rb
@@ -1,6 +1,30 @@
 # Model that has data fields necessary for displaying
 # anti microbial resistance (AMR) information for a
 # given pipeline run of a sample.
+#
+# Currently the following values exist for drug_family:
+#   ["AGly",
+#   "Bla",
+#   "Colistin",
+#   "Ecoli_Bla",
+#   "Fcd",
+#   "Fcyn",
+#   "Flq",
+#   "Gly",
+#   "hydrolase_Bla",
+#   "MLS",
+#   "Nitroimidazole_Gene_Ntmdz",
+#   "Oxzln",
+#   "Phe",
+#   "Rif",
+#   "Sul",
+#   "Tet",
+#   "Tmt"]
 class AmrCount < ApplicationRecord
   belongs_to :pipeline_run
+  validates :pipeline_run, presence: true
+
+  # AmrCount is designed to handle partial data. See pipeline_run_spec.rb.
+  validates :coverage, inclusion: 0..100, allow_nil: true
+  validates :depth, numericality: { greater_than: 0 }, allow_nil: true
 end

--- a/app/models/amr_count.rb
+++ b/app/models/amr_count.rb
@@ -22,9 +22,11 @@
 #   "Tmt"]
 class AmrCount < ApplicationRecord
   belongs_to :pipeline_run
-  validates :pipeline_run, presence: true
 
+  validates :gene, presence: true, if: :mass_validation_enabled?
+  validates :allele, presence: true, if: :mass_validation_enabled?
+  validates :drug_family, presence: true, if: :mass_validation_enabled?
   # AmrCount is designed to handle partial data. See pipeline_run_spec.rb.
-  validates :coverage, inclusion: 0..100, allow_nil: true
-  validates :depth, numericality: { greater_than: 0 }, allow_nil: true
+  validates :coverage, inclusion: 0..100, allow_nil: true, if: :mass_validation_enabled?
+  validates :depth, numericality: { greater_than: 0 }, allow_nil: true, if: :mass_validation_enabled?
 end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -23,5 +23,6 @@ class AppConfig < ApplicationRecord
   SHOW_LANDING_PUBLIC_SITE_BANNER = 'show_landing_public_site_banner'.freeze
 
   # Switch for additional ActiveRecord validations that were added en masse in Feb 2020.
+  # Presence of the flag switches on the feature.
   ENABLE_MASS_VALIDATION = 'enable_mass_validation'.freeze
 end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -18,6 +18,10 @@ class AppConfig < ApplicationRecord
   # When this is "1", the announcement banner on the top of the site header will be enabled.
   # Other conditions may check a time constraint.
   SHOW_ANNOUNCEMENT_BANNER = 'show_announcement_banner'.freeze
+
   # When this is "1", the COVID-19 Public Site banner on the landing page will be shown.
   SHOW_LANDING_PUBLIC_SITE_BANNER = 'show_landing_public_site_banner'.freeze
+
+  # Switch for additional ActiveRecord validations that were added en masse in Feb 2020.
+  ENABLE_MASS_VALIDATION = 'enable_mass_validation'.freeze
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,13 +8,11 @@ class ApplicationRecord < ActiveRecord::Base
   after_destroy { |record| log_analytics record, "destroyed" }
 
   # Condition for rollout of mass addition of validation rules.
-  # Memoizes for performance.
+  # Cached for performance.
   def mass_validation_enabled?
-    if AppConfig.table_exists?
-      if defined?(@enable_mass_validation)
-        return @enable_mass_validation
-      else
-        return @enable_mass_validation = AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
+    if AppConfig.table_exists? # for migrations previous to AppConfig creation
+      return Rails.cache.fetch("ApplicationRecord.mass_validation_enabled?") do
+        AppConfigHelper.get_app_config(AppConfig::ENABLE_MASS_VALIDATION)
       end
     end
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,7 +9,9 @@ class ApplicationRecord < ActiveRecord::Base
 
   # Condition for rollout of mass addition of validation rules.
   def mass_validation_enabled?
-    @enable_mass_validation ||= AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
+    if AppConfig.table_exists?
+      return @enable_mass_validation ||= AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
+    end
   end
 
   # Set current user and request to global for use in logging.

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,9 +8,8 @@ class ApplicationRecord < ActiveRecord::Base
   after_destroy { |record| log_analytics record, "destroyed" }
 
   # Condition for rollout of mass addition of validation rules.
-  self._enable_mass_validation = nil
   def mass_validation_enabled?
-    self._enable_mass_validation ||= AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
+    @enable_mass_validation ||= AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
   end
 
   # Set current user and request to global for use in logging.

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,7 +8,7 @@ class ApplicationRecord < ActiveRecord::Base
   after_destroy { |record| log_analytics record, "destroyed" }
 
   # Condition for rollout of mass addition of validation rules.
-  def validate_all?
+  def mass_validation_enabled?
     Rails.env.development? ||
       Rails.env.test? ||
       AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -7,12 +7,9 @@ class ApplicationRecord < ActiveRecord::Base
   after_update { |record| log_analytics record, "updated" }
   after_destroy { |record| log_analytics record, "destroyed" }
 
-  # Load once at boot for performance
-  ENABLE_MASS_VALIDATION = AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
-
   # Condition for rollout of mass addition of validation rules.
   def mass_validation_enabled?
-    ENABLE_MASS_VALIDATION
+    self._enable_mass_validation ||= AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
   end
 
   # Set current user and request to global for use in logging.

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -7,6 +7,13 @@ class ApplicationRecord < ActiveRecord::Base
   after_update { |record| log_analytics record, "updated" }
   after_destroy { |record| log_analytics record, "destroyed" }
 
+  # Condition for rollout of mass addition of validation rules.
+  def validate_all?
+    Rails.env.development? ||
+      Rails.env.test? ||
+      AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
+  end
+
   # Set current user and request to global for use in logging.
   # See https://stackoverflow.com/a/11670283/200312
   class << self

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,6 +8,7 @@ class ApplicationRecord < ActiveRecord::Base
   after_destroy { |record| log_analytics record, "destroyed" }
 
   # Condition for rollout of mass addition of validation rules.
+  self._enable_mass_validation = nil
   def mass_validation_enabled?
     self._enable_mass_validation ||= AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -7,11 +7,12 @@ class ApplicationRecord < ActiveRecord::Base
   after_update { |record| log_analytics record, "updated" }
   after_destroy { |record| log_analytics record, "destroyed" }
 
+  # Load once at boot for performance
+  ENABLE_MASS_VALIDATION = AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
+
   # Condition for rollout of mass addition of validation rules.
   def mass_validation_enabled?
-    Rails.env.development? ||
-      Rails.env.test? ||
-      AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
+    ENABLE_MASS_VALIDATION
   end
 
   # Set current user and request to global for use in logging.

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,9 +8,14 @@ class ApplicationRecord < ActiveRecord::Base
   after_destroy { |record| log_analytics record, "destroyed" }
 
   # Condition for rollout of mass addition of validation rules.
+  # Memoizes for performance.
   def mass_validation_enabled?
     if AppConfig.table_exists?
-      return @enable_mass_validation ||= AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
+      if defined?(@enable_mass_validation)
+        return @enable_mass_validation
+      else
+        return @enable_mass_validation = AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
+      end
     end
   end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -7,12 +7,12 @@ class ApplicationRecord < ActiveRecord::Base
   after_update { |record| log_analytics record, "updated" }
   after_destroy { |record| log_analytics record, "destroyed" }
 
-  after_validation :log_errors, if: proc { |m| m.errors.any? }
+  after_validation :log_errors, if: proc { |m| m.mass_validation_enabled? && m.errors.any? }
 
   def log_errors
     msg = errors.full_messages.join("\n")
     LogUtil.log_err_and_airbrake(msg)
-    LogUtil.log_backtrace(ActiveRecord::RecordInvalid.new(self))
+    Rails.logger.error("Backtrace:\n\t#{caller.join("\n\t")}")
   end
 
   # Condition for rollout of mass addition of validation rules.

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -7,7 +7,7 @@ class ApplicationRecord < ActiveRecord::Base
   after_update { |record| log_analytics record, "updated" }
   after_destroy { |record| log_analytics record, "destroyed" }
 
-  after_validation :log_errors, if: proc { |m| m.mass_validation_enabled? && m.errors.any? }
+  before_save :log_errors, if: proc { |m| m.mass_validation_enabled? && m.errors.any? }
 
   def log_errors
     msg = errors.full_messages.join("\n")

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -7,6 +7,14 @@ class ApplicationRecord < ActiveRecord::Base
   after_update { |record| log_analytics record, "updated" }
   after_destroy { |record| log_analytics record, "destroyed" }
 
+  after_validation :log_errors, if: proc { |m| m.errors.any? }
+
+  def log_errors
+    msg = errors.full_messages.join("\n")
+    LogUtil.log_err_and_airbrake(msg)
+    LogUtil.log_backtrace(ActiveRecord::RecordInvalid.new(self))
+  end
+
   # Condition for rollout of mass addition of validation rules.
   # Cached for performance.
   def mass_validation_enabled?

--- a/app/models/archived_background.rb
+++ b/app/models/archived_background.rb
@@ -1,2 +1,5 @@
 class ArchivedBackground < ApplicationRecord
+  validates :archive_of, presence: true, if: :mass_validation_enabled?
+  validates :data, presence: true, if: :mass_validation_enabled?
+  validates :s3_backup_path, presence: true, if: :mass_validation_enabled?
 end

--- a/app/models/background.rb
+++ b/app/models/background.rb
@@ -7,7 +7,7 @@ class Background < ApplicationRecord
   validate :validate_size
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   # Not sure why this is not a boolean
-  validates :ready, presence: true, inclusion: { in: [0, 1] }
+  validates :ready, presence: true, inclusion: { in: [0, 1] }, if: :mass_validation_enabled?
 
   after_save :submit_store_summary_job
   attr_accessor :just_updated

--- a/app/models/background.rb
+++ b/app/models/background.rb
@@ -3,8 +3,12 @@ class Background < ApplicationRecord
   has_many :samples, through: :pipeline_runs
   has_many :taxon_summaries, dependent: :destroy
   belongs_to :user, optional: true
+
   validate :validate_size
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+  # Not sure why this is not a boolean
+  validates :ready, presence: true, inclusion: { in: [0, 1] }
+
   after_save :submit_store_summary_job
   attr_accessor :just_updated
 

--- a/app/models/contig.rb
+++ b/app/models/contig.rb
@@ -1,6 +1,10 @@
 class Contig < ApplicationRecord
   # Contigs assembled from non_host reads
   belongs_to :pipeline_run
+  validates :pipeline_run, presence: true
+
+  validates :read_count, numericality: { greater_than_or_equal_to: 0 }
+
   def to_fa
     ">#{name}:#{read_count}:#{lineage_json}\n#{sequence}"
   end

--- a/app/models/contig.rb
+++ b/app/models/contig.rb
@@ -1,9 +1,10 @@
 class Contig < ApplicationRecord
   # Contigs assembled from non_host reads
   belongs_to :pipeline_run
-  validates :pipeline_run, presence: true
 
-  validates :read_count, numericality: { greater_than_or_equal_to: 0 }
+  validates :read_count, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
+  validates :sequence, presence: true, if: :mass_validation_enabled?
+  validates :lineage_json, presence: true, if: :mass_validation_enabled?
 
   def to_fa
     ">#{name}:#{read_count}:#{lineage_json}\n#{sequence}"

--- a/app/models/ercc_count.rb
+++ b/app/models/ercc_count.rb
@@ -2,6 +2,11 @@ require 'csv'
 
 class ErccCount < ApplicationRecord
   belongs_to :pipeline_run
+  validates :pipeline_run, presence: true
+
+  validates :count, numericality: { greater_than_or_equal_to: 0 }
+  validates :name, presence: true
+
   ercc_csv = File.join(File.dirname(__FILE__), '../lib/ercc_data.csv')
   BASELINE = CSV.table(ercc_csv).map(&:to_hash)
 end

--- a/app/models/ercc_count.rb
+++ b/app/models/ercc_count.rb
@@ -2,10 +2,9 @@ require 'csv'
 
 class ErccCount < ApplicationRecord
   belongs_to :pipeline_run
-  validates :pipeline_run, presence: true
 
-  validates :count, numericality: { greater_than_or_equal_to: 0 }
-  validates :name, presence: true
+  validates :count, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
+  validates :name, presence: true, if: :mass_validation_enabled?
 
   ercc_csv = File.join(File.dirname(__FILE__), '../lib/ercc_data.csv')
   BASELINE = CSV.table(ercc_csv).map(&:to_hash)

--- a/app/models/host_genome.rb
+++ b/app/models/host_genome.rb
@@ -7,8 +7,7 @@ class HostGenome < ApplicationRecord
   # in light of the data. See showAsOption below.
   # See https://jira.czi.team/browse/IDSEQ-2193.
   belongs_to :user, optional: true
-
-  before_create :add_default_metadata_fields!
+  belongs_to :default_background, optional: true, class_name: "Background", foreign_key: :default_background_id
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }, format: {
     with: /\A\w[\w|\s|\.|\-]+\z/,
@@ -32,6 +31,8 @@ class HostGenome < ApplicationRecord
     "non-human-animal",
   ], }, if: -> { respond_to?(:taxa_category) } # for migrations
 
+  before_create :add_default_metadata_fields!
+
   # NOTE: Consider updating the star and bowtie defaults if we ever add new ERCC index files.
   ERCC_PATH_PREFIX = "s3://idseq-database/host_filter/ercc/2017-09-01-utc-1504224000-unixtime__2017-09-01-utc-1504224000-unixtime/".freeze
   S3_STAR_INDEX_FILE = "STAR_genome.tar".freeze
@@ -48,12 +49,8 @@ class HostGenome < ApplicationRecord
   def as_json(options = {})
     hash = super(options)
     hash[:ercc_only] = ercc_only?
-    hash[:showAsOption] = show_as_option?
+    hash[:showAsOption] = user.nil?
     hash
-  end
-
-  def default_background
-    Background.find(default_background_id) if default_background_id
   end
 
   def add_default_metadata_fields!
@@ -68,9 +65,5 @@ class HostGenome < ApplicationRecord
   def ercc_only?
     s3_star_index_path.starts_with?(HostGenome::ERCC_PATH_PREFIX) &&
       s3_bowtie2_index_path.starts_with?(HostGenome::ERCC_PATH_PREFIX)
-  end
-
-  def show_as_option?
-    user.nil?
   end
 end

--- a/app/models/host_genome.rb
+++ b/app/models/host_genome.rb
@@ -49,7 +49,7 @@ class HostGenome < ApplicationRecord
   def as_json(options = {})
     hash = super(options)
     hash[:ercc_only] = ercc_only?
-    hash[:showAsOption] = user.nil?
+    hash[:showAsOption] = show_as_option?
     hash
   end
 
@@ -65,5 +65,9 @@ class HostGenome < ApplicationRecord
   def ercc_only?
     s3_star_index_path.starts_with?(HostGenome::ERCC_PATH_PREFIX) &&
       s3_bowtie2_index_path.starts_with?(HostGenome::ERCC_PATH_PREFIX)
+  end
+
+  def show_as_option?
+    user.nil?
   end
 end

--- a/app/models/input_file.rb
+++ b/app/models/input_file.rb
@@ -2,17 +2,24 @@ require 'aws-sdk-s3'
 require 'open3'
 class InputFile < ApplicationRecord
   belongs_to :sample
-  SOURCE_TYPE_LOCAL = 'local'.freeze
-  SOURCE_TYPE_S3 = 's3'.freeze
-  SOURCE_TYPE_BASESPACE = 'basespace'.freeze
+  validates :sample, presence: true
 
-  FILE_REGEX = /\A[A-Za-z0-9_][-.A-Za-z0-9_]{0,119}\.(fastq|fq|fastq.gz|fq.gz|fasta|fa|fasta.gz|fa.gz)\z/
   BULK_FILE_PAIRED_REGEX = /\A([A-Za-z0-9_][-.A-Za-z0-9_]{1,119})_R(\d)(_001)?\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
   BULK_FILE_SINGLE_REGEX = /\A([A-Za-z0-9_][-.A-Za-z0-9_]{1,119})\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
   S3_CP_PIPE_ERROR = '[Errno 32] Broken pipe'.freeze
 
+  FILE_REGEX = /\A[A-Za-z0-9_][-.A-Za-z0-9_]{0,119}\.(fastq|fq|fastq.gz|fq.gz|fasta|fa|fasta.gz|fa.gz)\z/
   validates :name, presence: true, format: { with: FILE_REGEX, message: "file must match format '#{FILE_REGEX}'" }
-  validates :source_type, presence: true, inclusion: { in: %w[local s3 basespace] }
+
+  SOURCE_TYPE_LOCAL = 'local'.freeze
+  SOURCE_TYPE_S3 = 's3'.freeze
+  SOURCE_TYPE_BASESPACE = 'basespace'.freeze
+  validates :source_type, presence: true, inclusion: { in: [
+    SOURCE_TYPE_LOCAL,
+    SOURCE_TYPE_S3,
+    SOURCE_TYPE_BASESPACE,
+  ], }
+
   validate :s3_source_check, on: :create
 
   def s3_source_check

--- a/app/models/input_file.rb
+++ b/app/models/input_file.rb
@@ -2,11 +2,6 @@ require 'aws-sdk-s3'
 require 'open3'
 class InputFile < ApplicationRecord
   belongs_to :sample
-  validates :sample, presence: true
-
-  BULK_FILE_PAIRED_REGEX = /\A([A-Za-z0-9_][-.A-Za-z0-9_]{1,119})_R(\d)(_001)?\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
-  BULK_FILE_SINGLE_REGEX = /\A([A-Za-z0-9_][-.A-Za-z0-9_]{1,119})\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
-  S3_CP_PIPE_ERROR = '[Errno 32] Broken pipe'.freeze
 
   FILE_REGEX = /\A[A-Za-z0-9_][-.A-Za-z0-9_]{0,119}\.(fastq|fq|fastq.gz|fq.gz|fasta|fa|fasta.gz|fa.gz)\z/
   validates :name, presence: true, format: { with: FILE_REGEX, message: "file must match format '#{FILE_REGEX}'" }
@@ -20,7 +15,12 @@ class InputFile < ApplicationRecord
     SOURCE_TYPE_BASESPACE,
   ], }
 
+  validates :source, presence: true, if: :mass_validation_enabled?
   validate :s3_source_check, on: :create
+
+  BULK_FILE_PAIRED_REGEX = /\A([A-Za-z0-9_][-.A-Za-z0-9_]{1,119})_R(\d)(_001)?\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
+  BULK_FILE_SINGLE_REGEX = /\A([A-Za-z0-9_][-.A-Za-z0-9_]{1,119})\.(fastq.gz|fq.gz|fastq|fq|fasta.gz|fa.gz|fasta|fa)\z/
+  S3_CP_PIPE_ERROR = '[Errno 32] Broken pipe'.freeze
 
   def s3_source_check
     source.strip! if source.present?

--- a/app/models/job_stat.rb
+++ b/app/models/job_stat.rb
@@ -1,7 +1,7 @@
 class JobStat < ApplicationRecord
   belongs_to :pipeline_run
-  validates :pipeline_run, presence: true
-  validates :task, presence: true, inclusion: { in: PipelineRunsHelper::ALL_STEP_NAMES }
-  validates :reads_before, numericality: { greater_than: 0 }
-  validates :reads_after, numericality: { greater_than: 0 }
+  validates :pipeline_run, presence: true, if: :mass_validation_enabled?
+  validates :task, presence: true, inclusion: { in: PipelineRunsHelper::ALL_STEP_NAMES }, if: :mass_validation_enabled?
+  validates :reads_before, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
+  validates :reads_after, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
 end

--- a/app/models/job_stat.rb
+++ b/app/models/job_stat.rb
@@ -1,3 +1,7 @@
 class JobStat < ApplicationRecord
   belongs_to :pipeline_run
+  validates :pipeline_run, presence: true
+  validates :task, presence: true, inclusion: { in: PipelineRunsHelper::ALL_STEP_NAMES }
+  validates :reads_before, numericality: { greater_than: 0 }
+  validates :reads_after, numericality: { greater_than: 0 }
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,6 +5,9 @@ class Location < ApplicationRecord
   belongs_to :subdivision, class_name: "Location", optional: true
   belongs_to :city, class_name: "Location", optional: true
 
+  validates :lat, inclusion: -90..90
+  validates :lng, inclusion: -180..180
+
   LOCATION_IQ_BASE_URL = "https://us1.locationiq.com/v1".freeze
   GEOSEARCH_BASE_QUERY = "search.php?addressdetails=1&normalizecity=1".freeze
   AUTOCOMPLETE_BASE_QUERY = "autocomplete.php?normalizecity=1".freeze

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,8 +5,10 @@ class Location < ApplicationRecord
   belongs_to :subdivision, class_name: "Location", optional: true
   belongs_to :city, class_name: "Location", optional: true
 
-  validates :lat, inclusion: -90..90, if: :mass_validation_enabled?
-  validates :lng, inclusion: -180..180, if: :mass_validation_enabled?
+  # Lat and lng may be null if the location provider is missing coordinates, as
+  # opposed to placing a location at (0,0)
+  validates :lat, inclusion: -90..90, allow_nil: true, if: :mass_validation_enabled?
+  validates :lng, inclusion: -180..180, allow_nil: true, if: :mass_validation_enabled?
   validates :osm_id, presence: true, if: :mass_validation_enabled?
   validates :locationiq_id, presence: true, if: :mass_validation_enabled?
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,8 +5,10 @@ class Location < ApplicationRecord
   belongs_to :subdivision, class_name: "Location", optional: true
   belongs_to :city, class_name: "Location", optional: true
 
-  validates :lat, inclusion: -90..90
-  validates :lng, inclusion: -180..180
+  validates :lat, inclusion: -90..90, if: :mass_validation_enabled?
+  validates :lng, inclusion: -180..180, if: :mass_validation_enabled?
+  validates :osm_id, presence: true, if: :mass_validation_enabled?
+  validates :locationiq_id, presence: true, if: :mass_validation_enabled?
 
   LOCATION_IQ_BASE_URL = "https://us1.locationiq.com/v1".freeze
   GEOSEARCH_BASE_QUERY = "search.php?addressdetails=1&normalizecity=1".freeze

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -5,9 +5,8 @@ class MetadataField < ApplicationRecord
 
   # Obeying the same rules as in MetadataHelper validate_metadata_csv_for_samples
   # Metadata fields are shared globally and can be created by users.
-  # TODO: (gdingle): is a custom field created by one user visible to another?
-  validates :name, presence: true, uniqueness: true
-  validates :display_name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, if: :mass_validation_enabled?
+  validates :display_name, presence: true, uniqueness: true, if: :mass_validation_enabled?
 
   validate :metadata_field_subsets
 
@@ -42,6 +41,7 @@ class MetadataField < ApplicationRecord
   validates :is_core, inclusion: { in: [0, 1] }
   validates :is_default, inclusion: { in: [0, 1] }
   validates :is_required, inclusion: { in: [0, 1] }
+  validates :default_for_new_host_genome, inclusion: { in: [0, 1] }, if: :mass_validation_enabled?
 
   # ActiveRecord documentation summary
 

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -3,6 +3,12 @@ class MetadataField < ApplicationRecord
   has_and_belongs_to_many :projects
   has_many :metadata, dependent: :destroy
 
+  # Obeying the same rules as in MetadataHelper validate_metadata_csv_for_samples
+  # Metadata fields are shared globally and can be created by users.
+  # TODO: (gdingle): is a custom field created by one user visible to another?
+  validates :name, presence: true, uniqueness: true
+  validates :display_name, presence: true, uniqueness: true
+
   validate :metadata_field_subsets
 
   # As of Feb 2020, we renamed "Host Genome" in the UI to better reflect its

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -41,7 +41,7 @@ class MetadataField < ApplicationRecord
   validates :is_core, inclusion: { in: [0, 1] }
   validates :is_default, inclusion: { in: [0, 1] }
   validates :is_required, inclusion: { in: [0, 1] }
-  validates :default_for_new_host_genome, inclusion: { in: [0, 1] }, if: :mass_validation_enabled?
+  validates :default_for_new_host_genome, inclusion: { in: [0, 1] }, if: -> { respond_to?(:default_for_new_host_genome) && mass_validation_enabled? } # respond_to? for migrations
 
   # ActiveRecord documentation summary
 

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -15,7 +15,9 @@ class Metadatum < ApplicationRecord
 
   # ActiveRecord related
   belongs_to :sample
+  validates :sample, presence: true
   belongs_to :metadata_field
+  validates :metadata_field, presence: true
   belongs_to :location, optional: true
 
   # Validations

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -15,9 +15,7 @@ class Metadatum < ApplicationRecord
 
   # ActiveRecord related
   belongs_to :sample
-  validates :sample, presence: true
   belongs_to :metadata_field
-  validates :metadata_field, presence: true
   belongs_to :location, optional: true
 
   # Validations

--- a/app/models/output_state.rb
+++ b/app/models/output_state.rb
@@ -1,6 +1,20 @@
 class OutputState < ApplicationRecord
   belongs_to :pipeline_run
-  validates :pipeline_run, presence: true
+
+  # Current values of output are:
+  # +----------------------+
+  # | output               |
+  # +----------------------+
+  # | ercc_counts          |
+  # | taxon_byteranges     |
+  # | taxon_counts         |
+  # | amr_counts           |
+  # | refined_taxon_counts |
+  # | contig_counts        |
+  # | contigs              |
+  # | input_validations    |
+  # +----------------------+
+  validates :output, presence: true, if: :mass_validation_enabled?
 
   validates :state, inclusion: { in: [
     PipelineRun::STATUS_LOADED,
@@ -8,5 +22,5 @@ class OutputState < ApplicationRecord
     PipelineRun::STATUS_LOADING,
     PipelineRun::STATUS_LOADING_QUEUED,
     PipelineRun::STATUS_LOADING_ERROR,
-  ], }
+  ], }, if: :mass_validation_enabled?
 end

--- a/app/models/output_state.rb
+++ b/app/models/output_state.rb
@@ -1,3 +1,12 @@
 class OutputState < ApplicationRecord
   belongs_to :pipeline_run
+  validates :pipeline_run, presence: true
+
+  validates :state, inclusion: { in: [
+    PipelineRun::STATUS_LOADED,
+    PipelineRun::STATUS_UNKNOWN,
+    PipelineRun::STATUS_LOADING,
+    PipelineRun::STATUS_LOADING_QUEUED,
+    PipelineRun::STATUS_LOADING_ERROR,
+  ], }
 end

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -3,16 +3,32 @@ class PhyloTree < ApplicationRecord
   include PipelineRunsHelper
   include SamplesHelper
   include ActionView::Helpers::DateHelper
+
   has_and_belongs_to_many :pipeline_runs
   belongs_to :user, counter_cache: true # use .size for cache, use .count to force COUNT query
+  validates :user, presence: true
   belongs_to :project
+  validates :project, presence: true
+
+  # TODO: (gdingle): should this be scoped to project or user?
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :tax_level, presence: true, inclusion: { in: [
+    TaxonCount::TAX_LEVEL_SPECIES,
+    TaxonCount::TAX_LEVEL_GENUS,
+  ], }
+
   after_create :create_visualization
 
   STATUS_INITIALIZED = 0
   STATUS_READY = 1
   STATUS_FAILED = 2
   STATUS_IN_PROGRESS = 3
+  validates :status, presence: true, inclusion: { in: [
+    STATUS_INITIALIZED,
+    STATUS_READY,
+    STATUS_FAILED,
+    STATUS_IN_PROGRESS,
+  ], }
 
   def self.in_progress
     where(status: STATUS_IN_PROGRESS)

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -10,7 +10,6 @@ class PhyloTree < ApplicationRecord
   # NOTE: this conflicts with phylo_trees_controller_spec.rb
   # belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :taxid, primary_key: :taxid
 
-  # TODO: (gdingle): should this be scoped to project or user?
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :taxid, presence: true, if: :mass_validation_enabled?
   validates :tax_name, presence: true, if: :mass_validation_enabled?

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -8,9 +8,7 @@ class PipelineRun < ApplicationRecord
   include PipelineRunsHelper
 
   belongs_to :sample
-  validates :sample, presence: true
   belongs_to :alignment_config
-  validates :alignment_config, presence: true
   has_many :pipeline_run_stages, dependent: :destroy
   accepts_nested_attributes_for :pipeline_run_stages
   has_and_belongs_to_many :backgrounds

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -11,11 +11,13 @@ class PipelineRun < ApplicationRecord
   belongs_to :alignment_config
   has_many :pipeline_run_stages, dependent: :destroy
   accepts_nested_attributes_for :pipeline_run_stages
+  validates_associated :pipeline_run_stages
   has_and_belongs_to_many :backgrounds
   has_and_belongs_to_many :phylo_trees
   has_and_belongs_to_many :bulk_downloads
 
   has_many :output_states, dependent: :destroy
+  validates_associated :output_states
   has_many :taxon_counts, dependent: :destroy
   has_many :job_stats, dependent: :destroy
   has_many :taxon_byteranges, dependent: :destroy
@@ -24,12 +26,19 @@ class PipelineRun < ApplicationRecord
   has_many :contigs, dependent: :destroy
   has_one :insert_size_metric_set, dependent: :destroy
   accepts_nested_attributes_for :taxon_counts
+  validates_associated :taxon_counts
   accepts_nested_attributes_for :job_stats
+  validates_associated :job_stats
   accepts_nested_attributes_for :taxon_byteranges
+  validates_associated :taxon_byteranges
   accepts_nested_attributes_for :ercc_counts
+  validates_associated :ercc_counts
   accepts_nested_attributes_for :amr_counts
+  validates_associated :amr_counts
   accepts_nested_attributes_for :contigs
+  validates_associated :contigs
   accepts_nested_attributes_for :insert_size_metric_set
+  validates_associated :insert_size_metric_set
 
   DEFAULT_SUBSAMPLING = 1_000_000 # number of fragments to subsample to, after host filtering
   DEFAULT_MAX_INPUT_FRAGMENTS = 75_000_000 # max fragments going into the pipeline

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1,12 +1,16 @@
 require 'open3'
 require 'json'
 require 'csv'
+
 class PipelineRun < ApplicationRecord
   include ApplicationHelper
   include PipelineOutputsHelper
   include PipelineRunsHelper
+
   belongs_to :sample
+  validates :sample, presence: true
   belongs_to :alignment_config
+  validates :alignment_config, presence: true
   has_many :pipeline_run_stages, dependent: :destroy
   accepts_nested_attributes_for :pipeline_run_stages
   has_and_belongs_to_many :backgrounds
@@ -121,9 +125,30 @@ class PipelineRun < ApplicationRecord
   STATUS_CHECKED = 'CHECKED'.freeze
   STATUS_FAILED = 'FAILED'.freeze
   STATUS_RUNNING = 'RUNNING'.freeze
-  STATUS_RUNNABLE = 'RUNNABLE'.freeze
+  STATUS_RUNNABLE = 'RUNNABLE'.freeze # TODO: (gdingle): not used anywhere?
   STATUS_READY = 'READY'.freeze
-
+  # NOTE: The current stored job_status are...
+  # +-------------------------------------------+
+  # | job_status                                |
+  # +-------------------------------------------+
+  # | 1.Host Filtering-FAILED                   |
+  # | 1.Host Filtering-FAILED|READY             |
+  # | 2.GSNAPL/RAPSEARCH alignment-FAILED       |
+  # | 2.GSNAPL/RAPSEARCH alignment-FAILED|READY |
+  # | 2.GSNAPL/RAPSEARCH alignment-RUNNING      |
+  # | 3.Post Processing-FAILED                  |
+  # | 3.Post Processing-FAILED|READY            |
+  # | 4.De-Novo Assembly-FAILED|READY           |
+  # | 4.Experimental-FAILED                     |
+  # | 4.Experimental-FAILED|READY               |
+  # | 4.Experimental-SUCCEEDED                  |
+  # | 4.Experimental-SUCCEEDED|READY            |
+  # | CHECKED                                   |
+  # | FAILED                                    |
+  # | LOADED                                    |
+  # +-------------------------------------------+
+  validates :job_status, presence: true
+  #
   # The RESULT MONITOR is responsible for keeping status of available outputs
   # and for loading those outputs in from S3.
   # It accomplishes this using the following:
@@ -139,7 +164,6 @@ class PipelineRun < ApplicationRecord
   # by checking whether REPORT_READY_OUTPUT has been loaded.
   # Note we don't put a default on results_finalized in the schema, so that we can
   # recognize old runs by results_finalized being nil.
-
   STATUS_LOADED = 'LOADED'.freeze
   STATUS_UNKNOWN = 'UNKNOWN'.freeze
   STATUS_LOADING = 'LOADING'.freeze
@@ -160,10 +184,17 @@ class PipelineRun < ApplicationRecord
   # Values for results_finalized are as follows.
   # Note we don't put a default on results_finalized in the schema, so that we can
   # recognize old runs by results_finalized being nil.
-
   IN_PROGRESS = 0
   FINALIZED_SUCCESS = 10
   FINALIZED_FAIL = 20
+  validates :results_finalized, presence: true, allow_nil: true, inclusion: { in: [
+    IN_PROGRESS,
+    FINALIZED_SUCCESS,
+    FINALIZED_FAIL,
+    # See also pre_result_monitor?
+  ], }
+
+  validates :finalized, presence: true, inclusion: { in: [0, 1] }
 
   # State machine for RESULT MONITOR:
   #

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -145,7 +145,8 @@ class PipelineRun < ApplicationRecord
   # | FAILED                                    |
   # | LOADED                                    |
   # +-------------------------------------------+
-  validates :job_status, presence: true
+  # NOTE: kickoff_pipeline does not set a job_status
+  validates :job_status, presence: true, allow_nil: true, if: :mass_validation_enabled?
   #
   # The RESULT MONITOR is responsible for keeping status of available outputs
   # and for loading those outputs in from S3.
@@ -182,6 +183,7 @@ class PipelineRun < ApplicationRecord
   # Values for results_finalized are as follows.
   # Note we don't put a default on results_finalized in the schema, so that we can
   # recognize old runs by results_finalized being nil.
+  # NOTE: kickoff_pipeline does not set results_finalized
   IN_PROGRESS = 0
   FINALIZED_SUCCESS = 10
   FINALIZED_FAIL = 20
@@ -190,9 +192,9 @@ class PipelineRun < ApplicationRecord
     FINALIZED_SUCCESS,
     FINALIZED_FAIL,
     # See also pre_result_monitor?
-  ], }
+  ], }, if: :mass_validation_enabled?
 
-  validates :finalized, presence: true, inclusion: { in: [0, 1] }
+  validates :finalized, presence: true, inclusion: { in: [0, 1] }, if: :mass_validation_enabled?
 
   # State machine for RESULT MONITOR:
   #

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -35,7 +35,7 @@ class PipelineRunStage < ApplicationRecord
   DAG_NAME_EXPERIMENTAL = "experimental".freeze
 
   # Older alignment configs might not have an s3_nt_info_db_path field, so use a reasonable default in this case.
-  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/2019-09-17/nt_info.sqlite3".freeze
+  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/#{AlignmentConfig::DEFAULT_NAME}/nt_info.sqlite3".freeze
 
   STAGE_INFO = {
     1 => {

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -4,10 +4,10 @@ class PipelineRunStage < ApplicationRecord
   include PipelineOutputsHelper
 
   belongs_to :pipeline_run
-  validates :name, presence: true
+  validates :name, presence: true, if: :mass_validation_enabled?
   # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
-  validates :step_number, presence: true, numericality: { greater_than: 0, integer_only: true }
-  validates :job_command_func, presence: true
+  validates :step_number, presence: true, numericality: { greater_than: 0, integer_only: true }, if: :mass_validation_enabled?
+  validates :job_command_func, presence: true, if: :mass_validation_enabled?
 
   JOB_TYPE_BATCH = 1
   COMMIT_SHA_FILE_ON_WORKER = "/mnt/idseq-pipeline/commit-sha.txt".freeze

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -1,4 +1,14 @@
 class PipelineRunStage < ApplicationRecord
+  include ApplicationHelper
+  include PipelineRunsHelper
+  include PipelineOutputsHelper
+
+  belongs_to :pipeline_run
+  validates :name, presence: true
+  # TODO: (gdingle): rename to stage_number. See https://jira.czi.team/browse/IDSEQ-1912.
+  validates :step_number, presence: true, numericality: { greater_than: 0, integer_only: true }
+  validates :job_command_func, presence: true
+
   JOB_TYPE_BATCH = 1
   COMMIT_SHA_FILE_ON_WORKER = "/mnt/idseq-pipeline/commit-sha.txt".freeze
 
@@ -25,7 +35,7 @@ class PipelineRunStage < ApplicationRecord
   DAG_NAME_EXPERIMENTAL = "experimental".freeze
 
   # Older alignment configs might not have an s3_nt_info_db_path field, so use a reasonable default in this case.
-  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/#{AlignmentConfig::DEFAULT_NAME}/nt_info.sqlite3".freeze
+  DEFAULT_S3_NT_INFO_DB_PATH = "s3://idseq-database/alignment_data/2019-09-17/nt_info.sqlite3".freeze
 
   STAGE_INFO = {
     1 => {
@@ -56,11 +66,6 @@ class PipelineRunStage < ApplicationRecord
 
   # Max number of times we resubmit a job when it gets killed by EC2.
   MAX_RETRIES = 5
-
-  include ApplicationHelper
-  include PipelineRunsHelper
-  include PipelineOutputsHelper
-  belongs_to :pipeline_run
 
   def started?
     job_command.present?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,7 @@ class Project < ApplicationRecord
     include Elasticsearch::Model
     include Elasticsearch::Model::Callbacks
   end
+  include ReportHelper
 
   has_and_belongs_to_many :users
   has_many :samples, dependent: :restrict_with_exception
@@ -11,8 +12,12 @@ class Project < ApplicationRecord
   has_many :phylo_trees, -> { order(created_at: :desc) }, dependent: :restrict_with_exception
   has_one :background
   has_and_belongs_to_many :metadata_fields
+
   validates :name, presence: true, uniqueness: { case_sensitive: false }
-  include ReportHelper
+  # NOTE: not sure why these columns were not created as booleans
+  validates :public_access, inclusion: { in: [0, 1] }
+  # NOTE: all values of background_flag in prod db are currently zero.
+  validates :background_flag, inclusion: { in: [0, 1] }, allow_nil: true
 
   before_create :add_default_metadata_fields
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,7 +15,7 @@ class Project < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   # NOTE: not sure why these columns were not created as booleans
-  validates :public_access, inclusion: { in: [0, 1] }
+  validates :public_access, inclusion: { in: [0, 1] }, if: :mass_validation_enabled?
   # NOTE: all values of background_flag in prod db are currently zero.
   validates :background_flag, inclusion: { in: [0, 1] }, allow_nil: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,7 +17,7 @@ class Project < ApplicationRecord
   # NOTE: not sure why these columns were not created as booleans
   validates :public_access, inclusion: { in: [0, 1] }, if: :mass_validation_enabled?
   # NOTE: all values of background_flag in prod db are currently zero.
-  validates :background_flag, inclusion: { in: [0, 1] }, allow_nil: true
+  validates :background_flag, inclusion: { in: [0, 1] }, allow_nil: true, if: :mass_validation_enabled?
 
   before_create :add_default_metadata_fields
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -52,7 +52,6 @@ class Sample < ApplicationRecord
   validate :input_files_checks
   validates :name, presence: true, uniqueness: { scope: :project_id, case_sensitive: false }
 
-  # TODO: (gdingle): allow blank for web_commit?!
   validates :web_commit, presence: true, allow_blank: true, if: :mass_validation_enabled?
   validates :pipeline_commit, presence: true, allow_blank: true, if: :mass_validation_enabled?
   validates :uploaded_from_basespace, presence: true, inclusion: { in: [0, 1] }, if: :mass_validation_enabled?

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -25,6 +25,17 @@ class Sample < ApplicationRecord
   include BasespaceHelper
   include ErrorHelper
 
+  belongs_to :project
+  # This is the user who uploaded the sample, possibly distinct from the user(s) owning the sample's project
+  belongs_to :user, counter_cache: true # use .size for cache, use .count to force COUNT query
+  belongs_to :host_genome, counter_cache: true # use .size for cache, use .count to force COUNT query
+  has_many :pipeline_runs, -> { order(created_at: :desc) }, dependent: :destroy
+  has_many :backgrounds, through: :pipeline_runs
+  has_many :input_files, dependent: :destroy
+  accepts_nested_attributes_for :input_files
+  has_many :metadata, dependent: :destroy
+  has_and_belongs_to_many :visualizations
+
   STATUS_CREATED = 'created'.freeze
   STATUS_UPLOADED = 'uploaded'.freeze
   STATUS_RERUN    = 'need_rerun'.freeze
@@ -36,10 +47,19 @@ class Sample < ApplicationRecord
     STATUS_RERUN,
     STATUS_RETRY_PR,
     STATUS_CHECKED,
-  ], }
+  ], }, if: :mass_validation_enabled?
 
-  # Not sure why this is not a boolean
-  validates :uploaded_from_basespace, presence: true, inclusion: { in: [0, 1] }
+  validate :input_files_checks
+  validates :name, presence: true, uniqueness: { scope: :project_id, case_sensitive: false }
+
+  # TODO: (gdingle): allow blank for web_commit?!
+  validates :web_commit, presence: true, allow_blank: true, if: :mass_validation_enabled?
+  validates :pipeline_commit, presence: true, allow_blank: true, if: :mass_validation_enabled?
+  validates :uploaded_from_basespace, presence: true, inclusion: { in: [0, 1] }, if: :mass_validation_enabled?
+
+  after_create :initiate_input_file_upload
+  before_save :check_host_genome, :concatenate_input_parts, :check_status
+  after_save :set_presigned_url_for_local_upload
 
   # Constants for upload errors.
   UPLOAD_ERROR_BASESPACE_UPLOAD_FAILED = "BASESPACE_UPLOAD_FAILED".freeze
@@ -78,26 +98,6 @@ class Sample < ApplicationRecord
 
   # These are temporary variables that are not saved to the database. They only persist for the lifetime of the Sample object.
   attr_accessor :bulk_mode, :basespace_dataset_id
-
-  belongs_to :project
-  validates :project, presence: true
-
-  # This is the user who uploaded the sample, possibly distinct from the user(s) owning the sample's project
-  belongs_to :user, counter_cache: true # use .size for cache, use .count to force COUNT query
-  belongs_to :host_genome, counter_cache: true # use .size for cache, use .count to force COUNT query
-  has_many :pipeline_runs, -> { order(created_at: :desc) }, dependent: :destroy
-  has_many :backgrounds, through: :pipeline_runs
-  has_many :input_files, dependent: :destroy
-  accepts_nested_attributes_for :input_files
-  has_many :metadata, dependent: :destroy
-  has_and_belongs_to_many :visualizations
-
-  validate :input_files_checks
-  after_create :initiate_input_file_upload
-  validates :name, presence: true, uniqueness: { scope: :project_id, case_sensitive: false }
-
-  before_save :check_host_genome, :concatenate_input_parts, :check_status
-  after_save :set_presigned_url_for_local_upload
 
   # getter
   attr_reader :bulk_mode

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -33,6 +33,7 @@ class Sample < ApplicationRecord
   has_many :backgrounds, through: :pipeline_runs
   has_many :input_files, dependent: :destroy
   accepts_nested_attributes_for :input_files
+  validates_associated :input_files
   has_many :metadata, dependent: :destroy
   has_and_belongs_to_many :visualizations
 

--- a/app/models/taxon_byterange.rb
+++ b/app/models/taxon_byterange.rb
@@ -1,12 +1,12 @@
 class TaxonByterange < ApplicationRecord
   belongs_to :pipeline_run
-  validates :pipeline_run, presence: true
+  belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid
 
   validates :hit_type, presence: true, inclusion: { in: [
     TaxonCount::COUNT_TYPE_NT,
     TaxonCount::COUNT_TYPE_NR,
-  ], }
+  ], }, if: :mass_validation_enabled?
 
-  validates :first_byte, numericality: { greater_than_or_equal_to: 0 }
-  validates :last_byte, numericality: { greater_than_or_equal_to: 1 }
+  validates :first_byte, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
+  validates :last_byte, numericality: { greater_than_or_equal_to: 1 }, if: :mass_validation_enabled?
 end

--- a/app/models/taxon_byterange.rb
+++ b/app/models/taxon_byterange.rb
@@ -1,3 +1,12 @@
 class TaxonByterange < ApplicationRecord
   belongs_to :pipeline_run
+  validates :pipeline_run, presence: true
+
+  validates :hit_type, presence: true, inclusion: { in: [
+    TaxonCount::COUNT_TYPE_NT,
+    TaxonCount::COUNT_TYPE_NR,
+  ], }
+
+  validates :first_byte, numericality: { greater_than_or_equal_to: 0 }
+  validates :last_byte, numericality: { greater_than_or_equal_to: 1 }
 end

--- a/app/models/taxon_byterange.rb
+++ b/app/models/taxon_byterange.rb
@@ -1,6 +1,7 @@
 class TaxonByterange < ApplicationRecord
   belongs_to :pipeline_run
-  belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid
+  # NOTE: this conflicts with phylo_trees_controller_spec.rb
+  # belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid
 
   validates :hit_type, presence: true, inclusion: { in: [
     TaxonCount::COUNT_TYPE_NT,
@@ -8,5 +9,5 @@ class TaxonByterange < ApplicationRecord
   ], }, if: :mass_validation_enabled?
 
   validates :first_byte, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
-  validates :last_byte, numericality: { greater_than_or_equal_to: 1 }, if: :mass_validation_enabled?
+  validates :last_byte, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
 end

--- a/app/models/taxon_count.rb
+++ b/app/models/taxon_count.rb
@@ -1,4 +1,5 @@
-# NOTE: validations are typically skipped because of update_all in results loader.
+# NOTE: Validations here are typically skipped because of update_all in results
+# loader.
 class TaxonCount < ApplicationRecord
   belongs_to :pipeline_run
   # NOTE: currently optional because some tests assume non-existant taxa
@@ -30,14 +31,12 @@ class TaxonCount < ApplicationRecord
     COUNT_TYPE_NR,
   ], }, if: :mass_validation_enabled?
 
-  # TODO: (gdingle): is it really okay to have a count of zero? that's what
-  # some existing rspec tests assume.
+  # NOTE: some existing rspec tests assume a value of zero
   validates :count, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
-
   validates :percent_identity, inclusion: 0..100, if: :mass_validation_enabled?
-  # TODO: (gdingle): is it really okay to have a alignment_length of zero?
-  # that's what some existing rspec tests assume.
+  # NOTE: some existing rspec tests assume a value of zero
   validates :alignment_length, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
+  validates :e_value, presence: true, if: :mass_validation_enabled?
 
   NAME_2_LEVEL = { 'species' => TAX_LEVEL_SPECIES,
                    'genus' => TAX_LEVEL_GENUS,

--- a/app/models/taxon_count.rb
+++ b/app/models/taxon_count.rb
@@ -20,23 +20,23 @@ class TaxonCount < ApplicationRecord
     TAX_LEVEL_PHYLUM,
     TAX_LEVEL_KINGDOM,
     TAX_LEVEL_SUPERKINGDOM,
-  ], }, if: :validate_all?
+  ], }, if: :mass_validation_enabled?
 
   COUNT_TYPE_NT = 'NT'.freeze
   COUNT_TYPE_NR = 'NR'.freeze
   validates :count_type, presence: true, inclusion: { in: [
     COUNT_TYPE_NT,
     COUNT_TYPE_NR,
-  ], }, if: :validate_all?
+  ], }, if: :mass_validation_enabled?
 
   # TODO: (gdingle): is it really okay to have a count of zero? that's what
   # some existing rspec tests assume.
-  validates :count, numericality: { greater_than_or_equal_to: 0 }, if: :validate_all?
+  validates :count, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
 
-  validates :percent_identity, inclusion: 0..100, if: :validate_all?
+  validates :percent_identity, inclusion: 0..100, if: :mass_validation_enabled?
   # TODO: (gdingle): is it really okay to have a alignment_length of zero?
   # that's what some existing rspec tests assume.
-  validates :alignment_length, numericality: { greater_than_or_equal_to: 0 }, if: :validate_all?
+  validates :alignment_length, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
 
   NAME_2_LEVEL = { 'species' => TAX_LEVEL_SPECIES,
                    'genus' => TAX_LEVEL_GENUS,

--- a/app/models/taxon_count.rb
+++ b/app/models/taxon_count.rb
@@ -1,6 +1,8 @@
 # NOTE: validations are typically skipped because of update_all in results loader.
 class TaxonCount < ApplicationRecord
   belongs_to :pipeline_run
+  # NOTE: currently optional because some tests assume non-existant taxa
+  belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid, optional: true
 
   TAX_LEVEL_SPECIES = 1
   TAX_LEVEL_GENUS = 2

--- a/app/models/taxon_count.rb
+++ b/app/models/taxon_count.rb
@@ -1,7 +1,8 @@
 # NOTE: validations are typically skipped because of update_all in results loader.
 class TaxonCount < ApplicationRecord
   belongs_to :pipeline_run
-  # NOTE: TaxonCount also has tax_id which is a key into TaxonLineage
+  # NOTE: currently optional because some tests assume non-existant taxa
+  belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid, optional: true
 
   TAX_LEVEL_SPECIES = 1
   TAX_LEVEL_GENUS = 2

--- a/app/models/taxon_count.rb
+++ b/app/models/taxon_count.rb
@@ -1,8 +1,6 @@
 # NOTE: validations are typically skipped because of update_all in results loader.
 class TaxonCount < ApplicationRecord
   belongs_to :pipeline_run
-  # NOTE: currently optional because some tests assume non-existant taxa
-  belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid, optional: true
 
   TAX_LEVEL_SPECIES = 1
   TAX_LEVEL_GENUS = 2

--- a/app/models/taxon_count.rb
+++ b/app/models/taxon_count.rb
@@ -1,5 +1,8 @@
+# NOTE: validations are typically skipped because of update_all in results loader.
 class TaxonCount < ApplicationRecord
   belongs_to :pipeline_run
+  # NOTE: TaxonCount also has tax_id which is a key into TaxonLineage
+
   TAX_LEVEL_SPECIES = 1
   TAX_LEVEL_GENUS = 2
   TAX_LEVEL_FAMILY = 3
@@ -8,8 +11,33 @@ class TaxonCount < ApplicationRecord
   TAX_LEVEL_PHYLUM = 6
   TAX_LEVEL_KINGDOM = 7
   TAX_LEVEL_SUPERKINGDOM = 8
+  validates :tax_level, presence: true, inclusion: { in: [
+    TAX_LEVEL_SPECIES,
+    TAX_LEVEL_GENUS,
+    TAX_LEVEL_FAMILY,
+    TAX_LEVEL_ORDER,
+    TAX_LEVEL_CLASS,
+    TAX_LEVEL_PHYLUM,
+    TAX_LEVEL_KINGDOM,
+    TAX_LEVEL_SUPERKINGDOM,
+  ], }, if: :validate_all?
+
   COUNT_TYPE_NT = 'NT'.freeze
   COUNT_TYPE_NR = 'NR'.freeze
+  validates :count_type, presence: true, inclusion: { in: [
+    COUNT_TYPE_NT,
+    COUNT_TYPE_NR,
+  ], }, if: :validate_all?
+
+  # TODO: (gdingle): is it really okay to have a count of zero? that's what
+  # some existing rspec tests assume.
+  validates :count, numericality: { greater_than_or_equal_to: 0 }, if: :validate_all?
+
+  validates :percent_identity, inclusion: 0..100, if: :validate_all?
+  # TODO: (gdingle): is it really okay to have a alignment_length of zero?
+  # that's what some existing rspec tests assume.
+  validates :alignment_length, numericality: { greater_than_or_equal_to: 0 }, if: :validate_all?
+
   NAME_2_LEVEL = { 'species' => TAX_LEVEL_SPECIES,
                    'genus' => TAX_LEVEL_GENUS,
                    'family' => TAX_LEVEL_FAMILY,
@@ -19,6 +47,7 @@ class TaxonCount < ApplicationRecord
                    'kingdom' => TAX_LEVEL_KINGDOM,
                    'superkingdom' => TAX_LEVEL_SUPERKINGDOM, }.freeze
   LEVEL_2_NAME = NAME_2_LEVEL.invert
+
   scope :type, ->(count_type) { where(count_type: count_type) }
   scope :level, ->(tax_level) { where(tax_level: tax_level) }
 end

--- a/app/models/taxon_description.rb
+++ b/app/models/taxon_description.rb
@@ -1,5 +1,5 @@
 class TaxonDescription < ApplicationRecord
-  validates :wikipedia_id, presence: true
+  validates :wikipedia_id, presence: true, if: :mass_validation_enabled?
 
   def wiki_url
     "https://en.wikipedia.org/wiki/index.html?curid=#{wikipedia_id}"

--- a/app/models/taxon_description.rb
+++ b/app/models/taxon_description.rb
@@ -1,4 +1,6 @@
 class TaxonDescription < ApplicationRecord
+  validates :wikipedia_id, presence: true
+
   def wiki_url
     "https://en.wikipedia.org/wiki/index.html?curid=#{wikipedia_id}"
   end

--- a/app/models/taxon_scoring_model.rb
+++ b/app/models/taxon_scoring_model.rb
@@ -35,6 +35,10 @@
 # }
 class TaxonScoringModel < ApplicationRecord
   include Math
+
+  validates :name, presence: true, if: :mass_validation_enabled?
+  validates :model_json, presence: true, if: :mass_validation_enabled?
+
   attr_accessor :model
   before_save :set_json, :validate_model
   after_find  :set_model

--- a/app/models/taxon_scoring_model.rb
+++ b/app/models/taxon_scoring_model.rb
@@ -1,3 +1,5 @@
+# NOTE: This is DEPRECATED because there has only ever been one model in use.
+#
 # Scoring Model for Taxon
 # the scoring model is represented in json with a tree structure where a parent will apply an operator to all the children and the leaf node could be a constant(const) or an attribute from the taxon (attr)
 # Currently the operators supported are addition (+), product (-) for nodes with multiple children and atomic transformation function for nodes with one children.

--- a/app/models/taxon_summary.rb
+++ b/app/models/taxon_summary.rb
@@ -3,6 +3,7 @@ class TaxonSummary < ApplicationRecord
   belongs_to :background
   # NOTE: this conflicts with pipeline_report_service_spec.rb
   # belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid
+  validates :tax_id, presence: true, if: :mass_validation_enabled?
 
   validates :count_type, presence: true, inclusion: { in: [
     TaxonCount::COUNT_TYPE_NT,
@@ -19,4 +20,5 @@ class TaxonSummary < ApplicationRecord
 
   validates :mean, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
   validates :stdev, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
+  validates :rpm_list, presence: true, if: :mass_validation_enabled?
 end

--- a/app/models/taxon_summary.rb
+++ b/app/models/taxon_summary.rb
@@ -1,8 +1,6 @@
 # This model gives, for each taxon, summary statistics (mean count, standard deviation) of the background model.
 class TaxonSummary < ApplicationRecord
   belongs_to :background
-  validates :background, presence: true
-  belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid
 
   validates :count_type, presence: true, inclusion: { in: [
     TaxonCount::COUNT_TYPE_NT,
@@ -10,13 +8,13 @@ class TaxonSummary < ApplicationRecord
     # Unclear meaning. Exists in database, but not in codebase.
     "NT+",
     "NR+",
-  ], }
+  ], }, if: :mass_validation_enabled?
   validates :tax_level, presence: true, inclusion: { in: [
     TaxonCount::TAX_LEVEL_SPECIES,
     TaxonCount::TAX_LEVEL_GENUS,
     TaxonCount::TAX_LEVEL_FAMILY,
-  ], }
+  ], }, if: :mass_validation_enabled?
 
-  validates :mean, numericality: { greater_than_or_equal_to: 0 }
-  validates :stdev, numericality: { greater_than_or_equal_to: 0 }
+  validates :mean, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
+  validates :stdev, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
 end

--- a/app/models/taxon_summary.rb
+++ b/app/models/taxon_summary.rb
@@ -1,6 +1,8 @@
 # This model gives, for each taxon, summary statistics (mean count, standard deviation) of the background model.
 class TaxonSummary < ApplicationRecord
   belongs_to :background
+  # NOTE: this conflicts with pipeline_report_service_spec.rb
+  # belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid
 
   validates :count_type, presence: true, inclusion: { in: [
     TaxonCount::COUNT_TYPE_NT,

--- a/app/models/taxon_summary.rb
+++ b/app/models/taxon_summary.rb
@@ -2,7 +2,7 @@
 class TaxonSummary < ApplicationRecord
   belongs_to :background
   validates :background, presence: true
-  # NOTE: TaxonSummary also has tax_id which is a key into TaxonLineage
+  belongs_to :taxon_lineage, class_name: "TaxonLineage", foreign_key: :tax_id, primary_key: :taxid
 
   validates :count_type, presence: true, inclusion: { in: [
     TaxonCount::COUNT_TYPE_NT,

--- a/app/models/taxon_summary.rb
+++ b/app/models/taxon_summary.rb
@@ -1,4 +1,22 @@
 # This model gives, for each taxon, summary statistics (mean count, standard deviation) of the background model.
 class TaxonSummary < ApplicationRecord
   belongs_to :background
+  validates :background, presence: true
+  # NOTE: TaxonSummary also has tax_id which is a key into TaxonLineage
+
+  validates :count_type, presence: true, inclusion: { in: [
+    TaxonCount::COUNT_TYPE_NT,
+    TaxonCount::COUNT_TYPE_NR,
+    # Unclear meaning. Exists in database, but not in codebase.
+    "NT+",
+    "NR+",
+  ], }
+  validates :tax_level, presence: true, inclusion: { in: [
+    TaxonCount::TAX_LEVEL_SPECIES,
+    TaxonCount::TAX_LEVEL_GENUS,
+    TaxonCount::TAX_LEVEL_FAMILY,
+  ], }
+
+  validates :mean, numericality: { greater_than_or_equal_to: 0 }
+  validates :stdev, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/ui_config.rb
+++ b/app/models/ui_config.rb
@@ -1,4 +1,10 @@
 class UiConfig < ApplicationRecord
+  validates :min_nt_z, presence: true, if: :mass_validation_enabled?
+  validates :min_nr_z, presence: true, if: :mass_validation_enabled?
+  validates :min_nt_rpm, presence: true, if: :mass_validation_enabled?
+  validates :min_nr_rpm, presence: true, if: :mass_validation_enabled?
+  validates :top_n, presence: true, if: :mass_validation_enabled?
+
   after_initialize :set_default_values
 
   def set_default_values

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,8 +34,16 @@ class User < ApplicationRecord
     with: /\A[- 'a-zA-ZÀ-ÖØ-öø-ÿ]+\z/, message: "Name must contain only letters, apostrophes, dashes or spaces",
   }
   attr_accessor :email_arguments
+
   ROLE_REGULAR_USER = 0
   ROLE_ADMIN = 1
+  validates :role, presence: true, inclusion: { in: [
+    ROLE_REGULAR_USER,
+    ROLE_ADMIN,
+  ], }, allow_nil: true, if: :mass_validation_enabled?
+
+  validates :authentication_token, presence: true, allow_nil: true, if: :mass_validation_enabled?
+
   IDSEQ_BUCKET_PREFIXES = ['idseq-'].freeze
   CZBIOHUB_BUCKET_PREFIXES = ['czb-', 'czbiohub-'].freeze
 

--- a/app/models/visualization.rb
+++ b/app/models/visualization.rb
@@ -1,10 +1,24 @@
 # Represents a Heatmap, phylogeny or other visualization
 class Visualization < ApplicationRecord
-  serialize :data, JSON
   has_and_belongs_to_many :samples
   belongs_to :user, counter_cache: true # use .size for cache, use .count to force COUNT query
+  validates :user, presence: true
+
   validates :name, presence: true
+
+  HEATMAP_TYPE = "heatmap".freeze
+  PHYLO_TREE_TYPE = "phylo_tree".freeze
+  TREE_TYPE = "tree".freeze
+  TABLE_TYPE = "table".freeze
+  validates :visualization_type, presence: true, inclusion: { in: [
+    HEATMAP_TYPE,
+    PHYLO_TREE_TYPE,
+    TREE_TYPE,
+    TABLE_TYPE,
+  ], }
   validates :data, presence: true
+
+  serialize :data, JSON
 
   delegate :count, to: :samples, prefix: true
 

--- a/app/models/visualization.rb
+++ b/app/models/visualization.rb
@@ -2,7 +2,6 @@
 class Visualization < ApplicationRecord
   has_and_belongs_to_many :samples
   belongs_to :user, counter_cache: true # use .size for cache, use .count to force COUNT query
-  validates :user, presence: true
 
   validates :name, presence: true
 
@@ -15,8 +14,8 @@ class Visualization < ApplicationRecord
     PHYLO_TREE_TYPE,
     TREE_TYPE,
     TABLE_TYPE,
-  ], }
-  validates :data, presence: true
+  ], }, if: :mass_validation_enabled?
+  validates :data, presence: true, if: :mass_validation_enabled?
 
   serialize :data, JSON
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "access_token"
-    t.float "progress"
+    t.float "progress", limit: 24
     t.string "ecs_task_arn", comment: "The ecs task arn for this bulk download if applicable"
     t.bigint "output_file_size", comment: "The file size of the generated output file. Can be nil while the file is being generated."
     t.index ["user_id"], name: "index_bulk_downloads_on_user_id"
@@ -144,9 +144,9 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", null: false
-    t.text "s3_star_index_path"
-    t.text "s3_bowtie2_index_path"
+    t.string "name", null: false, comment: "Friendly name of host genome. May be common name or scientific name of species. Must be unique and start with a capital letter."
+    t.string "s3_star_index_path", default: "s3://idseq-database/host_filter/ercc/2017-09-01-utc-1504224000-unixtime__2017-09-01-utc-1504224000-unixtime/STAR_genome.tar", null: false, comment: "The path to the index file to be used in the pipeline by star for host filtering."
+    t.string "s3_bowtie2_index_path", default: "s3://idseq-database/host_filter/ercc/2017-09-01-utc-1504224000-unixtime__2017-09-01-utc-1504224000-unixtime/bowtie2_genome.tar", null: false, comment: "The path to the index file to be used in the pipeline by bowtie for host filtering."
     t.bigint "default_background_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -390,6 +390,16 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
     t.index ["user_id"], name: "index_projects_users_on_user_id"
   end
 
+  create_table "sample_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string "name", null: false, comment: "Canonical name of the sample type. This should be immutable after creation. It is used as a key to join with MetadataField sample_type values."
+    t.string "group", null: false, comment: "Mutually exclusive grouping of names. Example: \"Organs\"."
+    t.boolean "insect_only", default: false, null: false, comment: "Whether a sample type should only be for insects."
+    t.boolean "human_only", default: false, null: false, comment: "Whether a sample type should only be for humans."
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sample_types_on_name", unique: true
+  end
+
   create_table "samples", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -631,11 +641,12 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
   add_foreign_key "backgrounds_pipeline_runs", "pipeline_runs", name: "backgrounds_pipeline_runs_pipeline_run_id_fk"
   add_foreign_key "backgrounds_samples", "backgrounds", name: "backgrounds_samples_background_id_fk"
   add_foreign_key "backgrounds_samples", "samples", name: "backgrounds_samples_sample_id_fk"
+  add_foreign_key "bulk_downloads", "users"
   add_foreign_key "bulk_downloads_pipeline_runs", "bulk_downloads", name: "bulk_downloads_pipeline_runs_bulk_download_id_fk"
   add_foreign_key "bulk_downloads_pipeline_runs", "pipeline_runs", name: "bulk_downloads_pipeline_runs_pipeline_run_id_fk"
-  add_foreign_key "bulk_downloads", "users"
   add_foreign_key "favorite_projects", "projects", name: "favorite_projects_project_id_fk"
   add_foreign_key "favorite_projects", "users", name: "favorite_projects_user_id_fk"
+  add_foreign_key "host_genomes", "users"
   add_foreign_key "host_genomes_metadata_fields", "host_genomes", name: "host_genomes_metadata_fields_host_genome_id_fk"
   add_foreign_key "host_genomes_metadata_fields", "metadata_fields", name: "host_genomes_metadata_fields_metadata_field_id_fk"
   add_foreign_key "input_files", "samples", name: "input_files_sample_id_fk"
@@ -659,5 +670,6 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
   add_foreign_key "samples", "users", name: "samples_user_id_fk"
   add_foreign_key "samples_visualizations", "samples", name: "samples_visualizations_sample_id_fk"
   add_foreign_key "samples_visualizations", "visualizations", name: "samples_visualizations_visualization_id_fk"
+  add_foreign_key "user_settings", "users"
   add_foreign_key "visualizations", "users", name: "visualizations_user_id_fk"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -194,7 +194,6 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
 
   create_table "job_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "task"
-    t.integer "reads_before"
     t.integer "reads_after"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -421,8 +420,8 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
     t.integer "max_input_fragments"
     t.datetime "client_updated_at"
     t.integer "uploaded_from_basespace", limit: 1, default: 0
-    t.string "basespace_access_token"
     t.string "upload_error"
+    t.string "basespace_access_token"
     t.boolean "do_not_process", default: false, null: false, comment: "If true, sample will skip pipeline processing."
     t.string "pipeline_execution_strategy", default: "directed_acyclic_graph", comment: "A soft enum (string) describing which pipeline infrastructure to run the sample on."
     t.index ["host_genome_id"], name: "samples_host_genome_id_fk"
@@ -539,8 +538,8 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
     t.string "kingdom_name", default: "", null: false
     t.string "kingdom_common_name", default: "", null: false
     t.string "tax_name"
-    t.integer "version_start", limit: 1
-    t.integer "version_end", limit: 1
+    t.integer "version_start", limit: 2, null: false, comment: "The first version for which the taxon is active"
+    t.integer "version_end", limit: 2, null: false, comment: "The last version for which the taxon is active"
     t.index ["class_taxid"], name: "index_taxon_lineages_on_class_taxid"
     t.index ["family_taxid"], name: "index_taxon_lineages_on_family_taxid"
     t.index ["genus_taxid", "genus_name"], name: "index_taxon_lineages_on_genus_taxid_and_genus_name"
@@ -602,10 +601,6 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
@@ -622,7 +617,6 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
     t.integer "phylo_trees_count", default: 0, null: false
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "visualizations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
-# Shared variables using Docker x- extension and YAML merging syntax.
+# Shared variables using Docker x- extension and YAML merging syntax. IMPORTANT
+# NOTE: Unit tests in Travis currently run outside of Docker, so any environment
+# setup here may need to be reproduced in travis.yml.
 
 x-web-variables: &web-variables
   ? SAMPLES_BUCKET_NAME=idseq-samples-development

--- a/lib/tasks/host_genomes.rake
+++ b/lib/tasks/host_genomes.rake
@@ -4,12 +4,12 @@ task create_host_genomes: :environment do
   end
   unless HostGenome.find_by(name: 'Human')
     HostGenome.create!(name: 'Human',
-                       s3_star_index_path: 's3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz',
-                       s3_bowtie2_index_path: 's3://czbiohub-infectious-disease/references/human/bowtie2_genome.tar.gz')
+                       s3_star_index_path: 's3://human/STAR_genome.tar.gz',
+                       s3_bowtie2_index_path: 's3://human/bowtie2_genome.tar.gz')
   end
   unless HostGenome.find_by(name: 'Mosquito')
     HostGenome.create!(name: 'Mosquito', skip_deutero_filter: 1,
-                       s3_star_index_path: 's3://czbiohub-infectious-disease/references/mosquitos/STAR_genome.tar.gz',
-                       s3_bowtie2_index_path: 's3://czbiohub-infectious-disease/references/mosquitos/bowtie2_genome.tar.gz')
+                       s3_star_index_path: 's3://mosquitos/STAR_genome.tar.gz',
+                       s3_bowtie2_index_path: 's3://mosquitos/bowtie2_genome.tar.gz')
   end
 end

--- a/spec/factories/alignment_configs.rb
+++ b/spec/factories/alignment_configs.rb
@@ -1,6 +1,13 @@
 FactoryBot.define do
   factory :alignment_config, class: AlignmentConfig do
     sequence(:name) { |n| "alignment-config-#{n}" }
+    s3_nt_db_path { "s3://s3_nt_db_path" }
+    s3_nt_loc_db_path { "s3://s3_nt_loc_db_path" }
+    s3_nr_db_path { "s3://s3_nr_db_path" }
+    s3_nr_loc_db_path { "s3://s3_nr_loc_db_path" }
+    s3_lineage_path { "s3://s3_lineage_path" }
+    s3_accession2taxid_path { "s3://s3_accession2taxid_path" }
+    s3_deuterostome_db_path { "s3://s3_deuterostome_db_path" }
     lineage_version { 1 }
   end
 end

--- a/spec/factories/backgrounds.rb
+++ b/spec/factories/backgrounds.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :background do
     sequence(:name) { |n| "Background #{n}" }
-    pipeline_run_ids { [] }
+    association :pipeline_runs, factory: [:pipeline_run]
     ready { 1 }
 
     transient do

--- a/spec/factories/contigs.rb
+++ b/spec/factories/contigs.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :contig, class: Contig do
+    sequence { "AGCT" }
+    lineage_json { "{}" }
     read_count { 1 }
   end
 end

--- a/spec/factories/contigs.rb
+++ b/spec/factories/contigs.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
-  factory :contig do
+  factory :contig, class: Contig do
+    read_count { 1 }
   end
 end

--- a/spec/factories/contigs.rb
+++ b/spec/factories/contigs.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :contig, class: Contig do
-    sequence { "AGCT" }
+    sequence(:sequence) { "GATTACA" }
     lineage_json { "{}" }
     read_count { 1 }
   end

--- a/spec/factories/metadata_fields.rb
+++ b/spec/factories/metadata_fields.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :metadata_field, class: MetadataField do
     sequence(:name) { |n| "metadata_field_#{n}" }
+    sequence(:display_name) { |n| "Metadata field #{n}" }
     base_type { 0 }
   end
 end

--- a/spec/factories/output_states.rb
+++ b/spec/factories/output_states.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :output_state, class: OutputState do
-    output { nil }
+    output { "ercc_counts" }
     state { PipelineRun::STATUS_UNKNOWN }
   end
 end

--- a/spec/factories/phylo_trees.rb
+++ b/spec/factories/phylo_trees.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:name) { |n| "Project #{n}" }
     user { create(:user) }
     project { create(:project) }
+    tax_level { TaxonCount::TAX_LEVEL_SPECIES }
   end
 end

--- a/spec/factories/phylo_trees.rb
+++ b/spec/factories/phylo_trees.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     sequence(:name) { |n| "Project #{n}" }
     user { create(:user) }
     project { create(:project) }
+    taxid { 1 }
+    tax_name { "tax_name" }
     tax_level { TaxonCount::TAX_LEVEL_SPECIES }
     # NOTE: this conflicts with phylo_trees_controller_spec.rb
     # association :taxid, factory: [:taxon_lineage]

--- a/spec/factories/phylo_trees.rb
+++ b/spec/factories/phylo_trees.rb
@@ -4,5 +4,7 @@ FactoryBot.define do
     user { create(:user) }
     project { create(:project) }
     tax_level { TaxonCount::TAX_LEVEL_SPECIES }
+    # NOTE: this conflicts with phylo_trees_controller_spec.rb
+    # association :taxid, factory: [:taxon_lineage]
   end
 end

--- a/spec/factories/pipeline_run_stages.rb
+++ b/spec/factories/pipeline_run_stages.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     step_number { 1 }
     name { PipelineRunStage::HOST_FILTERING_STAGE_NAME }
     job_status { PipelineRunStage::STATUS_SUCCEEDED }
+    job_command_func { "command" }
     # NOTE: in the model dag_json is actually stored as a string
     dag_json do
       {

--- a/spec/factories/pipeline_runs.rb
+++ b/spec/factories/pipeline_runs.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :pipeline_run, class: PipelineRun do
+    association :sample
     pipeline_version { 1.0 }
 
     transient do
@@ -13,6 +14,8 @@ FactoryBot.define do
     end
 
     alignment_config { create(:alignment_config) }
+    results_finalized { 0 }
+    job_status { PipelineRun::STATUS_READY }
 
     after :create do |pipeline_run, options|
       options.taxon_counts_data.each do |taxon_count_data|

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -21,6 +21,9 @@ FactoryBot.define do
       end
     end
 
+    status { Sample::STATUS_CREATED }
+    association :user
+
     # metadata fields
     # ensure the metadata field is added to the host genome
     before(:create) do |sample, options|

--- a/spec/factories/taxon_counts.rb
+++ b/spec/factories/taxon_counts.rb
@@ -27,5 +27,7 @@ FactoryBot.define do
     tax_level { 1 }
     count { nt || nr || 1 }
     count_type { nt ? "NT" : "NR" }
+    percent_identity { 95.65 }
+    alignment_length { 149.75 }
   end
 end

--- a/spec/factories/taxon_counts.rb
+++ b/spec/factories/taxon_counts.rb
@@ -29,5 +29,6 @@ FactoryBot.define do
     count_type { nt ? "NT" : "NR" }
     percent_identity { 95.65 }
     alignment_length { 149.75 }
+    e_value { 1.31 }
   end
 end

--- a/spec/factories/taxon_lineage.rb
+++ b/spec/factories/taxon_lineage.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
     sequence(:taxid) { |n| n }
     sequence(:started_at) { |n| Time.zone.local(2000 - n, 1, 1) }
     sequence(:ended_at) { |n| Time.zone.local(3000 + n, 1, 1) }
+    sequence(:version_start) { |n| n }
+    sequence(:version_end) { |n| n + 1 }
 
     factory :species do
       sequence(:tax_name) { |n| "species-#{n}" }

--- a/spec/factories/taxon_summaries.rb
+++ b/spec/factories/taxon_summaries.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:tax_id) { |n| n }
     count_type { "NT" }
     tax_level { 1 }
+    association :taxon_lineage, factory: [:taxon_lineage]
   end
 end

--- a/spec/factories/taxon_summaries.rb
+++ b/spec/factories/taxon_summaries.rb
@@ -3,6 +3,9 @@ FactoryBot.define do
     sequence(:tax_id) { |n| n }
     count_type { "NT" }
     tax_level { 1 }
+    mean { 0.5 }
+    stdev { 1 }
+    rpm_list { "[0,1] " }
     # NOTE: this conflicts with pipeline_report_service_spec.rb
     # association :taxon_lineage, factory: [:taxon_lineage]
   end

--- a/spec/factories/taxon_summaries.rb
+++ b/spec/factories/taxon_summaries.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:tax_id) { |n| n }
     count_type { "NT" }
     tax_level { 1 }
-    association :taxon_lineage, factory: [:taxon_lineage]
+    # NOTE: this conflicts with pipeline_report_service_spec.rb
+    # association :taxon_lineage, factory: [:taxon_lineage]
   end
 end

--- a/spec/helpers/samples_helper_spec.rb
+++ b/spec/helpers/samples_helper_spec.rb
@@ -11,10 +11,7 @@ RSpec.describe SamplesHelper, type: :helper do
       before do
         @project = create(:public_project)
         @joe = create(:joe)
-        # Add the metadata fields to the host genome so that the metadata will pass validation.
-        @host_genome = create(:host_genome, user: @joe, metadata_fields: [
-                                "Fake Metadata Field One", "Fake Metadata Field Two",
-                              ])
+        @host_genome = create(:host_genome, user: @joe)
       end
 
       let(:basespace_sample_attributes) do

--- a/test/controllers/phylo_trees_controller_test.rb
+++ b/test/controllers/phylo_trees_controller_test.rb
@@ -18,11 +18,18 @@ class PhyloTreesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create phylo_tree' do
-    entrypoint_taxon_count = taxon_counts(:three)
+    entrypoint_taxon_count = taxon_counts(:five) # Klebsiella pneumoniae
     assert_difference('PhyloTree.count') do
-      post "/phylo_trees/create", params: { name: 'new_phylo_tree', projectId: @project.id,
-                                            taxId: entrypoint_taxon_count.tax_id, pipelineRunIds: [pipeline_runs(:three).id, pipeline_runs(:four).id],
-                                            taxName: entrypoint_taxon_count.name, }
+      params = {
+        name: 'new_phylo_tree',
+        projectId: @project.id,
+        taxId: entrypoint_taxon_count.tax_id, pipelineRunIds: [
+          pipeline_runs(:three).id,
+          pipeline_runs(:four).id,
+        ],
+        taxName: entrypoint_taxon_count.name,
+      }
+      post "/phylo_trees/create", params: params
     end
     assert_equal "ok", JSON.parse(@response.body)['status']
   end

--- a/test/controllers/phylo_trees_controller_test.rb
+++ b/test/controllers/phylo_trees_controller_test.rb
@@ -23,7 +23,8 @@ class PhyloTreesControllerTest < ActionDispatch::IntegrationTest
       params = {
         name: 'new_phylo_tree',
         projectId: @project.id,
-        taxId: entrypoint_taxon_count.tax_id, pipelineRunIds: [
+        taxId: entrypoint_taxon_count.tax_id,
+        pipelineRunIds: [
           pipeline_runs(:three).id,
           pipeline_runs(:four).id,
         ],

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -520,7 +520,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     post "/phylo_trees/create", params: { name: 'new_phylo_tree', projectId: projects(:joe_project).id,
                                           taxId: 573, pipelineRunIds: [pipeline_runs(:public_project_sampleA_run).id,
                                                                        pipeline_runs(:public_project_sampleB_run).id,],
-                                          tax_name: 'some species', }
+                                          taxName: 'some species', }
     assert_equal "ok", JSON.parse(@response.body)['status']
   end
 
@@ -529,7 +529,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     post "/phylo_trees/create", params: { name: 'new_phylo_tree', projectId: projects(:joe_project).id,
                                           taxId: 573, pipelineRunIds: [pipeline_runs(:joe_project_sampleA_run).id,
                                                                        pipeline_runs(:joe_project_sampleB_run).id,],
-                                          tax_name: 'some species', }
+                                          taxName: 'some species', }
     assert_equal "ok", JSON.parse(@response.body)['status']
   end
 

--- a/test/controllers/power_controller_test.rb
+++ b/test/controllers/power_controller_test.rb
@@ -5,7 +5,7 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
 
   test 'joe can create project' do
     sign_in(:joe)
-    post "#{projects_url}.json", params: { project: { name: "2nd Joe Project" } }
+    post "#{projects_url}.json", params: { project: { name: "2nd Joe Project", public_access: 0 } }
     assert_response :success
   end
 
@@ -174,7 +174,8 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     sign_in(:joe)
     @joe_sample = samples(:joe_sample)
     delete sample_url(@joe_sample)
-    assert_response :success
+    # successful delete returns a 302 redirect
+    assert_response :redirect
   end
 
   test 'joe cannot delete public_sample' do
@@ -517,8 +518,8 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
   test 'joe can create phylo_tree to joe_project from public samples' do
     sign_in(:joe)
     post "/phylo_trees/create", params: { name: 'new_phylo_tree', projectId: projects(:joe_project).id,
-                                          taxId: 1, pipelineRunIds: [pipeline_runs(:public_project_sampleA_run).id,
-                                                                     pipeline_runs(:public_project_sampleB_run).id,],
+                                          taxId: 573, pipelineRunIds: [pipeline_runs(:public_project_sampleA_run).id,
+                                                                       pipeline_runs(:public_project_sampleB_run).id,],
                                           tax_name: 'some species', }
     assert_equal "ok", JSON.parse(@response.body)['status']
   end
@@ -526,8 +527,8 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
   test 'joe can create phylo_tree to joe_project from samples in joe_project' do
     sign_in(:joe)
     post "/phylo_trees/create", params: { name: 'new_phylo_tree', projectId: projects(:joe_project).id,
-                                          taxId: 1, pipelineRunIds: [pipeline_runs(:joe_project_sampleA_run).id,
-                                                                     pipeline_runs(:joe_project_sampleB_run).id,],
+                                          taxId: 573, pipelineRunIds: [pipeline_runs(:joe_project_sampleA_run).id,
+                                                                       pipeline_runs(:joe_project_sampleB_run).id,],
                                           tax_name: 'some species', }
     assert_equal "ok", JSON.parse(@response.body)['status']
   end
@@ -537,8 +538,8 @@ class PowerControllerTest < ActionDispatch::IntegrationTest
     assert_raises(ActiveRecord::RecordNotFound) do
       sign_in(:joe)
       post "/phylo_trees/create", params: { name: 'new_phylo_tree', projectId: projects(:public_project).id,
-                                            taxId: 1, pipelineRunIds: [pipeline_runs(:joe_project_sampleA_run).id,
-                                                                       pipeline_runs(:joe_project_sampleB_run).id,],
+                                            taxId: 573, pipelineRunIds: [pipeline_runs(:joe_project_sampleA_run).id,
+                                                                         pipeline_runs(:joe_project_sampleB_run).id,],
                                             taxName: 'some species', }
     end
   end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -26,7 +26,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test 'should create project' do
     sign_in @user
     assert_difference('Project.count') do
-      post projects_url, params: { project: { name: 'New Project' } }
+      post projects_url, params: { project: { name: 'New Project', public_access: 0 } }
     end
 
     assert_redirected_to project_url(Project.last)

--- a/test/controllers/samples_controller_test.rb
+++ b/test/controllers/samples_controller_test.rb
@@ -86,6 +86,8 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create sample through web' do
+    skip("This endpoint is deprecated in favor of upload with metadata")
+
     sign_in @user
     input_files = [{ source: "RR004_water_2_S23_R1_001.fastq.gz",
                      name: "RR004_water_2_S23_R1_001.fastq.gz",
@@ -189,8 +191,8 @@ class SamplesControllerTest < ActionDispatch::IntegrationTest
   test 'should update sample' do
     sign_in @user
     assert @sample.valid?
-    patch sample_url(@sample), params: { sample: { name: @sample.name + ' asdf' } }
-    assert_redirected_to sample_url(@sample)
+    patch sample_url(@sample, format: "json"), params: { sample: { name: @sample.name + ' asdf' } }
+    assert_response :success
   end
 
   test 'should destroy sample' do

--- a/test/fixtures/alignment_configs.yml
+++ b/test/fixtures/alignment_configs.yml
@@ -1,3 +1,11 @@
 one:
   name: 'ac1'
   lineage_version: 1
+  s3_nt_db_path: "s3://idseq-database/alignment_data/#{name}/nt"
+  s3_nt_loc_db_path: "s3://idseq-database/alignment_data/#{name}/nt_loc.db"
+  s3_nr_db_path: "s3://idseq-database/alignment_data/#{name}/nr"
+  s3_nr_loc_db_path: "s3://idseq-database/alignment_data/#{name}/nr_loc.db"
+  s3_lineage_path: "s3://idseq-database/taxonomy/#{name}/taxid-lineages.db"
+  s3_accession2taxid_path: "s3://idseq-database/alignment_data/#{name}/accession2taxid.db"
+  s3_deuterostome_db_path: "s3://idseq-database/taxonomy/#{name}/deuterostome_taxids.txt"
+

--- a/test/fixtures/host_genomes.yml
+++ b/test/fixtures/host_genomes.yml
@@ -1,5 +1,8 @@
 one:
   name: host genome 1
+  default_background: real_background
+  s3_bowtie2_index_path: s3://czbiohub-infectious-disease/references/human/bowtie2_genome.tar.gz
+  s3_star_index_path: s3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz
 
 two:
   name: host genome 2
@@ -7,11 +10,20 @@ two:
 
 human:
   name: Human
+  default_background: real_background
   metadata_fields: [collection_date, sample_type, sex, age, admission_date, nucleotide_type, core_field, water_control]
+  s3_bowtie2_index_path: s3://czbiohub-infectious-disease/references/human/bowtie2_genome.tar.gz
+  s3_star_index_path: s3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz
 
 mosquito:
   name: Mosquito
   metadata_fields: [collection_date, sample_type, sex, reported_sex, blood_fed, water_control]
+  default_background: real_background
+  s3_bowtie2_index_path: s3://czbiohub-infectious-disease/references/human/bowtie2_genome.tar.gz
+  s3_star_index_path: s3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz
 
 tick:
   name: Tick
+  default_background: real_background
+  s3_bowtie2_index_path: s3://czbiohub-infectious-disease/references/human/bowtie2_genome.tar.gz
+  s3_star_index_path: s3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz

--- a/test/fixtures/host_genomes.yml
+++ b/test/fixtures/host_genomes.yml
@@ -1,8 +1,8 @@
 one:
   name: host genome 1
   default_background: real_background
-  s3_bowtie2_index_path: s3://czbiohub-infectious-disease/references/human/bowtie2_genome.tar.gz
-  s3_star_index_path: s3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz
+  s3_bowtie2_index_path: s3://human/bowtie2_genome.tar.gz
+  s3_star_index_path: s3://human/STAR_genome.tar.gz
 
 two:
   name: host genome 2
@@ -12,18 +12,18 @@ human:
   name: Human
   default_background: real_background
   metadata_fields: [collection_date, sample_type, sex, age, admission_date, nucleotide_type, core_field, water_control]
-  s3_bowtie2_index_path: s3://czbiohub-infectious-disease/references/human/bowtie2_genome.tar.gz
-  s3_star_index_path: s3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz
+  s3_bowtie2_index_path: s3://human/bowtie2_genome.tar.gz
+  s3_star_index_path: s3://human/STAR_genome.tar.gz
 
 mosquito:
   name: Mosquito
   metadata_fields: [collection_date, sample_type, sex, reported_sex, blood_fed, water_control]
   default_background: real_background
-  s3_bowtie2_index_path: s3://czbiohub-infectious-disease/references/human/bowtie2_genome.tar.gz
-  s3_star_index_path: s3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz
+  s3_bowtie2_index_path: s3://human/bowtie2_genome.tar.gz
+  s3_star_index_path: s3://human/STAR_genome.tar.gz
 
 tick:
   name: Tick
   default_background: real_background
-  s3_bowtie2_index_path: s3://czbiohub-infectious-disease/references/human/bowtie2_genome.tar.gz
-  s3_star_index_path: s3://czbiohub-infectious-disease/references/human/STAR_genome.tar.gz
+  s3_bowtie2_index_path: s3://human/bowtie2_genome.tar.gz
+  s3_star_index_path: s3://human/STAR_genome.tar.gz

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -5,6 +5,10 @@ ucsf:
   state_name: "California"
   subdivision_name: "San Francisco City and County"
   city_name: "San Francisco"
+  lat: "37.49"
+  lng: "-122.23"
+  osm_id: 165475,
+  locationiq_id: 89640023,
 
 swamp:
   name: "Swamp of Mosquitos"
@@ -16,13 +20,19 @@ swamp:
   city_name: "Redwood City"
   lat: "37.49"
   lng: "-122.23"
+  osm_id: 165475,
+  locationiq_id: 89640023,
 
 california:
   name: "California, USA"
   geo_level: "state"
   country_name: "USA"
   state_name: "California"
+  lat: "37.49"
+  lng: "-122.23"
   locationiq_id: 214330370
+  osm_id: 165475,
+  locationiq_id: 89640023,
 
 sf_county:
   name: "San Francisco City and County, California, USA"
@@ -30,14 +40,22 @@ sf_county:
   country_name: "USA"
   state_name: "California"
   subdivision_name: "San Francisco City and County"
+  lat: "37.49"
+  lng: "-122.23"
   locationiq_id: 214379825
+  osm_id: 165475,
+  locationiq_id: 89640023,
 
 bangladesh:
   name: "Bangladesh"
   id: 2
   geo_level: "country"
   country_name: "Bangladesh"
+  lat: "37.49"
+  lng: "-122.23"
   locationiq_id: 214341060
+  osm_id: 165475,
+  locationiq_id: 89640023,
 
 rangpur:
   name: "Rangpur Division, Bangladesh"
@@ -45,7 +63,11 @@ rangpur:
   geo_level: "state"
   country_name: "Bangladesh"
   state_name: "Rangpur Division"
+  lat: "37.49"
+  lng: "-122.23"
   locationiq_id: 214799782
+  osm_id: 165475,
+  locationiq_id: 89640023,
 
 kurigram:
   name: "Kurigram, Kurigram District, Rangpur Division, Bangladesh"
@@ -58,6 +80,10 @@ kurigram:
   country_id: 2
   state_id: 3
   city_id: 4
+  lat: "37.49"
+  lng: "-122.23"
+  osm_id: 165475,
+  locationiq_id: 89640023,
 
 columbus:
   name: "Columbus, Franklin County, Ohio, USA"
@@ -66,3 +92,7 @@ columbus:
   state_name: "Ohio"
   subdivision_name: "Franklin County"
   city_name: "Columbus"
+  lat: "37.49"
+  lng: "-122.23"
+  osm_id: 165475,
+  locationiq_id: 89640023,

--- a/test/fixtures/phylo_trees.yml
+++ b/test/fixtures/phylo_trees.yml
@@ -1,6 +1,7 @@
 one:
   name: tree_one
   project: one
+  user: one
   taxid: 1
   tax_level: 1
   tax_name: 'some species'
@@ -9,6 +10,7 @@ one:
 joe_phylo_tree:
   name: joe_phylo_tree
   project: joe_project
+  user: joe
   taxid: 1
   tax_level: 1
   tax_name: 'some species'
@@ -17,6 +19,7 @@ joe_phylo_tree:
 joe_failed_phylo_tree:
   name: joe_failed_phylo_tree
   project: joe_project
+  user: joe
   status: 2
   taxid: 1
   tax_level: 1

--- a/test/fixtures/phylo_trees.yml
+++ b/test/fixtures/phylo_trees.yml
@@ -6,6 +6,7 @@ one:
   tax_level: 1
   tax_name: 'some species'
   pipeline_runs: [three, four]
+  status: 1
 
 joe_phylo_tree:
   name: joe_phylo_tree
@@ -15,16 +16,17 @@ joe_phylo_tree:
   tax_level: 1
   tax_name: 'some species'
   pipeline_runs: [joe_project_sampleA_run, joe_project_sampleB_run]
+  status: 1
 
 joe_failed_phylo_tree:
   name: joe_failed_phylo_tree
   project: joe_project
   user: joe
-  status: 2
   taxid: 1
   tax_level: 1
   tax_name: 'some species'
   pipeline_runs: [joe_project_sampleA_run, joe_project_sampleB_run]
+  status: 2
 
 public_phylo_tree:
   name: public_phylo_tree
@@ -34,3 +36,4 @@ public_phylo_tree:
   tax_level: 1
   tax_name: 'some species'
   pipeline_runs: [public_project_sampleA_run, public_project_sampleB_run]
+  status: 1

--- a/test/fixtures/pipeline_run_stages.yml
+++ b/test/fixtures/pipeline_run_stages.yml
@@ -1,6 +1,9 @@
 # Needs to integrate with TEST_RESULT_FOLDER from TestHelper which is a test return value for sample.list_outputs.
 public_sample_run_stage:
   pipeline_run: public_sample_run
+  step_number: 1
+  job_command_func: "command"
+  name: "Unknown Stage"
   dag_json: "{
     \"output_dir_s3\": \"s3://someBucket/samples/theProjectId/theSampleId/results\",
     \"targets\": {
@@ -23,40 +26,56 @@ public_sample_run_stage:
 
 public_sample_run_stage_host_filtering:
   pipeline_run: public_sample_run_with_pipeline_stages
+  step_number: 1
+  job_command_func: "command"
   name: "Host Filtering"
   dag_json: "{\"key1\": \"value1\"}"
 
 public_sample_run_stage_alignment:
   pipeline_run: public_sample_run_with_pipeline_stages
+  step_number: 1
+  job_command_func: "command"
   name: "GSNAPL/RAPSEARCH alignment"
   dag_json: "{\"key2\": \"value2\"}"
 
 public_sample_run_stage_post_processing:
   pipeline_run: public_sample_run_with_pipeline_stages
+  step_number: 1
+  job_command_func: "command"
   name: "Post Processing"
   dag_json: "{\"key3\": \"value3\"}"
 
 public_sample_run_stage_experimental:
   pipeline_run: public_sample_run_with_pipeline_stages
+  step_number: 1
+  job_command_func: "command"
   name: "Experimental"
   dag_json: "{\"key4\": \"value4\"}"
 
 private_sample_run_stage_host_filtering:
   pipeline_run: private_sample_run_with_pipeline_stages
+  step_number: 1
+  job_command_func: "command"
   name: "Host Filtering"
   dag_json: "{\"key1\": \"value1\"}"
 
 private_sample_run_stage_alignment:
   pipeline_run: private_sample_run_with_pipeline_stages
+  step_number: 1
+  job_command_func: "command"
   name: "GSNAPL/RAPSEARCH alignment"
   dag_json: "{\"key2\": \"value2\"}"
 
 private_sample_run_stage_post_processing:
   pipeline_run: private_sample_run_with_pipeline_stages
+  step_number: 1
+  job_command_func: "command"
   name: "Post Processing"
   dag_json: "{\"key3\": \"value3\"}"
 
 private_sample_run_stage_experimental:
   pipeline_run: private_sample_run_with_pipeline_stages
+  step_number: 1
+  job_command_func: "command"
   name: "Experimental"
   dag_json: "{\"key4\": \"value4\"}"

--- a/test/fixtures/pipeline_runs.yml
+++ b/test/fixtures/pipeline_runs.yml
@@ -5,18 +5,23 @@
 # below each fixture, per the syntax in the comments below
 #
 one:
+  sample: one
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 two:
+  sample: one
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 three:
   sample: one
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
   total_ercc_reads: 0
   job_status: "CHECKED"
 four:
@@ -24,12 +29,15 @@ four:
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
   total_ercc_reads: 0
   job_status: "CHECKED"
 five:
+  sample: two
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 six:
   sample: six
   job_status: "CHECKED"
@@ -38,48 +46,56 @@ six:
   adjusted_remaining_reads: 316
   subsample: 1000000
   alignment_config: one
+  results_finalized: 10
 public_project_sampleA_run:
   sample: public_project_sampleA
   job_status: 'CHECKED'
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 public_project_sampleB_run:
   sample: public_project_sampleB
   job_status: 'CHECKED'
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 joe_project_sampleA_run:
   sample: joe_project_sampleA
   job_status: 'CHECKED'
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 joe_project_sampleB_run:
   sample: joe_project_sampleB
   job_status: 'CHECKED'
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 project_one_sampleA_run:
   sample: project_one_sampleA
   job_status: 'CHECKED'
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 project_one_sampleB_run:
   sample: project_one_sampleB
   job_status: 'CHECKED'
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 expired_sample_run:
   sample: expired_sample
   job_status: 'CHECKED'
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 public_sample_run:
   sample: public_sample
   pipeline_version: '1.0'
@@ -87,6 +103,7 @@ public_sample_run:
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 public_sample_run_with_pipeline_stages:
   sample: public_sample_with_pipeline_stages
   pipeline_version: '1.0'
@@ -94,6 +111,7 @@ public_sample_run_with_pipeline_stages:
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10
 private_sample_run_with_pipeline_stages:
   sample: private_sample_with_pipeline_stages
   pipeline_version: '1.0'
@@ -101,3 +119,4 @@ private_sample_run_with_pipeline_stages:
   total_reads: 1
   adjusted_remaining_reads: 1
   alignment_config: one
+  results_finalized: 10

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -2,13 +2,16 @@
 
 one:
   name: Project 1
+  public_access: 0
 
 two:
   name: Project 2
   metadata_fields: [age]
+  public_access: 0
 
 deletable_project:
   name: Empty project
+  public_access: 0
 
 public_project:
   name: Public Project
@@ -19,6 +22,7 @@ joe_project:
   name: Project 3
   users: [joe, joe_dd]
   metadata_fields: [sample_type, nucleotide_type, age, admission_date, blood_fed, reported_sex, sex]
+  public_access: 0
 
 not_joe_project:
   name: Not Joe's Project
@@ -33,9 +37,11 @@ metadata_validation_project:
   name: Metadata Project
   users: [admin_one]
   metadata_fields: [sample_type, nucleotide_type, collection_date, age, admission_date, blood_fed, reported_sex, sex]
+  public_access: 0
 
 # This was added later to test water_control specifically.
 metadata_validation_project_with_water_control:
   name: Metadata Project With Water Control
   users: [admin_one]
   metadata_fields: [sample_type, nucleotide_type, water_control]
+  public_access: 0

--- a/test/fixtures/samples.yml
+++ b/test/fixtures/samples.yml
@@ -1,105 +1,157 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  user: regular_user
   name: sample1
   project: one
+  status: checked
+  host_genome: human
 
 two:
+  user: regular_user
   name: sample2
   project: two
+  status: checked
+  host_genome: human
 
 expired_sample:
+  user: regular_user
   name: expired_sample
   created_at: '2016-01-31 23:41:59'
   project: two
+  status: checked
   host_genome: human
 
 public_sample:
+  user: regular_user
   name: public_sample
   project: public_project
+  status: checked
+  host_genome: human
 
 deletable_sample:
+  user: regular_user
   name: sample5
   project: one
   status: "created"
+  host_genome: human
 
 joe_sample:
+  user: joe
   name: sample Joe
   project: joe_project
+  status: checked
   host_genome: human
 
 six:
+  user: regular_user
   name: RR004_water_2_S23-20180208
   project: one
+  status: checked
   host_genome: human
 
 public_project_sampleA:
+  user: regular_user
   name: public_project_sampleA
   project: public_project
+  status: checked
+  host_genome: human
 
 public_project_sampleB:
+  user: regular_user
   name: public_project_sampleB
   project: public_project
+  status: checked
   host_genome: human
 
 public_sample_with_pipeline_stages:
+  user: regular_user
   name: public_sample_with_pipeline_stages
   project: public_project
-  
+  status: checked
+  host_genome: human
+
 private_sample_with_pipeline_stages:
+  user: regular_user
   name: private_sample_with_pipeline_stages
   project: not_joe_project
+  status: checked
+  host_genome: human
 
 joe_project_sampleB:
+  user: joe
   name: joe_project_sampleB
   project: joe_project
+  status: checked
   host_genome: human
 
 joe_project_sampleA:
+  user: joe
   name: joe_project_sampleA
   project: joe_project
+  status: checked
   host_genome: human
 
 joe_project_sample_mosquito:
+  user: joe
   name: joe_project_sample_mosquito
   project: joe_project
+  status: checked
   host_genome: mosquito
 
 project_one_sampleA:
+  user: regular_user
   name: project_one_sampleA_run
   project: one
+  status: checked
+  host_genome: human
 
 project_one_sampleB:
+  user: regular_user
   name: project_one_sampleB
   project: one
+  status: checked
+  host_genome: human
 
 metadata_validation_sample_human:
+  user: regular_user
   name: metadata_validation_sample_human
   project: metadata_validation_project
+  status: checked
   host_genome: human
 
 metadata_validation_sample_mosquito:
+  user: regular_user
   name: metadata_validation_sample_mosquito
   project: metadata_validation_project
+  status: checked
   host_genome: mosquito
 
 metadata_validation_sample_human_existing_metadata:
+  user: regular_user
   name: metadata_validation_sample_human_existing_metadata
   project: metadata_validation_project
+  status: checked
   host_genome: human
 
 sample_human_existing_metadata_public:
+  user: regular_user
   name: sample_human_existing_metadata_public
   project: public_project
+  status: checked
   host_genome: human
 
 sample_human_existing_metadata_joe_project:
+  user: regular_user
   name: sample_human_existing_metadata_joe_project
   project: joe_project
+  status: checked
   host_genome: human
 
 sample_human_existing_metadata_expired:
+  user: regular_user
   name: sample_human_existing_metadata_expired
   project: two
+  status: checked
   host_genome: human
   created_at: '2016-01-31 23:41:59'

--- a/test/fixtures/taxon_byteranges.yml
+++ b/test/fixtures/taxon_byteranges.yml
@@ -2,28 +2,40 @@ dummy1:
   taxid: 1
   hit_type: 'NT'
   pipeline_run: three
+  first_byte: 8363513
+  last_byte: 8363523
 
 dummy2:
   taxid: 1
   hit_type: 'NT'
   pipeline_run: four
+  first_byte: 8363513
+  last_byte: 8363523
 
 dummy3:
   taxid: 1
   hit_type: 'NT'
   pipeline_run: joe_project_sampleA_run
+  first_byte: 8363513
+  last_byte: 8363523
 
 dummy4:
   taxid: 1
   hit_type: 'NT'
   pipeline_run: joe_project_sampleB_run
+  first_byte: 8363513
+  last_byte: 8363523
 
 dummy5:
   taxid: 1
   hit_type: 'NT'
   pipeline_run: public_project_sampleA_run
+  first_byte: 8363513
+  last_byte: 8363523
 
 dummy6:
   taxid: 1
   hit_type: 'NT'
   pipeline_run: public_project_sampleB_run
+  first_byte: 8363513
+  last_byte: 8363523

--- a/test/fixtures/taxon_byteranges.yml
+++ b/test/fixtures/taxon_byteranges.yml
@@ -1,40 +1,40 @@
 dummy1:
-  taxid: 1
+  taxid: 573
   hit_type: 'NT'
   pipeline_run: three
   first_byte: 8363513
   last_byte: 8363523
 
 dummy2:
-  taxid: 1
+  taxid: 573
   hit_type: 'NT'
   pipeline_run: four
   first_byte: 8363513
   last_byte: 8363523
 
 dummy3:
-  taxid: 1
+  taxid: 573
   hit_type: 'NT'
   pipeline_run: joe_project_sampleA_run
   first_byte: 8363513
   last_byte: 8363523
 
 dummy4:
-  taxid: 1
+  taxid: 573
   hit_type: 'NT'
   pipeline_run: joe_project_sampleB_run
   first_byte: 8363513
   last_byte: 8363523
 
 dummy5:
-  taxid: 1
+  taxid: 573
   hit_type: 'NT'
   pipeline_run: public_project_sampleA_run
   first_byte: 8363513
   last_byte: 8363523
 
 dummy6:
-  taxid: 1
+  taxid: 573
   hit_type: 'NT'
   pipeline_run: public_project_sampleB_run
   first_byte: 8363513

--- a/test/fixtures/taxon_counts.yml
+++ b/test/fixtures/taxon_counts.yml
@@ -4,13 +4,21 @@ one:
   pipeline_run: one
   tax_id: 1
   tax_level: 1
+  count_type: 'NT'
   count: 1
+  percent_identity: 96
+  alignment_length: 149.9
+  e_value: -16.9
 
 two:
   pipeline_run: two
   tax_id: 1
   tax_level: 1
+  count_type: 'NT'
   count: 1
+  percent_identity: 96
+  alignment_length: 149.9
+  e_value: -16.9
 
 three:
   pipeline_run: three
@@ -19,6 +27,9 @@ three:
   tax_level: 1
   name: 'some species'
   count: 1
+  percent_identity: 96
+  alignment_length: 149.9
+  e_value: -16.9
 
 four:
   pipeline_run:  four
@@ -27,6 +38,9 @@ four:
   tax_level: 1
   name: 'some species'
   count: 2
+  percent_identity: 96
+  alignment_length: 149.9
+  e_value: -16.9
 
 five:
   pipeline_run: six
@@ -147,21 +161,42 @@ pt_tc1:
   count_type: 'NT'
   count: 1
   pipeline_run: joe_project_sampleA_run
+  tax_level: 1
+  name: "Streptococcus mitis"
+  percent_identity: 95.65
+  alignment_length: 149.75
+  e_value: -81.478
+
 
 pt_tc2:
   tax_id: 1
   count_type: 'NT'
   count: 1
   pipeline_run: joe_project_sampleB_run
+  tax_level: 1
+  name: "Streptococcus mitis"
+  percent_identity: 95.65
+  alignment_length: 149.75
+  e_value: -81.478
 
 pt_tc3:
   tax_id: 1
   count_type: 'NT'
   count: 1
   pipeline_run: public_project_sampleA_run
+  tax_level: 1
+  name: "Streptococcus mitis"
+  percent_identity: 95.65
+  alignment_length: 149.75
+  e_value: -81.478
 
 pt_tc4:
   tax_id: 1
   count_type: 'NT'
   count: 1
   pipeline_run: public_project_sampleB_run
+  tax_level: 1
+  name: "Streptococcus mitis"
+  percent_identity: 95.65
+  alignment_length: 149.75
+  e_value: -81.478

--- a/test/fixtures/taxon_summaries.yml
+++ b/test/fixtures/taxon_summaries.yml
@@ -5,6 +5,7 @@ one:
   tax_level: 1
   mean: 29.9171
   stdev: 236.332
+  rpm_list: "[]"
 two:
   background: real_background
   tax_id: 573
@@ -12,6 +13,7 @@ two:
   tax_level: 1
   mean: 9.35068
   stdev: 26.4471
+  rpm_list: "[]"
 three:
   background: real_background
   tax_id: 570
@@ -19,6 +21,7 @@ three:
   tax_level: 2
   mean: 35.0207
   stdev: 238.639
+  rpm_list: "[]"
 four:
   background: real_background
   tax_id: 570
@@ -26,6 +29,7 @@ four:
   tax_level: 2
   mean: 18.3311
   stdev: 64.2056
+  rpm_list: "[]"
 five:
   background: real_background
   tax_id: 1313
@@ -33,6 +37,7 @@ five:
   tax_level: 1
   mean: 81.3845
   stdev: 404.076
+  rpm_list: "[]"
 six:
   background: real_background
   tax_id: 1313
@@ -40,6 +45,7 @@ six:
   tax_level: 1
   mean: 81.6257
   stdev: 442.207
+  rpm_list: "[]"
 seven:
   background: real_background
   tax_id: 1301
@@ -47,6 +53,7 @@ seven:
   tax_level: 2
   mean: 201.318
   stdev: 942.975
+  rpm_list: "[]"
 eight:
   background: real_background
   tax_id: 1301
@@ -54,6 +61,7 @@ eight:
   tax_level: 2
   mean: 290.481
   stdev: 1482.97
+  rpm_list: "[]"
 nine:
   background: real_background
   tax_id: 28037
@@ -61,6 +69,7 @@ nine:
   tax_level: 1
   mean: 25.6849
   stdev: 139.526
+  rpm_list: "[]"
 ten:
   background: real_background
   tax_id: 28037
@@ -68,3 +77,4 @@ ten:
   tax_level: 1
   mean: 65.9058
   stdev: 374.243
+  rpm_list: "[]"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -14,7 +14,7 @@ joe:
   email: joe@gmail.com
   name: User Three
   allowed_features: "[\"pipeline_viz\"]"
-  
+
 admin:
   email: admin@example.com
   name: Admin User

--- a/test/fixtures/visualizations.yml
+++ b/test/fixtures/visualizations.yml
@@ -4,6 +4,7 @@ joe_visualization:
   visualization_type: heatmap
   name: joe_visualization
   samples: [one, two]
+  data: "{}"
 
 admin_visualization:
   user: admin
@@ -11,6 +12,7 @@ admin_visualization:
   visualization_type: heatmap
   name: admin_visualization
   samples: [one, two]
+  data: "{}"
 
 private_visualization:
   user: admin_one
@@ -18,6 +20,7 @@ private_visualization:
   visualization_type: heatmap
   name: private_visualization
   samples: [one, two]
+  data: "{}"
 
 public_visualization:
   user: admin_one
@@ -25,3 +28,4 @@ public_visualization:
   visualization_type: heatmap
   name: public_visualization
   samples: [one, two]
+  data: "{}"

--- a/test/models/input_file_test.rb
+++ b/test/models/input_file_test.rb
@@ -11,7 +11,7 @@ class InputFileTest < ActiveSupport::TestCase
   end
 
   test "validate name presence" do
-    file = InputFile.new(source_type: 'local')
+    file = InputFile.new(source_type: 'local', source: 'file1.fastq.gz')
     assert_not file.valid?
     assert_equal [:sample, :name], file.errors.keys
   end
@@ -19,7 +19,7 @@ class InputFileTest < ActiveSupport::TestCase
   test "validate name format" do
     invalid_names = ['.fastq', 'a .fastq.gz', 'a/b.fastq.gz']
     invalid_names.each do |name|
-      file = InputFile.new(source_type: 'local')
+      file = InputFile.new(source_type: 'local', source: 'file1.fastq.gz')
       file.name = name
       assert_not file.valid?
       assert_equal [:sample, :name], file.errors.keys
@@ -27,7 +27,7 @@ class InputFileTest < ActiveSupport::TestCase
   end
 
   test "validate source_type" do
-    file = InputFile.new(source_type: 'invalid', name: 'valid.fastq.gz')
+    file = InputFile.new(source_type: 'invalid', name: 'valid.fastq.gz', source: 'file1.fastq.gz')
     assert_not file.valid?
     assert_equal [:sample, :source_type], file.errors.keys
   end


### PR DESCRIPTION
# Description

This is a revival of #2478 using a more incremental approach. Apologies for the long description but I feel it's important explain more than usual for such a change.

## Motivation

Historically, idseq-web has used few active record validators and has not consistently restricted the use of `NULL` values in MySQL (which are passed on as `nil` in ruby and `null` in JS). This causes cognitive load on all developers of idseq-web, if not outright bugs. 

For example, recently I added a null host genome to a sample in staging by accident because of a bug. The effect was to crash the data discovery interface for all users who could see the sample. Programmers throughout the app should not have to defend against any value coming from the database being `NULL`. They should be able to safely assume that certain values are always present. 
 
(Note that the uncertainty is compounded by the dynamic languages Ruby and Javascript which means that there are no guarantees anywhere in the stack.)

See also https://guides.rubyonrails.org/active_record_validations.html#why-use-validations-questionmark .

## Background

Six months ago, In an attempt to improve the situation, I found all the columns in our prod database which have all non-NULL values but which will still allow NULLs. See https://czi.quip.com/LWbJAyLuX7fn/2019-08-02-NULL-values-in-database . In #2478, I merely wrote a migration to change columns to `NOT NULL`. I abandoned #2478 because the rollout would have been too risky. Any intermediate state of the database where a `NOT NULL` column would need to hold a `NULL` temporarily would cause a crash. And testing all affected code paths would have been impractical.

## Implementation

This PR leverages active record validators to check for `NULL` values while avoiding any crash in production by making validation depend on the deployment environment. For example:

```
  validates :s3_nt_db_path, presence: true, if: :mass_validation_enabled?

  def mass_validation_enabled?
    Rails.env.development? ||
      Rails.env.test? ||
      AppConfig.find_by(key: AppConfig::ENABLE_MASS_VALIDATION)
  end
```
 The `AppConfig` exists to later enable switching on in staging and production.

Note that the validators in this PR provide considerable value as documentation alone. 

The full change algorithm I followed was:
1. Inspected prod db (as described above)
2. Created list of "no nulls" columns that were not "not null" already
3. Added `validates :attribute, presence: true` to all such columns as model attributes
4. Added extra validation where obvious
* Inclusion in set of constants
* Range of number
5. Added `if: :mass_validation_enabled?` to all new validators
6. Ran all mintiest and rspec
        * Updated fixtures and factories as needed
        * Updated test cases only when no good alternative

# Notes

* To aid my work and future code readers, I standardized the order of lines at the top of models. The order I aimed for is:
  1. Assocs
  2. Validations
  3. Callbacks
  4. Constants
* I discovered some Rails-level associations were missing, most often from some model that `belongs_to` `TaxonLineage` via `taxid`. I added these but commented them out if they caused any unit test failure for lack of time. I feel the associations are important at least as documentation. 
* I found we always use integer in `[0, 1]` instead of Rails and Mysql boolean types. I don't think it is worth the effort to refactor these but I would support changing the pattern for new columns.
* I found some columns which had always the same value in the prod database so it looks like they are not serving any purpose. Similarly, the taxon scoring model model is a singleton after several years in production.
* Annoying mix of `taxid` and `tax_id`. What is preferred?
* Several tables copy data from an associated table without explanation. This violates the normalization of the database (which is nearly complete). What is the point of having `tax_name` and `tax_id` when `tax_name` is derived from `tax_id`?
* A lot of "status" columns that allow `NULL` which seems pretty bad
* A bunch of json columns with different APIs. Why can't we use one of many gems for json attributes? 
* I added some comments on current values for columns that looked like enums but for which it wasn't clear where the possible values are defined. Any pointers would be most welcome to complete the documentation. 
* I got an odd rspec error when running certain files in isolation, such as: `"WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request"`

# Tests

Ran all mintiest and rspec. See point 6. above. 

Created a project and uploaded a sample in local host.

# Rollout plan

After merging to master, my plan is to: 
1. wait two weeks for any validation errors that happen in developers's localhosts. 
2. turn on `ENABLE_MASS_VALIDATION` in staging
3. ask QA team to exercise all features that create or update objects
4. wait two weeks for any new validation errors that happen in staging
5. turn on `ENABLE_MASS_VALIDATION` in prod
6. react to any new prod validation error by turning off `ENABLE_MASS_VALIDATION` then fixing the issue
7. begin on the second PR which will add `NOT NULL`s to the database schema