### PR TITLE
[Public] Remove HTTP Authentication configuration + add link

### DIFF
--- a/app/assets/src/components/common/CoverageVizBottomSidebar/HitGroupViz.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/HitGroupViz.jsx
@@ -18,6 +18,8 @@ import { getTooltipStyle } from "~/components/utils/tooltip";
 import cs from "./coverage_viz_bottom_sidebar.scss";
 import { generateContigReadVizData, getGenomeVizTooltipData } from "./utils";
 
+const NCOV_PUBLIC_SITE = true;
+
 const DEFAULT_CONTIG_COPY_MESSAGE = "Copy Contig Sequence to Clipboard";
 
 const totalByterangeLength = byteranges =>
@@ -291,7 +293,8 @@ export default class HitGroupViz extends React.Component {
         {genomeVizTooltipLocation &&
           genomeVizTooltipData &&
           this.renderGenomeVizTooltip()}
-        {contigDownloaderLocation &&
+        {!NCOV_PUBLIC_SITE &&
+          contigDownloaderLocation &&
           contigDownloaderData &&
           this.renderContigDownloader()}
       </div>

--- a/app/assets/src/components/views/support/PublicNcovHomepage.jsx
+++ b/app/assets/src/components/views/support/PublicNcovHomepage.jsx
@@ -95,6 +95,18 @@ export default class PublicNcovHomepage extends React.Component {
       </ExternalLink>
     );
 
+    const MANUSCRIPT_LINK = (
+      <ExternalLink
+        className={cs.link}
+        href={appConfig.publicManuscriptUrl}
+        onClick={() =>
+          logAnalyticsEvent("PublicNCovHomePage_manuscript-link_clicked")
+        }
+      >
+        a rapidly implemented response to the nCOV-2019 outbreak (manuscript)
+      </ExternalLink>
+    );
+
     return (
       <NarrowContainer className={cs.publicNcovHomepage} size="small">
         <div className={cs.title}>
@@ -130,11 +142,10 @@ export default class PublicNcovHomepage extends React.Component {
         </p>
         <h2>About</h2>
         <p className={cs.large}>
-          In a rapidly implemented response to the nCOV-2019 outbreak, the{" "}
-          NIH-CNM team and Institut Pasteur used metagenomic next-generation
-          sequencing (mNGS) and the IDseq bioinformatics platform to review the
-          Cambodian index nCOV-2019 case in less than 48 hours from sample
-          receipt.
+          In {MANUSCRIPT_LINK}, the NIH-CNM team and Institut Pasteur used
+          metagenomic next-generation sequencing (mNGS) and the IDseq
+          bioinformatics platform to review the Cambodian index nCOV-2019 case
+          in less than 48 hours from sample receipt.
         </p>
         <p className={cs.large}>This project had 2 goals:</p>
         <ol>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  # NOTE: This is for public preview purposes only and not regular user auth.
-  # If the AppConfig vars were not initially set, you may need to set them and
-  # restart the server.
-  PUBLIC_PREVIEW_USER = AppConfigHelper.get_app_config(AppConfig::PUBLIC_PREVIEW_USER) || SecureRandom.base64
-  PUBLIC_PREVIEW_KEY = AppConfigHelper.get_app_config(AppConfig::PUBLIC_PREVIEW_KEY) || SecureRandom.base64
-  http_basic_authenticate_with name: PUBLIC_PREVIEW_USER, password: PUBLIC_PREVIEW_KEY
-
   before_action :authenticate_user!
   before_action :check_for_maintenance
   before_action :check_rack_mini_profiler

--- a/app/helpers/app_config_helper.rb
+++ b/app/helpers/app_config_helper.rb
@@ -44,6 +44,7 @@ module AppConfigHelper
                            AppConfig::PUBLIC_INDEX_CASE_URL_RESEQUENCED,
                            AppConfig::PUBLIC_INDEX_CASE_URL_ENRICHED,
                            AppConfig::PUBLIC_PROTOCOL_URL,
+                           AppConfig::PUBLIC_MANUSCRIPT_URL,
                          ])
                   .map { |app_config| [app_config.key, app_config.value] }
                   .to_h
@@ -60,6 +61,7 @@ module AppConfigHelper
       publicIndexCaseUrlResequenced: app_configs[AppConfig::PUBLIC_INDEX_CASE_URL_RESEQUENCED],
       publicIndexCaseUrlEnriched: app_configs[AppConfig::PUBLIC_INDEX_CASE_URL_ENRICHED],
       publicProtocolUrl: app_configs[AppConfig::PUBLIC_PROTOCOL_URL],
+      publicManuscriptUrl: app_configs[AppConfig::PUBLIC_MANUSCRIPT_URL],
     }
   end
 end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -30,8 +30,5 @@ class AppConfig < ApplicationRecord
   PUBLIC_INDEX_CASE_URL_WITH_OLD_PIPELINE = 'public_index_case_url_with_old_pipeline'.freeze
   PUBLIC_INDEX_CASE_URL_RESEQUENCED = 'public_index_case_url_resequenced'.freeze
   PUBLIC_INDEX_CASE_URL_ENRICHED = 'public_index_case_url_enriched'.freeze
-  # Control for public preview.
-  PUBLIC_PREVIEW_USER = 'public_preview_user'.freeze
-  PUBLIC_PREVIEW_KEY = 'public_preview_key'.freeze
   PUBLIC_PROTOCOL_URL = 'public_protocol_url'.freeze
 end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -31,4 +31,5 @@ class AppConfig < ApplicationRecord
   PUBLIC_INDEX_CASE_URL_RESEQUENCED = 'public_index_case_url_resequenced'.freeze
   PUBLIC_INDEX_CASE_URL_ENRICHED = 'public_index_case_url_enriched'.freeze
   PUBLIC_PROTOCOL_URL = 'public_protocol_url'.freeze
+  PUBLIC_MANUSCRIPT_URL = 'public_manuscript_url'.freeze
 end

--- a/config/initializers/auth0.rb
+++ b/config/initializers/auth0.rb
@@ -1,9 +1,8 @@
 require 'digest/sha1'
 
-# Replaced with Basic Auth in ApplicationController for preview purposes.
-# Rails.application.config.middleware.use Warden::Manager do |manager|
-#   manager.failure_app = proc { |_env| ['401', { 'Content-Type' => 'application/json' }, { error: 'Unauthorized', code: 401 }] }
-# end
+Rails.application.config.middleware.use Warden::Manager do |manager|
+  manager.failure_app = proc { |_env| ['401', { 'Content-Type' => 'application/json' }, { error: 'Unauthorized', code: 401 }] }
+end
 
 Warden::Manager.serialize_into_session do |user|
   # convert to warden_session_obj

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,10 +177,9 @@ Rails.application.routes.draw do
     get :sample_locations, on: :collection
   end
 
-  # Replaced Warden 'authenticate' with BasicAuth in ApplicationController.
-  # authenticate :auth0_user, ->(u) { u.admin? } do
-  #   mount RESQUE_SERVER, at: "/resque"
-  # end
+  authenticate :auth0_user, ->(u) { u.admin? } do
+    mount RESQUE_SERVER, at: "/resque"
+  end
 
   # See health_check gem
   get 'health_check' => "health_check/health_check#index"


### PR DESCRIPTION
# Description
- Revert of #3105 to release the site broadly.
- Also add another manuscript link to the landing page.
- One more change to hide the contig downloader.

# Tests
- Tested locally.