### PR TITLE
Fix bug in Institution user field

### DIFF
--- a/app/assets/src/components/CreateUser.jsx
+++ b/app/assets/src/components/CreateUser.jsx
@@ -36,6 +36,7 @@ class CreateUser extends React.Component {
       adminstatus: this.selectedUser.adminStatus,
       id: this.selectedUser.id,
       sendActivation: true,
+      institution: this.selectedUser.institution || "",
     };
   }
 


### PR DESCRIPTION
# Description
- Quick fix. Noticed this yesterday when updating a user. Not sure how I missed it before.
- The "institution" wasn't showing up in the User Edit admin page, even though the value was OK in the db. This didn't affect setting the field using the form.

# Tests
Before:
<img width="435" alt="Screen Shot 2020-03-04 at 11 07 38 AM" src="https://user-images.githubusercontent.com/5652739/75914018-ddabe200-5e08-11ea-89e5-319f1a264e35.png">

After:
<img width="443" alt="Screen Shot 2020-03-04 at 11 08 27 AM" src="https://user-images.githubusercontent.com/5652739/75914026-e2709600-5e08-11ea-981d-60ee9e551671.png">