### PR TITLE
[Data Discovery] Fix taxon filtering crash

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/AsyncMultipleDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/AsyncMultipleDropdown.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { find, unionBy } from "lodash/fp";
+import { find, unionBy, debounce } from "lodash/fp";
 import MultipleDropdown from "./MultipleDropdown";
-import { debounce } from "lodash/fp";
 const AUTOCOMPLETE_DEBOUNCE_DELAY = 200;
 
 class AsyncMultipleDropdown extends React.Component {

--- a/app/assets/src/components/ui/controls/dropdowns/AsyncMultipleDropdown.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/AsyncMultipleDropdown.jsx
@@ -60,12 +60,11 @@ class AsyncMultipleDropdown extends React.Component {
     const { selectedOptions } = this.state;
     let options = await onFilterChange(query);
 
-    // If the query has since changed, discard the response.
-    if (query != this._lastQuery) {
-      return;
+    // If the query has since changed, discard the response (don't do anything).
+    // Otherwise, update the state with the query response.
+    if (query == this._lastQuery) {
+      this.setState({ options: unionBy("value", options, selectedOptions) });
     }
-
-    this.setState({ options: unionBy("value", options, selectedOptions) });
   });
 
   render() {

--- a/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryFilters.jsx
@@ -160,7 +160,7 @@ class DiscoveryFilters extends React.Component {
           <TaxonFilter
             domain={domain}
             onChange={this.handleChange.bind(this, "taxonSelected")}
-            selected={taxonSelected}
+            selectedOptions={taxonSelected}
           />
           {this.renderTags("taxon")}
         </div>


### PR DESCRIPTION
# Description

See IDSEQ-2991.

(Warning, description is kind of long to detail my understanding of the problem since I'm not sure if the solution I went with is the most elegant one. Extremely open to other suggestions!)

**Issue**
After some experimentation, was able to pretty consistently replicate the crash and pinpoint the issue:
* Try filtering for taxon "Pneumocystis jirovecii" by typing "pn."
  * This will trigger **two** [search requests](https://github.com/chanzuckerberg/idseq-web/blob/de23afde0917e84adf1aa5c212a045d760a3a6f1/app/assets/src/components/common/filters/TaxonFilter.jsx#L11), one for the string "p" and another for the string "pn."
  * The search for "pn" is much quicker, so those results will always return first.
![image](https://user-images.githubusercontent.com/53838890/75075251-3fd42100-54b2-11ea-98b2-37fdddbb0720.png)
* Select "Pneumocystis jirovecii" and wait a little; you'll see the search results suddenly change.
![image](https://user-images.githubusercontent.com/53838890/75075320-6befa200-54b2-11ea-83c8-34f2c985955e.png)
  * This is caused by the results for the search for "p" returning.
  * At this point, the state of the `AsyncMultipleDropdown` and `MultipleDropdown` components have the dropdown *options* corresponding to the results for "p" (which **do not** include "Pneumocystis jirovecii") and the *selected option* of "Pneumocystis jirovecii."
* Close and reopen the dropdown menu to trigger the crash.
  * When trying to render the dropdown menu's options, `MultipleDropdown` will always try to display already [selected options on top](https://github.com/chanzuckerberg/idseq-web/blob/f4b1c8206ddbe0219e5881f70dca1ec08479ae5a/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx#L63), like so:
![image](https://user-images.githubusercontent.com/53838890/75075915-bcb3ca80-54b3-11ea-957f-35de1660b941.png)
  However, it does this by pulling the checked value from the [options](https://github.com/chanzuckerberg/idseq-web/blob/f4b1c8206ddbe0219e5881f70dca1ec08479ae5a/app/assets/src/components/ui/controls/dropdowns/MultipleDropdown.jsx#L66).
  * So in this case, `options` (results for "p" query) doesn't contain our already selected value ("Pneumocystis jirovecii," which came from a different query), and results in the `undefined` error.

**Fix**
I followed the pattern used in [TaxonHitSelect](https://github.com/chanzuckerberg/idseq-web/blob/84bd8eda2b415109e73e179930a87e88812cbe89/app/assets/src/components/views/bulk_download/TaxonHitSelect.jsx#L35):
* Debounce the `handleFilterChange` function in `AsyncMultipleDropdown` so that the search query would only be triggered after the user has stopped typing, rather than triggering a query for every keystroke.
* Additionally, after receiving the search results, check if the query has changed since making the request; if so, discard the response.

# Notes

* `TaxonFilter` seems to be the only DataDiscovery filter with this issue since it's the only one using `AsynMultipleDropdown`.
* Noticed that taxons would still be checked in the Taxon Filter dropdown menu even after removing the filter by clicking X on the label; found it was due to a typo (passing `selected` instead of `selectedOptions` into TaxonFilter from DiscoveryFilters), so fixed that as well.

# Tests

* Followed the flow detailed above and verified that the page no longer crashes.
* Also replicated the flow shown in the original JIRA ticket and verified that the page behaves as expected.
