### PR TITLE
Guard against missing selected metadata fields in heatmap.

### DIFF
--- a/app/assets/src/components/ui/controls/SearchBoxList.jsx
+++ b/app/assets/src/components/ui/controls/SearchBoxList.jsx
@@ -53,10 +53,14 @@ class SearchBoxList extends React.Component {
     });
     unselectedOptions.sort(sortByLabel);
 
-    return Array.from(selected)
-      .map(optionValue => selectedOptions[optionValue])
-      .sort(sortByLabel)
-      .concat(unselectedOptions);
+    return (
+      Array.from(selected)
+        .map(optionValue => selectedOptions[optionValue])
+        // Filter out any selected fields that aren't present. Otherwise, this will cause an error.
+        .filter(option => option !== undefined)
+        .sort(sortByLabel)
+        .concat(unselectedOptions)
+    );
   }
 
   render() {


### PR DESCRIPTION
# Description

This bug was originally found when working on the public site.
If you try to select a metadata field for display on the heatmap that doesn't exist, the heatmap will crash. (one way to do this is to add selectedMetadata[]=blah in the url, or save it in the visualization object)
With this fix, we now ignore any selected fields that don't exist.

# Tests

* Verifed that the heatmap crashed previously and no longer crashes.
