### PR TITLE
Handle duplicate sample names in AMR Heatmap

### DIFF
--- a/app/assets/src/components/views/amr_heatmap/AMRHeatmapView.jsx
+++ b/app/assets/src/components/views/amr_heatmap/AMRHeatmapView.jsx
@@ -104,16 +104,19 @@ export default class AMRHeatmapView extends React.Component {
   }
 
   correctSampleAndGeneNames(filteredSamples) {
-    let sampleNames = {};
+    let sampleNames = new Map();
     let duplicateSampleNames = new Set();
     filteredSamples.forEach(sample => {
       // Keep track of samples with the same name, which may occur if
       // a user selects samples from multiple projects.
-      if (Object.keys(sampleNames).includes(sample.sampleName)) {
-        sampleNames[sample.sampleName].push(sample);
+      if (sampleNames.has(sample.sampleName)) {
+        let duplicateSamples = sampleNames
+          .get(sample.sampleName)
+          .concat([sample]);
+        sampleNames.set(sample.sampleName, duplicateSamples);
         duplicateSampleNames.add(sample.sampleName);
       } else {
-        sampleNames[sample.sampleName] = [sample];
+        sampleNames.set(sample.sampleName, [sample]);
       }
 
       sample.amrCounts.forEach(amrCount => {
@@ -129,8 +132,8 @@ export default class AMRHeatmapView extends React.Component {
 
     // Append a number to a sample's name to differentiate between samples with the same name.
     duplicateSampleNames.forEach(sampleName => {
-      for (let i = 0; i < sampleNames[sampleName].length; i++) {
-        let sample = sampleNames[sampleName][i];
+      for (let i = 0; i < sampleNames.get(sampleName).length; i++) {
+        let sample = sampleNames.get(sampleName)[i];
         sample.sampleName = `${sampleName} (${i + 1})`;
       }
     });

--- a/app/assets/src/components/views/amr_heatmap/AMRHeatmapView.jsx
+++ b/app/assets/src/components/views/amr_heatmap/AMRHeatmapView.jsx
@@ -104,19 +104,17 @@ export default class AMRHeatmapView extends React.Component {
   }
 
   correctSampleAndGeneNames(filteredSamples) {
-    let sampleNames = new Map();
-    let duplicateSampleNames = new Set();
+    let sampleNamesCounts = new Map();
     filteredSamples.forEach(sample => {
       // Keep track of samples with the same name, which may occur if
       // a user selects samples from multiple projects.
-      if (sampleNames.has(sample.sampleName)) {
-        let duplicateSamples = sampleNames
-          .get(sample.sampleName)
-          .concat([sample]);
-        sampleNames.set(sample.sampleName, duplicateSamples);
-        duplicateSampleNames.add(sample.sampleName);
+      if (sampleNamesCounts.has(sample.sampleName)) {
+        // Append a number to a sample's name to differentiate between samples with the same name.
+        let count = sampleNamesCounts.get(sample.sampleName);
+        sample.sampleName = `${sample.sampleName} (${count})`;
+        sampleNamesCounts.set(sample.sampleName, count + 1);
       } else {
-        sampleNames.set(sample.sampleName, [sample]);
+        sampleNamesCounts.set(sample.sampleName, 1);
       }
 
       sample.amrCounts.forEach(amrCount => {
@@ -128,14 +126,6 @@ export default class AMRHeatmapView extends React.Component {
         const geneName = geneNameExtractionRegex.exec(amrCount.gene)[0];
         amrCount.gene = geneName;
       });
-    });
-
-    // Append a number to a sample's name to differentiate between samples with the same name.
-    duplicateSampleNames.forEach(sampleName => {
-      for (let i = 0; i < sampleNames.get(sampleName).length; i++) {
-        let sample = sampleNames.get(sampleName)[i];
-        sample.sampleName = `${sampleName} (${i + 1})`;
-      }
     });
 
     return filteredSamples;

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -375,8 +375,7 @@ class SamplesHeatmapView extends React.Component {
 
   extractData(rawData) {
     let sampleIds = [];
-    let sampleNames = {};
-    let duplicateSampleNames = new Set();
+    let sampleNamesCounts = new Map();
     let sampleDetails = {};
     let allTaxonIds = [];
     let allTaxonDetails = {};
@@ -389,11 +388,13 @@ class SamplesHeatmapView extends React.Component {
 
       // Keep track of samples with the same name, which may occur if
       // a user selects samples from multiple projects.
-      if (Object.keys(sampleNames).includes(sample.name)) {
-        sampleNames[sample.name].push(sample.sample_id);
-        duplicateSampleNames.add(sample.name);
+      if (sampleNamesCounts.has(sample.name)) {
+        // Append a number to a sample's name to differentiate between samples with the same name.
+        let count = sampleNamesCounts.get(sample.name);
+        sample.name = `${sample.name} (${count})`;
+        sampleNamesCounts.set(sample.name, count + 1);
       } else {
-        sampleNames[sample.name] = [sample.sample_id];
+        sampleNamesCounts.set(sample.name, 1);
       }
 
       sampleDetails[sample.sample_id] = {
@@ -441,15 +442,6 @@ class SamplesHeatmapView extends React.Component {
         }
       }
     }
-
-    // Append a number to a sample's name to differentiate between samples with the same name.
-    duplicateSampleNames.forEach(sampleName => {
-      for (let i = 0; i < sampleNames[sampleName].length; i++) {
-        let sampleId = sampleNames[sampleName][i];
-        sampleDetails[sampleId]["name"] = `${sampleName} (${i + 1})`;
-        sampleDetails[sampleId]["duplicate"] = true;
-      }
-    });
 
     return {
       // The server should always pass back the same set of sampleIds, but possibly in a different order.


### PR DESCRIPTION
# Description

Related to https://github.com/chanzuckerberg/idseq-web/pull/3152.

Differentiate between samples with duplicate names in the AMR heatmap by adding (#) at the end.
![image](https://user-images.githubusercontent.com/53838890/76559419-5f7cba80-645c-11ea-8e51-e764762e56c2.png)

# Tests

* Created an AMR heatmap using samples with the same name from two different projects and verified that the sample names and metadata rendered as expected.
