### PR TITLE
Ensure correct length of abbreviated git sha during deployments

### DIFF
--- a/bin/deploy_automation/_shared_functions.sh
+++ b/bin/deploy_automation/_shared_functions.sh
@@ -26,7 +26,7 @@ _trace() {
 
 _get_latest_commit() {
   declare git_rev="$1" # https://git-scm.com/docs/git-rev-parse#_specifying_revisions
-  git log -n 1 --pretty=format:"%h" "$git_rev"
+  git log -n 1 --pretty=format:"%h" "$git_rev" --abbrev=8
 }
 
 _fetch_current_release_checklist_from_github() {

--- a/bin/deploy_automation/close_release_cycle.sh
+++ b/bin/deploy_automation/close_release_cycle.sh
@@ -56,7 +56,7 @@ main() {
 
   # deploy instructions
   _log "Release cycle $staging_tag_version successfully closed." \
-       "Please deploy ${tag} ($(git log -n1 "${tag}" --format=%h)) to ${PROD_ENV}"
+       "Please deploy ${tag} ($(git log -n1 "${tag}" --format=%h --abbrev=8)) to ${PROD_ENV}"
 }
 
 main "$@"

--- a/bin/deploy_automation/deploy_rev.sh
+++ b/bin/deploy_automation/deploy_rev.sh
@@ -13,7 +13,7 @@ main() {
 
   _git_fetch_and_cleanup
 
-  declare sha; sha=$(git log -n1 "${git_rev}" --format=%h)
+  declare sha; sha=$(git log -n1 "${git_rev}" --format=%h --abbrev=8)
   declare docker_image="${DOCKER_REPOSITORY_NAME}:sha-$sha"
 
   _log "Starting deployment of $git_rev (sha-$sha) to $env"

--- a/bin/deploy_automation/make_release_checklist.sh
+++ b/bin/deploy_automation/make_release_checklist.sh
@@ -27,7 +27,7 @@ __make_release_checklist() {
   declare release_checklist_body; release_checklist_body=$(
     echo "# Release checklist"
     echo "_Please check your commits after testing:_"
-    git log --date-order --pretty=format:$'### %an\t* [ ] %h - % %s %d (%cD)' "${target_commit}..${source_commit}" \
+    git log --date-order --abbrev=8 --pretty=format:$'### %an\t* [ ] %h - % %s %d (%cD)' "${target_commit}..${source_commit}" \
       | awk -F $'\t' '{ a[$1] = a[$1] "\n" $2; } END { for (i in a) print i a[i]; }'
     echo
     echo "_(included commits: ($source_commit)..($target_commit), created on $(date '+%Y-%m-%d %H:%M:%S'))_"

--- a/bin/deploy_automation/start_release_cycle.sh
+++ b/bin/deploy_automation/start_release_cycle.sh
@@ -51,7 +51,7 @@ main() {
   git tag -a -m "Started release cycle $next_version" "${tag}" "origin/$MASTER_BRANCH"
 
   # point staging branch head to master
-  declare sha; sha=$(git log -n1 "${tag}" --format=%h)
+  declare sha; sha=$(git log -n1 "${tag}" --format=%h --abbrev=8)
   _log "Pointing ${STAGING_BRANCH} branch to tag ${tag}..."
   git branch -f "${STAGING_BRANCH}" "${sha}"
 
@@ -63,7 +63,7 @@ main() {
 
   # deploy instructions
   _log "Release cycle ready." \
-       "Please deploy ${tag} ($(git log -n1 "${tag}" --format=%h)) to ${STAGING_ENV}"
+       "Please deploy ${tag} ($(git log -n1 "${tag}" --format=%h --abbrev=8)) to ${STAGING_ENV}"
 }
 
 main "$@"

--- a/bin/deploy_automation/update_release_checklist.sh
+++ b/bin/deploy_automation/update_release_checklist.sh
@@ -64,7 +64,7 @@ __add_commits_to_checklist_body() {
 
   declare old_IFS="$IFS"
   IFS=$'\n'
-  for commit in $(git log --date-order --pretty=format:$'* [ ] %h - % %s %d (%cD) **%an**' "${source_commit}..${target_commit}")
+  for commit in $(git log --date-order --abbrev=8 --pretty=format:$'* [ ] %h - % %s %d (%cD) **%an**' "${source_commit}..${target_commit}")
   do
     declare sha="${commit:6:8}"
     if ( grep -qE '^\* \[.\]\s*'"$sha"' - ' <<< "$new_checklist_body" )


### PR DESCRIPTION
# Description

This change ensures we are retrieving the abbreviated git sha with the correct length to infer the Docker image name during deployments, regardless any specific local git configuration.

# Tests

* Manual
