### PR TITLE
[Report Page] Send caching metrics to DataDog

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -169,7 +169,7 @@ class ApplicationController < ActionController::Base
   # given cache_key and fills out custom response headers.
   # If the attempt results in a cache miss, then the response is generated normally and
   # will be stored in the cache.
-  def fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate, _event_name)
+  def fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate)
     if skip_cache
       yield
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -169,11 +169,11 @@ class ApplicationController < ActionController::Base
   # given cache_key and fills out custom response headers.
   # If the attempt results in a cache miss, then the response is generated normally and
   # will be stored in the cache.
-  def fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate)
+  def fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate, event_name)
     if skip_cache
       yield
     else
-      MetricUtil.put_metric_now("samples.cache.requested", 1) unless skip_cache
+      MetricUtil.put_metric_now(event_name + ".cache.requested", 1) unless skip_cache
       # This allows 304 Not Modified to be returned so that the client can use its
       # local cache and avoid the large download.
       response.headers["Last-Modified"] = httpdate
@@ -183,7 +183,7 @@ class ApplicationController < ActionController::Base
       Rails.logger.info("Requesting #{cache_key}")
 
       Rails.cache.fetch(cache_key, expires_in: 30.days) do
-        MetricUtil.put_metric_now("samples.cache.miss", 1)
+        MetricUtil.put_metric_now(event_name + ".cache.miss", 1)
         response.headers["X-IDseq-Cache"] = 'missed'
         yield
       end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -770,7 +770,7 @@ class SamplesController < ApplicationController
       httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
 
       json =
-        fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate, "PipelineReport") do
+        fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate) do
           PipelineReportService.call(pipeline_run, background_id)
         end
     else

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -770,7 +770,7 @@ class SamplesController < ApplicationController
       httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
 
       json =
-        fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate) do
+        fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate, "samples") do
           PipelineReportService.call(pipeline_run, background_id)
         end
     else

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -770,7 +770,7 @@ class SamplesController < ApplicationController
       httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
 
       json =
-        fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate, "samples") do
+        fetch_from_or_store_in_cache(skip_cache, cache_key, httpdate, "samples.report") do
           PipelineReportService.call(pipeline_run, background_id)
         end
     else

--- a/app/lib/metric_util.rb
+++ b/app/lib/metric_util.rb
@@ -28,7 +28,7 @@ class MetricUtil
     location_geosearched: "location_geosearched",
   }.freeze
 
-  # DEPRECATED. Use log_analytics_event.
+  # Use for system monitoring (e.g. performance) metrics. Sends to DataDog.
   def self.put_metric_now(name, value, tags = [], type = "count")
     put_metric(name, value, Time.now.to_i, tags, type)
   end
@@ -39,6 +39,8 @@ class MetricUtil
   # https://segment.com/docs/sources/server/http/#rate-limits. In addition,
   # segment says the server lib batches automatically. See
   # https://segment.com/docs/sources/server/http/#batch.
+
+  # Use for usage metrics. Sends to GoogleAnalytics.
   def self.log_analytics_event(event, user, properties = {}, request = nil)
     if SEGMENT_ANALYTICS && !a_test?(request)
       # current_user should be passed from a controller


### PR DESCRIPTION
# Description

See IDSEQ-2224. The caching metrics for the new report page were being sent to Google Analytics rather than DataDog.

Switch from using `log_analytics_event` to `put_metric_now` for the new report page's caching metrics so they're sent to DataDog for consistency with the old report page.

# Notes

Updated some comments related to `put_metric_now` and `log_analytics_event`.
