### PR TITLE
[Release fix] Always hide additional output from host filtering

### DIFF
--- a/app/services/retrieve_pipeline_viz_graph_data_service.rb
+++ b/app/services/retrieve_pipeline_viz_graph_data_service.rb
@@ -240,8 +240,17 @@ class RetrievePipelineVizGraphDataService
   end
 
   def remove_host_filtering_urls(edges)
+    # Removing host filtering URLs is important because the host filtering files
+    #  may contain PGI. Removing the urls stops them from being downloadable.
     edges.each do |edge|
-      if (edge[:to] && edge[:to][:stageIndex].zero?) || edge[:from].nil?
+      to_host_filtering = edge[:to] && edge[:to][:stageIndex].zero?
+      from_nowhere = edge[:from].nil?
+      # Also remove the URLs of additional output from the host filtering stage
+      #  Additional output has no :to so it won't be caught in `to_host_filtering`.
+      #  These are removed for safety (in case one is added that still contains PGI)
+      #  and so that they are consist with the other host filtering files.
+      host_filtering_additional_output = edge[:from] && edge[:from][:stageIndex].zero? && edge[:to].nil?
+      if to_host_filtering || from_nowhere || host_filtering_additional_output
         edge[:files].each { |file| file[:url] = nil }
       end
     end


### PR DESCRIPTION
# Description

Prevents downloading additional outputs in the pipeline viz.

# Testing

I spun up my local environment with the pipeline runs from my previous tests. I hard-coded hiding host filtering files by setting that modifier to true (so it will treat me as if I don't own the samples). I checked all of the cases (errored case, having files, not having files, steps with additional outputs, normal steps). I checked in both the pipeline viz and the results folder.
