### PR TITLE
Clarify ALIGNMENT_CONFIG_DEFAULT_NAME

### DIFF
--- a/app/models/alignment_config.rb
+++ b/app/models/alignment_config.rb
@@ -1,5 +1,6 @@
 class AlignmentConfig < ApplicationRecord
   # configuration for alignment database for pipelines
+  #   set in SSM and loaded via chamber
   DEFAULT_NAME = ENV["ALIGNMENT_CONFIG_DEFAULT_NAME"]
   has_many :pipeline_runs, dependent: :restrict_with_exception
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 # Shared variables using Docker x- extension and YAML merging syntax.
 
 x-web-variables: &web-variables
-  ? ALIGNMENT_CONFIG_DEFAULT_NAME=2020-02-10
   ? SAMPLES_BUCKET_NAME=idseq-samples-development
   ? ES_ADDRESS=http://elasticsearch:9200
   ? AIRBRAKE_PROJECT_ID


### PR DESCRIPTION
# Description

Removes the setting of `ALIGNMENT_CONFIG_DEFAULT_NAME` from `docker-compose.yml` as it will always be overridden by chamber.

Added a comment above it's access to specify that this configuration is loaded from ssm/chamber.

# Tests

This effects local only.
