### PR TITLE
Show only "all" sample types for unknown hosts

### DIFF
--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -65,8 +65,7 @@ class MetadataInput extends React.Component {
       onSave,
       metadataType,
       className,
-      isHuman,
-      isInsect,
+      taxaCategory,
       sampleTypes,
     } = this.props;
     const { warning } = this.state;
@@ -86,8 +85,7 @@ class MetadataInput extends React.Component {
             // Result can be plain text or a match. We treat them the same.
             onChange(metadataType.key, result.name || result, true);
           }}
-          isHuman={isHuman}
-          isInsect={isInsect}
+          taxaCategory={taxaCategory}
           sampleTypes={sampleTypes}
         />
       );
@@ -127,7 +125,7 @@ class MetadataInput extends React.Component {
           onChange={val => onChange(metadataType.key, val)}
           onBlur={() => onSave && onSave(metadataType.key)}
           value={ensureDefinedValue(value)}
-          placeholder={isHuman ? "YYYY-MM" : "YYYY-MM-DD"}
+          placeholder={taxaCategory === "human" ? "YYYY-MM" : "YYYY-MM-DD"}
           type="text"
         />
       );
@@ -142,7 +140,7 @@ class MetadataInput extends React.Component {
             onResultSelect={({ result: selection }) => {
               const { result, warning } = processLocationSelection(
                 selection,
-                isHuman
+                taxaCategory === "human"
               );
               // Set warnedValue, so that a LOCATION_PRIVACY_WARNING warning isn't overwritten when the result propagates back down
               // as this.props.value.
@@ -196,8 +194,7 @@ MetadataInput.propTypes = {
   onChange: PropTypes.func.isRequired,
   onSave: PropTypes.func,
   withinModal: PropTypes.bool,
-  isHuman: PropTypes.bool,
-  isInsect: PropTypes.bool,
+  taxaCategory: PropTypes.string,
   warning: PropTypes.string,
   sampleTypes: PropTypes.arrayOf(PropTypes.SampleTypeProps).isRequired,
 };

--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -431,8 +431,7 @@ class MetadataManualInput extends React.Component {
                     });
                   }}
                   withinModal={this.props.withinModal}
-                  isHuman={hostGenome.taxa_category === "human"}
-                  isInsect={hostGenome.taxa_category === "insect"}
+                  taxaCategory={hostGenome.taxa_category}
                   sampleTypes={this.props.sampleTypes}
                 />
                 {this.props.samples.length > 1 &&

--- a/app/assets/src/components/common/SampleTypeSearchBox.jsx
+++ b/app/assets/src/components/common/SampleTypeSearchBox.jsx
@@ -29,17 +29,24 @@ class SampleTypeSearchBox extends React.Component {
     );
 
     // Sample types are grouped differently based on whether the current
-    // sample's host genome is an insect, a human, or neither. The "suggested"
-    // group is shown first, then the "all" group.
+    // sample's host genome is an insect, a human, a non-human animal or
+    // unknown. The "suggested" group is shown first, then the "all" group.
     const getSampleTypeCategory = sampleType => {
+      const { taxaCategory } = this.props;
+      const isHuman = taxaCategory === "human";
+      const isInsect = taxaCategory === "insect";
+      const isNonHumanAnimal = "non-human-animal";
+
       if (sampleType.insect_only) {
-        return this.props.isInsect ? SUGGESTED : ALL;
+        return isInsect ? SUGGESTED : ALL;
       }
       if (sampleType.human_only) {
-        return this.props.isHuman ? SUGGESTED : ALL;
+        return isHuman ? SUGGESTED : ALL;
       }
-      // insects should only be suggested insect body parts
-      return this.isInsect ? ALL : SUGGESTED;
+      if (isNonHumanAnimal) {
+        return SUGGESTED;
+      }
+      return ALL;
     };
     return groupBy(getSampleTypeCategory, sortedSampleTypes);
   }
@@ -100,8 +107,7 @@ SampleTypeSearchBox.propTypes = {
   onResultSelect: PropTypes.func.isRequired,
   value: PropTypes.string,
   sampleTypes: PropTypes.arrayOf(PropTypes.SampleTypeProps).isRequired,
-  isHuman: PropTypes.bool.isRequired,
-  isInsect: PropTypes.bool.isRequired,
+  taxaCategory: PropTypes.string,
   showDescription: PropTypes.bool,
 };
 

--- a/app/assets/src/components/common/SampleTypeSearchBox.jsx
+++ b/app/assets/src/components/common/SampleTypeSearchBox.jsx
@@ -35,7 +35,7 @@ class SampleTypeSearchBox extends React.Component {
       const { taxaCategory } = this.props;
       const isHuman = taxaCategory === "human";
       const isInsect = taxaCategory === "insect";
-      const isNonHumanAnimal = "non-human-animal";
+      const isNonHumanAnimal = taxaCategory === "non-human-animal";
 
       if (sampleType.insect_only) {
         return isInsect ? SUGGESTED : ALL;

--- a/app/models/host_genome.rb
+++ b/app/models/host_genome.rb
@@ -28,6 +28,8 @@ class HostGenome < ApplicationRecord
     # https://docs.google.com/spreadsheets/d/1_hPkQe5LI0Zw_C0Ls4HVCEDsc_FNNVOaU_aAfoaiZRE/
     "human",
     "insect",
+    "unknown",
+    "non-human-animal",
   ], }, if: -> { respond_to?(:taxa_category) } # for migrations
 
   # NOTE: Consider updating the star and bowtie defaults if we ever add new ERCC index files.

--- a/db/migrate/20200219181808_add_taxa_category_values_to_host_genome.rb
+++ b/db/migrate/20200219181808_add_taxa_category_values_to_host_genome.rb
@@ -10,5 +10,8 @@ class AddTaxaCategoryValuesToHostGenome < ActiveRecord::Migration[5.1]
 
     # By previous migration, these are all non-human
     HostGenome.where(user: nil, taxa_category: nil).find_each { |u| u.update(taxa_category: "non-human-animal") }
+
+    change_column_default :host_genomes, "taxa_category", from: nil, to: "unknown"
+    change_column_null :host_genomes, "taxa_category", false
   end
 end

--- a/db/migrate/20200219181808_add_taxa_category_values_to_host_genome.rb
+++ b/db/migrate/20200219181808_add_taxa_category_values_to_host_genome.rb
@@ -12,6 +12,5 @@ class AddTaxaCategoryValuesToHostGenome < ActiveRecord::Migration[5.1]
     HostGenome.where(user: nil, taxa_category: nil).find_each { |u| u.update(taxa_category: "non-human-animal") }
 
     change_column_default :host_genomes, "taxa_category", from: nil, to: "unknown"
-    change_column_null :host_genomes, "taxa_category", false
   end
 end

--- a/db/migrate/20200219181808_add_taxa_category_values_to_host_genome.rb
+++ b/db/migrate/20200219181808_add_taxa_category_values_to_host_genome.rb
@@ -1,0 +1,14 @@
+# This adds more values to taxa_category. Initial values were from:
+# https://czi.quip.com/yPgpAPj1dtEC/Hosts-Dropdown-Options
+# See also AddTaxaCategoryToHostGenome.
+class AddTaxaCategoryValuesToHostGenome < ActiveRecord::Migration[5.1]
+  def change
+    unknowns = ['Unknown', 'ERCC only']
+    HostGenome.where(name: unknowns).find_each { |u| u.update(taxa_category: "unknown") }
+    # Any hosts created by users
+    HostGenome.where.not(user: nil).where(taxa_category: nil).find_each { |u| u.update(taxa_category: "unknown") }
+
+    # By previous migration, these are all non-human
+    HostGenome.where(user: nil, taxa_category: nil).find_each { |u| u.update(taxa_category: "non-human-animal") }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_207_200_038) do
+ActiveRecord::Schema.define(version: 20_200_219_181_808) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -69,6 +69,18 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.index ["name"], name: "index_backgrounds_on_name", unique: true
   end
 
+  create_table "backgrounds__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "id", default: 0, null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "project_id"
+    t.text "description"
+    t.integer "public_access", limit: 1
+    t.integer "ready", limit: 1, default: 0
+    t.bigint "user_id"
+  end
+
   create_table "backgrounds_pipeline_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "background_id"
     t.bigint "pipeline_run_id"
@@ -92,7 +104,7 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "access_token"
-    t.float "progress"
+    t.float "progress", limit: 24
     t.string "ecs_task_arn", comment: "The ecs task arn for this bulk download if applicable"
     t.bigint "output_file_size", comment: "The file size of the generated output file. Can be nil while the file is being generated."
     t.index ["user_id"], name: "index_bulk_downloads_on_user_id"
@@ -112,7 +124,7 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.integer "read_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "lineage_json"
+    t.text "lineage_json", limit: 16_777_215
     t.integer "species_taxid_nt"
     t.integer "species_taxid_nr"
     t.integer "genus_taxid_nt"
@@ -144,13 +156,18 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
   end
 
   create_table "host_genomes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "name", null: false
-    t.text "s3_star_index_path"
-    t.text "s3_bowtie2_index_path"
+    t.string "name", null: false, comment: "Friendly name of host genome. May be common name or scientific name of species. Must be unique and start with a capital letter."
+    t.string "s3_star_index_path", default: "s3://idseq-database/host_filter/ercc/2017-09-01-utc-1504224000-unixtime__2017-09-01-utc-1504224000-unixtime/STAR_genome.tar", null: false, comment: "The path to the index file to be used in the pipeline by star for host filtering."
+    t.string "s3_bowtie2_index_path", default: "s3://idseq-database/host_filter/ercc/2017-09-01-utc-1504224000-unixtime__2017-09-01-utc-1504224000-unixtime/bowtie2_genome.tar", null: false, comment: "The path to the index file to be used in the pipeline by bowtie for host filtering."
     t.bigint "default_background_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "skip_deutero_filter"
+    t.integer "skip_deutero_filter", default: 0, null: false, comment: "See https://en.wikipedia.org/wiki/Deuterostome. This affects the pipeline."
+    t.string "taxa_category", default: "unknown", null: false, comment: "An informal taxa name for grouping hosts. First implemented for sample type suggestions."
+    t.integer "samples_count", default: 0, null: false, comment: "Added to enable ranking of host genomes by popularity"
+    t.bigint "user_id"
+    t.index ["name"], name: "index_host_genomes_on_name", unique: true
+    t.index ["user_id"], name: "index_host_genomes_on_user_id"
   end
 
   create_table "host_genomes_metadata_fields", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -166,7 +183,7 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.bigint "sample_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "source_type", null: false
+    t.string "source_type"
     t.text "source"
     t.text "parts"
     t.index ["sample_id"], name: "index_input_files_on_sample_id"
@@ -174,13 +191,22 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
 
   create_table "job_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "task"
-    t.integer "reads_before"
     t.integer "reads_after"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "pipeline_run_id"
     t.index ["pipeline_run_id"], name: "index_job_stats_on_pipeline_run_id"
     t.index ["task"], name: "index_job_stats_on_task"
+  end
+
+  create_table "job_stats__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "id", default: 0, null: false
+    t.string "task"
+    t.integer "reads_before"
+    t.integer "reads_after"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "pipeline_run_id"
   end
 
   create_table "locations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -210,7 +236,7 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
   end
 
   create_table "metadata", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "key", null: false
+    t.string "key", null: false, collation: "latin1_swedish_ci"
     t.string "raw_value"
     t.string "string_validated_value"
     t.decimal "number_validated_value", precision: 36, scale: 9
@@ -222,6 +248,21 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.bigint "location_id"
     t.index ["metadata_field_id"], name: "index_metadata_on_metadata_field_id"
     t.index ["sample_id", "key"], name: "index_metadata_on_sample_id_and_key", unique: true
+  end
+
+  create_table "metadata__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "id", default: 0, null: false
+    t.string "key", null: false, collation: "latin1_swedish_ci"
+    t.string "raw_value"
+    t.string "string_validated_value"
+    t.decimal "number_validated_value", precision: 36, scale: 9
+    t.bigint "sample_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "date_validated_value"
+    t.bigint "metadata_field_id"
+    t.string "specificity"
+    t.bigint "location_id"
   end
 
   create_table "metadata_fields", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -240,6 +281,25 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.string "examples"
     t.integer "default_for_new_host_genome", limit: 1, default: 0
     t.index ["group"], name: "index_metadata_fields_on_group"
+  end
+
+  create_table "metadata_fields__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "id", default: 0, null: false
+    t.string "name", null: false
+    t.string "display_name"
+    t.string "description"
+    t.integer "base_type", limit: 1, null: false
+    t.string "validation_type"
+    t.string "options"
+    t.integer "force_options", limit: 1, default: 0
+    t.integer "is_core", limit: 1, default: 0
+    t.integer "is_default", limit: 1, default: 0
+    t.integer "is_required", limit: 1, default: 0
+    t.string "group"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "examples"
+    t.integer "default_for_new_host_genome", limit: 1, default: 0
   end
 
   create_table "metadata_fields_projects", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -350,11 +410,51 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.index ["sample_id"], name: "index_pipeline_runs_on_sample_id"
   end
 
+  create_table "pipeline_runs__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "id", default: 0, null: false
+    t.string "job_id"
+    t.text "command"
+    t.string "command_stdout"
+    t.text "command_error"
+    t.string "command_status"
+    t.bigint "sample_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "job_status"
+    t.text "job_description"
+    t.string "job_log_id"
+    t.string "postprocess_status"
+    t.integer "finalized", default: 0, null: false
+    t.bigint "total_reads"
+    t.bigint "adjusted_remaining_reads"
+    t.bigint "unmapped_reads"
+    t.text "version"
+    t.integer "subsample"
+    t.string "pipeline_branch"
+    t.integer "ready_step"
+    t.integer "total_ercc_reads"
+    t.float "fraction_subsampled", limit: 24
+    t.string "pipeline_version"
+    t.string "pipeline_commit"
+    t.text "assembled_taxids"
+    t.bigint "truncated"
+    t.integer "results_finalized"
+    t.bigint "alignment_config_id"
+    t.integer "alert_sent", default: 0
+    t.text "dag_vars"
+    t.integer "assembled", limit: 2
+    t.integer "completed_gsnap_chunks"
+    t.integer "completed_rapsearch_chunks"
+    t.integer "max_input_fragments"
+    t.text "error_message"
+    t.string "known_user_error"
+  end
+
   create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "public_access", limit: 1
+    t.integer "public_access", limit: 1, default: 0
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.text "description"
@@ -366,6 +466,16 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.bigint "user_id", null: false
     t.index ["project_id"], name: "index_projects_users_on_project_id"
     t.index ["user_id"], name: "index_projects_users_on_user_id"
+  end
+
+  create_table "sample_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string "name", null: false, comment: "Canonical name of the sample type. This should be immutable after creation. It is used as a key to join with MetadataField sample_type values."
+    t.string "group", null: false, comment: "Mutually exclusive grouping of names. Example: \"Organs\"."
+    t.boolean "insect_only", default: false, null: false, comment: "Whether a sample type should only be for insects."
+    t.boolean "human_only", default: false, null: false, comment: "Whether a sample type should only be for humans."
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sample_types_on_name", unique: true
   end
 
   create_table "samples", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -389,8 +499,8 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.integer "max_input_fragments"
     t.datetime "client_updated_at"
     t.integer "uploaded_from_basespace", limit: 1, default: 0
-    t.string "basespace_access_token"
     t.string "upload_error"
+    t.string "basespace_access_token"
     t.boolean "do_not_process", default: false, null: false, comment: "If true, sample will skip pipeline processing."
     t.index ["host_genome_id"], name: "samples_host_genome_id_fk"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
@@ -432,6 +542,18 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.index ["taxid"], name: "index_taxon_byteranges_on_taxid"
   end
 
+  create_table "taxon_byteranges__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "id", default: 0, null: false
+    t.integer "taxid"
+    t.bigint "first_byte"
+    t.bigint "last_byte"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "hit_type"
+    t.integer "tax_level"
+    t.bigint "pipeline_run_id"
+  end
+
   create_table "taxon_confirmations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid"
     t.integer "sample_id"
@@ -464,12 +586,36 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
   end
 
+  create_table "taxon_counts__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "id", default: 0, null: false
+    t.integer "tax_id"
+    t.integer "tax_level"
+    t.integer "count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name"
+    t.string "count_type"
+    t.float "percent_identity", limit: 24
+    t.float "alignment_length", limit: 24
+    t.float "e_value", limit: 24
+    t.integer "genus_taxid", default: -200, null: false
+    t.integer "superkingdom_taxid", default: -700, null: false
+    t.float "percent_concordant", limit: 24
+    t.float "species_total_concordant", limit: 24
+    t.float "genus_total_concordant", limit: 24
+    t.float "family_total_concordant", limit: 24
+    t.bigint "pipeline_run_id"
+    t.string "common_name"
+    t.integer "family_taxid", default: -300, null: false
+    t.integer "is_phage", limit: 1, default: 0, null: false
+  end
+
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid", null: false
     t.bigint "wikipedia_id"
     t.string "title"
-    t.text "summary"
-    t.text "description"
+    t.text "summary", limit: 16_777_215
+    t.text "description", limit: 16_777_215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["taxid"], name: "index_taxon_descriptions_on_taxid", unique: true
@@ -506,8 +652,8 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.string "kingdom_name", default: "", null: false
     t.string "kingdom_common_name", default: "", null: false
     t.string "tax_name"
-    t.integer "version_start", limit: 1
-    t.integer "version_end", limit: 1
+    t.integer "version_start", limit: 2, null: false, comment: "The first version for which the taxon is active"
+    t.integer "version_end", limit: 2, null: false, comment: "The last version for which the taxon is active"
     t.index ["class_taxid"], name: "index_taxon_lineages_on_class_taxid"
     t.index ["family_taxid"], name: "index_taxon_lineages_on_family_taxid"
     t.index ["genus_taxid", "genus_name"], name: "index_taxon_lineages_on_genus_taxid_and_genus_name"
@@ -533,6 +679,16 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.index ["name"], name: "index_taxon_scoring_models_on_name", unique: true
   end
 
+  create_table "taxon_scoring_models__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "id", default: 0, null: false
+    t.string "name"
+    t.text "model_json"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "model_type"
+    t.bigint "user_id"
+  end
+
   create_table "taxon_summaries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "background_id"
     t.integer "tax_id"
@@ -544,6 +700,20 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.datetime "updated_at", null: false
     t.text "rpm_list"
     t.index ["background_id", "tax_id", "count_type", "tax_level"], name: "index_bg_tax_ct_level", unique: true
+  end
+
+  create_table "taxon_summaries__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "id", default: 0, null: false
+    t.bigint "background_id"
+    t.integer "tax_id"
+    t.string "count_type"
+    t.integer "tax_level"
+    t.string "name"
+    t.float "mean", limit: 24
+    t.float "stdev", limit: 24
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "rpm_list"
   end
 
   create_table "ui_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -565,14 +735,10 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string "email", default: "", null: false
+    t.string "email"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
@@ -589,7 +755,6 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
     t.integer "phylo_trees_count", default: 0, null: false
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "visualizations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -608,11 +773,12 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
   add_foreign_key "backgrounds_pipeline_runs", "pipeline_runs", name: "backgrounds_pipeline_runs_pipeline_run_id_fk"
   add_foreign_key "backgrounds_samples", "backgrounds", name: "backgrounds_samples_background_id_fk"
   add_foreign_key "backgrounds_samples", "samples", name: "backgrounds_samples_sample_id_fk"
+  add_foreign_key "bulk_downloads", "users"
   add_foreign_key "bulk_downloads_pipeline_runs", "bulk_downloads", name: "bulk_downloads_pipeline_runs_bulk_download_id_fk"
   add_foreign_key "bulk_downloads_pipeline_runs", "pipeline_runs", name: "bulk_downloads_pipeline_runs_pipeline_run_id_fk"
-  add_foreign_key "bulk_downloads", "users"
   add_foreign_key "favorite_projects", "projects", name: "favorite_projects_project_id_fk"
   add_foreign_key "favorite_projects", "users", name: "favorite_projects_user_id_fk"
+  add_foreign_key "host_genomes", "users"
   add_foreign_key "host_genomes_metadata_fields", "host_genomes", name: "host_genomes_metadata_fields_host_genome_id_fk"
   add_foreign_key "host_genomes_metadata_fields", "metadata_fields", name: "host_genomes_metadata_fields_metadata_field_id_fk"
   add_foreign_key "input_files", "samples", name: "input_files_sample_id_fk"
@@ -636,5 +802,6 @@ ActiveRecord::Schema.define(version: 20_200_207_200_038) do
   add_foreign_key "samples", "users", name: "samples_user_id_fk"
   add_foreign_key "samples_visualizations", "samples", name: "samples_visualizations_sample_id_fk"
   add_foreign_key "samples_visualizations", "visualizations", name: "samples_visualizations_visualization_id_fk"
+  add_foreign_key "user_settings", "users"
   add_foreign_key "visualizations", "users", name: "visualizations_user_id_fk"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,18 +69,6 @@ ActiveRecord::Schema.define(version: 20_200_219_181_808) do
     t.index ["name"], name: "index_backgrounds_on_name", unique: true
   end
 
-  create_table "backgrounds__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "id", default: 0, null: false
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "project_id"
-    t.text "description"
-    t.integer "public_access", limit: 1
-    t.integer "ready", limit: 1, default: 0
-    t.bigint "user_id"
-  end
-
   create_table "backgrounds_pipeline_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "background_id"
     t.bigint "pipeline_run_id"
@@ -199,16 +187,6 @@ ActiveRecord::Schema.define(version: 20_200_219_181_808) do
     t.index ["task"], name: "index_job_stats_on_task"
   end
 
-  create_table "job_stats__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "id", default: 0, null: false
-    t.string "task"
-    t.integer "reads_before"
-    t.integer "reads_after"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "pipeline_run_id"
-  end
-
   create_table "locations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name", default: "", null: false, comment: "Full display name, such as a complete address"
     t.string "geo_level", limit: 20, default: "", null: false, comment: "Level of specificity (country, state, subdivision, or city)"
@@ -250,21 +228,6 @@ ActiveRecord::Schema.define(version: 20_200_219_181_808) do
     t.index ["sample_id", "key"], name: "index_metadata_on_sample_id_and_key", unique: true
   end
 
-  create_table "metadata__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "id", default: 0, null: false
-    t.string "key", null: false, collation: "latin1_swedish_ci"
-    t.string "raw_value"
-    t.string "string_validated_value"
-    t.decimal "number_validated_value", precision: 36, scale: 9
-    t.bigint "sample_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.date "date_validated_value"
-    t.bigint "metadata_field_id"
-    t.string "specificity"
-    t.bigint "location_id"
-  end
-
   create_table "metadata_fields", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name", null: false
     t.string "display_name"
@@ -281,25 +244,6 @@ ActiveRecord::Schema.define(version: 20_200_219_181_808) do
     t.string "examples"
     t.integer "default_for_new_host_genome", limit: 1, default: 0
     t.index ["group"], name: "index_metadata_fields_on_group"
-  end
-
-  create_table "metadata_fields__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "id", default: 0, null: false
-    t.string "name", null: false
-    t.string "display_name"
-    t.string "description"
-    t.integer "base_type", limit: 1, null: false
-    t.string "validation_type"
-    t.string "options"
-    t.integer "force_options", limit: 1, default: 0
-    t.integer "is_core", limit: 1, default: 0
-    t.integer "is_default", limit: 1, default: 0
-    t.integer "is_required", limit: 1, default: 0
-    t.string "group"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "examples"
-    t.integer "default_for_new_host_genome", limit: 1, default: 0
   end
 
   create_table "metadata_fields_projects", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -410,46 +354,6 @@ ActiveRecord::Schema.define(version: 20_200_219_181_808) do
     t.index ["sample_id"], name: "index_pipeline_runs_on_sample_id"
   end
 
-  create_table "pipeline_runs__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "id", default: 0, null: false
-    t.string "job_id"
-    t.text "command"
-    t.string "command_stdout"
-    t.text "command_error"
-    t.string "command_status"
-    t.bigint "sample_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "job_status"
-    t.text "job_description"
-    t.string "job_log_id"
-    t.string "postprocess_status"
-    t.integer "finalized", default: 0, null: false
-    t.bigint "total_reads"
-    t.bigint "adjusted_remaining_reads"
-    t.bigint "unmapped_reads"
-    t.text "version"
-    t.integer "subsample"
-    t.string "pipeline_branch"
-    t.integer "ready_step"
-    t.integer "total_ercc_reads"
-    t.float "fraction_subsampled", limit: 24
-    t.string "pipeline_version"
-    t.string "pipeline_commit"
-    t.text "assembled_taxids"
-    t.bigint "truncated"
-    t.integer "results_finalized"
-    t.bigint "alignment_config_id"
-    t.integer "alert_sent", default: 0
-    t.text "dag_vars"
-    t.integer "assembled", limit: 2
-    t.integer "completed_gsnap_chunks"
-    t.integer "completed_rapsearch_chunks"
-    t.integer "max_input_fragments"
-    t.text "error_message"
-    t.string "known_user_error"
-  end
-
   create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -542,18 +446,6 @@ ActiveRecord::Schema.define(version: 20_200_219_181_808) do
     t.index ["taxid"], name: "index_taxon_byteranges_on_taxid"
   end
 
-  create_table "taxon_byteranges__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "id", default: 0, null: false
-    t.integer "taxid"
-    t.bigint "first_byte"
-    t.bigint "last_byte"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "hit_type"
-    t.integer "tax_level"
-    t.bigint "pipeline_run_id"
-  end
-
   create_table "taxon_confirmations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "taxid"
     t.integer "sample_id"
@@ -584,30 +476,6 @@ ActiveRecord::Schema.define(version: 20_200_219_181_808) do
     t.integer "is_phage", limit: 1, default: 0, null: false
     t.index ["pipeline_run_id", "tax_id", "count_type", "tax_level"], name: "index_pr_tax_hit_level_tc", unique: true
     t.index ["tax_id"], name: "index_taxon_counts_on_tax_id"
-  end
-
-  create_table "taxon_counts__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "id", default: 0, null: false
-    t.integer "tax_id"
-    t.integer "tax_level"
-    t.integer "count"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "name"
-    t.string "count_type"
-    t.float "percent_identity", limit: 24
-    t.float "alignment_length", limit: 24
-    t.float "e_value", limit: 24
-    t.integer "genus_taxid", default: -200, null: false
-    t.integer "superkingdom_taxid", default: -700, null: false
-    t.float "percent_concordant", limit: 24
-    t.float "species_total_concordant", limit: 24
-    t.float "genus_total_concordant", limit: 24
-    t.float "family_total_concordant", limit: 24
-    t.bigint "pipeline_run_id"
-    t.string "common_name"
-    t.integer "family_taxid", default: -300, null: false
-    t.integer "is_phage", limit: 1, default: 0, null: false
   end
 
   create_table "taxon_descriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -679,16 +547,6 @@ ActiveRecord::Schema.define(version: 20_200_219_181_808) do
     t.index ["name"], name: "index_taxon_scoring_models_on_name", unique: true
   end
 
-  create_table "taxon_scoring_models__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "id", default: 0, null: false
-    t.string "name"
-    t.text "model_json"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "model_type"
-    t.bigint "user_id"
-  end
-
   create_table "taxon_summaries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "background_id"
     t.integer "tax_id"
@@ -700,20 +558,6 @@ ActiveRecord::Schema.define(version: 20_200_219_181_808) do
     t.datetime "updated_at", null: false
     t.text "rpm_list"
     t.index ["background_id", "tax_id", "count_type", "tax_level"], name: "index_bg_tax_ct_level", unique: true
-  end
-
-  create_table "taxon_summaries__dropped_cols_backup", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint "id", default: 0, null: false
-    t.bigint "background_id"
-    t.integer "tax_id"
-    t.string "count_type"
-    t.integer "tax_level"
-    t.string "name"
-    t.float "mean", limit: 24
-    t.float "stdev", limit: 24
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "rpm_list"
   end
 
   create_table "ui_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
# Description

Previously, we treated new or unknown hosts as nonhuman animals. This PR adds a new category "unknown" and shows no "suggestions" in the dropdown for them. 

![image](https://user-images.githubusercontent.com/28797/74865225-ac5ded00-5305-11ea-965f-c6df7733b2ab.png)

# Tests

* try migration
* try each category of host, see appropriate suggestions and "all"
