### PR TITLE
Add support for a custom taxon whitelist processing mode, behind feature flag

### DIFF
--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -44,6 +44,7 @@ export const bulkUploadLocalWithMetadata = async ({
       "project_id",
       "do_not_process",
       "pipeline_execution_strategy",
+      "use_taxon_whitelist",
     ]),
     samples
   );

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -41,6 +41,7 @@ class ReviewStep extends React.Component {
     showUploadModal: false,
     skipSampleProcessing: false,
     useStepFunctionPipeline: false,
+    useTaxonWhitelist: false,
   };
 
   componentDidMount() {
@@ -198,6 +199,13 @@ class ReviewStep extends React.Component {
     });
   };
 
+  toggleUseTaxonWhitelist = () => {
+    const { useTaxonWhitelist } = this.state;
+    this.setState({
+      useTaxonWhitelist: !useTaxonWhitelist,
+    });
+  };
+
   // This is only for admins and QA testers.
   renderSkipSampleProcessingOption = () => {
     const { skipSampleProcessing, useStepFunctionPipeline } = this.state;
@@ -222,6 +230,18 @@ class ReviewStep extends React.Component {
         checked={useStepFunctionPipeline && !skipSampleProcessing}
         disabled={skipSampleProcessing}
         onChange={this.toggleUseStepFunctionPipeline}
+        label="Use wdl / step function pipeline."
+      />
+    );
+  };
+
+  renderUseTaxonWhitelist = () => {
+    const { useTaxonWhitelist } = this.state;
+    return (
+      <Checkbox
+        className={cs.sampleProcessingOption}
+        checked={useTaxonWhitelist}
+        onChange={this.toggleUseTaxonWhitelist}
         label="Use wdl / step function pipeline."
       />
     );

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -447,6 +447,7 @@ class ReviewStep extends React.Component {
               project={project}
               skipSampleProcessing={skipSampleProcessing}
               useStepFunctionPipeline={useStepFunctionPipeline}
+              useTaxonWhitelist={useTaxonWhitelist}
             />
           )}
         </div>

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -242,7 +242,7 @@ class ReviewStep extends React.Component {
         className={cs.sampleProcessingOption}
         checked={useTaxonWhitelist}
         onChange={this.toggleUseTaxonWhitelist}
-        label="Use wdl / step function pipeline."
+        label="Use respiratory pathogen whitelist mode."
       />
     );
   };
@@ -271,6 +271,7 @@ class ReviewStep extends React.Component {
       skipSampleProcessing,
       consentChecked,
       useStepFunctionPipeline,
+      useTaxonWhitelist,
     } = this.state;
 
     const {
@@ -406,6 +407,7 @@ class ReviewStep extends React.Component {
             this.renderSkipSampleProcessingOption()}
           {allowedFeatures.includes("step_function_pipeline") &&
             this.renderUseStepFunctionPipelineOption()}
+          {this.renderUseTaxonWhitelist()}
           <TermsAgreement
             checked={consentChecked}
             onChange={() =>

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -407,7 +407,8 @@ class ReviewStep extends React.Component {
             this.renderSkipSampleProcessingOption()}
           {allowedFeatures.includes("step_function_pipeline") &&
             this.renderUseStepFunctionPipelineOption()}
-          {this.renderUseTaxonWhitelist()}
+          {allowedFeatures.includes("taxon_whitelist") &&
+            this.renderUseTaxonWhitelist()}
           <TermsAgreement
             checked={consentChecked}
             onChange={() =>

--- a/app/assets/src/components/views/SampleUploadFlow/UploadProgressModal.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadProgressModal.jsx
@@ -121,7 +121,11 @@ export default class UploadProgressModal extends React.Component {
 
   // Add any flags selected by the user in the Review Step.
   addFlagsToSamples = samples => {
-    const { skipSampleProcessing, useStepFunctionPipeline } = this.props;
+    const {
+      skipSampleProcessing,
+      useStepFunctionPipeline,
+      useTaxonWhitelist,
+    } = this.props;
 
     const pipeline_execution_strategy = useStepFunctionPipeline
       ? PIPELINE_EXECUTION_STRATEGIES.step_function
@@ -131,6 +135,7 @@ export default class UploadProgressModal extends React.Component {
       ...sample,
       do_not_process: skipSampleProcessing,
       pipeline_execution_strategy,
+      use_taxon_whitelist: useTaxonWhitelist,
     }));
   };
 
@@ -524,4 +529,5 @@ UploadProgressModal.propTypes = {
   project: PropTypes.Project,
   skipSampleProcessing: PropTypes.bool,
   useStepFunctionPipeline: PropTypes.bool,
+  useTaxonWhitelist: PropTypes.bool,
 };

--- a/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
+++ b/app/assets/src/components/views/SampleViewV2/SampleViewV2.jsx
@@ -862,11 +862,22 @@ export default class SampleViewV2 extends React.Component {
     );
   };
 
+  whitelistedMessage = () => {
+    const {
+      reportMetadata: { taxonWhitelisted },
+    } = this.state;
+    return (
+      taxonWhitelisted &&
+      `Report was processed with a whitelist filter of respiratory pathogens.`
+    );
+  };
+
   renderReportInfo = () => {
     return compact([
       this.truncatedMessage(),
       this.subsamplingMessage(),
       this.filteredMessage(),
+      this.whitelistedMessage(),
     ]).map((msg, i) => (
       <span className={cs.reportInfoMsg} key={`msg-${i}`}>
         {msg}

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1390,7 +1390,7 @@ class SamplesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def samples_params
-    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name, :basespace_dataset_id, :basespace_access_token, :skip_cache, :do_not_process, :pipeline_execution_strategy,
+    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name, :basespace_dataset_id, :basespace_access_token, :skip_cache, :do_not_process, :pipeline_execution_strategy, :use_taxon_whitelist,
                                          input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts],])
     new_params[:samples] if new_params
   end
@@ -1400,7 +1400,7 @@ class SamplesController < ApplicationController
                         :s3_star_index_path, :s3_bowtie2_index_path,
                         :host_genome_id, :host_genome_name,
                         :sample_notes, :search, :subsample, :max_input_fragments,
-                        :basespace_dataset_id, :basespace_access_token, :client, :do_not_process, :pipeline_execution_strategy,
+                        :basespace_dataset_id, :basespace_access_token, :client, :do_not_process, :pipeline_execution_strategy, :use_taxon_whitelist,
                         input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts],]
     permitted_params.concat([:pipeline_branch, :dag_vars, :s3_preload_result_path, :alignment_config_name, :subsample]) if current_user.admin?
     params.require(:sample).permit(*permitted_params)

--- a/app/lib/dags/non_host_alignment.json.jbuilder
+++ b/app/lib/dags/non_host_alignment.json.jbuilder
@@ -47,11 +47,14 @@ json.steps do
     job_tag_prefix: attr[:job_tag_prefix],
     job_tag_refresh_seconds: attr[:job_tag_refresh_seconds],
     draining_tag: attr[:draining_tag],
-    use_taxon_whitelist: attr[:use_taxon_whitelist],
   }
 
   if attr[:index_dir_suffix]
     additional_attributes["index_dir_suffix"] = attr[:index_dir_suffix]
+  end
+
+  if attr[:use_taxon_whitelist]
+    additional_attributes["use_taxon_whitelist"] = attr[:use_taxon_whitelist]
   end
 
   steps << {
@@ -73,11 +76,14 @@ json.steps do
     job_tag_prefix: attr[:job_tag_prefix],
     job_tag_refresh_seconds: attr[:job_tag_refresh_seconds],
     draining_tag: attr[:draining_tag],
-    use_taxon_whitelist: attr[:use_taxon_whitelist],
   }
 
   if attr[:index_dir_suffix]
     additional_attributes["index_dir_suffix"] = attr[:index_dir_suffix]
+  end
+
+  if attr[:use_taxon_whitelist]
+    additional_attributes["use_taxon_whitelist"] = attr[:use_taxon_whitelist]
   end
 
   steps << {

--- a/app/lib/dags/non_host_alignment.json.jbuilder
+++ b/app/lib/dags/non_host_alignment.json.jbuilder
@@ -73,6 +73,7 @@ json.steps do
     job_tag_prefix: attr[:job_tag_prefix],
     job_tag_refresh_seconds: attr[:job_tag_refresh_seconds],
     draining_tag: attr[:draining_tag],
+    use_taxon_whitelist: attr[:use_taxon_whitelist],
   }
 
   if attr[:index_dir_suffix]

--- a/app/lib/dags/non_host_alignment.json.jbuilder
+++ b/app/lib/dags/non_host_alignment.json.jbuilder
@@ -47,6 +47,7 @@ json.steps do
     job_tag_prefix: attr[:job_tag_prefix],
     job_tag_refresh_seconds: attr[:job_tag_refresh_seconds],
     draining_tag: attr[:draining_tag],
+    use_taxon_whitelist: attr[:use_taxon_whitelist],
   }
 
   if attr[:index_dir_suffix]

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -298,7 +298,7 @@ class PipelineRunStage < ApplicationRecord
       chunks_in_flight: PipelineRun::MAX_CHUNKS_IN_FLIGHT,
       gsnap_m8: PipelineRun::GSNAP_M8,
       rapsearch_m8: PipelineRun::RAPSEARCH_M8,
-      use_taxon_whitelist: sample.use_taxon_whitelist,
+      use_taxon_whitelist: pipeline_run.use_taxon_whitelist,
     }
     return generate_json(attribute_dict)
   end

--- a/app/models/pipeline_run_stage.rb
+++ b/app/models/pipeline_run_stage.rb
@@ -298,6 +298,7 @@ class PipelineRunStage < ApplicationRecord
       chunks_in_flight: PipelineRun::MAX_CHUNKS_IN_FLIGHT,
       gsnap_m8: PipelineRun::GSNAP_M8,
       rapsearch_m8: PipelineRun::RAPSEARCH_M8,
+      use_taxon_whitelist: sample.use_taxon_whitelist,
     }
     return generate_json(attribute_dict)
   end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -741,6 +741,8 @@ class Sample < ApplicationRecord
     pr.max_input_fragments = max_input_fragments || PipelineRun::DEFAULT_MAX_INPUT_FRAGMENTS
     pr.pipeline_branch = pipeline_branch.blank? ? "master" : pipeline_branch
     pr.pipeline_execution_strategy = pipeline_execution_strategy.blank? ? PipelineRun.directed_acyclic_graph : pipeline_execution_strategy
+    pr.use_taxon_whitelist = use_taxon_whitelist
+
     pr.dag_vars = dag_vars if dag_vars
     pr.pipeline_commit = Sample.pipeline_commit(pr.pipeline_branch)
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -742,6 +742,7 @@ class Sample < ApplicationRecord
     pr.pipeline_branch = pipeline_branch.blank? ? "master" : pipeline_branch
     pr.pipeline_execution_strategy = pipeline_execution_strategy.blank? ? PipelineRun.directed_acyclic_graph : pipeline_execution_strategy
     pr.dag_vars = dag_vars if dag_vars
+    pr.use_taxon_whitelist = use_taxon_whitelist
     pr.pipeline_commit = Sample.pipeline_commit(pr.pipeline_branch)
 
     pr.alignment_config = AlignmentConfig.find_by(name: alignment_config_name) if alignment_config_name

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -741,8 +741,6 @@ class Sample < ApplicationRecord
     pr.max_input_fragments = max_input_fragments || PipelineRun::DEFAULT_MAX_INPUT_FRAGMENTS
     pr.pipeline_branch = pipeline_branch.blank? ? "master" : pipeline_branch
     pr.pipeline_execution_strategy = pipeline_execution_strategy.blank? ? PipelineRun.directed_acyclic_graph : pipeline_execution_strategy
-    pr.use_taxon_whitelist = use_taxon_whitelist
-
     pr.dag_vars = dag_vars if dag_vars
     pr.pipeline_commit = Sample.pipeline_commit(pr.pipeline_branch)
 

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -262,6 +262,7 @@ class PipelineReportService
                                 truncatedReadsCount: @pipeline_run.truncated,
                                 adjustedRemainingReadsCount: @pipeline_run.adjusted_remaining_reads,
                                 subsampledReadsCount: @pipeline_run.subsampled_reads,
+                                taxonWhitelisted: @pipeline_run.use_taxon_whitelist,
                                 hasByteRanges: has_byte_ranges,
                                 alignVizAvailable: align_viz_available)
 

--- a/db/migrate/20200311210521_add_use_taxon_whitelist_to_samples.rb
+++ b/db/migrate/20200311210521_add_use_taxon_whitelist_to_samples.rb
@@ -1,0 +1,5 @@
+class AddUseTaxonWhitelistToSamples < ActiveRecord::Migration[5.1]
+  def change
+    add_column :samples, :use_taxon_whitelist, :boolean, default: false, null: false, comment: "If true, sample processing will filter for a whitelist of taxons."
+  end
+end

--- a/db/migrate/20200311210521_add_use_taxon_whitelist_to_samples.rb
+++ b/db/migrate/20200311210521_add_use_taxon_whitelist_to_samples.rb
@@ -1,5 +1,6 @@
 class AddUseTaxonWhitelistToSamples < ActiveRecord::Migration[5.1]
   def change
     add_column :samples, :use_taxon_whitelist, :boolean, default: false, null: false, comment: "If true, sample processing will filter for a whitelist of taxons."
+    add_column :pipeline_runs, :use_taxon_whitelist, :boolean, default: false, null: false, comment: "If true, pipeline processing will filter for a whitelist of taxons."
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_227_225_541) do
+ActiveRecord::Schema.define(version: 20_200_311_225_541) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -425,6 +425,7 @@ ActiveRecord::Schema.define(version: 20_200_227_225_541) do
     t.string "upload_error"
     t.boolean "do_not_process", default: false, null: false, comment: "If true, sample will skip pipeline processing."
     t.string "pipeline_execution_strategy", default: "directed_acyclic_graph", comment: "A soft enum (string) describing which pipeline infrastructure to run the sample on."
+    t.boolean "use_taxon_whitelist", default: false, null: false, comment: "If true, sample processing will filter for a whitelist of taxons."
     t.index ["host_genome_id"], name: "samples_host_genome_id_fk"
     t.index ["project_id", "name"], name: "index_samples_name_project_id", unique: true
     t.index ["user_id"], name: "index_samples_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -367,6 +367,7 @@ ActiveRecord::Schema.define(version: 20_200_311_225_541) do
     t.string "known_user_error"
     t.string "pipeline_execution_strategy", default: "directed_acyclic_graph", comment: "A soft enum (string) describing which pipeline infrastructure the pipeline run was performed on."
     t.string "sfn_execution_arn", comment: "step function execution ARN for pipeline runs using pipeline_execution_strategy=step_function"
+    t.boolean "use_taxon_whitelist", default: false, null: false, comment: "If true, pipeline processing will filter for a whitelist of taxons."
     t.index ["alignment_config_id"], name: "pipeline_runs_alignment_config_id_fk"
     t.index ["job_status"], name: "index_pipeline_runs_on_job_status"
     t.index ["sample_id"], name: "index_pipeline_runs_on_sample_id"


### PR DESCRIPTION
### Description
- This adds a feature flag that adds a checkbox that adds an additional_attribute to enable a custom taxon whitelist processing mode, for a special use case.
- This goes along with this PR: https://github.com/chanzuckerberg/idseq-dag/pull/263

### Notes
- Similar addition to the flag in #3098.
- I wanted to keep it an explicit flag with `use_taxon_whitelist` for simplicity. The whitelist S3 path doesn't have to live in idseq-web at all, and we don't need that level of customizability yet. This is similar to the `do_not_process` attribute.
- I noticed we still had dag_vars around but it looks like having the explicit attributes is preferred now (with the v2 upload page).

### Testing
- I've tested this end-to-end locally, with a dag branch, so it should be good to go.

Checkbox:
![Screen Shot 2020-03-11 at 4 04 18 PM](https://user-images.githubusercontent.com/5652739/76472194-0b1d0080-63b2-11ea-9b2c-47e74d57ad91.png)

Dag example:
![Screen Shot 2020-03-11 at 3 45 56 PM](https://user-images.githubusercontent.com/5652739/76471258-6e596380-63af-11ea-9a07-817f5209ddb1.png)

Report example:
![Screen Shot 2020-03-11 at 3 02 49 PM](https://user-images.githubusercontent.com/5652739/76471382-b5475900-63af-11ea-95f5-f90f1abb093f.png)

Steps for QA:
- Ask me to add the "taxon_whitelist" feature flag for you.
- Go through the upload process normally. On the Review Step, check "Use respiratory pathogen whitelist mode".
- Sample should process successfully. Samples without the flag should also process successfully.