### PR TITLE
Append [Datadog] to alerting logs

### DIFF
--- a/app/jobs/autoscaling.py
+++ b/app/jobs/autoscaling.py
@@ -155,9 +155,11 @@ def autoscaling_update(config):
     except Exception as error:
         # If any error occurs while performing an autoscaling update, append [Datadog] to ensure that the log is
         # forwarded to Datadog.
-        # TODO(julie): Note that this is part of a temporary stopgap measure as we move away from Datadog and should be
+        # TODO(julie 2/25/20): Note that this is part of a temporary stopgap measure as we move away from Datadog and should be
         # reverted once we transition to CloudWatch (or other replacements).
+        # See JIRA IDSEQ-2236
         print "[Datadog] ", error
+        raise error
 
 
 def _default_json_serializer(obj):

--- a/app/jobs/compute_background.rb
+++ b/app/jobs/compute_background.rb
@@ -3,6 +3,6 @@ class ComputeBackground
   def self.perform(background_id)
     Background.find(background_id).store_summary
   rescue
-    LogUtil.log_err_and_airbrake("Background computation failed for background_id #{background_id}")
+    LogUtil.log_err_and_airbrake("[Datadog] Background computation failed for background_id #{background_id}")
   end
 end

--- a/app/jobs/result_monitor_loader.rb
+++ b/app/jobs/result_monitor_loader.rb
@@ -15,7 +15,7 @@ class ResultMonitorLoader
       # TODO: revisit this
       sleep(Time.now.to_i % 30)
       output_state.update(state: PipelineRun::STATUS_LOADING_ERROR)
-      message = "SampleFailedEvent: Pipeline Run #{pr.id} for Sample #{pr.sample.id} by #{pr.sample.user.email} failed loading #{output} with #{pr.adjusted_remaining_reads || 0} reads remaining after #{pr.duration_hrs} hours. See: #{pr.status_url}"
+      message = "[Datadog] SampleFailedEvent: Pipeline Run #{pr.id} for Sample #{pr.sample.id} by #{pr.sample.user.email} failed loading #{output} with #{pr.adjusted_remaining_reads || 0} reads remaining after #{pr.duration_hrs} hours. See: #{pr.status_url}"
       LogUtil.log_err_and_airbrake(message)
       raise
     end

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -132,7 +132,7 @@ class PhyloTree < ApplicationRecord
     if job_status == PipelineRunStage::STATUS_FAILED ||
        (job_status == "SUCCEEDED" && !required_outputs.all? { |ro| exists_in_s3?(s3_outputs[ro]["s3_path"]) })
       self.status = STATUS_FAILED
-      LogUtil.log_err_and_airbrake("Phylo tree creation failed for #{name} (#{id}). See #{log_url}.")
+      LogUtil.log_err_and_airbrake("[Datadog] Phylo tree creation failed for #{name} (#{id}). See #{log_url}.")
     end
     save
   end
@@ -146,7 +146,7 @@ class PhyloTree < ApplicationRecord
       self.status = STATUS_IN_PROGRESS
     else
       self.status = STATUS_FAILED
-      LogUtil.log_err_and_airbrake("Phylo tree failed to kick off for #{name} (#{id}).")
+      LogUtil.log_err_and_airbrake("[Datadog] Phylo tree failed to kick off for #{name} (#{id}).")
     end
     save
   end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -959,7 +959,7 @@ class PipelineRun < ApplicationRecord
     automatic_restart_text = automatic_restart ? "Automatic restart is being triggered. " : "** Manual action required **. "
     known_user_error = known_user_error ? "Known user error #{known_user_error}. " : ""
 
-    "SampleFailedEvent: Sample #{sample.id} by #{sample.user.role_name} failed #{prs.step_number}-#{prs.name} #{reads_remaining_text}" \
+    "[Datadog] SampleFailedEvent: Sample #{sample.id} by #{sample.user.role_name} failed #{prs.step_number}-#{prs.name} #{reads_remaining_text}" \
       "after #{duration_hrs} hours. #{automatic_restart_text}#{known_user_error}"\
       "See: #{status_url}"
   end
@@ -1015,7 +1015,7 @@ class PipelineRun < ApplicationRecord
       # NOTE (2019-08-02): Based on the last 3000 successful samples, only 0.17% took longer than 12 hours.
       threshold = 12.hours
       if run_time > threshold
-        msg = "LongRunningSampleEvent: Sample #{sample.id} by #{sample.user.role_name} has been running #{duration_hrs} hours. #{job_status_display} " \
+        msg = "[Datadog] LongRunningSampleEvent: Sample #{sample.id} by #{sample.user.role_name} has been running #{duration_hrs} hours. #{job_status_display} " \
           "See: #{status_url}"
         LogUtil.log_err_and_airbrake(msg)
         update(alert_sent: 1)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -394,7 +394,7 @@ class Sample < ApplicationRecord
     self.status = STATUS_UPLOADED
     save! # this triggers pipeline command
   rescue => e
-    LogUtil.log_err_and_airbrake("SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id}): #{e}")
+    LogUtil.log_err_and_airbrake("[Datadog] SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id}): #{e}")
     self.status = STATUS_CHECKED
     self.upload_error = Sample::UPLOAD_ERROR_S3_UPLOAD_FAILED
     save!

--- a/lib/tasks/pipeline_monitor.rake
+++ b/lib/tasks/pipeline_monitor.rake
@@ -80,9 +80,9 @@ class CheckPipelineRuns
     last_chunk_counts = autoscaling_state[:chunk_counts]
     new_chunk_counts = PipelineRun.count_alignment_chunks_in_progress
     if last_chunk_counts.nil?
-      Rails.logger.info("Autoscaling update to #{new_chunk_counts} chunks.")
+      Rails.logger.info("[Datadog] Autoscaling update to #{new_chunk_counts} chunks.")
     else
-      Rails.logger.info("Autoscaling update from #{last_chunk_counts} chunks to #{new_chunk_counts} chunks.")
+      Rails.logger.info("[Datadog] Autoscaling update from #{last_chunk_counts} chunks to #{new_chunk_counts} chunks.")
     end
     autoscaling_state[:t_last] = t_now
     autoscaling_state[:chunk_counts] = new_chunk_counts

--- a/lib/tasks/result_monitor.rake
+++ b/lib/tasks/result_monitor.rake
@@ -54,7 +54,7 @@ class MonitorPipelineResults
     samples = Sample.current_stalled_local_uploads(18.hours)
     unless samples.empty?
       LogUtil.log_err_and_airbrake(
-        "SampleFailedEvent: Failed to upload local samples after 18 hours #{samples.pluck(:id)}"
+        "[Datadog] SampleFailedEvent: Failed to upload local samples after 18 hours #{samples.pluck(:id)}"
       )
       samples.update_all( # rubocop:disable Rails/SkipsModelValidations
         status: Sample::STATUS_CHECKED,


### PR DESCRIPTION
# Description

See IDSEQ-2239.

As a temporary stopgap measure as we move away from using Datadog, relevant alerting log lines will have "[Datadog]" appended to the front, and only those logs will be sent via the Lambda. (The Lambda should probably be modified **after** this PR makes it into prod.)

# Notes

This should just be a temporary solution until the Datadog monitors are completely replaced.
