### PR TITLE
Fix issue with jq on linux

### DIFF
--- a/bin/deploy_automation/_shared_functions.sh
+++ b/bin/deploy_automation/_shared_functions.sh
@@ -47,7 +47,7 @@ _assert_no_release_checklist() {
 }
 
 _get_current_release_checklist_json() {
-  if ! (_fetch_current_release_checklist_from_github | jq -e); then
+  if ! _fetch_current_release_checklist_from_github | jq -e .; then
     _exit_with_err_msg "INVALID STATE: Couldn't find an open release checklist."
   fi
 }


### PR DESCRIPTION
# Description

`jq` has an inconsistent behavior in linux, where `jq -e` would fail. Rewriting the command as `jq -e .` produces the expected results in both osx and linux.

I also removed the parentheses surrounding this command, since a sub-shell isn't necessary in this case.

# Tests

* Manual
