### PR TITLE
Change puma version in Gemfile.lock from yanked 3.12.3 to 3.12.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -962,7 +962,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
-    puma (3.12.3)
+    puma (3.12.4)
     quantile (0.2.1)
     raabro (1.1.6)
     rack (2.0.8)


### PR DESCRIPTION
# Description

puma 3.12.3 has been yanked, causing Travis builds and Docker image builds to fail. This changes the version in `Gemfile.lock` to 3.12.4.

# Notes

see https://rubygems.org/gems/puma/versions and https://github.com/puma/puma/issues/2132#issuecomment-592718436

# Tests

qed
