### PR TITLE
Add error message when bulk download creation fails unexpectedly.

### DIFF
--- a/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModal.jsx
@@ -20,6 +20,9 @@ import BulkDownloadModalOptions from "./BulkDownloadModalOptions";
 import BulkDownloadModalFooter from "./BulkDownloadModalFooter";
 import cs from "./bulk_download_modal.scss";
 
+const DEFAULT_CREATION_ERROR =
+  "An unknown error occurred. Please contact us for help.";
+
 const assembleSelectedDownload = memoize(
   (
     selectedDownloadTypeName,
@@ -274,7 +277,7 @@ class BulkDownloadModal extends React.Component {
       this.setState({
         waitingForCreate: false,
         createStatus: "error",
-        createError: e.error,
+        createError: e.error || DEFAULT_CREATION_ERROR,
       });
       logAnalyticsEvent("BulkDownloadModal_bulk-download-creation_failed");
       return;


### PR DESCRIPTION

# Description

When an unknown error occurred, it was noted that the bulk download displayed an empty error message. This provides a default message to show instead.
See https://jira.czi.team/browse/IDSEQ-2418

<img width="748" alt="Screen Shot 2020-03-13 at 12 55 37 PM" src="https://user-images.githubusercontent.com/837004/76655282-2dd22500-652a-11ea-8744-ca2cff2b2cdb.png">

# Tests
* Verified that error message displays if failure with no error message occurs.
