### PR TITLE
Special case reads remaining display for cdhitdup

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -112,6 +112,16 @@ class PipelineTab extends React.Component {
 
     const totalReads = this.props.pipelineRun.total_reads;
     let readsAfter = step["reads_after"];
+
+    // Special case cdhitdup. All steps after cdhitdup transform their counts by
+    // in the pipeline by the compression ratio to return nonunique reads.
+    let uniqueReads = null;
+    if (stepKey === "cdhitdup_out") {
+      const previousStep = this.state.pipelineStepDict["steps"]["priceseq_out"];
+      uniqueReads = readsAfter;
+      readsAfter = previousStep["reads_after"];
+    }
+
     let percentReads = (readsAfter / totalReads * 100).toFixed(2);
 
     return (
@@ -127,6 +137,9 @@ class PipelineTab extends React.Component {
         <div className={cs.narrowMetadataValueContainer}>
           <div className={cs.metadataValue}>
             {readsAfter ? readsAfter.toLocaleString() : ""}
+            {uniqueReads && (
+              <div>{` (${uniqueReads.toLocaleString()} unique)`}</div>
+            )}
           </div>
         </div>
         <div className={cs.narrowMetadataValueContainer}>

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/PipelineTab.jsx
@@ -116,7 +116,10 @@ class PipelineTab extends React.Component {
     // Special case cdhitdup. All steps after cdhitdup transform their counts by
     // in the pipeline by the compression ratio to return nonunique reads.
     let uniqueReads = null;
-    if (stepKey === "cdhitdup_out") {
+    if (
+      stepKey === "cdhitdup_out" &&
+      this.props.pipelineRun.pipeline_version > "4"
+    ) {
       const previousStep = this.state.pipelineStepDict["steps"]["priceseq_out"];
       uniqueReads = readsAfter;
       readsAfter = previousStep["reads_after"];

--- a/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/sample_details_mode.scss
+++ b/app/assets/src/components/common/DetailsSidebar/SampleDetailsMode/sample_details_mode.scss
@@ -111,7 +111,7 @@
   }
 
   .narrowMetadataValueContainer {
-    width: 100px;
+    width: 140px; // to fit largest plausible numbers
     margin-right: 15px;
     display: inline-flex;
     text-align: right;

--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -10,7 +10,7 @@ module PipelineRunsHelper
         "star_out" => "Remove host reads using STAR.",
         "trimmomatic_out" => "Trim Illumina adapters using trimmomatic.",
         "priceseq_out" => "Remove low-quality reads using PriceSeqFilter.",
-        "cdhitdup_out" => "Remove duplicate reads using CD-HIT-DUP.",
+        "cdhitdup_out" => "Identify duplicate reads using CD-HIT-DUP. All reads at this step remain in downstream analysis.",
         "lzw_out" => "Remove low-complexity reads using LZW compression filter.",
         "bowtie2_out" => "Remove remaining host reads using Bowtie2.",
         "star_human_out" => "Remove human reads using STAR.",


### PR DESCRIPTION
# Description

This change communicates the new meaning of reads after the cdhitdup changes. NOTE: it should only be committed after https://github.com/chanzuckerberg/idseq-dag/pull/252/files . 

![image](https://user-images.githubusercontent.com/28797/76020970-46fb2600-5ed9-11ea-849a-c29cb06ccaca.png)

# Tests

* try in localhost, see updated display