### PR TITLE
[Datadog] Include exception type in autoscaling update error logs

### DIFF
--- a/app/jobs/autoscaling.py
+++ b/app/jobs/autoscaling.py
@@ -158,7 +158,7 @@ def autoscaling_update(config):
         # TODO(julie 2/25/20): Note that this is part of a temporary stopgap measure as we move away from Datadog and should be
         # reverted once we transition to CloudWatch (or other replacements).
         # See JIRA IDSEQ-2236
-        print "[Datadog] ", error
+        print "[Datadog] ", repr(error)
         raise error
 
 


### PR DESCRIPTION
# Description

Small fix related to https://github.com/chanzuckerberg/idseq-web/pull/3104.

The Datadog monitor for Python subprocess errors in the pipeline monitor explicitly looks for the error type `subprocess.CalledProcessError`, which wasn't getting printed out with the log tagged with `"[Datadog]"`. This change adds the error type so the monitor can be triggered as expected.