### PR TITLE
Clean up unneeded contig code

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -144,16 +144,16 @@ class ReportTable extends React.Component {
       },
       assemblyEnabled && {
         cellDataGetter: ({ rowData }) =>
-          this.getNtNrFromDataRow(rowData, "contigCount", 0),
+          this.getNtNrFromDataRow(rowData, "contigs", 0),
         cellRenderer: this.renderNtNrDecimalValues,
         columnData: REPORT_TABLE_COLUMNS["contigs"],
-        dataKey: "contigCount",
+        dataKey: "contigs",
         label: "contig",
         sortFunction: ({ data, sortDirection }) =>
           this.nestedNtNrSortFunction({
             data,
             sortDirection,
-            path: ["contigCount"],
+            path: ["contigs"],
             nullValue: 0,
             limits: NUMBER_NULL_VALUES,
           }),
@@ -161,16 +161,16 @@ class ReportTable extends React.Component {
       },
       assemblyEnabled && {
         cellDataGetter: ({ rowData }) =>
-          this.getNtNrFromDataRow(rowData, "readsCount", 0),
+          this.getNtNrFromDataRow(rowData, "contig_r", 0),
         cellRenderer: this.renderNtNrDecimalValues,
         columnData: REPORT_TABLE_COLUMNS["contigreads"],
-        dataKey: "readsCount",
+        dataKey: "contig_r",
         label: "contig r",
         sortFunction: ({ data, sortDirection }) =>
           this.nestedNtNrSortFunction({
             data,
             sortDirection,
-            path: ["readsCount"],
+            path: ["contig_r"],
             nullValue: 0,
             limits: NUMBER_NULL_VALUES,
           }),

--- a/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewHeader.jsx
@@ -28,7 +28,6 @@ export default function SampleViewHeader({
   reportPresent,
   sample,
   view,
-  minContigReads,
 }) {
   const userContext = useContext(UserContext);
 
@@ -163,7 +162,6 @@ export default function SampleViewHeader({
           pipelineRun={pipelineRun}
           editable={editable}
           view={view}
-          minContigReads={minContigReads}
         />
       </ViewHeader.Controls>
     </ViewHeader>
@@ -189,5 +187,4 @@ SampleViewHeader.propTypes = {
   reportPresent: PropTypes.bool,
   sample: PropTypes.Sample,
   view: PropTypes.string.isRequired,
-  minContigReads: PropTypes.number,
 };

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -1,11 +1,9 @@
 import React from "react";
 import {
   compact,
-  entries,
   every,
   find,
   flatten,
-  flow,
   get,
   keys,
   map,
@@ -160,7 +158,6 @@ export default class SampleViewV2 extends React.Component {
     return {
       categories: {},
       metric: TREE_METRICS[0].value,
-      minContigReads: 4,
       nameType: "Scientific name",
       readSpecificity: 0,
       thresholds: [],
@@ -251,7 +248,6 @@ export default class SampleViewV2 extends React.Component {
     }
 
     this.setDisplayName({ reportData, ...selectedOptions });
-    this.setContigStats({ reportData, ...selectedOptions });
     const filteredReportData = this.filterReportData({
       reportData,
       filters: selectedOptions,
@@ -397,25 +393,6 @@ export default class SampleViewV2 extends React.Component {
       !readSpecificity ||
       (row.taxLevel === "genus" ? row.taxId > 0 : row.genus_tax_id > 0)
     );
-  };
-
-  setRowContigStats = ({ row, minContigReads }) => {
-    ["nr", "nt"].forEach(dbType => {
-      const dbTypeRow = row[dbType];
-      if (dbTypeRow) {
-        dbTypeRow.contigCount = get([dbType, "contigs"], row);
-        dbTypeRow.readsCount = get([dbType, "contig_r"], row);
-      }
-    });
-  };
-
-  setContigStats = ({ reportData, minContigReads }) => {
-    reportData.forEach(genus => {
-      this.setRowContigStats({ row: genus, minContigReads });
-      genus.species.forEach(species => {
-        this.setRowContigStats({ row: species, minContigReads });
-      });
-    });
   };
 
   setDisplayName = ({ reportData, nameType }) => {
@@ -662,11 +639,6 @@ export default class SampleViewV2 extends React.Component {
 
     // different behavior given type of option
     switch (key) {
-      // - min contig size: recompute contig statistics with new size and refresh display
-      case "minContigReads":
-        this.setContigStats({ reportData, ...newSelectedOptions });
-        this.setState({ reportData: [...reportData] });
-        break;
       // - name type: reset table to force a rerender
       case "nameType":
         this.setDisplayName({ reportData, ...newSelectedOptions });
@@ -1095,7 +1067,6 @@ export default class SampleViewV2 extends React.Component {
               reportPresent={!!reportMetadata.reportReady}
               sample={sample}
               view={view}
-              minContigReads={selectedOptions.minContigReads}
             />
           </div>
           <div className={cs.tabsContainer}>

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -420,6 +420,7 @@ export default class SampleViewV2 extends React.Component {
     });
   };
 
+  // TODO (gdingle): fix me
   computeContigStats = ({ reportData, minContigReads }) => {
     reportData.forEach(genus => {
       this.computeRowContigStats({ row: genus, minContigReads });

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -251,7 +251,7 @@ export default class SampleViewV2 extends React.Component {
     }
 
     this.setDisplayName({ reportData, ...selectedOptions });
-    this.computeContigStats({ reportData, ...selectedOptions });
+    this.setContigStats({ reportData, ...selectedOptions });
     const filteredReportData = this.filterReportData({
       reportData,
       filters: selectedOptions,
@@ -399,28 +399,21 @@ export default class SampleViewV2 extends React.Component {
     );
   };
 
-  // TODO (gdingle): rename me
-  computeRowContigStats = ({ row, minContigReads }) => {
+  setRowContigStats = ({ row, minContigReads }) => {
     ["nr", "nt"].forEach(dbType => {
       const dbTypeRow = row[dbType];
       if (dbTypeRow) {
-        if (get([dbType, "contigs"], row)) {
-          console.log(row, minContigReads);
-          debugger;
-        }
-
         dbTypeRow.contigCount = get([dbType, "contigs"], row);
         dbTypeRow.readsCount = get([dbType, "contig_r"], row);
       }
     });
   };
 
-  // TODO (gdingle): fix me
-  computeContigStats = ({ reportData, minContigReads }) => {
+  setContigStats = ({ reportData, minContigReads }) => {
     reportData.forEach(genus => {
-      this.computeRowContigStats({ row: genus, minContigReads });
+      this.setRowContigStats({ row: genus, minContigReads });
       genus.species.forEach(species => {
-        this.computeRowContigStats({ row: species, minContigReads });
+        this.setRowContigStats({ row: species, minContigReads });
       });
     });
   };
@@ -671,7 +664,7 @@ export default class SampleViewV2 extends React.Component {
     switch (key) {
       // - min contig size: recompute contig statistics with new size and refresh display
       case "minContigReads":
-        this.computeContigStats({ reportData, ...newSelectedOptions });
+        this.setContigStats({ reportData, ...newSelectedOptions });
         this.setState({ reportData: [...reportData] });
         break;
       // - name type: reset table to force a rerender

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -399,23 +399,18 @@ export default class SampleViewV2 extends React.Component {
     );
   };
 
+  // TODO (gdingle): rename me
   computeRowContigStats = ({ row, minContigReads }) => {
     ["nr", "nt"].forEach(dbType => {
-      const contigDetails = get([dbType, "contigs"], row);
-      if (contigDetails && keys(contigDetails).length) {
-        const dbTypeRow = row[dbType];
-        dbTypeRow.contigCount = 0;
-        dbTypeRow.readsCount = 0;
+      const dbTypeRow = row[dbType];
+      if (dbTypeRow) {
+        if (get([dbType, "contigs"], row)) {
+          console.log(row, minContigReads);
+          debugger;
+        }
 
-        flow(
-          entries,
-          map(([readsPerContig, count]) => {
-            if (readsPerContig >= minContigReads) {
-              dbTypeRow.contigCount += count;
-              dbTypeRow.readsCount += count * readsPerContig;
-            }
-          })
-        )(contigDetails);
+        dbTypeRow.contigCount = get([dbType, "contigs"], row);
+        dbTypeRow.readsCount = get([dbType, "contig_r"], row);
       }
     });
   };

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1619,16 +1619,14 @@ class PipelineRun < ApplicationRecord
     output
   end
 
+  # TODO: (gdingle): make sure actually passing in min_contig_reads everywhere
   # TODO: (gdingle): fix me
+  # Stores the number of contigs that match a given taxid, count_type (nt or
+  # nr). Create and store default values for the hash if the key doesn't exist yet
   def get_summary_contig_counts_v2(min_contig_reads)
-    # Stores the number of contigs that match a given taxid, count_type (nt or
-    # nr), and read_count (number of reads aligned to that contig). Create and
-    # store default values for the hash if the key doesn't exist yet
     summary_dict = Hash.new do |summary, taxid|
       summary[taxid] = Hash.new do |taxid_hash, count_type| # rubocop forces different variable names
-        taxid_hash[count_type] = Hash.new do |count_type_hash, read_count|
-          count_type_hash[read_count] = 0
-        end
+        taxid_hash[count_type] = 0
       end
     end
     contig_taxids = contigs.where("read_count >= ?", min_contig_reads)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1619,14 +1619,14 @@ class PipelineRun < ApplicationRecord
     output
   end
 
-  # TODO: (gdingle): make sure actually passing in min_contig_reads everywhere
-  # TODO: (gdingle): fix me
-  # Stores the number of contigs that match a given taxid, count_type (nt or
-  # nr). Create and store default values for the hash if the key doesn't exist yet
   def get_summary_contig_counts_v2(min_contig_reads)
+    # Stores the number of contigs that match a given taxid, count_type (nt or nr), and read_count (number of reads aligned to that contig).
+    # Create and store default values for the hash if the key doesn't exist yet
     summary_dict = Hash.new do |summary, taxid|
       summary[taxid] = Hash.new do |taxid_hash, count_type| # rubocop forces different variable names
-        taxid_hash[count_type] = 0
+        taxid_hash[count_type] = Hash.new do |count_type_hash, read_count|
+          count_type_hash[read_count] = 0
+        end
       end
     end
     contig_taxids = contigs.where("read_count >= ?", min_contig_reads)

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1619,9 +1619,11 @@ class PipelineRun < ApplicationRecord
     output
   end
 
+  # TODO: (gdingle): fix me
   def get_summary_contig_counts_v2(min_contig_reads)
-    # Stores the number of contigs that match a given taxid, count_type (nt or nr), and read_count (number of reads aligned to that contig).
-    # Create and store default values for the hash if the key doesn't exist yet
+    # Stores the number of contigs that match a given taxid, count_type (nt or
+    # nr), and read_count (number of reads aligned to that contig). Create and
+    # store default values for the hash if the key doesn't exist yet
     summary_dict = Hash.new do |summary, taxid|
       summary[taxid] = Hash.new do |taxid_hash, count_type| # rubocop forces different variable names
         taxid_hash[count_type] = Hash.new do |count_type_hash, read_count|

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -47,6 +47,7 @@ class PipelineReportService
   Z_SCORE_WHEN_ABSENT_FROM_SAMPLE = -100
 
   DEFAULT_SORT_PARAM = :agg_score
+  # See also PipelineRun::MIN_CONTIG_READS
   DEFAULT_MIN_CONTIG_READS = 0
 
   CATEGORIES = {

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -122,7 +122,6 @@ class PipelineReportService
 
     if @parallel
       parallel_steps = [
-        # TODO: (gdingle): fix me
         -> { @pipeline_run.get_summary_contig_counts_v2(@min_contig_reads) },
         -> { fetch_taxon_counts(@pipeline_run.id, @background_id) },
         -> { fetch_taxons_absent_from_sample(@pipeline_run.id, @background_id) },
@@ -143,7 +142,6 @@ class PipelineReportService
       @timer.split("parallel_fetch_report_data")
       contigs, taxon_counts_and_summaries, taxons_absent_from_sample = *results
     else
-      # TODO: (gdingle): fix me
       contigs = @pipeline_run.get_summary_contig_counts_v2(@min_contig_reads)
       @timer.split("get_contig_summary")
 

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -174,7 +174,7 @@ class PipelineReportService
       )
       @timer.split("cleanup_missing_genus_counts")
 
-      merge_contigs(contigs, counts_by_tax_level, @csv)
+      merge_contigs(contigs, counts_by_tax_level)
       @timer.split("merge_contigs")
 
       counts_by_tax_level.each_value do |tax_level_taxa|
@@ -412,8 +412,7 @@ class PipelineReportService
     return counts_hash
   end
 
-  # TODO: (gdingle): fix me
-  def merge_contigs(contigs, counts_by_tax_level, _csv)
+  def merge_contigs(contigs, counts_by_tax_level)
     contigs.each do |tax_id, contigs_per_db_type|
       contigs_per_db_type.each do |db_type, contigs_per_read_count|
         norm_count_type = db_type.downcase.to_sym

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -413,7 +413,7 @@ class PipelineReportService
   end
 
   # TODO: (gdingle): fix me
-  def merge_contigs(contigs, counts_by_tax_level, csv)
+  def merge_contigs(contigs, counts_by_tax_level, _csv)
     contigs.each do |tax_id, contigs_per_db_type|
       contigs_per_db_type.each do |db_type, contigs_per_read_count|
         norm_count_type = db_type.downcase.to_sym
@@ -423,18 +423,14 @@ class PipelineReportService
         end
 
         if counts_per_db_type
-          if csv
-            contigs = 0
-            contig_r = 0
-            contigs_per_read_count.each do |reads, count|
-              contigs += count
-              contig_r += count * reads
-            end
-            counts_per_db_type[:contigs] = contigs
-            counts_per_db_type[:contig_r] = contig_r
-          else
-            counts_per_db_type[:contigs] = contigs_per_read_count
+          contigs = 0
+          contig_r = 0
+          contigs_per_read_count.each do |reads, count|
+            contigs += count
+            contig_r += count * reads
           end
+          counts_per_db_type[:contigs] = contigs
+          counts_per_db_type[:contig_r] = contig_r
         else
           # TODO(tiago): not sure if this case ever happens
           Rails.logger.warn("[PR=#{@pipeline_run.id}] PR has contigs but not taxon counts for taxon #{tax_id} in #{db_type}: #{contigs_per_read_count}")

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -122,6 +122,7 @@ class PipelineReportService
 
     if @parallel
       parallel_steps = [
+        # TODO: (gdingle): fix me
         -> { @pipeline_run.get_summary_contig_counts_v2(@min_contig_reads) },
         -> { fetch_taxon_counts(@pipeline_run.id, @background_id) },
         -> { fetch_taxons_absent_from_sample(@pipeline_run.id, @background_id) },
@@ -142,6 +143,7 @@ class PipelineReportService
       @timer.split("parallel_fetch_report_data")
       contigs, taxon_counts_and_summaries, taxons_absent_from_sample = *results
     else
+      # TODO: (gdingle): fix me
       contigs = @pipeline_run.get_summary_contig_counts_v2(@min_contig_reads)
       @timer.split("get_contig_summary")
 
@@ -410,6 +412,7 @@ class PipelineReportService
     return counts_hash
   end
 
+  # TODO: (gdingle): fix me
   def merge_contigs(contigs, counts_by_tax_level, csv)
     contigs.each do |tax_id, contigs_per_db_type|
       contigs_per_db_type.each do |db_type, contigs_per_read_count|


### PR DESCRIPTION
# Description

Following #3157 , we no longer need to compute and send per count taxa info to the report page. 

## Before

![image](https://user-images.githubusercontent.com/28797/76471126-1589cb00-63af-11ea-9c30-3630dce463f7.png)

## After

![image](https://user-images.githubusercontent.com/28797/76471137-1e7a9c80-63af-11ea-94a9-5ec047366813.png)

# Tests

* try http://localhost:3000/samples/13435 
* see no change in contig rows before and after