### PR TITLE
Remove table_exists call

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -23,7 +23,7 @@ class ApplicationRecord < ActiveRecord::Base
   def mass_validation_enabled?
     @@mass_validation_enabled ||= AppConfigHelper.get_app_config(AppConfig::ENABLE_MASS_VALIDATION) || false # rubocop:disable Style/ClassVars
   rescue StandardError
-    # This will occur during some migrations
+    # This will occur during CreateAppConfigTable migration
     @@mass_validation_enabled = false # rubocop:disable Style/ClassVars
   end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -21,12 +21,14 @@ class ApplicationRecord < ActiveRecord::Base
   # Condition for rollout of mass addition of validation rules.
   # Cached for performance.
   def mass_validation_enabled?
-    # for migrations previous to AppConfig creation
-    if AppConfig.table_exists?
-      @@mass_validation_enabled = !!AppConfigHelper.get_app_config(AppConfig::ENABLE_MASS_VALIDATION) if @@mass_validation_enabled.nil? # rubocop:disable Style/ClassVars,Style/DoubleNegation
+    if AppConfig.table_exists? # for migrations previous to AppConfig creation
+      @@mass_validation_enabled ||= AppConfigHelper.get_app_config(AppConfig::ENABLE_MASS_VALIDATION) || false # rubocop:disable Style/ClassVars
     end
-    @@mass_validation_enabled
+  rescue Mysql2::Error
+    # This will occur during some migrations
+    @@mass_validation_enabled = false # rubocop:disable Style/ClassVars
   end
+
   # Set current user and request to global for use in logging.
   # See https://stackoverflow.com/a/11670283/200312
   class << self

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -22,7 +22,7 @@ class ApplicationRecord < ActiveRecord::Base
   # Cached for performance.
   def mass_validation_enabled?
     @@mass_validation_enabled ||= AppConfigHelper.get_app_config(AppConfig::ENABLE_MASS_VALIDATION) || false # rubocop:disable Style/ClassVars
-  rescue Mysql2::Error
+  rescue StandardError
     # This will occur during some migrations
     @@mass_validation_enabled = false # rubocop:disable Style/ClassVars
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -21,9 +21,7 @@ class ApplicationRecord < ActiveRecord::Base
   # Condition for rollout of mass addition of validation rules.
   # Cached for performance.
   def mass_validation_enabled?
-    if AppConfig.table_exists? # for migrations previous to AppConfig creation
-      @@mass_validation_enabled ||= AppConfigHelper.get_app_config(AppConfig::ENABLE_MASS_VALIDATION) || false # rubocop:disable Style/ClassVars
-    end
+    @@mass_validation_enabled ||= AppConfigHelper.get_app_config(AppConfig::ENABLE_MASS_VALIDATION) || false # rubocop:disable Style/ClassVars
   rescue Mysql2::Error
     # This will occur during some migrations
     @@mass_validation_enabled = false # rubocop:disable Style/ClassVars


### PR DESCRIPTION
# Description

This call was actually executing a SQL query which hurt performance in staging. The fix is to catch the exception produced during migrations. 

# Tests

try RAILS_ENV=test bin/rails db:drop db:create db:migrate db:seed
see no exception

check after deploy to staging
