### PR TITLE
Update default alignment config date for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Shared variables using Docker x- extension and YAML merging syntax.
 
 x-web-variables: &web-variables
-  ? ALIGNMENT_CONFIG_DEFAULT_NAME=2020-02-03
+  ? ALIGNMENT_CONFIG_DEFAULT_NAME=2020-02-10
   ? SAMPLES_BUCKET_NAME=idseq-samples-development
   ? ES_ADDRESS=http://elasticsearch:9200
   ? AIRBRAKE_PROJECT_ID


### PR DESCRIPTION
### Description
- Update hardcoded '2020-02-03' reference that is used in local dev.

### Notes
- Thanks Lucia for reminding me to update this.
- The docker-compose.yml default gets overwritten as long as the env variables are loaded from Parameter Store, but in local development that's not usually the case. I don't see an obvious way to change this besides always loading from Parameter Store (?).
- See: https://github.com/chanzuckerberg/idseq-web/pull/3060