### PR TITLE
Add launched features

### DIFF
--- a/app/helpers/app_config_helper.rb
+++ b/app/helpers/app_config_helper.rb
@@ -28,6 +28,10 @@ module AppConfigHelper
     default_value
   end
 
+  def set_json_app_config(key, value)
+    AppConfigHelper.set_app_config(key, JSON.dump(value))
+  end
+
   # Return all app configs that should be sent to the front-end React application.
   def configs_for_context
     # Fetch all app configs in one query.

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -28,5 +28,6 @@ class AppConfig < ApplicationRecord
   # Presence of the flag switches on the feature.
   ENABLE_MASS_VALIDATION = 'enable_mass_validation'.freeze
   # List of launched features still guarded by a flag.
+  # Use the features rake tasks for editing this key
   LAUNCHED_FEATURES = 'launched_features'.freeze
 end

--- a/app/models/app_config.rb
+++ b/app/models/app_config.rb
@@ -18,11 +18,11 @@ class AppConfig < ApplicationRecord
   # When this is "1", the announcement banner on the top of the site header will be enabled.
   # Other conditions may check a time constraint.
   SHOW_ANNOUNCEMENT_BANNER = 'show_announcement_banner'.freeze
-
   # When this is "1", the COVID-19 Public Site banner on the landing page will be shown.
   SHOW_LANDING_PUBLIC_SITE_BANNER = 'show_landing_public_site_banner'.freeze
-
   # Switch for additional ActiveRecord validations that were added en masse in Feb 2020.
   # Presence of the flag switches on the feature.
   ENABLE_MASS_VALIDATION = 'enable_mass_validation'.freeze
+  # List of launched features still guarded by a flag.
+  LAUNCHED_FEATURES = 'launched_features'.freeze
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,7 +64,7 @@ class User < ApplicationRecord
   end
 
   def allowed_feature_list
-    launched = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES) || []
+    launched = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES, [])
     JSON.parse(allowed_features || "[]") | launched
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,7 +64,8 @@ class User < ApplicationRecord
   end
 
   def allowed_feature_list
-    JSON.parse(allowed_features || "[]")
+    launched = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES) || []
+    JSON.parse(allowed_features || "[]") | launched
   end
 
   def allowed_feature?(feature)

--- a/lib/tasks/features.rake
+++ b/lib/tasks/features.rake
@@ -1,0 +1,27 @@
+namespace "features" do
+  task :launch, [:feature_name] => :environment do |_, args|
+    new_features = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES, []) | [args[:feature_name]]
+    AppConfigHelper.set_json_app_config(AppConfig::LAUNCHED_FEATURES, new_features)
+    puts "Add feature: #{args[:feature_name]}"
+    puts "Currently launched: #{new_features}"
+  end
+
+  # rake features:remove[<f]
+  task :remove, [:feature_name] => :environment do |_, args|
+    features = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES, [])
+    if features.include?(args[:feature_name])
+      features -= [args[:feature_name]]
+      AppConfigHelper.set_json_app_config(AppConfig::LAUNCHED_FEATURES, features)
+      puts "Removed feature: #{args[:feature_name]}"
+    else
+      puts "Feature is not launched: #{args[:feature_name]}"
+    end
+    puts "Currently launched: #{features}"
+  end
+
+  # rake features:show
+  task :show => :environment do
+    features = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES, [])
+    puts "Currently launched: #{features}"
+  end
+end

--- a/lib/tasks/features.rake
+++ b/lib/tasks/features.rake
@@ -1,4 +1,6 @@
 namespace "features" do
+
+  # rake features:launch[<feature_name>]
   task :launch, [:feature_name] => :environment do |_, args|
     new_features = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES, []) | [args[:feature_name]]
     AppConfigHelper.set_json_app_config(AppConfig::LAUNCHED_FEATURES, new_features)
@@ -6,7 +8,7 @@ namespace "features" do
     puts "Currently launched: #{new_features}"
   end
 
-  # rake features:remove[<f]
+  # rake features:remove[<feature_name>]
   task :remove, [:feature_name] => :environment do |_, args|
     features = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES, [])
     if features.include?(args[:feature_name])
@@ -19,8 +21,8 @@ namespace "features" do
     puts "Currently launched: #{features}"
   end
 
-  # rake features:show
-  task :show => :environment do
+  # rake features:list
+  task :list => :environment do
     features = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES, [])
     puts "Currently launched: #{features}"
   end

--- a/lib/tasks/features.rake
+++ b/lib/tasks/features.rake
@@ -1,5 +1,4 @@
 namespace "features" do
-
   # rake features:launch[<feature_name>]
   task :launch, [:feature_name] => :environment do |_, args|
     new_features = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES, []) | [args[:feature_name]]
@@ -22,7 +21,7 @@ namespace "features" do
   end
 
   # rake features:list
-  task :list => :environment do
+  task list: :environment do
     features = AppConfigHelper.get_json_app_config(AppConfig::LAUNCHED_FEATURES, [])
     puts "Currently launched: #{features}"
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+LAUNCHED_FEATURES = ["feature_1", "feature_2"].freeze
+USER_FEATURES = ["feature_1", "feature_3"].freeze
+
+describe User, type: :model do
+  context "#allowed_feature_list" do
+    let(:user) { create(:user, allowed_features: JSON.dump(USER_FEATURES)) }
+    subject { user.allowed_feature_list }
+
+    it "returns both features launched and enabled for user" do
+      create(:app_config, key: AppConfig::LAUNCHED_FEATURES, value: JSON.dump(LAUNCHED_FEATURES))
+      expect(subject).to contain_exactly("feature_1", "feature_2", "feature_3")
+    end
+
+    it "if launched features not configured return only user allowed features" do
+      expect(subject).to contain_exactly("feature_1", "feature_3")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,5 +16,9 @@ describe User, type: :model do
     it "if launched features not configured return only user allowed features" do
       expect(subject).to contain_exactly("feature_1", "feature_3")
     end
+
+    it "if user features not configured return only launched features" do
+      expect(subject).to contain_exactly("feature_1", "feature_2")
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,20 +5,32 @@ USER_FEATURES = ["feature_1", "feature_3"].freeze
 
 describe User, type: :model do
   context "#allowed_feature_list" do
-    let(:user) { create(:user, allowed_features: JSON.dump(USER_FEATURES)) }
     subject { user.allowed_feature_list }
 
-    it "returns both features launched and enabled for user" do
-      create(:app_config, key: AppConfig::LAUNCHED_FEATURES, value: JSON.dump(LAUNCHED_FEATURES))
-      expect(subject).to contain_exactly("feature_1", "feature_2", "feature_3")
+    context "if user has allowed features" do
+      let(:user) { create(:user, allowed_features: JSON.dump(USER_FEATURES)) }
+
+      context "if launched features configured" do
+        let!(:app_config) { create(:app_config, key: AppConfig::LAUNCHED_FEATURES, value: JSON.dump(LAUNCHED_FEATURES)) }
+        it "shows merged features" do
+          expect(subject).to contain_exactly("feature_1", "feature_2", "feature_3")
+        end
+      end
+
+      context "if launched features is nil" do
+        it "returns only user allowed features" do
+          expect(subject).to contain_exactly("feature_1", "feature_3")
+        end
+      end
     end
 
-    it "if launched features not configured return only user allowed features" do
-      expect(subject).to contain_exactly("feature_1", "feature_3")
-    end
+    context "if user has nil allowed features " do
+      let(:user) { create(:user) }
+      let!(:app_config) { create(:app_config, key: AppConfig::LAUNCHED_FEATURES, value: JSON.dump(LAUNCHED_FEATURES)) }
 
-    it "if user features not configured return only launched features" do
-      expect(subject).to contain_exactly("feature_1", "feature_2")
+      it "return only launched features" do
+        expect(subject).to contain_exactly("feature_1", "feature_2")
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

* This PR adds a mechanism - through app config - to enable features for all users. This removes the urgency of removing flags from code, leaving some more time to test with all users and allowing quick deactivation of new flag-guarded features if necessary.
* Includes rake tasks to facilitate launching, removing and listing features

# Tests

* Unit tests
* Move feature from user_allowed_features into app_config and verify that feature sill shows up.