### PR TITLE
IDSEQ-1398: Ensure required metadata fields (and host defaults) are associated with all host genomes

### DIFF
--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -53,7 +53,7 @@ module MetadataHelper
   # Accepts ActiveRelation or array, but always outputs array.
   def self.order_metadata_fields_for_csv(fields)
     # Show fields with is_required=1 first in the CSV, but otherwise keep the default order.
-    fields = fields.sort_by { |f| [-f.is_required, f.created_at] }
+    fields = fields.sort_by { |f| [-f.is_required, f.id] }
 
     # Hide legacy collection_location (v1) field from CSV templates.
     # TODO(jsheu): Remove legacy field and swap in collection_location_v2.

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -53,7 +53,7 @@ module MetadataHelper
   # Accepts ActiveRelation or array, but always outputs array.
   def self.order_metadata_fields_for_csv(fields)
     # Show fields with is_required=1 first in the CSV, but otherwise keep the default order.
-    fields = fields.sort_by { |f| [-f.is_required, f.id] }
+    fields = fields.sort_by { |f| [-f.is_required, f.created_at] }
 
     # Hide legacy collection_location (v1) field from CSV templates.
     # TODO(jsheu): Remove legacy field and swap in collection_location_v2.

--- a/app/models/host_genome.rb
+++ b/app/models/host_genome.rb
@@ -46,9 +46,9 @@ class HostGenome < ApplicationRecord
     HostGenome::ERCC_PATH_PREFIX + HostGenome::S3_BOWTIE2_INDEX_FILE
   end
 
-  # This is designed to be called only during migrations and console sessions.
   def self.all_without_metadata_field(name)
-    joins(:metadata_fields).where.not(metadata_fields: { name: [name] }).distinct
+    exists = joins(:metadata_fields).where(metadata_fields: { name: [name] })
+    where.not(id: [exists.pluck(:id).uniq])
   end
 
   def as_json(options = {})

--- a/app/models/host_genome.rb
+++ b/app/models/host_genome.rb
@@ -47,8 +47,8 @@ class HostGenome < ApplicationRecord
   end
 
   def self.all_without_metadata_field(name)
-    exists = joins(:metadata_fields).where(metadata_fields: { name: [name] })
-    where.not(id: [exists.pluck(:id).uniq])
+    exists = joins(:metadata_fields).where(metadata_fields: { name: [name] }).distinct
+    where.not(id: exists)
   end
 
   def as_json(options = {})

--- a/app/models/host_genome.rb
+++ b/app/models/host_genome.rb
@@ -46,6 +46,11 @@ class HostGenome < ApplicationRecord
     HostGenome::ERCC_PATH_PREFIX + HostGenome::S3_BOWTIE2_INDEX_FILE
   end
 
+  # This is designed to be called only during migrations and console sessions.
+  def self.all_without_metadata_field(name)
+    joins(:metadata_fields).where.not(metadata_fields: { name: [name] }).distinct
+  end
+
   def as_json(options = {})
     hash = super(options)
     hash[:ercc_only] = ercc_only?

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -138,7 +138,9 @@ class MetadataField < ApplicationRecord
   end
 
   def update_host_genomes!
-    host_genomes << HostGenome.all_without_metadata_field(name)
+    if is_required
+      host_genomes << HostGenome.all_without_metadata_field(name)
+    end
   end
 
   # Important attributes for the frontend

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -125,6 +125,11 @@ class MetadataField < ApplicationRecord
   validates :is_required, inclusion: { in: [0, 1] }
   validates :default_for_new_host_genome, inclusion: { in: [0, 1] }, if: -> { respond_to?(:default_for_new_host_genome) && mass_validation_enabled? } # respond_to? for migrations
 
+  def default_for_host_genome?
+    # for migration compatibility
+    respond_to?(:default_for_new_host_genome) && default_for_new_host_genome == 1
+  end
+
   def metadata_field_subsets
     if is_default == 1 && is_core == 0
       errors[:name] << 'Default field must also be core field'
@@ -132,16 +137,15 @@ class MetadataField < ApplicationRecord
     if is_required == 1 && is_default == 0
       errors[:name] << 'Required field must also be default field'
     end
-    if respond_to?(:default_for_new_host_genome) && # for migration compatibility
-       is_required == 1 && default_for_new_host_genome == 0 &&
-       errors[:name] << 'Required field must also be default_for_new_host_genome field'
+    if is_required == 1 && !default_for_host_genome?
+      errors[:name] << 'Required field must also be default_for_new_host_genome field'
     end
   end
 
   # This method is designed to be called when a field is made required or
   # default by an admin to update existing host genomes.
   def update_host_genomes!
-    if is_required == 1 || default_for_new_host_genome == 1
+    if is_required == 1 || default_for_host_genome?
       host_genomes << HostGenome.all_without_metadata_field(name)
     end
   end

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -138,7 +138,7 @@ class MetadataField < ApplicationRecord
   end
 
   def update_host_genomes!
-    if is_required
+    if is_required == 1
       host_genomes << HostGenome.all_without_metadata_field(name)
     end
   end

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -89,7 +89,7 @@ class MetadataField < ApplicationRecord
 
   validate :metadata_field_subsets
 
-  before_create :update_host_genomes!
+  before_save :update_host_genomes!
 
   # As of Feb 2020, we renamed "Host Genome" in the UI to better reflect its
   # purpose as "Host Organism". For backwards compatibility, especially for CSV

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -1,3 +1,82 @@
+# ActiveRecord documentation summary
+
+# Name/key ex: "sample_type"
+# t.string :name
+
+# User-friendly display name ex: "Sample Type"
+# t.string :display_name
+
+# Human-readable description e.g. "Type of sample or tissue such as plasma, whole blood, etc."
+# t.string :description
+
+# Base data type. 0 for string, 1 for number, 2 for dates. Used for figuring out which column
+# to use in "metadata-data" ex: string_validated_value, number_validated_value,
+# date_validated_value.
+# t.integer :base_type
+
+# Name of a validation type corresponding to a 'hardcoded' validation function.
+# Ex: "positive_number" here would call a positive_number validator in code dynamically (with
+# a restricted set of functions we make).
+
+# An array of options when applicable. Ex for nucleotide_type: ["DNA", "RNA"]. Unfortunately our
+# RDS flavor/version doesn't support json types so this is string.
+# t.string :options
+
+# If true then only allow users to use the options (i.e. no freetext).
+# t.integer :force_options
+
+# A hash that maps host genome ids to an array of examples for that metadata field and host genome.
+# Stored as JSON.
+# If the key is "all", the examples apply to all host genomes.
+# We separate by host genome because, for example, valid sample_types are different for human vs mosquito,
+# and the examples should reflect this.
+# t.string :examples
+
+# +----------------------+
+# |      All fields      |
+# | +------------------+ |
+# | |      Core        | |
+# | | +--------------+ | |
+# | | |   Default    | | |
+# | | | +----------+ | | |
+# | | | | Required | | | |
+# | | | +__________+ | | |
+# | | +______________+ | |
+# | +__________________+ |
+# +______________________+
+
+# The core fields are basically the set of fields that we think are important/interesting/have
+# curated ourselves. All user-created custom types will not be core (unless we make them).
+# Ex: lat_lon could be a core field but not on new projects by default.
+# t.integer :is_core
+
+# Default fields are a subset of the core fields that will appear on a project when someone
+# creates a project. These can be removed from a project.
+# See add_default_metadata_fields in project.rb.
+# t.integer :is_default
+
+# Required fields are a subset of the core/default fields that cannot be removed from the
+# project. This is the strictest level. Ex: collection_date, location, nucleotide_type, etc.
+# t.integer :is_required
+
+# Name of a group of fields for the frontend. Ex: Sample, Donor, Infection, Sequencing, etc.
+# t.string :group
+
+# Certain meta-fields are appropriate for different (and potentially multiple) hosts. E.g.
+# "Discharge Date" is only for humans. Therefore host genomes have many meta-fields and
+# meta-fields have many host genomes. This is a way of handling many-to-many /
+# has_and_belongs_to_many in Rails.
+# create_join_table :host_genomes, :metadata_fields
+
+# User-defined meta-fields will belong to each (and potentially multiple) projects. So
+# meta-fields have many projects and projects have many meta-fields.
+# When a user creates a new project, they'll basically get a list of all the meta-fields marked
+# "default". Then they can add and subtract from their set of meta-fields from there.
+# create_join_table :projects, :metadata_fields
+
+# Whether this metadata field should be added automatically to new host genomes.
+# See add_default_metadata_fields in host_genome.rb.
+# t.integer :default_for_new_host_genome, limit: 1, default: 0
 class MetadataField < ApplicationRecord
   has_and_belongs_to_many :host_genomes
   has_and_belongs_to_many :projects
@@ -9,6 +88,8 @@ class MetadataField < ApplicationRecord
   validates :display_name, presence: true, uniqueness: true, if: :mass_validation_enabled?
 
   validate :metadata_field_subsets
+
+  before_create :update_host_genomes!
 
   # As of Feb 2020, we renamed "Host Genome" in the UI to better reflect its
   # purpose as "Host Organism". For backwards compatibility, especially for CSV
@@ -43,86 +124,6 @@ class MetadataField < ApplicationRecord
   validates :is_required, inclusion: { in: [0, 1] }
   validates :default_for_new_host_genome, inclusion: { in: [0, 1] }, if: -> { respond_to?(:default_for_new_host_genome) && mass_validation_enabled? } # respond_to? for migrations
 
-  # ActiveRecord documentation summary
-
-  # Name/key ex: "sample_type"
-  # t.string :name
-
-  # User-friendly display name ex: "Sample Type"
-  # t.string :display_name
-
-  # Human-readable description e.g. "Type of sample or tissue such as plasma, whole blood, etc."
-  # t.string :description
-
-  # Base data type. 0 for string, 1 for number, 2 for dates. Used for figuring out which column
-  # to use in "metadata-data" ex: string_validated_value, number_validated_value,
-  # date_validated_value.
-  # t.integer :base_type
-
-  # Name of a validation type corresponding to a 'hardcoded' validation function.
-  # Ex: "positive_number" here would call a positive_number validator in code dynamically (with
-  # a restricted set of functions we make).
-
-  # An array of options when applicable. Ex for nucleotide_type: ["DNA", "RNA"]. Unfortunately our
-  # RDS flavor/version doesn't support json types so this is string.
-  # t.string :options
-
-  # If true then only allow users to use the options (i.e. no freetext).
-  # t.integer :force_options
-
-  # A hash that maps host genome ids to an array of examples for that metadata field and host genome.
-  # Stored as JSON.
-  # If the key is "all", the examples apply to all host genomes.
-  # We separate by host genome because, for example, valid sample_types are different for human vs mosquito,
-  # and the examples should reflect this.
-  # t.string :examples
-
-  # +----------------------+
-  # |      All fields      |
-  # | +------------------+ |
-  # | |      Core        | |
-  # | | +--------------+ | |
-  # | | |   Default    | | |
-  # | | | +----------+ | | |
-  # | | | | Required | | | |
-  # | | | +__________+ | | |
-  # | | +______________+ | |
-  # | +__________________+ |
-  # +______________________+
-
-  # The core fields are basically the set of fields that we think are important/interesting/have
-  # curated ourselves. All user-created custom types will not be core (unless we make them).
-  # Ex: lat_lon could be a core field but not on new projects by default.
-  # t.integer :is_core
-
-  # Default fields are a subset of the core fields that will appear on a project when someone
-  # creates a project. These can be removed from a project.
-  # See add_default_metadata_fields in project.rb.
-  # t.integer :is_default
-
-  # Required fields are a subset of the core/default fields that cannot be removed from the
-  # project. This is the strictest level. Ex: collection_date, location, nucleotide_type, etc.
-  # t.integer :is_required
-
-  # Name of a group of fields for the frontend. Ex: Sample, Donor, Infection, Sequencing, etc.
-  # t.string :group
-
-  # Certain meta-fields are appropriate for different (and potentially multiple) hosts. E.g.
-  # "Discharge Date" is only for humans. Therefore host genomes have many meta-fields and
-  # meta-fields have many host genomes. This is a way of handling many-to-many /
-  # has_and_belongs_to_many in Rails.
-  # create_join_table :host_genomes, :metadata_fields
-
-  # User-defined meta-fields will belong to each (and potentially multiple) projects. So
-  # meta-fields have many projects and projects have many meta-fields.
-  # When a user creates a new project, they'll basically get a list of all the meta-fields marked
-  # "default". Then they can add and subtract from their set of meta-fields from there.
-  # create_join_table :projects, :metadata_fields
-
-  # Whether this metadata field should be added automatically to new host genomes.
-  # See add_default_metadata_fields in host_genome.rb.
-  # t.integer :default_for_new_host_genome, limit: 1, default: 0
-
   def metadata_field_subsets
     if is_default == 1 && is_core == 0
       errors[:name] << 'Default field must also be core field'
@@ -133,6 +134,10 @@ class MetadataField < ApplicationRecord
     if is_required == 1 && default_for_new_host_genome == 0
       errors[:name] << 'Required field must also be default_for_new_host_genome field'
     end
+  end
+
+  def update_host_genomes!
+    host_genomes << HostGenome.all_without_metadata_field(name)
   end
 
   # Important attributes for the frontend

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -138,7 +138,7 @@ class MetadataField < ApplicationRecord
   end
 
   def update_host_genomes!
-    if is_required == 1
+    if is_required == 1 || default_for_new_host_genome == 1
       host_genomes << HostGenome.all_without_metadata_field(name)
     end
   end

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -77,6 +77,7 @@
 # Whether this metadata field should be added automatically to new host genomes.
 # See add_default_metadata_fields in host_genome.rb.
 # t.integer :default_for_new_host_genome, limit: 1, default: 0
+# NOTE: making the attribute true will also add the field to all existing host genomes.
 class MetadataField < ApplicationRecord
   has_and_belongs_to_many :host_genomes
   has_and_belongs_to_many :projects
@@ -137,6 +138,8 @@ class MetadataField < ApplicationRecord
     end
   end
 
+  # This method is designed to be called when a field is made required or
+  # default by an admin to update existing host genomes.
   def update_host_genomes!
     if is_required == 1 || default_for_new_host_genome == 1
       host_genomes << HostGenome.all_without_metadata_field(name)

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -130,6 +130,9 @@ class MetadataField < ApplicationRecord
     if is_required == 1 && is_default == 0
       errors[:name] << 'Required field must also be default field'
     end
+    if is_required == 1 && default_for_new_host_genome == 0
+      errors[:name] << 'Required field must also be default_for_new_host_genome field'
+    end
   end
 
   # Important attributes for the frontend

--- a/app/models/metadata_field.rb
+++ b/app/models/metadata_field.rb
@@ -131,8 +131,9 @@ class MetadataField < ApplicationRecord
     if is_required == 1 && is_default == 0
       errors[:name] << 'Required field must also be default field'
     end
-    if is_required == 1 && default_for_new_host_genome == 0
-      errors[:name] << 'Required field must also be default_for_new_host_genome field'
+    if respond_to?(:default_for_new_host_genome) && # for migration compatibility
+       is_required == 1 && default_for_new_host_genome == 0 &&
+       errors[:name] << 'Required field must also be default_for_new_host_genome field'
     end
   end
 

--- a/spec/factories/host_genomes.rb
+++ b/spec/factories/host_genomes.rb
@@ -8,15 +8,12 @@ FactoryBot.define do
     # up to this point have been created by admins.
     association :user, factory: [:admin]
 
-    after :create do |host_genome, options|
+    after :create do |_host_genome, options|
       options.metadata_fields.each do |metadata_field_name|
         metadata_field = MetadataField.find_by(name: metadata_field_name)
         unless metadata_field
-          metadata_field = create(:metadata_field, name: metadata_field_name)
+          create(:metadata_field, name: metadata_field_name)
         end
-
-        # Add the metadata field to the host genome if it doesn't already exist.
-        host_genome.metadata_fields << metadata_field unless host_genome.metadata_field_ids.include?(metadata_field.id)
       end
     end
   end

--- a/spec/factories/host_genomes.rb
+++ b/spec/factories/host_genomes.rb
@@ -8,12 +8,13 @@ FactoryBot.define do
     # up to this point have been created by admins.
     association :user, factory: [:admin]
 
-    after :create do |_host_genome, options|
+    after :create do |host_genome, options|
       options.metadata_fields.each do |metadata_field_name|
         metadata_field = MetadataField.find_by(name: metadata_field_name)
         unless metadata_field
           create(:metadata_field, name: metadata_field_name)
         end
+        host_genome.metadata_fields << metadata_field unless host_genome.metadata_fields.include?(metadata_field)
       end
     end
   end

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -26,12 +26,14 @@ FactoryBot.define do
 
     # metadata fields
     # ensure the metadata field is added to the host genome
-    before(:create) do |_sample, options|
+    before(:create) do |sample, options|
       options.metadata_fields.each_key do |metadata_field_name|
         metadata_field = MetadataField.find_by(name: metadata_field_name)
         unless metadata_field
-          create(:metadata_field, name: metadata_field_name)
+          metadata_field = create(:metadata_field, name: metadata_field_name)
         end
+        host_genome = sample.host_genome
+        host_genome.metadata_fields << metadata_field unless host_genome.metadata_fields.include?(metadata_field)
       end
     end
 

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -26,16 +26,12 @@ FactoryBot.define do
 
     # metadata fields
     # ensure the metadata field is added to the host genome
-    before(:create) do |sample, options|
+    before(:create) do |_sample, options|
       options.metadata_fields.each_key do |metadata_field_name|
         metadata_field = MetadataField.find_by(name: metadata_field_name)
         unless metadata_field
-          metadata_field = create(:metadata_field, name: metadata_field_name)
+          create(:metadata_field, name: metadata_field_name)
         end
-        # This is needed to make metadata pass validation below
-        metadata_field.default_for_new_host_genome = 1
-        metadata_field.save!
-        sample.host_genome.metadata_fields << metadata_field
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :admin, class: User do
-    email { "admin@example.com" }
+    sequence(:email, 'a') { |n| "admin-#{n}@example.com" }
     name { "Admin User" }
     role { 1 }
   end

--- a/spec/helpers/bulk_download_helper_spec.rb
+++ b/spec/helpers/bulk_download_helper_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe BulkDownloadsHelper, type: :helper do
     before do
       @joe = create(:joe)
       @project = create(:project, users: [@joe])
-      create(:metadata_field, name: "sample_type", is_required: 1, is_default: 1, is_core: 1, default_for_new_host_genome: 1)
+      create(:metadata_field, name: "sample_type", is_default: 1, is_core: 1)
       @sample_one = create(:sample, project: @project, name: "Test Sample 1",
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }],
                                     metadata_fields: { collection_location_v2: "San Francisco, USA", sample_type: "Serum", custom_field_one: "Value One" })

--- a/spec/helpers/bulk_download_helper_spec.rb
+++ b/spec/helpers/bulk_download_helper_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe BulkDownloadsHelper, type: :helper do
     before do
       @joe = create(:joe)
       @project = create(:project, users: [@joe])
-      create(:metadata_field, name: "sample_type", is_required: 1, is_default: 1, is_core: 1)
+      create(:metadata_field, name: "sample_type", is_required: 1, is_default: 1, is_core: 1, default_for_new_host_genome: 1)
       @sample_one = create(:sample, project: @project, name: "Test Sample 1",
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }],
                                     metadata_fields: { collection_location_v2: "San Francisco, USA", sample_type: "Serum", custom_field_one: "Value One" })

--- a/spec/helpers/bulk_download_helper_spec.rb
+++ b/spec/helpers/bulk_download_helper_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe BulkDownloadsHelper, type: :helper do
     before do
       @joe = create(:joe)
       @project = create(:project, users: [@joe])
-      create(:metadata_field, name: "sample_type", is_default: 1, is_core: 1)
+      create(:metadata_field, name: "sample_type", is_required: 1, is_default: 1, is_core: 1, default_for_new_host_genome: 1)
       @sample_one = create(:sample, project: @project, name: "Test Sample 1",
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }],
                                     metadata_fields: { collection_location_v2: "San Francisco, USA", sample_type: "Serum", custom_field_one: "Value One" })

--- a/spec/helpers/bulk_download_helper_spec.rb
+++ b/spec/helpers/bulk_download_helper_spec.rb
@@ -191,6 +191,8 @@ RSpec.describe BulkDownloadsHelper, type: :helper do
       @joe = create(:joe)
       @project = create(:project, users: [@joe])
       create(:metadata_field, name: "sample_type", is_required: 1, is_default: 1, is_core: 1, default_for_new_host_genome: 1)
+      # while normally required, this field is expected to be not required here
+      MetadataField.where(name: "collection_location_v2").update(is_required: 0)
       @sample_one = create(:sample, project: @project, name: "Test Sample 1",
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }],
                                     metadata_fields: { collection_location_v2: "San Francisco, USA", sample_type: "Serum", custom_field_one: "Value One" })

--- a/spec/helpers/samples_helper_spec.rb
+++ b/spec/helpers/samples_helper_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe SamplesHelper, type: :helper do
     before do
       @joe = create(:joe)
       @project = create(:project, users: [@joe])
-      create(:metadata_field, name: "sample_type", is_required: 1, is_default: 1, is_core: 1)
+      create(:metadata_field, name: "sample_type", is_required: 1, is_default: 1, is_core: 1, default_for_new_host_genome: 1)
       @sample_one = create(:sample, project: @project, name: "Test Sample 1",
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }],
                                     metadata_fields: { collection_location_v2: "San Francisco, USA", sample_type: "Serum", custom_field_one: "Value One" })

--- a/spec/helpers/samples_helper_spec.rb
+++ b/spec/helpers/samples_helper_spec.rb
@@ -247,6 +247,8 @@ RSpec.describe SamplesHelper, type: :helper do
       @joe = create(:joe)
       @project = create(:project, users: [@joe])
       create(:metadata_field, name: "sample_type", is_required: 1, is_default: 1, is_core: 1, default_for_new_host_genome: 1)
+      # while normally required, this field is expected to be not required here
+      MetadataField.where(name: "collection_location_v2").update(is_required: 0)
       @sample_one = create(:sample, project: @project, name: "Test Sample 1",
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }],
                                     metadata_fields: { collection_location_v2: "San Francisco, USA", sample_type: "Serum", custom_field_one: "Value One" })

--- a/spec/models/host_genome_spec.rb
+++ b/spec/models/host_genome_spec.rb
@@ -5,4 +5,12 @@ RSpec.describe HostGenome, type: :model do
     hg = create(:host_genome)
     expect(hg.s3_star_index_path).to include('/ercc/')
   end
+
+  it 'all_without_metadata_field returns all hosts for unknown metadata' do
+    expect(HostGenome.all_without_metadata_field('DOESNOTEXIST').count).to eq(HostGenome.all.count)
+  end
+
+  it 'all_without_metadata_field returns subset hosts for required metadata' do
+    expect(HostGenome.all_without_metadata_field('sample_type').count).to be <= HostGenome.all.count
+  end
 end

--- a/spec/models/metadata_field_spec.rb
+++ b/spec/models/metadata_field_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 # This spec was created well after MetadataField, for the boolean? method.
 describe MetadataField, type: :model do
+  def find_test_field(host_genome)
+    host_genome.metadata_fields.find { |mf| mf.name == 'test' }
+  end
+
   let(:options) { '["Yes", "No"]' }
 
   it 'not be boolean if not force_options' do
@@ -47,23 +51,34 @@ describe MetadataField, type: :model do
 
   it 'will update all hosts needed when a required field is created' do
     host_genome = create(:host_genome)
-    metadata_field = host_genome.metadata_fields.find { |mf| mf.name == 'test' }
+    metadata_field = find_test_field(host_genome)
     expect(metadata_field).to be_nil
 
     create(:metadata_field, name: 'test', is_default: 1, is_core: 1, default_for_new_host_genome: 1, is_required: 1)
     host_genome = HostGenome.find(host_genome.id)
-    metadata_field = host_genome.metadata_fields.find { |mf| mf.name == 'test' }
+    metadata_field = find_test_field(host_genome)
+    expect(metadata_field).to_not be_nil
+  end
+
+  it 'will update all hosts needed when a default_for_new_host_genome field is created' do
+    host_genome = create(:host_genome)
+    metadata_field = find_test_field(host_genome)
+    expect(metadata_field).to be_nil
+
+    create(:metadata_field, name: 'test', is_default: 0, is_core: 0, default_for_new_host_genome: 1, is_required: 0)
+    host_genome = HostGenome.find(host_genome.id)
+    metadata_field = find_test_field(host_genome)
     expect(metadata_field).to_not be_nil
   end
 
   it 'will not update all hosts needed when a non-required field is created' do
     host_genome = create(:host_genome)
-    metadata_field = host_genome.metadata_fields.find { |mf| mf.name == 'test' }
+    metadata_field = find_test_field(host_genome)
     expect(metadata_field).to be_nil
 
     create(:metadata_field, name: 'test', is_default: 0, is_core: 0, default_for_new_host_genome: 0, is_required: 0)
     host_genome = HostGenome.find(host_genome.id)
-    metadata_field = host_genome.metadata_fields.find { |mf| mf.name == 'test' }
+    metadata_field = find_test_field(host_genome)
     expect(metadata_field).to be_nil
   end
 end

--- a/spec/models/metadata_field_spec.rb
+++ b/spec/models/metadata_field_spec.rb
@@ -26,4 +26,34 @@ describe MetadataField, type: :model do
     expect { create(:metadata_field, name: 'sample_name') }.to raise_error(ActiveRecord::RecordInvalid)
     expect { create(:metadata_field, name: 'my_name') }.to_not raise_error
   end
+
+  it 'will not create a required field that is not default_for_new_host_genome' do
+    expect { create(:metadata_field, name: 'test', is_default: 1, is_core: 1, default_for_new_host_genome: 0, is_required: 1) }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'will not update to required a field that is not default_for_new_host_genome' do
+    metadata_field = create(:metadata_field, name: 'test', is_default: 1, is_core: 1, default_for_new_host_genome: 0)
+    expect { metadata_field.update!(is_required: 1) }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'will create a required field that is default_for_new_host_genome' do
+    expect { create(:metadata_field, name: 'test', is_default: 1, is_core: 1, default_for_new_host_genome: 1, is_required: 1) }.to_not raise_error
+  end
+
+  it 'will update to required a field that is default_for_new_host_genome' do
+    metadata_field = create(:metadata_field, name: 'test', is_default: 1, is_core: 1, default_for_new_host_genome: 1)
+    expect { metadata_field.update(is_required: 1) }.to_not raise_error
+  end
+
+  it 'will update all hosts needed when a required field is created' do
+    host_genome = create(:host_genome)
+    metadata_field = host_genome.metadata_fields.find { |mf| mf.name == 'test' }
+    expect(metadata_field).to be_nil
+
+    create(:metadata_field, name: 'test', is_default: 1, is_core: 1, default_for_new_host_genome: 1, is_required: 1)
+    # refetch fresh data
+    host_genome = HostGenome.find(host_genome.id)
+    metadata_field = host_genome.metadata_fields.find { |mf| mf.name == 'test' }
+    expect(metadata_field).to_not be_nil
+  end
 end

--- a/spec/models/metadata_field_spec.rb
+++ b/spec/models/metadata_field_spec.rb
@@ -51,9 +51,19 @@ describe MetadataField, type: :model do
     expect(metadata_field).to be_nil
 
     create(:metadata_field, name: 'test', is_default: 1, is_core: 1, default_for_new_host_genome: 1, is_required: 1)
-    # refetch fresh data
     host_genome = HostGenome.find(host_genome.id)
     metadata_field = host_genome.metadata_fields.find { |mf| mf.name == 'test' }
     expect(metadata_field).to_not be_nil
+  end
+
+  it 'will not update all hosts needed when a non-required field is created' do
+    host_genome = create(:host_genome)
+    metadata_field = host_genome.metadata_fields.find { |mf| mf.name == 'test' }
+    expect(metadata_field).to be_nil
+
+    create(:metadata_field, name: 'test', is_default: 0, is_core: 0, default_for_new_host_genome: 0, is_required: 0)
+    host_genome = HostGenome.find(host_genome.id)
+    metadata_field = host_genome.metadata_fields.find { |mf| mf.name == 'test' }
+    expect(metadata_field).to be_nil
   end
 end

--- a/spec/requests/sample_request_spec.rb
+++ b/spec/requests/sample_request_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe "Sample request", type: :request do
         # Sample setup
         project = create(:public_project, users: [@joe])
         create(:alignment_config, name: AlignmentConfig::DEFAULT_NAME)
+        hg = create(:host_genome, name: "Human", id: 1)
         @sample_params = {
           client: "web",
-          host_genome_id: 1,
-          host_genome_name: "Human",
+          host_genome_id: hg.id,
+          host_genome_name: hg.name,
           input_files_attributes: [
             { source_type: "local", source: "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R1.fastq.gz", parts: "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R1.fastq.gz" },
             { source_type: "local", source: "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R2.fastq.gz", parts: "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R2.fastq.gz" },

--- a/spec/requests/sample_request_spec.rb
+++ b/spec/requests/sample_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Sample request", type: :request do
         # Sample setup
         project = create(:public_project, users: [@joe])
         create(:alignment_config, name: AlignmentConfig::DEFAULT_NAME)
-        hg = create(:host_genome, name: "Human", id: 1)
+        hg = create(:host_genome)
         @sample_params = {
           client: "web",
           host_genome_id: hg.id,


### PR DESCRIPTION
# Description

In IDSEQ-1398, a user was unable to upload because their host (bat) did not have required field `collection_location_v2`. This adds model validation and a callback to ensure this can't happen again.

In addition, I will run the following script in prod to update existing hosts.

```
  MetadataField.where(is_required: 1).each do |mf|  
    mf.update_host_genomes!
    mf.save!
  end

  MetadataField.where(default_for_new_host_genome: 1).each do |mf|  
    mf.update_host_genomes!
    mf.save!
  end
```

# Notes

* This also raises the question of whether we should update existing projects on adding a required field

# Tests

* try creating a required field with no default_for_new_host_genome
* try updating to a required field with no default_for_new_host_genome
* try creating a new field that is required, see hosts update