### PR TITLE
Insert Metrics Link Update + Allow Bold in viz

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
+++ b/app/assets/src/components/common/DetailsSidebar/PipelineStepDetailsMode/pipeline_step_details_mode.scss
@@ -120,10 +120,6 @@
     // Override color: inherit in _header.scss.
     color: $primary-light !important;
   }
-
-  strong {
-    font-weight: inherit; // Override bolding from markdown.
-  }
 }
 
 .fileLink {

--- a/app/assets/src/components/views/samples/constants.js
+++ b/app/assets/src/components/views/samples/constants.js
@@ -69,7 +69,7 @@ export const SAMPLE_TABLE_COLUMNS_V2 = {
   meanInsertSize: {
     tooltip:
       "Mean length of the fragmented nucleic acid sequences input for sequencing.",
-    link: DOC_BASE_LINK + "360034790554-Pipeline-Details",
+    link: DOC_BASE_LINK + "360034790554#mean-insert-size",
   },
 };
 


### PR DESCRIPTION
# Description

- Updates the link for insert size metrics to an anchor link for the specific description
- Remove a style that suppressed bolds in step descriptions in the pipeline viz.

# Tests

Tested the link locally
Looked at every pipeline step description for several pipeline runs, with and without insert metrics.
