### PR TITLE
[IDSEQ-2366] Clarify tooltip for total reads

### DIFF
--- a/app/assets/src/components/views/samples/constants.js
+++ b/app/assets/src/components/views/samples/constants.js
@@ -19,7 +19,7 @@ export const SAMPLE_TABLE_COLUMNS_V2 = {
     tooltip: "User-defined location from which the sample was collected.",
   },
   totalReads: {
-    tooltip: "The total number of reads uploaded.",
+    tooltip: "The total number of single-end reads uploaded.",
   },
   nonHostReads: {
     tooltip: `The percentage of reads that came out of step (8) of the host filtration


### PR DESCRIPTION
### Description
- I intend to also get this rebased into the `public` branch.
- Clarify that total reads refers to single-end reads.
- "A suggestion: in the little pop up when hovering over Total Reads, can you specify these are single end reads as to not confuse people who are sequencing paired end reads?"

### Testing
- Hover over Total Reads in the right sidebar and see the updated text.