### PR TITLE
Remove dead code from pipeline monitor

### DIFF
--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -88,7 +88,7 @@ module PipelineRunsHelper
       job_status = PipelineRunStage::STATUS_ERROR # transient error, job is still "in progress"
       job_status = PipelineRunStage::STATUS_FAILED if stderr =~ /IndexError/ # job no longer exists
     end
-    [job_status, job_log_id, job_hash, stdout]
+    [job_status, job_log_id, stdout]
   end
 
   def file_generated_since_run(record, s3_path)

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -125,7 +125,7 @@ class PhyloTree < ApplicationRecord
     # Detect if batch job has failed so we can stop polling for results.
     # Also, populate job_log_id.
     return if throttle && rand >= 0.1 # if throttling, do time-consuming aegea checks only 10% of the time
-    job_status, job_log_id_response, _job_hash, self.job_description = job_info(job_id, id)
+    job_status, job_log_id_response, self.job_description = job_info(job_id, id)
     self.job_log_id = job_log_id_response unless job_log_id # don't overwrite once it's been set (job_log_id_response could be nil after job has terminated)
     required_outputs = select_outputs("required")
     update_pipeline_version(self, :dag_version, dag_version_file) if job_status == "SUCCEEDED" && dag_version.blank?

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -137,12 +137,6 @@ class PipelineRunStage < ApplicationRecord
     end
   end
 
-  def instance_terminated?(job_hash)
-    job_hash['status'] == STATUS_FAILED &&
-      job_hash['statusReason'].start_with?("Host EC2 (instance") &&
-      job_hash['statusReason'].end_with?(") terminated.")
-  end
-
   def add_failed_job
     existing_failed_jobs = failed_jobs ? "#{failed_jobs}, " : ""
     new_failed_job = "[#{job_id}, #{job_log_id}]"
@@ -168,37 +162,15 @@ class PipelineRunStage < ApplicationRecord
     if failed? || succeeded?
       unless job_log_id
         # set log id if not set
-        _job_status, self.job_log_id, _job_hash, self.job_description = job_info(job_id, id)
+        _job_status, self.job_log_id, self.job_description = job_info(job_id, id)
         save
       end
       return
     end
     # The job appears to be in progress.  Check to make sure it hasn't been killed in AWS.   But not too frequently.
     return unless due_for_aegea_check?
-    self.job_status, self.job_log_id, job_hash, self.job_description = job_info(job_id, id)
-    if [STATUS_ERROR, STATUS_FAILED].include?(job_status)
-      save
-      return
-    end
-    unless instance_terminated?(job_hash)
-      save
-      return
-    end
-
-    # This code path is not being used anymore because we no longer use spot
-    # instances for the Batch jobs. Spot instances can be terminated at any time
-    # if someone bids more, so a retry is necessary. Now we use on-demand
-    # instances. If we decided to go back to spot instances, this code would
-    # ensure that terminated Batch jobs get resubmitted.
-
-    # note failed attempt and retry
-    add_failed_job
-    unless count_failed_tries <= MAX_RETRIES
-      LogUtil.log_err_and_airbrake("Job #{job_id} for pipeline run #{id} was killed #{MAX_RETRIES} times.")
-      save
-      return
-    end
-    run_job # this saves
+    self.job_status, self.job_log_id, self.job_description = job_info(job_id, id)
+    save
   end
 
   def terminate_job


### PR DESCRIPTION
# Description

It looks like the original intent was restarting the job when the reason for batch termination was a EC2 instance being terminated (supposedly killed by an evicted spot instance, but could be something else). We already have auto-restarts in a different part of the code, so this is redundant.

The code is marked as "not being used" for more than 2 years, and adds unnecessary complexity. So I'm removing it.

# Tests

* None