### PR TITLE
IDSEQ-2287: Fix additional samples in phylo tree

### DIFF
--- a/app/controllers/phylo_trees_controller.rb
+++ b/app/controllers/phylo_trees_controller.rb
@@ -149,7 +149,7 @@ class PhyloTreesController < ApplicationController
 
     # Retrieve pipeline runs that contain the specified taxid.
     eligible_pipeline_runs = current_power.pipeline_runs.top_completed_runs
-    pipeline_run_ids_with_taxid = TaxonByterange.where(taxid: taxid).order(id: :desc).limit(PIPELINE_RUN_IDS_WITH_TAXID_LIMIT).pluck(:id)
+    pipeline_run_ids_with_taxid = TaxonByterange.where(taxid: taxid).order(id: :desc).limit(PIPELINE_RUN_IDS_WITH_TAXID_LIMIT).pluck(:pipeline_run_id)
     eligible_pipeline_run_ids_with_taxid =
       eligible_pipeline_runs.where(id: pipeline_run_ids_with_taxid)
                             .order(id: :desc).limit(ELIGIBLE_PIPELINE_RUNS_LIMIT).pluck(:id)


### PR DESCRIPTION
# Description

In a previous fix #3051 , I introduced a bug which prevented the results for "additional samples". 

![image](https://user-images.githubusercontent.com/28797/74885717-1f2d8f00-532b-11ea-9711-7464edc14ed6.png)

# Tests

* open phylo tree dialog
* see additional samples for "kleb"