### PR TITLE
Fix bug with uncontrolled inputs.

### DIFF
--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isUndefined, isArray } from "lodash/fp";
+import { isUndefined, isNull, isArray } from "lodash/fp";
 import cx from "classnames";
 
 import { UserContext } from "~/components/common/UserContext";
@@ -15,6 +15,14 @@ import AlertIcon from "~ui/icons/AlertIcon";
 import Toggle from "~ui/controls/Toggle";
 
 import cs from "./metadata_input.scss";
+
+// If value is undefined or null, an empty string should be displayed.
+// However, if the MetadataInput is re-used for different samples, and the second sample has no value
+// a particular metadata field, undefined will be passed to the MetadataInput for that field
+// and the first sample's metadata value will contain to be shown.
+// To avoid this, we explicitly pass in the empty string whenever the field is undefined or null.
+const ensureDefinedValue = value =>
+  isUndefined(value) || isNull(value) ? "" : value;
 
 class MetadataInput extends React.Component {
   constructor(props) {
@@ -118,9 +126,7 @@ class MetadataInput extends React.Component {
           className={className}
           onChange={val => onChange(metadataType.key, val)}
           onBlur={() => onSave && onSave(metadataType.key)}
-          // If value is undefined, an empty string should be displayed.
-          // We need to explicitly pass in the empty string. Otherwise, the previous value will be retained.
-          value={isUndefined(value) ? "" : value}
+          value={ensureDefinedValue(value)}
           placeholder={isHuman ? "YYYY-MM" : "YYYY-MM-DD"}
           type="text"
         />
@@ -164,9 +170,7 @@ class MetadataInput extends React.Component {
           className={className}
           onChange={val => onChange(metadataType.key, val)}
           onBlur={() => onSave && onSave(metadataType.key)}
-          // If value is undefined, an empty string should be displayed.
-          // We need to explicitly pass in the empty string. Otherwise, the previous value will be retained.
-          value={isUndefined(value) ? "" : value}
+          value={ensureDefinedValue(value)}
           type={metadataType.dataType === "number" ? "number" : "text"}
         />
       );

--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isArray } from "lodash/fp";
+import { isUndefined, isArray } from "lodash/fp";
 import cx from "classnames";
 
 import { UserContext } from "~/components/common/UserContext";
@@ -118,7 +118,9 @@ class MetadataInput extends React.Component {
           className={className}
           onChange={val => onChange(metadataType.key, val)}
           onBlur={() => onSave && onSave(metadataType.key)}
-          value={value}
+          // If value is undefined, an empty string should be displayed.
+          // We need to explicitly pass in the empty string. Otherwise, the previous value will be retained.
+          value={isUndefined(value) ? "" : value}
           placeholder={isHuman ? "YYYY-MM" : "YYYY-MM-DD"}
           type="text"
         />
@@ -162,7 +164,9 @@ class MetadataInput extends React.Component {
           className={className}
           onChange={val => onChange(metadataType.key, val)}
           onBlur={() => onSave && onSave(metadataType.key)}
-          value={value}
+          // If value is undefined, an empty string should be displayed.
+          // We need to explicitly pass in the empty string. Otherwise, the previous value will be retained.
+          value={isUndefined(value) ? "" : value}
           type={metadataType.dataType === "number" ? "number" : "text"}
         />
       );

--- a/app/assets/src/components/ui/controls/Input.jsx
+++ b/app/assets/src/components/ui/controls/Input.jsx
@@ -14,16 +14,12 @@ class Input extends React.Component {
   };
 
   render() {
-    let { className, disableAutocomplete, value, ...props } = this.props;
+    let { className, disableAutocomplete, ...props } = this.props;
     className = "idseq-ui " + className;
     return (
       <SemanticInput
         {...props}
         className={className}
-        // If undefined is passed to SemanticInput, the previous value of the input will continue to
-        // be displayed instead of an empty string.
-        // Therefore, we force an empty string to be passed.
-        value={value || ""}
         onChange={this.handleChange}
         // Chrome ignores autocomplete="off" on purpose, so use a non-standard
         // label. See: https://stackoverflow.com/questions/15738259/disabling-chrome-autofill

--- a/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
+++ b/app/assets/src/components/views/phylo_tree/PhyloTreeCreation.jsx
@@ -550,7 +550,6 @@ class PhyloTreeCreation extends React.Component {
                 }
                 placeholder="Tree Name"
                 onChange={this.handleNameChange}
-                value={this.state.treeName}
               />
             </div>
             {this.props.admin === 1 && (


### PR DESCRIPTION
# Description

This fixes a bug caused by a previous bug fix #3084.
The previous fix broke all uncontrolled inputs (you can no longer type in them).

This reverts the previous change, so now inputs can be both controlled and uncontrolled again.
It fixes the original bug in a different way, by making sure the empty-string is passed in by the caller of the Input.

# Tests

* Verified that broken inputs (heatmap metadata) now work.
* Verified that the original bug is still fixed. (by going through the Sample Upload process).
