### PR TITLE
IDSEQ-2273: Change wording of "create a collection" to "create a background"

### DIFF
--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1673,7 +1673,7 @@ class BackgroundModal extends React.Component {
         className="modal project-popup add-user-modal"
       >
         <Modal.Header className="project_modal_header">
-          Create a Background
+          Create a Collection
         </Modal.Header>
         <Modal.Content className="modal-content">
           <div>

--- a/app/assets/src/components/Samples.jsx
+++ b/app/assets/src/components/Samples.jsx
@@ -1673,7 +1673,7 @@ class BackgroundModal extends React.Component {
         className="modal project-popup add-user-modal"
       >
         <Modal.Header className="project_modal_header">
-          Create a Collection
+          Create a Background
         </Modal.Header>
         <Modal.Content className="modal-content">
           <div>

--- a/app/assets/src/components/views/samples/CollectionModal.jsx
+++ b/app/assets/src/components/views/samples/CollectionModal.jsx
@@ -1,15 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import { createBackground } from "~/api";
+import { withAnalytics } from "~/api/analytics";
 import PrimaryButton from "~ui/controls/buttons/PrimaryButton";
 import SecondaryButton from "~ui/controls/buttons/SecondaryButton";
 import Input from "~ui/controls/Input";
 import Textarea from "~ui/controls/Textarea";
-import { createBackground } from "~/api";
-import { withAnalytics } from "~/api/analytics";
 import Modal from "~ui/containers/Modal";
-
+import ExternalLink from "~/components/ui/controls/ExternalLink";
 import Notification from "~ui/notifications/Notification";
+
 import cs from "./collection_modal.scss";
 
 /**
@@ -183,7 +184,13 @@ class CollectionModal extends React.Component {
               A background is a group of samples. You can use a background as a
               statistical model to compare your samples to. When you select a
               background on a report or heatmap, the z-scores will indicate how
-              much a sample deviates from the mean of that background.
+              much a sample deviates from the mean of that background.{" "}
+              <ExternalLink
+                className={cs.link}
+                href="https://chanzuckerberg.zendesk.com/hc/en-us/articles/360035166174-How-do-I-create-and-use-background-models-in-IDseq-"
+              >
+                Learn More
+              </ExternalLink>.
             </div>
             {this.renderForm()}
             {backgroundCreationResponse && this.renderStatus()}

--- a/app/assets/src/components/views/samples/CollectionModal.jsx
+++ b/app/assets/src/components/views/samples/CollectionModal.jsx
@@ -141,12 +141,12 @@ class CollectionModal extends React.Component {
     return (
       <div>
         {backgroundCreationResponse.status === "ok" ? (
-          <Notification type="success">
-            Background is being created and will be visible on the report page
-            once statistics have been computed.
+          <Notification className={cs.notification} type="success">
+            Your Background Model is being created and will be visible on the
+            report page once statistics have been computed.
           </Notification>
         ) : (
-          <Notification type="error">
+          <Notification className={cs.notification} type="error">
             {backgroundCreationResponse.message}
           </Notification>
         )}
@@ -178,7 +178,7 @@ class CollectionModal extends React.Component {
             )}
             className={cs.collectionModal}
           >
-            <div className={cs.title}>Create a Background</div>
+            <div className={cs.title}>Create a Background Model</div>
             <div className={cs.description}>
               A background is a group of samples. You can use a background as a
               statistical model to compare your samples to. When you select a

--- a/app/assets/src/components/views/samples/CollectionModal.jsx
+++ b/app/assets/src/components/views/samples/CollectionModal.jsx
@@ -12,6 +12,10 @@ import Modal from "~ui/containers/Modal";
 import Notification from "~ui/notifications/Notification";
 import cs from "./collection_modal.scss";
 
+/**
+ * NOTE: "Collections" were an unrealized generalization of the background concept.
+ * For the time being, a collection is equivalent to a background.
+ */
 class CollectionModal extends React.Component {
   constructor(props) {
     super(props);
@@ -39,7 +43,7 @@ class CollectionModal extends React.Component {
         <div className={cs.warning}>
           <Notification className={cs.notification} type="warn">
             A large number of samples may increase the processing time before
-            your collection can be used as a background.
+            your background can be used in reports.
           </Notification>
         </div>
         <ul className={cs.selectedSamples}>
@@ -138,7 +142,7 @@ class CollectionModal extends React.Component {
       <div>
         {backgroundCreationResponse.status === "ok" ? (
           <Notification type="success">
-            Collection is being created and will be visible on the report page
+            Background is being created and will be visible on the report page
             once statistics have been computed.
           </Notification>
         ) : (
@@ -174,12 +178,12 @@ class CollectionModal extends React.Component {
             )}
             className={cs.collectionModal}
           >
-            <div className={cs.title}>Create a Collection</div>
+            <div className={cs.title}>Create a Background</div>
             <div className={cs.description}>
-              A collection is a group of samples. You can use this collection as
-              a background model to be selected on a sample report page. It will
-              update the calculated z-score to indicate how much the the sample
-              deviates from the norm for that collection.
+              A background is a group of samples. You can use a background as a
+              statistical model to compare your samples to. When you select a
+              background on a report or heatmap, the z-scores will indicate how
+              much a sample deviates from the mean of that background.
             </div>
             {this.renderForm()}
             {backgroundCreationResponse && this.renderStatus()}

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -343,7 +343,7 @@ class SamplesView extends React.Component {
         className={cs.action}
         disabled
         icon={saveIcon}
-        popupText={"Save a Background"}
+        popupText={"Background Model"}
         popupSubtitle="Select at least 2 samples"
       />
     ) : (
@@ -352,7 +352,7 @@ class SamplesView extends React.Component {
           <ToolbarIcon
             className={cs.action}
             icon={saveIcon}
-            popupText={"Save a Background"}
+            popupText={"Background Model"}
           />
         }
         selectedSampleIds={selectedSampleIds}

--- a/app/assets/src/components/views/samples/SamplesView.jsx
+++ b/app/assets/src/components/views/samples/SamplesView.jsx
@@ -343,7 +343,7 @@ class SamplesView extends React.Component {
         className={cs.action}
         disabled
         icon={saveIcon}
-        popupText={"Save a Collection"}
+        popupText={"Save a Background"}
         popupSubtitle="Select at least 2 samples"
       />
     ) : (
@@ -352,7 +352,7 @@ class SamplesView extends React.Component {
           <ToolbarIcon
             className={cs.action}
             icon={saveIcon}
-            popupText={"Save a Collection"}
+            popupText={"Save a Background"}
           />
         }
         selectedSampleIds={selectedSampleIds}

--- a/app/assets/src/components/views/samples/collection_modal.scss
+++ b/app/assets/src/components/views/samples/collection_modal.scss
@@ -8,8 +8,8 @@
     .label {
       @include font-body-s;
 
-      padding-top: 20px;
-      padding-bottom: 10px;
+      margin-top: 20px;
+      margin-bottom: 10px;
       font-weight: $font-weight-semibold;
 
       .optional {
@@ -62,6 +62,7 @@
   }
 
   .notification {
+    margin-top: 20px;
     margin-bottom: 20px;
   }
 }

--- a/app/assets/src/components/views/samples/collection_modal.scss
+++ b/app/assets/src/components/views/samples/collection_modal.scss
@@ -65,4 +65,10 @@
     margin-top: 20px;
     margin-bottom: 20px;
   }
+
+  .link {
+    // Overwrite <a> inherit rule in header.scss
+    color: $primary-light !important;
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
# Description

"Collections" were an unrealized generalization of the background concept. For the time being, it's better to use "background".

Before:
![image](https://user-images.githubusercontent.com/28797/74883144-2a7dbc00-5325-11ea-8c31-b9c34bee3ab7.png)

![image](https://user-images.githubusercontent.com/28797/74882866-b7744580-5324-11ea-93e7-12d9f6f3b621.png)

After: 
![image](https://user-images.githubusercontent.com/28797/74883137-28b3f880-5325-11ea-991f-cab6a65e0a8a.png)

![image](https://user-images.githubusercontent.com/28797/74882879-bb07cc80-5324-11ea-8d75-38f6ec66ac93.png)


# Notes

* I did this along with #3087 
* I searched the codebase for other instances of "collection" and found also `app/assets/src/components/Samples.jsx` which appears to be deprecated
* I noticed the tooltip for "save a background" is the only one that is the "verb object". the rest are simply "object" like "heatmap"
* I updated the background explanation to be a little more accurate
* It seems like it would be good to add some text about who can see a background

# Tests

* try dialog
* see text changes