### PR TITLE
Fix sfn_info error undefined method

### DIFF
--- a/app/helpers/pipeline_runs_helper.rb
+++ b/app/helpers/pipeline_runs_helper.rb
@@ -103,7 +103,7 @@ module PipelineRunsHelper
     if status.exitstatus.zero?
       sfn_execution_history_hash = JSON.parse(stdout)
       sfn_hash = parse_sfn_execution_history_hash(sfn_execution_history_hash)
-      job_status = sfn_hash[stage_number.to_s]["status"]
+      job_status = sfn_hash.dig(stage_number.to_s, "status") || "PENDING"
     else
       LogUtil.log_err_and_airbrake("Error for update sfn status for record #{run_id} - stage #{stage_number} with error #{stderr}")
       job_status = PipelineRunStage::STATUS_ERROR # transient error, job is still "in progress"

--- a/spec/helpers/pipeline_runs_helper_spec.rb
+++ b/spec/helpers/pipeline_runs_helper_spec.rb
@@ -165,6 +165,25 @@ RSpec.describe PipelineRunsHelper, type: :helper do
           it { is_expected.to eq(["FAILED", nil]) }
         end
       end
+
+      context "and it is in progress of stage 2" do
+        let(:fixture_file) { "sfn-execution-history_in-progress.json" }
+
+        context "and fetching status for stage 1" do
+          let(:stage_number) { 1 }
+          it { is_expected.to eq(["SUCCEEDED", nil]) }
+        end
+
+        context "and fetching status for stage 2" do
+          let(:stage_number) { 2 }
+          it { is_expected.to eq(["RUNNING", nil]) }
+        end
+
+        context "and fetching status for stage 3" do
+          let(:stage_number) { 3 }
+          it { is_expected.to eq(["PENDING", nil]) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

Fix a bug where `sfn_info` breaks with `undefined method []' for nil:NilClass` error when checking status for a stage that hasn't started yet.

# Tests

* Unit tests
