### PR TITLE
Add metadata bulk download type.

### DIFF
--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -113,6 +113,29 @@ class BulkDownloadModal extends React.Component {
     const invalidSampleNames = sampleValidationInfo.invalidSampleNames;
     const validationError = sampleValidationInfo.error;
 
+    // Set any default bulk download field values.
+    let newSelectedFields = this.state.selectedFields;
+    let newSelectedFieldsDisplay = this.state.selectedFieldsDisplay;
+
+    bulkDownloadTypes.forEach(type => {
+      if (type.fields) {
+        type.fields.forEach(field => {
+          if (field.default_value) {
+            newSelectedFields = set(
+              [type.type, field.type],
+              field.default_value.value,
+              newSelectedFields
+            );
+            newSelectedFieldsDisplay = set(
+              [type.type, field.type],
+              field.default_value.display_name,
+              newSelectedFieldsDisplay
+            );
+          }
+        });
+      }
+    });
+
     this.setState({
       bulkDownloadTypes,
       validSampleIds,
@@ -121,6 +144,8 @@ class BulkDownloadModal extends React.Component {
       backgroundOptions,
       metricsOptions,
       allSamplesUploadedByCurrentUser,
+      selectedFields: newSelectedFields,
+      selectedFieldsDisplay: newSelectedFieldsDisplay,
       loading: false,
     });
   }

--- a/app/assets/src/components/views/bulk_download/BulkDownloadModalOptions.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModalOptions.jsx
@@ -8,6 +8,7 @@ import StatusLabel from "~ui/labels/StatusLabel";
 import Dropdown from "~ui/controls/dropdowns/Dropdown";
 import LoadingMessage from "~/components/common/LoadingMessage";
 import RadioButton from "~ui/controls/RadioButton";
+import Checkbox from "~ui/controls/Checkbox";
 import BasicPopup from "~/components/BasicPopup";
 import { UserContext } from "~/components/common/UserContext";
 
@@ -73,6 +74,22 @@ class BulkDownloadModalOptions extends React.Component {
 
     // Set different props for the dropdown depending on the field type.
     switch (field.type) {
+      case "include_metadata":
+        return (
+          <Checkbox
+            className={cs.checkboxField}
+            label="Include sample metadata in this table"
+            onChange={(_, isChecked) =>
+              onFieldSelect(
+                downloadType.type,
+                field.type,
+                isChecked /* value */,
+                isChecked ? "Yes" : "No" /* display name */
+              )
+            }
+            checked={selectedField}
+          />
+        );
       case "file_format":
         dropdownOptions = field.options.map(option => ({
           text: option,

--- a/app/assets/src/components/views/bulk_download/bulk_download_modal_options.scss
+++ b/app/assets/src/components/views/bulk_download/bulk_download_modal_options.scss
@@ -142,4 +142,9 @@
       color: $dark-grey;
     }
   }
+
+  .checkboxField {
+    @include font-body-xxs;
+    color: $dark-grey;
+  }
 }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -292,8 +292,7 @@ class ProjectsController < ApplicationController
     end
     selected_sample_ids = (params[:sampleIds] || "").split(",").map(&:to_i)
     samples = samples.where(id: selected_sample_ids) unless selected_sample_ids.empty?
-    formatted_samples = format_samples(samples)
-    project_csv = generate_sample_list_csv(formatted_samples)
+    project_csv = generate_sample_list_csv(samples)
     send_data project_csv, filename: project_name + '_sample-table.csv'
   end
 

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -1,5 +1,6 @@
 module BulkDownloadTypesHelper
   SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE = "sample_overview".freeze
+  SAMPLE_METADATA_BULK_DOWNLOAD_TYPE = "sample_metadata".freeze
   SAMPLE_TAXON_REPORT_BULK_DOWNLOAD_TYPE = "sample_taxon_report".freeze
   COMBINED_SAMPLE_TAXON_RESULTS_BULK_DOWNLOAD_TYPE = "combined_sample_taxon_results".freeze
   CONTIG_SUMMARY_REPORT_BULK_DOWNLOAD_TYPE = "contig_summary_report".freeze
@@ -13,6 +14,9 @@ module BulkDownloadTypesHelper
   VARIABLE_EXECUTION_TYPE = "variable".freeze
   ECS_EXECUTION_TYPE = "ecs".freeze
 
+  # The "type" value of the bulk download fields is really the field key.
+  # There isn't currently anything that specifies what data type the field is.
+  # The front-end is hard-coded to display a select dropdown or a checkbox depending on the field type.
   BULK_DOWNLOAD_TYPES = [
     {
       type: SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE,
@@ -21,6 +25,24 @@ module BulkDownloadTypesHelper
       category: "report",
       execution_type: RESQUE_EXECUTION_TYPE,
       # This will be displayed in the bulk-download creation modal.
+      file_type_display: ".csv",
+      fields: [
+        {
+          display_name: "Include Metadata",
+          type: "include_metadata",
+          default_value: {
+            value: false,
+            display_name: "No",
+          },
+        },
+      ],
+    },
+    {
+      type: SAMPLE_METADATA_BULK_DOWNLOAD_TYPE,
+      display_name: "Sample Metadata",
+      description: "User-uploaded metadata, including sample collection location, collection date, sample type",
+      category: "report",
+      execution_type: RESQUE_EXECUTION_TYPE,
       file_type_display: ".csv",
     },
     {

--- a/spec/helpers/samples_helper_spec.rb
+++ b/spec/helpers/samples_helper_spec.rb
@@ -244,4 +244,43 @@ RSpec.describe SamplesHelper, type: :helper do
       expect(response[3]["sample_count"]).to be 1
     end
   end
+
+  describe "#generate_sample_list_csv" do
+    before do
+      @joe = create(:joe)
+      @project = create(:project, users: [@joe])
+      create(:metadata_field, name: "sample_type", is_required: 1, is_default: 1, is_core: 1)
+      @sample_one = create(:sample, project: @project, name: "Test Sample 1",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }],
+                                    metadata_fields: { collection_location_v2: "San Francisco, USA", sample_type: "Serum", custom_field_one: "Value One" })
+      @sample_two = create(:sample, project: @project, name: "Test Sample 2",
+                                    pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED }],
+                                    metadata_fields: { collection_location_v2: "Los Angeles, USA", sample_type: "CSF", custom_field_two: "Value Two" })
+    end
+
+    it "includes specific metadata fields in basic case" do
+      samples = Sample.where(id: [@sample_one.id, @sample_two.id])
+      csv_string = helper.generate_sample_list_csv(samples)
+      headers = csv_string.split("\n")[0]
+      expect(headers.include?("sample_type")).to be true
+      expect(headers.include?("nucleotide_type")).to be true
+      expect(headers.include?("collection_location")).to be true
+      # Does not include custom metadata
+      expect(headers.include?("custom_field_one")).to be false
+      expect(headers.include?("custom_field_two")).to be false
+    end
+
+    it "includes specific metadata fields in basic case" do
+      samples = Sample.where(id: [@sample_one.id, @sample_two.id])
+      csv_string = helper.generate_sample_list_csv(samples, include_all_metadata: true)
+      headers = csv_string.split("\n")[0]
+      expect(headers.include?("sample_type")).to be true
+      expect(headers.include?("collection_location")).to be true
+      # Doesn't include nucleotide_type because none of the samples have it
+      expect(headers.include?("nucleotide_type")).to be false
+      # Includes custom metadata
+      expect(headers.include?("custom_field_one")).to be true
+      expect(headers.include?("custom_field_two")).to be true
+    end
+  end
 end


### PR DESCRIPTION
# Description

Also add option to add metadata to Samples Overview download type, per Jenn's mock.

![Screen Shot 2020-03-07 at 11 13 38 PM](https://user-images.githubusercontent.com/837004/76158293-4d4ff480-60c9-11ea-894c-baa7bb6201eb.png)

# Notes

* A method in phylo_trees_controller uses `Metadata.by_sample_ids` with `use_raw_date_strings: true`, so I wasn't able to easily merge that parameter with `use_csv_compatible_values`. 

# Tests

* Verified that the metadata bulk download and the modified samples overview bulk download behave as expected, with up to 237 samples and including old samples with no metadata.
* Verified that phylo tree creation still works.
* Verified that old project_csv endpoint (`projects/1/csv`) still works.
* Updated rspec tests.
