### PR TITLE
[Public] Add Basic Auth for preview and testing purposes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   # NOTE: This is for public preview purposes only and not regular user auth.
+  # If the AppConfig vars were not initially set, you may need to set them and
+  # restart the server.
   PUBLIC_PREVIEW_USER = AppConfigHelper.get_app_config(AppConfig::PUBLIC_PREVIEW_USER) || SecureRandom.base64
   PUBLIC_PREVIEW_KEY = AppConfigHelper.get_app_config(AppConfig::PUBLIC_PREVIEW_KEY) || SecureRandom.base64
   http_basic_authenticate_with name: PUBLIC_PREVIEW_USER, password: PUBLIC_PREVIEW_KEY

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  # NOTE: This is for public preview purposes only and not regular user auth.
+  PUBLIC_PREVIEW_USER = AppConfigHelper.get_app_config(AppConfig::PUBLIC_PREVIEW_USER) || SecureRandom.base64
+  PUBLIC_PREVIEW_KEY = AppConfigHelper.get_app_config(AppConfig::PUBLIC_PREVIEW_KEY) || SecureRandom.base64
+  http_basic_authenticate_with name: PUBLIC_PREVIEW_USER, password: PUBLIC_PREVIEW_KEY
+
   before_action :authenticate_user!
   before_action :check_for_maintenance
   before_action :check_rack_mini_profiler

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -33,4 +33,7 @@ class AppConfig < ApplicationRecord
   PUBLIC_FAMILY_1_URL = 'public_family_1_url'.freeze
   PUBLIC_FAMILY_2_URL = 'public_family_2_url'.freeze
   PUBLIC_FAMILY_3_URL = 'public_family_3_url'.freeze
+  # Control for public preview.
+  PUBLIC_PREVIEW_USER = 'public_preview_user'.freeze
+  PUBLIC_PREVIEW_KEY = 'public_preview_key'.freeze
 end

--- a/config/initializers/auth0.rb
+++ b/config/initializers/auth0.rb
@@ -1,8 +1,9 @@
 require 'digest/sha1'
 
-Rails.application.config.middleware.use Warden::Manager do |manager|
-  manager.failure_app = proc { |_env| ['401', { 'Content-Type' => 'application/json' }, { error: 'Unauthorized', code: 401 }] }
-end
+# Replaced with Basic Auth in ApplicationController for preview purposes.
+# Rails.application.config.middleware.use Warden::Manager do |manager|
+#   manager.failure_app = proc { |_env| ['401', { 'Content-Type' => 'application/json' }, { error: 'Unauthorized', code: 401 }] }
+# end
 
 Warden::Manager.serialize_into_session do |user|
   # convert to warden_session_obj

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,7 @@ Rails.application.routes.draw do
     get :sample_locations, on: :collection
   end
 
+  # Replaced Warden 'authenticate' with BasicAuth in ApplicationController.
   # authenticate :auth0_user, ->(u) { u.admin? } do
   #   mount RESQUE_SERVER, at: "/resque"
   # end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,9 +177,9 @@ Rails.application.routes.draw do
     get :sample_locations, on: :collection
   end
 
-  authenticate :auth0_user, ->(u) { u.admin? } do
-    mount RESQUE_SERVER, at: "/resque"
-  end
+  # authenticate :auth0_user, ->(u) { u.admin? } do
+  #   mount RESQUE_SERVER, at: "/resque"
+  # end
 
   # See health_check gem
   get 'health_check' => "health_check/health_check#index"


### PR DESCRIPTION
### Description
- We agreed to add Basic Auth in the interim (as opposed to no auth whatsoever) to facilitate previewing the site. We can take this away later.

### Tests
- You can test in the browser normally at `http://localhost:3000/` or with a command like `curl -v http://user:password@localhost:3000`