### PR TITLE
Add 2020-02-10 AlignmentConfig for local dev

### DIFF
--- a/db/migrate/20200304012055_add_updated_alignment_config.rb
+++ b/db/migrate/20200304012055_add_updated_alignment_config.rb
@@ -4,7 +4,7 @@ class AddUpdatedAlignmentConfig < ActiveRecord::Migration[5.1]
   def up
     unless AlignmentConfig.find_by(name: NEW_DATE)
       ENV["NCBI_DATE"] = NEW_DATE
-      ENV["LINEAGE_VERSION"] = (TaxonLineage.maximum('version_end') + 1).to_s
+      ENV["LINEAGE_VERSION"] = (TaxonLineage.maximum('version_end') || 0 + 1).to_s
 
       Rails.application.load_tasks
       Rake::Task['create_alignment_config'].invoke

--- a/db/migrate/20200304012055_add_updated_alignment_config.rb
+++ b/db/migrate/20200304012055_add_updated_alignment_config.rb
@@ -1,0 +1,20 @@
+class AddUpdatedAlignmentConfig < ActiveRecord::Migration[5.1]
+  NEW_DATE = "2020-02-10".freeze
+
+  def up
+    unless AlignmentConfig.find_by(name: NEW_DATE)
+      ENV["NCBI_DATE"] = NEW_DATE
+      ENV["LINEAGE_VERSION"] = (TaxonLineage.maximum('version_end') + 1).to_s
+
+      Rails.application.load_tasks
+      Rake::Task['create_alignment_config'].invoke
+    end
+  end
+
+  def down
+    exists = AlignmentConfig.find_by(name: NEW_DATE)
+    if exists
+      exists.delete
+    end
+  end
+end


### PR DESCRIPTION
### Description
- This adds the "2020-02-10" AlignmentConfig for local development. The rake task was manually run in sandbox/staging/prod so it won't affect those.

### Notes
- I'm not sure how this was handled in the "2019-09-17" case b/c I don't see any migrations for creating that AlignmentConfig. Thoughts?

- Local commands:
```
NCBI_DATE=2020-02-10 rake update_lineage_db
NCBI_DATE=2020-02-10 LINEAGE_VERSION=6 rake create_alignment_config
```
- Going to repost in Slack about running `update_lineage_db`, since that wouldn't work well to run in a migration. This would be necessary if you actually want to view the new results of your test run.

### Testing
- Tested by running 
```
docker-compose run web "rake db:migrate"
docker-compose run web "rake db:rollback STEP=1"
```
back and forth and verifying the AlignmentConfig created in local console.