### PR TITLE
[Release fix CP] [Heatmap] Fix bug with multiple duplicate sample names on heatmaps

### DIFF
--- a/app/assets/src/components/views/amr_heatmap/AMRHeatmapView.jsx
+++ b/app/assets/src/components/views/amr_heatmap/AMRHeatmapView.jsx
@@ -111,8 +111,9 @@ export default class AMRHeatmapView extends React.Component {
       if (sampleNamesCounts.has(sample.sampleName)) {
         // Append a number to a sample's name to differentiate between samples with the same name.
         let count = sampleNamesCounts.get(sample.sampleName);
+        let originalName = sample.sampleName;
         sample.sampleName = `${sample.sampleName} (${count})`;
-        sampleNamesCounts.set(sample.sampleName, count + 1);
+        sampleNamesCounts.set(originalName, count + 1);
       } else {
         sampleNamesCounts.set(sample.sampleName, 1);
       }

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -391,8 +391,9 @@ class SamplesHeatmapView extends React.Component {
       if (sampleNamesCounts.has(sample.name)) {
         // Append a number to a sample's name to differentiate between samples with the same name.
         let count = sampleNamesCounts.get(sample.name);
+        let originalName = sample.name;
         sample.name = `${sample.name} (${count})`;
-        sampleNamesCounts.set(sample.name, count + 1);
+        sampleNamesCounts.set(originalName, count + 1);
       } else {
         sampleNamesCounts.set(sample.name, 1);
       }


### PR DESCRIPTION
See https://github.com/chanzuckerberg/idseq-web/pull/3187

# Description

Oversight in the order of updating the sample name variable resulted in the duplicate name bug persisting if more than 2 samples with the same name were selected.

![image](https://user-images.githubusercontent.com/53838890/76802034-067e9080-6794-11ea-845f-cfd4fcd8e74f.png)

# Tests

* Verified that both Taxon and AMR heatmaps display properly if multiple samples with the exact same name are selected.
![image](https://user-images.githubusercontent.com/53838890/76802137-48a7d200-6794-11ea-8492-5783ca4ce087.png)
