### PR TITLE
[Public] Remove more download options and buttons

### DIFF
--- a/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
@@ -420,27 +420,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
         </div>
         <div className={cs.fill} />
         <div className={cs.headerControls}>
-          <div className={cs.vizLinkContainer}>
-            <a
-              className={cs.vizLink}
-              href={params.alignmentVizUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() =>
-                logAnalyticsEvent(
-                  "CoverageVizBottomSidebar_alignment-viz-link_clicked",
-                  {
-                    accessionId: currentAccessionSummary.id,
-                    taxonId: params.taxonId,
-                    sampleId,
-                  }
-                )
-              }
-            >
-              View read-level visualization
-              <i className={cx("fa fa-chevron-right", cs.rightArrow)} />
-            </a>
-          </div>
+          <div className={cs.vizLinkContainer} />
         </div>
       </div>
     );
@@ -597,24 +577,6 @@ export default class CoverageVizBottomSidebar extends React.Component {
                 Sorry, the coverage visualization is only available for taxons
                 with at least one assembled contig in NT.
               </div>
-              <a
-                className={cs.vizLink}
-                href={params.alignmentVizUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() =>
-                  logAnalyticsEvent(
-                    "CoverageVizBottomSidebar_no-data-alignment-viz-link_clicked",
-                    {
-                      taxonId: params.taxonId,
-                      sampleId,
-                    }
-                  )
-                }
-              >
-                View read-level visualization
-                <i className={cx("fa fa-chevron-right", cs.rightArrow)} />
-              </a>
             </div>
             <BacteriaIcon className={cs.icon} />
           </div>

--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -160,10 +160,6 @@ class Header extends React.Component {
             // Initialize the toast container - can be done anywhere (has absolute positioning)
           }
           <ToastContainer />
-          <iframe
-            className={cs.backgroundRefreshFrame}
-            src="/auth0/background_refresh"
-          />
         </div>
       )
     );

--- a/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
+++ b/app/assets/src/components/views/report/ReportTable/HoverActions.jsx
@@ -47,24 +47,6 @@ class HoverActions extends React.Component {
         disabledMessage: "NCBI Taxonomy Not Found",
         params,
       },
-      {
-        key: `fasta_download_${params.taxId}`,
-        message: "FASTA Download",
-        icon: "fa-download",
-        handleClick: this.props.onFastaActionClick,
-        enabled: this.props.fastaEnabled,
-        disabledMessage: "FASTA Download Not Available",
-        params,
-      },
-      {
-        key: `contigs_download_${params.taxId}`,
-        message: "Contigs Download",
-        icon: "fa-puzzle-piece",
-        handleClick: this.props.onContigVizClick,
-        enabled: this.props.contigVizEnabled,
-        disabledMessage: "No Contigs Available",
-        params,
-      },
       hasCoverageViz
         ? {
             key: `coverage_viz_${params.taxId}`,

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -34,12 +34,7 @@ class SamplesController < ApplicationController
   TOKEN_AUTH_ACTIONS = [:create, :update, :bulk_upload, :bulk_upload_with_metadata].freeze
 
   # Endpoints made public for public ncov page.
-  PUBLIC_NCOV_ENDPOINTS = [
-    :index_v2, :dimensions, :stats, :samples_going_public, :search_suggestions, :report_v2, :report, :show_v2, :show,
-    :show_taxid_fasta, :taxid_contigs, :show_taxid_alignment_viz, :coverage_viz_summary, :coverage_viz_data,
-    :contigs_fasta_by_byteranges, :contigs_sequences_by_byteranges, :metadata, :metadata_fields, :results_folder,
-    :report_csv,
-  ].freeze
+  PUBLIC_NCOV_ENDPOINTS = [:index_v2, :dimensions, :stats, :samples_going_public, :search_suggestions, :report_v2, :report, :show_v2, :show, :show_taxid_alignment_viz, :coverage_viz_summary, :coverage_viz_data, :metadata, :metadata_fields, :results_folder, :report_csv].freeze
 
   # For API-like access
   skip_before_action :verify_authenticity_token, only: TOKEN_AUTH_ACTIONS

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1580,14 +1580,11 @@ class PipelineRun < ApplicationRecord
           end
           file_info << file_info_for_output
         end
-        if file_info.present?
-          result[prs.name]["steps"][target_name] = {
-            "step_description" => STEP_DESCRIPTIONS[prs.name]["steps"][target_name],
-            # Do not send list of files.
-            # "file_list" => file_info,
-            "reads_after" => (job_stats_by_task[target_name] || {})["reads_after"],
-          }
-        end
+
+        result[prs.name]["steps"][target_name] = {
+          "step_description" => STEP_DESCRIPTIONS[prs.name]["steps"][target_name],
+          "reads_after" => (job_stats_by_task[target_name] || {})["reads_after"],
+        }
       end
     end
     result


### PR DESCRIPTION
### Description
- Remove these download endpoints `show_taxid_fasta, taxid_contigs, contigs_fasta_by_byteranges, contigs_sequences_by_byteranges` and HoverAction buttons.
- Other changes bundled as commented.

### Tests
- Tested locally.