### PR TITLE
Handle null readsAfter case

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -125,7 +125,9 @@ class PipelineTab extends React.Component {
           />
         </div>
         <div className={cs.narrowMetadataValueContainer}>
-          <div className={cs.metadataValue}>{readsAfter.toLocaleString()}</div>
+          <div className={cs.metadataValue}>
+            {readsAfter && readsAfter.toLocaleString()}
+          </div>
         </div>
         <div className={cs.narrowMetadataValueContainer}>
           <div className={cs.metadataValue}>{percentReads}%</div>

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -126,7 +126,7 @@ class PipelineTab extends React.Component {
         </div>
         <div className={cs.narrowMetadataValueContainer}>
           <div className={cs.metadataValue}>
-            {readsAfter && readsAfter.toLocaleString()}
+            {readsAfter ? readsAfter.toLocaleString() : ""}
           </div>
         </div>
         <div className={cs.narrowMetadataValueContainer}>


### PR DESCRIPTION
# Description

I noticed a bug when I was refreshing the page and looking at the sample details panel a lot. For a brief period of time `readsAfter` for a certain step is null. This is normally fine but we call a method on it creating a WSOD (aside from the top bar).

# Tests

It still works with it. It is a bit hard to reproduce. I think this is a very safe change.
