### PR TITLE
Fix collection and phylo tree name inputs

### DIFF
--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -550,6 +550,7 @@ class PhyloTreeCreation extends React.Component {
                 }
                 placeholder="Tree Name"
                 onChange={this.handleNameChange}
+                value={this.state.treeName}
               />
             </div>
             {this.props.admin === 1 && (

--- a/app/assets/src/components/views/samples/CollectionModal.jsx
+++ b/app/assets/src/components/views/samples/CollectionModal.jsx
@@ -95,7 +95,11 @@ class CollectionModal extends React.Component {
     return (
       <div className={cs.form}>
         <div className={cs.label}>Name</div>
-        <Input fluid onChange={this.handleNameChange} />
+        <Input
+          fluid
+          onChange={this.handleNameChange}
+          value={this.state.backgroundName}
+        />
         <div className={cs.label}>
           Description
           <span className={cs.optional}>Optional</span>


### PR DESCRIPTION
# Description

#3034 changed the behavior of the common `Input` component to not accept undefined `value`. In react terms, `Input` was expected to be fully controlled. 

![image](https://user-images.githubusercontent.com/28797/74881590-711de700-5322-11ea-920c-39199c90d1d3.png)

![image](https://user-images.githubusercontent.com/28797/74881712-ad514780-5322-11ea-8cf0-6f289e51e8b0.png)

# Notes

* It seems like we should check **all call sites** of `Input` if we want to keep the current behavior
* It seems like we should make `value` `isRequired` if we want to keep the current behavior

# Tests

* open collection dialog, enter name
* open phylo dialog, enter name