### PR TITLE
Migrate from Dockerhub to Amazon ECR.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,13 +82,14 @@ jobs:
         - ./node_modules/.bin/eslint app/assets/src --ext .js,.jsx
         - npm test
     - name: "Docker Build"
-      language: python
+      language: shell
       services:
         - docker
       cache: pip
       before_script:
         # Need to install the AWS command line to authenticate to ECR.
-        - pip install awscli
+        # Need to use user to avoid permission error on Travis CI when using shell language.
+        - pip install --user awscli
         # Need to set the region to do ECR authentication.
         - aws configure set default.region ${AWS_REGION}
         - $(aws ecr get-login --no-include-email)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 addons:
   # Emulate docker compose routing
   #   Docker compose maps the host db and redis to the mysql and redis containers
-  #   We are using travis-ci services, which use localhost, for testing instead of docker compose 
+  #   We are using travis-ci services, which use localhost, for testing instead of docker compose
   #   we need to map these hosts to localhost to maintain compatibility between the two.
   hosts:
     - db
@@ -70,7 +70,7 @@ jobs:
       before_install:
         # Upgrade bundler to v2 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
         - gem install bundler
-      script: 
+      script:
         - bundle exec rubocop -R --config .rubocop_todo.yml
         # Block on High Confidence warnings
         - bundle exec brakeman --no-pager -w3
@@ -82,9 +82,16 @@ jobs:
         - ./node_modules/.bin/eslint app/assets/src --ext .js,.jsx
         - npm test
     - name: "Docker Build"
-      language: shell
+      language: python
       services:
         - docker
+      cache: pip
+      before_script:
+        # Need to install the AWS command line to authenticate to ECR.
+        - pip install awscli
+        # Need to set the region to do ECR authentication.
+        - aws configure set default.region ${AWS_REGION}
+        - $(aws ecr get-login --no-include-email)
       script:
         - bin/build-docker $TRAVIS_BRANCH ${TRAVIS_COMMIT::8}
         - bin/push-docker $TRAVIS_BRANCH ${TRAVIS_COMMIT::8}

--- a/bin/build-docker
+++ b/bin/build-docker
@@ -1,4 +1,6 @@
 #!/bin/bash
+# NOTE: We push all created tags to the Docker repo, but only the commit, branch, and latest tags matter.
+# Cache and compose are noise.
 set -e
 
 export REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web"

--- a/bin/build-docker
+++ b/bin/build-docker
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export REPO=chanzuckerberg/idseq-web
+export REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web"
 
 BRANCH="$1"
 BRANCH_CLEANED=`echo $BRANCH | sed 's/\//-/g'`
@@ -20,8 +20,8 @@ echo '--'
 
 # Try to pull the latest image for this branch, otherwise pull latest image for caching
 if ! ( docker pull $BRANCH_TAG && docker tag $BRANCH_TAG $CACHE_TAG ); then
-  docker pull $LATEST_TAG
-  docker tag $LATEST_TAG $CACHE_TAG
+  # If we fail to fetch the latest image, continue the build without a cache image.
+  (docker pull $LATEST_TAG && docker tag $LATEST_TAG $CACHE_TAG) || true
 fi
 
 docker build -t $COMPOSE_TAG --cache-from $CACHE_TAG --build-arg GIT_COMMIT=${COMMIT} .

--- a/bin/deploy
+++ b/bin/deploy
@@ -63,6 +63,7 @@ end
 
 def post_slack_message(payload, slack_hook)
   puts `curl -X POST --data-urlencode payload=#{Shellwords.escape(JSON.dump(payload))} #{slack_hook}`
+
 end
 
 def tags_and_branches(image)
@@ -79,15 +80,16 @@ notify_slack(env, image, "start")
 begin
   os = RbConfig::CONFIG['host_os'] =~ /darwin/ ? 'darwin' : 'linux'
   system!("curl -L https://github.com/chanzuckerberg/czecs/releases/download/v0.1.1/czecs_0.1.1_#{os}_amd64.tar.gz | tar xz -C /tmp czecs")
-  task_definition_arn = `/tmp/czecs register --quiet -f balances.json --set tag=#{image} --set env=#{env} czecs.json`.strip
+  system!("export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query='Account' | tr -d '\"')")
+  task_definition_arn = `/tmp/czecs register -f balances.json --set tag=#{image} --set env=#{env} --set account_id=$AWS_ACCOUNT_ID czecs.json`.strip
   $?.exitstatus == 0 || abort("\n== Could not register task ==\n")
   puts 'running migrations'
   system!("/tmp/czecs task -f balances.json --timeout 0 --set taskDefinitionArn=#{task_definition_arn} --set cluster=#{cluster} czecs-task-migrate.json")
   system!("/tmp/czecs upgrade --task-definition-arn #{task_definition_arn} #{cluster} idseq-#{env}-web")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers #{cluster} idseq-#{env}-resque czecs-resque.json")
+  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers --set account_id=$AWS_ACCOUNT_ID #{cluster} idseq-#{env}-resque czecs-resque.json")
   unless env == "sandbox"
-    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
-    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor #{cluster} idseq-#{env}-resque-result-monitor czecs-resque.json")
+    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor --set account_id=$AWS_ACCOUNT_ID #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
+    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor --set account_id=$AWS_ACCOUNT_ID #{cluster} idseq-#{env}-resque-result-monitor czecs-resque.json")
   end
   notify_slack(env, image, "end")
 rescue Exception  # Even on abort/SystemExit

--- a/bin/deploy
+++ b/bin/deploy
@@ -63,7 +63,6 @@ end
 
 def post_slack_message(payload, slack_hook)
   puts `curl -X POST --data-urlencode payload=#{Shellwords.escape(JSON.dump(payload))} #{slack_hook}`
-
 end
 
 def tags_and_branches(image)
@@ -80,16 +79,16 @@ notify_slack(env, image, "start")
 begin
   os = RbConfig::CONFIG['host_os'] =~ /darwin/ ? 'darwin' : 'linux'
   system!("curl -L https://github.com/chanzuckerberg/czecs/releases/download/v0.1.1/czecs_0.1.1_#{os}_amd64.tar.gz | tar xz -C /tmp czecs")
-  system!("export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query='Account' | tr -d '\"')")
-  task_definition_arn = `/tmp/czecs register -f balances.json --set tag=#{image} --set env=#{env} --set account_id=$AWS_ACCOUNT_ID czecs.json`.strip
+  aws_account_id = `aws sts get-caller-identity --query="Account" | tr -d '\"'`.strip
+  task_definition_arn = `/tmp/czecs register -f balances.json --set tag=#{image} --set env=#{env} --set account_id=#{aws_account_id} czecs.json`.strip
   $?.exitstatus == 0 || abort("\n== Could not register task ==\n")
   puts 'running migrations'
   system!("/tmp/czecs task -f balances.json --timeout 0 --set taskDefinitionArn=#{task_definition_arn} --set cluster=#{cluster} czecs-task-migrate.json")
   system!("/tmp/czecs upgrade --task-definition-arn #{task_definition_arn} #{cluster} idseq-#{env}-web")
-  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers --set account_id=$AWS_ACCOUNT_ID #{cluster} idseq-#{env}-resque czecs-resque.json")
+  system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque --set rake_command=resque:workers --set account_id=#{aws_account_id} #{cluster} idseq-#{env}-resque czecs-resque.json")
   unless env == "sandbox"
-    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor --set account_id=$AWS_ACCOUNT_ID #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
-    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor --set account_id=$AWS_ACCOUNT_ID #{cluster} idseq-#{env}-resque-result-monitor czecs-resque.json")
+    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-pipeline-monitor --set rake_command=pipeline_monitor --set account_id=#{aws_account_id} #{cluster} idseq-#{env}-resque-pipeline-monitor czecs-resque.json")
+    system!("/tmp/czecs upgrade -f balances.json --set tag=#{image} --set env=#{env} --set name=resque-result-monitor --set rake_command=result_monitor --set account_id=#{aws_account_id} #{cluster} idseq-#{env}-resque-result-monitor czecs-resque.json")
   end
   notify_slack(env, image, "end")
 rescue Exception  # Even on abort/SystemExit

--- a/bin/push-docker
+++ b/bin/push-docker
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export REPO=chanzuckerberg/idseq-web
+export REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web"
 
 BRANCH="branch-$1"
 COMMIT="sha-$2"
@@ -10,25 +10,6 @@ echo $COMMIT
 echo $REPO
 echo $TAG
 echo '--'
-
-# Retry up to 5 times total if failed Docker login
-run=1
-count=1
-while [ $run -eq 1 ] ; do
-    echo "Trying Docker login..."
-    docker login -u $DOCKER_USER -p $DOCKER_PASS
-    if [ $? -eq 0 ]; then  # Success
-        run=0
-        break
-    fi
-    if [ $count -ge 5 ]; then
-        run=0
-        echo "Error: Exceeded retries with Docker."
-        exit 1
-    fi
-    count=$((count+1))
-    sleep 15
-done
 
 # Retry up to 5 times total if failed Docker push
 run=1

--- a/bin/push-docker
+++ b/bin/push-docker
@@ -1,4 +1,6 @@
 #!/bin/bash
+# NOTE: We push all created tags to the Docker repo, but only the commit, branch, and latest tags matter.
+# Cache and compose are noise.
 
 export REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web"
 

--- a/bin/push-docker
+++ b/bin/push-docker
@@ -11,19 +11,20 @@ echo $REPO
 echo $TAG
 echo '--'
 
-# Retry up to 5 times total if failed Docker push
+# Retry up to 5 times total if we fail to push to Amazon ECR
 run=1
 count=1
 while [ $run -eq 1 ] ; do
-    echo "Trying Docker push..."
+    echo "Trying Amazon ECR push..."
     docker push $REPO
     if [ $? -eq 0 ]; then  # Success
         run=0
         break
     fi
+    echo "Failed. Trying again in 15s..."
     if [ $count -ge 5 ]; then
         run=0
-        echo "Error: Exceeded retries with Docker."
+        echo "Error: Exceeded max retries pushing to Amazon ECR."
         exit 1
     fi
     count=$((count+1))

--- a/czecs-resque.json
+++ b/czecs-resque.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [
     {
       "name": "idseq-{{ .Values.name }}",
-      "image": "chanzuckerberg/idseq-web:{{ .Values.tag }}",
+      "image": "{{ .Values.account_id }}.dkr.ecr.{{ .Values.region }}.amazonaws.com/idseq-web:{{ .Values.tag }}",
       "cpu": 1024,
       "memoryReservation": 3072,
       "essential": true,

--- a/czecs.json
+++ b/czecs.json
@@ -3,7 +3,7 @@
   "containerDefinitions": [
     {
       "name": "rails",
-      "image": "chanzuckerberg/idseq-web:{{ .Values.tag }}",
+      "image": "{{ .Values.account_id }}.dkr.ecr.{{ .Values.region }}.amazonaws.com/idseq-web:{{ .Values.tag }}",
       "cpu": 2048,
       "memoryReservation": 7168,
       "essential": true,


### PR DESCRIPTION
# Description

* Change the travis-ci build/push scripts and deployment scripts to use ECR for the docker registry.

# Notes
* Created new idseq-web ECR repo.
* Also needed to add appropriate permissions to travis-ci IAM role. These permissions are scoped to only the newly created idseq-web ECR repo.
* AWS authentication on Travis CI relies on Travis CI repository variables already set on the idseq-web repo in Travis CI. The only variable we needed to add was the aws account id.

# Tests

* Verified that Travis CI builds successfully. Verified that Travis CI properly uses cached image on subsequent builds (and speeds up from 8m to 3m).
* Verified that deployment to sandbox environment succeeds.
