### PR TITLE
Filter out user created host genomes from metadata dict

### DIFF
--- a/app/assets/src/components/views/metadata/MetadataDictionary.jsx
+++ b/app/assets/src/components/views/metadata/MetadataDictionary.jsx
@@ -49,6 +49,8 @@ class MetadataDictionary extends React.Component {
       officialFields
     );
 
+    hostGenomes = hostGenomes.filter(hg => hg.showAsOption);
+
     this.setState({
       officialFields,
       hostGenomes,


### PR DESCRIPTION
# Description

As title. I forgot this callsite. 

![image](https://user-images.githubusercontent.com/28797/75599620-9796fd00-5a5b-11ea-8650-d2e7b7a85746.png)


# Tests

* open metadata dict
* see only admin created hosts