### PR TITLE
Fix logic of mass_validation_enabled class var

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -21,11 +21,12 @@ class ApplicationRecord < ActiveRecord::Base
   # Condition for rollout of mass addition of validation rules.
   # Cached for performance.
   def mass_validation_enabled?
-    if AppConfig.table_exists? # for migrations previous to AppConfig creation
-      @@mass_validation_enabled ||= AppConfigHelper.get_app_config(AppConfig::ENABLE_MASS_VALIDATION) || false # rubocop:disable Style/ClassVars
+    # for migrations previous to AppConfig creation
+    if AppConfig.table_exists?
+      @@mass_validation_enabled = !!AppConfigHelper.get_app_config(AppConfig::ENABLE_MASS_VALIDATION) if @@mass_validation_enabled.nil? # rubocop:disable Style/ClassVars,Style/DoubleNegation
     end
+    @@mass_validation_enabled
   end
-
   # Set current user and request to global for use in logging.
   # See https://stackoverflow.com/a/11670283/200312
   class << self


### PR DESCRIPTION
# Description

The original `||=` allowed the db query to run. 

# Tests

* unit tests
* tested by @tfrcarvalho in pipeline monitor
