### PR TITLE
cdhit dagly webs cleanup

### DIFF
--- a/app/lib/dags/host_filter.json.jbuilder
+++ b/app/lib/dags/host_filter.json.jbuilder
@@ -21,7 +21,7 @@ json.targets do
   priceseq_out << 'priceseq2.fa' if attr[:fastq2]
   json.priceseq_out priceseq_out
 
-  cdhitdup_out = ['dedup1.fa']
+  cdhitdup_out = ['dedup1.fa', 'dedup1.fa.clstr', "cdhitdup_cluster_sizes.tsv"]
   cdhitdup_out << 'dedup2.fa' if attr[:fastq2]
   json.cdhitdup_out cdhitdup_out
 
@@ -105,7 +105,7 @@ json.steps do
     additional_attributes: {},
   }
   steps << {
-    in: ['cdhitdup_out'],
+    in: ['cdhitdup_out', "cdhitdup_cluster_sizes.tsv"],
     out: 'lzw_out',
     class: 'PipelineStepRunLZW',
     module: 'idseq_dag.steps.run_lzw',
@@ -116,7 +116,7 @@ json.steps do
     },
   }
   steps << {
-    in: ['lzw_out'],
+    in: ['lzw_out', "cdhitdup_cluster_sizes.tsv"],
     out: 'bowtie2_out',
     class: 'PipelineStepRunBowtie2',
     module: 'idseq_dag.steps.run_bowtie2',
@@ -126,7 +126,7 @@ json.steps do
     additional_attributes: { output_sam_file: 'bowtie2.sam' },
   }
   steps << {
-    in: ['bowtie2_out'],
+    in: ['bowtie2_out', "cdhitdup_cluster_sizes.tsv"],
     out: 'subsampled_out',
     class: 'PipelineStepRunSubsample',
     module: 'idseq_dag.steps.run_subsample',
@@ -144,7 +144,7 @@ json.steps do
       additional_attributes: {},
     }
     steps << {
-      in: ['star_human_out'],
+      in: ['star_human_out', "cdhitdup_cluster_sizes.tsv"],
       out: 'bowtie2_human_out',
       class: 'PipelineStepRunBowtie2',
       module: 'idseq_dag.steps.run_bowtie2',
@@ -154,7 +154,7 @@ json.steps do
   end
 
   steps << {
-    in: [attr[:host_genome] != 'human' ? 'bowtie2_human_out' : 'subsampled_out'],
+    in: [attr[:host_genome] != 'human' ? 'bowtie2_human_out' : 'subsampled_out', "cdhitdup_cluster_sizes.tsv"],
     out: 'gsnap_filter_out',
     class: 'PipelineStepRunGsnapFilter',
     module: 'idseq_dag.steps.run_gsnap_filter',

--- a/app/lib/dags/host_filter.json.jbuilder
+++ b/app/lib/dags/host_filter.json.jbuilder
@@ -105,7 +105,7 @@ json.steps do
     additional_attributes: {},
   }
   steps << {
-    in: ['cdhitdup_out', "cdhitdup_cluster_sizes.tsv"],
+    in: ['cdhitdup_out', "cdhitdup_cluster_sizes"],
     out: 'lzw_out',
     class: 'PipelineStepRunLZW',
     module: 'idseq_dag.steps.run_lzw',
@@ -116,7 +116,7 @@ json.steps do
     },
   }
   steps << {
-    in: ['lzw_out', "cdhitdup_cluster_sizes.tsv"],
+    in: ['lzw_out', "cdhitdup_cluster_sizes"],
     out: 'bowtie2_out',
     class: 'PipelineStepRunBowtie2',
     module: 'idseq_dag.steps.run_bowtie2',
@@ -126,7 +126,7 @@ json.steps do
     additional_attributes: { output_sam_file: 'bowtie2.sam' },
   }
   steps << {
-    in: ['bowtie2_out', "cdhitdup_cluster_sizes.tsv"],
+    in: ['bowtie2_out', "cdhitdup_cluster_sizes"],
     out: 'subsampled_out',
     class: 'PipelineStepRunSubsample',
     module: 'idseq_dag.steps.run_subsample',
@@ -144,7 +144,7 @@ json.steps do
       additional_attributes: {},
     }
     steps << {
-      in: ['star_human_out', "cdhitdup_cluster_sizes.tsv"],
+      in: ['star_human_out', "cdhitdup_cluster_sizes"],
       out: 'bowtie2_human_out',
       class: 'PipelineStepRunBowtie2',
       module: 'idseq_dag.steps.run_bowtie2',
@@ -154,7 +154,7 @@ json.steps do
   end
 
   steps << {
-    in: [attr[:host_genome] != 'human' ? 'bowtie2_human_out' : 'subsampled_out', "cdhitdup_cluster_sizes.tsv"],
+    in: [attr[:host_genome] != 'human' ? 'bowtie2_human_out' : 'subsampled_out', "cdhitdup_cluster_sizes"],
     out: 'gsnap_filter_out',
     class: 'PipelineStepRunGsnapFilter',
     module: 'idseq_dag.steps.run_gsnap_filter',

--- a/app/lib/dags/host_filter.json.jbuilder
+++ b/app/lib/dags/host_filter.json.jbuilder
@@ -21,8 +21,10 @@ json.targets do
   priceseq_out << 'priceseq2.fa' if attr[:fastq2]
   json.priceseq_out priceseq_out
 
-  cdhitdup_out = ['dedup1.fa', 'dedup1.fa.clstr', "cdhitdup_cluster_sizes.tsv"]
+  cdhitdup_out = ['dedup1.fa']
   cdhitdup_out << 'dedup2.fa' if attr[:fastq2]
+  cdhitdup_out << 'dedup1.fa.clstr'
+  cdhitdup_out << 'cdhitdup_cluster_sizes.tsv'
   json.cdhitdup_out cdhitdup_out
 
   lzw_out = ['lzw1.fa']
@@ -105,7 +107,7 @@ json.steps do
     additional_attributes: {},
   }
   steps << {
-    in: ['cdhitdup_out', "cdhitdup_cluster_sizes"],
+    in: ['cdhitdup_out'],
     out: 'lzw_out',
     class: 'PipelineStepRunLZW',
     module: 'idseq_dag.steps.run_lzw',
@@ -116,7 +118,7 @@ json.steps do
     },
   }
   steps << {
-    in: ['lzw_out', "cdhitdup_cluster_sizes"],
+    in: ['lzw_out', "cdhitdup_out"],
     out: 'bowtie2_out',
     class: 'PipelineStepRunBowtie2',
     module: 'idseq_dag.steps.run_bowtie2',
@@ -126,7 +128,7 @@ json.steps do
     additional_attributes: { output_sam_file: 'bowtie2.sam' },
   }
   steps << {
-    in: ['bowtie2_out', "cdhitdup_cluster_sizes"],
+    in: ['bowtie2_out', "cdhitdup_out"],
     out: 'subsampled_out',
     class: 'PipelineStepRunSubsample',
     module: 'idseq_dag.steps.run_subsample',
@@ -136,7 +138,7 @@ json.steps do
 
   if attr[:host_genome] != 'human'
     steps << {
-      in: %w[subsampled_out validate_input_out],
+      in: %w[subsampled_out validate_input_out cdhitdup_out],
       out: 'star_human_out',
       class: 'PipelineStepRunStarDownstream',
       module: 'idseq_dag.steps.run_star_downstream',
@@ -144,7 +146,7 @@ json.steps do
       additional_attributes: {},
     }
     steps << {
-      in: ['star_human_out', "cdhitdup_cluster_sizes"],
+      in: ['star_human_out', "cdhitdup_out"],
       out: 'bowtie2_human_out',
       class: 'PipelineStepRunBowtie2',
       module: 'idseq_dag.steps.run_bowtie2',
@@ -154,7 +156,7 @@ json.steps do
   end
 
   steps << {
-    in: [attr[:host_genome] != 'human' ? 'bowtie2_human_out' : 'subsampled_out', "cdhitdup_cluster_sizes"],
+    in: [(attr[:host_genome] != 'human' ? 'bowtie2_human_out' : 'subsampled_out'), "cdhitdup_out"],
     out: 'gsnap_filter_out',
     class: 'PipelineStepRunGsnapFilter',
     module: 'idseq_dag.steps.run_gsnap_filter',

--- a/app/lib/dags/non_host_alignment.json.jbuilder
+++ b/app/lib/dags/non_host_alignment.json.jbuilder
@@ -23,6 +23,11 @@ json.targets do
   ]
   json.taxon_count_out ["taxon_counts.json"]
   json.annotated_out ["annotated_merged.fa", "unidentified.fa"]
+
+  json.cdhitdup_cluster_sizes [
+    "cdhitdup_cluster_sizes.tsv",
+
+  ]
 end
 
 json.steps do
@@ -58,7 +63,7 @@ json.steps do
   end
 
   steps << {
-    in: ["host_filter_out"],
+    in: ["host_filter_out", "cdhitdup_cluster_sizes.tsv"],
     out: "gsnap_out",
     class: "PipelineStepRunAlignmentRemotely",
     module: "idseq_dag.steps.run_alignment_remotely",
@@ -87,7 +92,7 @@ json.steps do
   end
 
   steps << {
-    in: ["host_filter_out"],
+    in: ["host_filter_out", "cdhitdup_cluster_sizes.tsv"],
     out: "rapsearch2_out",
     class: "PipelineStepRunAlignmentRemotely",
     module: "idseq_dag.steps.run_alignment_remotely",
@@ -105,7 +110,7 @@ json.steps do
   }
 
   steps << {
-    in: ["host_filter_out", "gsnap_out", "rapsearch2_out"],
+    in: ["host_filter_out", "gsnap_out", "rapsearch2_out", "cdhitdup_cluster_sizes.tsv"],
     out: "annotated_out",
     class: "PipelineStepGenerateAnnotatedFasta",
     module: "idseq_dag.steps.generate_annotated_fasta",
@@ -118,6 +123,10 @@ end
 
 json.given_targets do
   json.host_filter_out do
+    json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
+  end
+
+  json.cdhitdup_cluster_sizes do
     json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
   end
 end

--- a/app/lib/dags/non_host_alignment.json.jbuilder
+++ b/app/lib/dags/non_host_alignment.json.jbuilder
@@ -26,7 +26,6 @@ json.targets do
 
   json.cdhitdup_cluster_sizes [
     "cdhitdup_cluster_sizes.tsv",
-
   ]
 end
 
@@ -63,7 +62,7 @@ json.steps do
   end
 
   steps << {
-    in: ["host_filter_out", "cdhitdup_cluster_sizes.tsv"],
+    in: ["host_filter_out", "cdhitdup_cluster_sizes"],
     out: "gsnap_out",
     class: "PipelineStepRunAlignmentRemotely",
     module: "idseq_dag.steps.run_alignment_remotely",
@@ -92,7 +91,7 @@ json.steps do
   end
 
   steps << {
-    in: ["host_filter_out", "cdhitdup_cluster_sizes.tsv"],
+    in: ["host_filter_out", "cdhitdup_cluster_sizes"],
     out: "rapsearch2_out",
     class: "PipelineStepRunAlignmentRemotely",
     module: "idseq_dag.steps.run_alignment_remotely",
@@ -110,7 +109,7 @@ json.steps do
   }
 
   steps << {
-    in: ["host_filter_out", "gsnap_out", "rapsearch2_out", "cdhitdup_cluster_sizes.tsv"],
+    in: ["host_filter_out", "gsnap_out", "rapsearch2_out", "cdhitdup_cluster_sizes"],
     out: "annotated_out",
     class: "PipelineStepGenerateAnnotatedFasta",
     module: "idseq_dag.steps.generate_annotated_fasta",

--- a/app/lib/dags/non_host_alignment.json.jbuilder
+++ b/app/lib/dags/non_host_alignment.json.jbuilder
@@ -13,15 +13,15 @@ json.targets do
     attr[:gsnap_m8],
     "gsnap.deduped.m8",
     "gsnap.hitsummary.tab",
-    "gsnap_counts.json",
+    "gsnap_counts_with_dcr.json",
   ]
   json.rapsearch2_out [
     attr[:rapsearch_m8],
     "rapsearch2.deduped.m8",
     "rapsearch2.hitsummary.tab",
-    "rapsearch2_counts.json",
+    "rapsearch2_counts_with_dcr.json",
   ]
-  json.taxon_count_out ["taxon_counts.json"]
+  json.taxon_count_out ["taxon_counts_with_dcr.json"]
   json.annotated_out ["annotated_merged.fa", "unidentified.fa"]
 
   json.cdhitdup_cluster_sizes [

--- a/app/lib/dags/postprocess.json.jbuilder
+++ b/app/lib/dags/postprocess.json.jbuilder
@@ -13,13 +13,13 @@ json.targets do
     "gsnap.m8",
     "gsnap.deduped.m8",
     "gsnap.hitsummary.tab",
-    "gsnap_counts.json",
+    "gsnap_counts_with_dcr.json",
   ]
   json.rapsearch2_out [
     "rapsearch2.m8",
     "rapsearch2.deduped.m8",
     "rapsearch2.hitsummary.tab",
-    "rapsearch2_counts.json",
+    "rapsearch2_counts_with_dcr.json",
   ]
   json.assembly_out [
     "assembly/contigs.fasta",
@@ -37,7 +37,7 @@ json.targets do
     "assembly/gsnap.blast.m8",
     "assembly/gsnap.reassigned.m8",
     "assembly/gsnap.hitsummary2.tab",
-    "assembly/refined_gsnap_counts.json",
+    "assembly/refined_gsnap_counts_with_dcr.json",
     "assembly/gsnap_contig_summary.json",
     "assembly/gsnap.blast.top.m8",
   ]
@@ -45,11 +45,11 @@ json.targets do
     "assembly/rapsearch2.blast.m8",
     "assembly/rapsearch2.reassigned.m8",
     "assembly/rapsearch2.hitsummary2.tab",
-    "assembly/refined_rapsearch2_counts.json",
+    "assembly/refined_rapsearch2_counts_with_json.json",
     "assembly/rapsearch2_contig_summary.json",
     "assembly/rapsearch2.blast.top.m8",
   ]
-  json.refined_taxon_count_out ["assembly/refined_taxon_counts.json"]
+  json.refined_taxon_count_out ["assembly/refined_taxon_counts_with_dcr.json"]
   json.contig_summary_out ["assembly/combined_contig_summary.json"]
 
   json.refined_annotated_out ["assembly/refined_annotated_merged.fa", "assembly/refined_unidentified.fa"]

--- a/app/lib/dags/postprocess.json.jbuilder
+++ b/app/lib/dags/postprocess.json.jbuilder
@@ -45,7 +45,7 @@ json.targets do
     "assembly/rapsearch2.blast.m8",
     "assembly/rapsearch2.reassigned.m8",
     "assembly/rapsearch2.hitsummary2.tab",
-    "assembly/refined_rapsearch2_counts_with_json.json",
+    "assembly/refined_rapsearch2_counts_with_dcr.json",
     "assembly/rapsearch2_contig_summary.json",
     "assembly/rapsearch2.blast.top.m8",
   ]

--- a/app/lib/dags/postprocess.json.jbuilder
+++ b/app/lib/dags/postprocess.json.jbuilder
@@ -79,7 +79,7 @@ json.steps do
   steps = []
 
   steps << {
-    in: ["host_filter_out", "cdhitdup_cluster_sizes.tsv"],
+    in: ["host_filter_out", "cdhitdup_cluster_sizes"],
     out: "assembly_out",
     class: "PipelineStepRunAssembly",
     module: "idseq_dag.steps.run_assembly",
@@ -136,7 +136,7 @@ json.steps do
   end
 
   steps << {
-    in: ["gsnap_out", "assembly_out", "gsnap_accessions_out", "cdhitdup_cluster_sizes.tsv"],
+    in: ["gsnap_out", "assembly_out", "gsnap_accessions_out", "cdhitdup_cluster_sizes"],
     out: "refined_gsnap_out",
     class: "PipelineStepBlastContigs",
     module: "idseq_dag.steps.blast_contigs",
@@ -147,7 +147,7 @@ json.steps do
   }
 
   steps << {
-    in: ["rapsearch2_out", "assembly_out", "rapsearch2_accessions_out", "cdhitdup_cluster_sizes.tsv"],
+    in: ["rapsearch2_out", "assembly_out", "rapsearch2_accessions_out", "cdhitdup_cluster_sizes"],
     out: "refined_rapsearch2_out",
     class: "PipelineStepBlastContigs",
     module: "idseq_dag.steps.blast_contigs",
@@ -176,7 +176,7 @@ json.steps do
   }
 
   steps << {
-    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out", "cdhitdup_cluster_sizes.tsv"],
+    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out", "cdhitdup_cluster_sizes"],
     out: "refined_annotated_out",
     class: "PipelineStepGenerateAnnotatedFasta",
     module: "idseq_dag.steps.generate_annotated_fasta",

--- a/app/lib/dags/postprocess.json.jbuilder
+++ b/app/lib/dags/postprocess.json.jbuilder
@@ -69,13 +69,17 @@ json.targets do
     "assembly/refined_taxid_locations_family_nr.json",
     "assembly/refined_taxid_locations_combined.json",
   ]
+
+  json.cdhitdup_cluster_sizes [
+    "cdhitdup_cluster_sizes.tsv",
+  ]
 end
 
 json.steps do
   steps = []
 
   steps << {
-    in: ["host_filter_out"],
+    in: ["host_filter_out", "cdhitdup_cluster_sizes.tsv"],
     out: "assembly_out",
     class: "PipelineStepRunAssembly",
     module: "idseq_dag.steps.run_assembly",
@@ -132,7 +136,7 @@ json.steps do
   end
 
   steps << {
-    in: ["gsnap_out", "assembly_out", "gsnap_accessions_out"],
+    in: ["gsnap_out", "assembly_out", "gsnap_accessions_out", "cdhitdup_cluster_sizes.tsv"],
     out: "refined_gsnap_out",
     class: "PipelineStepBlastContigs",
     module: "idseq_dag.steps.blast_contigs",
@@ -143,7 +147,7 @@ json.steps do
   }
 
   steps << {
-    in: ["rapsearch2_out", "assembly_out", "rapsearch2_accessions_out"],
+    in: ["rapsearch2_out", "assembly_out", "rapsearch2_accessions_out", "cdhitdup_cluster_sizes.tsv"],
     out: "refined_rapsearch2_out",
     class: "PipelineStepBlastContigs",
     module: "idseq_dag.steps.blast_contigs",
@@ -172,7 +176,7 @@ json.steps do
   }
 
   steps << {
-    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out"],
+    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out", "cdhitdup_cluster_sizes.tsv"],
     out: "refined_annotated_out",
     class: "PipelineStepGenerateAnnotatedFasta",
     module: "idseq_dag.steps.generate_annotated_fasta",
@@ -213,6 +217,10 @@ json.given_targets do
   end
 
   json.rapsearch2_out do
+    json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
+  end
+
+  json.cdhitdup_cluster_sizes do
     json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
   end
 end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -58,7 +58,7 @@ class PipelineRun < ApplicationRecord
 
   GSNAP_M8 = "gsnap.m8".freeze
   RAPSEARCH_M8 = "rapsearch2.m8".freeze
-  OUTPUT_JSON_NAME = 'taxon_counts.json'.freeze
+  OUTPUT_JSON_NAME = 'taxon_counts_with_dcr.json'.freeze
   PIPELINE_VERSION_FILE = "pipeline_version.txt".freeze
   STATS_JSON_NAME = "stats.json".freeze
   INPUT_VALIDATION_NAME = "validate_input_summary.json".freeze
@@ -68,7 +68,7 @@ class PipelineRun < ApplicationRecord
   AMR_DRUG_SUMMARY_RESULTS = 'amr_summary_results.csv'.freeze
   AMR_FULL_RESULTS_NAME = 'amr_processed_results.csv'.freeze
   TAXID_BYTERANGE_JSON_NAME = 'taxid_locations_combined.json'.freeze
-  REFINED_TAXON_COUNTS_JSON_NAME = 'assembly/refined_taxon_counts.json'.freeze
+  REFINED_TAXON_COUNTS_JSON_NAME = 'assembly/refined_taxon_counts_with_dcr.json'.freeze
   REFINED_TAXID_BYTERANGE_JSON_NAME = 'assembly/refined_taxid_locations_combined.json'.freeze
   READS_PER_GENE_STAR_TAB_NAME = 'reads_per_gene.star.tab'.freeze
 
@@ -812,6 +812,10 @@ class PipelineRun < ApplicationRecord
     acceptable_tax_levels << TaxonCount::TAX_LEVEL_GENUS if multihit?
     acceptable_tax_levels << TaxonCount::TAX_LEVEL_FAMILY if multihit?
     taxon_counts_attributes_filtered = taxon_counts_attributes.select do |tcnt|
+      # Delete attributes that aren't in the DB schema.  These are emitted in versions >= v3.21
+      tcnt.delete "dcr"
+      tcnt.delete "unique_count"
+      tcnt.delete "nonunique_count"
       # TODO:  Better family support.
       acceptable_tax_levels.include?(tcnt['tax_level'].to_i) && !invalid_family_call?(tcnt)
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -751,7 +751,7 @@ class Sample < ApplicationRecord
     pr.save!
   rescue StandardError => err
     LogUtil.log_err_and_airbrake("Error saving pipeline run: #{err.inspect}")
-    # This will cause a message a to be shown to the user on the sample page.
+    # This will cause a message to be shown to the user on the sample page.
     # See app/assets/src/components/utils/sample.js
     self.upload_error = Sample::UPLOAD_ERROR_PIPELINE_KICKOFF
     save!


### PR DESCRIPTION
Post-deployment cleanup for the CD-HIT-DUP work.   Pre-requisite to https://github.com/chanzuckerberg/idseq-dag/pull/268.   Based on Greg's initial draft PR.

It does two things:

1) Emit orrect DAG

2) Tolerate additional attributes in [refined_]taxon_counts_with_dcr.json

Please see comments below for test plan and post-deployment.