### PR TITLE
Fix unknown firstpos: NilClass bug in development.

### DIFF
--- a/config/initializers/routes.rb
+++ b/config/initializers/routes.rb
@@ -1,0 +1,19 @@
+# # Fixes 'ArgumentError: unknown firstpos: NilClass' for development.
+
+# See: https://stackoverflow.com/questions/44465118/rails-5-1-unknown-firstpos-nilclass-issue-reloading-application
+# Fixed in a later version of Rails with: https://github.com/rails/rails/pull/33118
+
+if Rails.env == 'development'
+  module ActionDispatch
+    module Journey
+      class Routes
+        def simulator
+          @simulator ||= begin
+            gtg = GTG::Builder.new(ast).transition_table if ast.present?
+            GTG::Simulator.new(gtg)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

![q1Ac2](https://user-images.githubusercontent.com/837004/76587382-e6ec1d00-64a0-11ea-8ba5-fa19f4e61f49.png)

Fix bug that causes this screen in development when changing Rails code.
Fix taken from: # See: https://stackoverflow.com/questions/44465118/rails-5-1-unknown-firstpos-nilclass-issue-reloading-application

Enabling this fix only in development (since it doesn't affect other environments).

# Tests

* Verified that bug no longer appears in development.
* Verified that code changes are correctly picked up when the page is reloaded once.
* Since the bug appears to be related to routing, visited some different pages and verified the routing worked properly.
