### PR TITLE
Remove webtest from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,17 +105,6 @@ services:
       - '6379:6379'
     volumes:
       - ./redis-data:/var/lib/redis/data
-  webtest:
-    # "webtest" service configuration is meant to be used only in the CI environment.
-    # To run unit tests locally, use "web" service configuration instead.
-    image: chanzuckerberg/idseq-web:compose
-    volumes:
-      - ~/.aws:/root/.aws:ro
-    network_mode: host
-    environment:
-      <<: *web-variables
-      <<: *travis-variables
-    command: bash
   web:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,33 +38,6 @@ x-env-variables: &env-variables
   ? ENVIRONMENT
   ? OFFLINE
 
-x-travis-variables: &travis-variables
-  ? CI
-  ? CONTINUOUS_INTEGRATION
-  ? TRAVIS_ALLOW_FAILURE
-  ? TRAVIS_BRANCH
-  ? TRAVIS_BUILD_DIR
-  ? TRAVIS_BUILD_ID
-  ? TRAVIS_BUILD_NUMBER
-  ? TRAVIS_COMMIT
-  ? TRAVIS_COMMIT_MESSAGE
-  ? TRAVIS_COMMIT_RANGE
-  ? TRAVIS_EVENT_TYPE
-  ? TRAVIS_FILTERED
-  ? TRAVIS_JOB_ID
-  ? TRAVIS_JOB_NUMBER
-  ? TRAVIS_LANGUAGE
-  ? TRAVIS_OS_NAME
-  ? TRAVIS_PRE_CHEF_BOOTSTRAP_TIME
-  ? TRAVIS_PULL_REQUEST_BRANCH
-  ? TRAVIS_PULL_REQUEST
-  ? TRAVIS_PULL_REQUEST_SHA
-  ? TRAVIS_PULL_REQUEST_SLUG
-  ? TRAVIS_REPO_SLUG
-  ? TRAVIS_SECURE_ENV_VARS
-  ? TRAVIS_TAG
-  ? TRAVIS
-
 x-honeycomb-variables: &honeycomb-variables
   ? IDSEQ_HONEYCOMB_DB_DATA_SET
   ? IDSEQ_HONEYCOMB_DATA_SET
@@ -131,7 +104,6 @@ services:
     environment:
       <<: *web-variables
       <<: *aws-variables
-      <<: *travis-variables
       <<: *honeycomb-variables
       <<: *auth0-variables
       <<: *env-variables
@@ -150,7 +122,6 @@ services:
     environment:
       <<: *web-variables
       <<: *aws-variables
-      <<: *travis-variables
     command: bundle exec "COUNT=5 rake resque:workers"
   resque_result_monitor:
     image: chanzuckerberg/idseq-web:compose
@@ -166,7 +137,6 @@ services:
     environment:
       <<: *web-variables
       <<: *aws-variables
-      <<: *travis-variables
     command: bundle exec "rake result_monitor"
   resque_pipeline_monitor:
     image: chanzuckerberg/idseq-web:compose
@@ -182,5 +152,4 @@ services:
     environment:
       <<: *web-variables
       <<: *aws-variables
-      <<: *travis-variables
     command: bundle exec "rake pipeline_monitor"


### PR DESCRIPTION
# Description

The `webtest` service in our `docker-compose.yml` was used for running tests in travis-ci only. Since we have moved away from tests in docker it is no longer necessary. It prevents us from spinning up the whole application locally with:

```bash
docker-compose up
```

Because it conflicts with `web`. I should have removed this earlier.

# Tests

Spun up local environment without it.