### PR TITLE
Always hide additional output from host filtering

### DIFF
--- a/app/services/retrieve_pipeline_viz_graph_data_service.rb
+++ b/app/services/retrieve_pipeline_viz_graph_data_service.rb
@@ -241,7 +241,10 @@ class RetrievePipelineVizGraphDataService
 
   def remove_host_filtering_urls(edges)
     edges.each do |edge|
-      if (edge[:to] && edge[:to][:stageIndex].zero?) || edge[:from].nil?
+      to_host_filtering = edge[:to] && edge[:to][:stageIndex].zero?
+      from_nowhere = edge[:from].nil?
+      host_filtering_additional_output = edge[:from] && edge[:from][:stageIndex].zero? && edge[:to].nil?
+      if to_host_filtering || from_nowhere || host_filtering_additional_output
         edge[:files].each { |file| file[:url] = nil }
       end
     end


### PR DESCRIPTION
# Description

Prevents downloading additional outputs in the pipeline viz.

Opposite of https://github.com/chanzuckerberg/idseq-web/pull/3120.

# Testing

I spun up my local environment with the pipeline runs from my previous tests. I hard-coded hiding host filtering files by setting that modifier to true (so it will treat me as if I don't own the samples). I checked all of the cases (errored case, having files, not having files, steps with additional outputs, normal steps). I checked in both the pipeline viz and the results folder.
