### PR TITLE
Further tweaks to public site.

### DIFF
--- a/app/assets/src/components/common/Header.jsx
+++ b/app/assets/src/components/common/Header.jsx
@@ -364,7 +364,7 @@ const UserMenuDropDown = ({
       <BareDropdown
         trigger={
           <div className={cs.userName}>
-            {!NCOV_PUBLIC_SITE ? userName : "Menu"}
+            {!NCOV_PUBLIC_SITE ? userName : "Terms"}
           </div>
         }
         className={cs.userDropdown}

--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -35,6 +35,9 @@ const TAX_LEVEL_INDICES = {
   genus: 2,
 };
 
+// Expand the coronavirus taxid by default.
+const BETACORONAVIRUS_GENUS_TAXID = 694002;
+
 class ReportTable extends React.Component {
   constructor(props) {
     super(props);
@@ -43,7 +46,7 @@ class ReportTable extends React.Component {
 
     this.state = {
       expandAllOpened: false,
-      expandedGenusIds: new Set(),
+      expandedGenusIds: new Set([BETACORONAVIRUS_GENUS_TAXID]),
       dbType: this.props.initialDbType,
     };
 

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { difference, isEmpty, union } from "lodash/fp";
+import { sortBy, difference, isEmpty, union } from "lodash/fp";
 import React from "react";
 
 import BareDropdown from "~ui/controls/dropdowns/BareDropdown";
@@ -31,6 +31,26 @@ import cs from "./samples_view.scss";
 import csTableRenderer from "../discovery/table_renderers.scss";
 
 const NCOV_PUBLIC_SITE = true;
+
+const NCOV_SAMPLE_ORDER = [
+  "Index Case",
+  "Family Member 1",
+  "Family Member 2",
+  "Family Member 3",
+  "Water Control 1",
+  "Water Control 2",
+  "Water Control 3",
+  "Water Control 4",
+];
+
+const sortPublicNcovSamples = sampleRows =>
+  sortBy(
+    row =>
+      NCOV_SAMPLE_ORDER.includes(row.sample.name)
+        ? NCOV_SAMPLE_ORDER.indexOf(row.sample.name)
+        : 100,
+    sampleRows
+  );
 
 class SamplesView extends React.Component {
   constructor(props) {
@@ -434,6 +454,7 @@ class SamplesView extends React.Component {
           selected={selectedSampleIds}
           selectAllChecked={selectAllChecked}
           selectableCellClassName={cs.selectableCell}
+          customSampleSortFn={sortPublicNcovSamples}
         />
       </div>
     );

--- a/app/assets/src/components/visualizations/table/InfiniteTable.jsx
+++ b/app/assets/src/components/visualizations/table/InfiniteTable.jsx
@@ -58,7 +58,7 @@ class InfiniteTable extends React.Component {
   };
 
   loadMoreRows = async ({ startIndex, stopIndex }) => {
-    const { onLoadRows, minimumBatchSize } = this.props;
+    const { onLoadRows, minimumBatchSize, customSampleSortFn } = this.props;
 
     for (let i = startIndex; i <= stopIndex; i++) {
       this.loadedRowsMap[i] = STATUS_LOADING;
@@ -71,6 +71,9 @@ class InfiniteTable extends React.Component {
       .then(newRows => {
         const requestedNumberOfRows = stopIndex - startIndex + 1;
         this.rows.splice(startIndex, requestedNumberOfRows, ...newRows);
+        if (customSampleSortFn) {
+          this.rows = customSampleSortFn(this.rows);
+        }
 
         if (requestedNumberOfRows !== newRows.length) {
           this.setState({ rowCount: this.rows.length });
@@ -205,6 +208,8 @@ InfiniteTable.propTypes = {
   rowCount: PropTypes.number,
   defaultRowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   threshold: PropTypes.number,
+  // Sort the rows after they are fetched. This is a hack to allow for specifying a particular order for the
+  customSampleSortFn: PropTypes.func,
 };
 
 export default InfiniteTable;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
   get 'cli_user_instructions', to: 'samples#cli_user_instructions'
   get 'select', to: 'home#index'
   get 'home', to: 'home#index'
+  get 'covid-19', to: 'home#index'
   get 'legacy', to: 'home#legacy'
   get 'taxon_descriptions', to: 'home#taxon_descriptions'
   get 'public', to: 'home#public'


### PR DESCRIPTION
# Description
* Sort the samples in a very particular way based on name.
* Change "menu" to "terms" in the header.
* Add a new more permanent url at /covid-19.
* Open the Betacoronavirus genus row by default in the report page.
