### PR TITLE
Turn off ActiveRecordQueryTrace

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,7 +82,8 @@ Rails.application.configure do
     "http://127.0.0.1:3000",
   ]
 
-  ActiveRecordQueryTrace.enabled = true
+  # Enable this line to get tracebacks for all SQL queries
+  # ActiveRecordQueryTrace.enabled = true
 
   # Development logging configuration
   logger           = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
# Description

This turns off a dev only option to show full tracebacks with all queries. The option adds a lot of lines which are not worth it in my experience. 

## Before
```
[2020-03-17T18:31:28] DEBUG ActiveRecord::Base :   PipelineRun Load (0.8ms)  SELECT  `pipeline_runs`.* FROM `pipeline_runs` WHERE `pipeline_runs`.`sample_id` = 13444 ORDER BY `pipeline_runs`.`created_at` DESC LIMIT 1
[2020-03-17T18:31:28] DEBUG ActiveRecord::Base : Query Trace:
      app/models/sample.rb:924:in `first_pipeline_run'
      app/views/samples/pipeline_runs.html.erb:31:in `_app_views_samples_pipeline_runs_html_erb___95362624109686033_70140354077900'
      app/controllers/application_controller.rb:163:in `instrument_with_timer'
      app/middleware/resque_middleware.rb:13:in `call'
[2020-03-17T18:31:28] DEBUG ActiveRecord::Base :   PipelineRunStage Load (0.6ms)  SELECT `pipeline_run_stages`.* FROM `pipeline_run_stages` WHERE `pipeline_run_stages`.`pipeline_run_id` = 20161
[2020-03-17T18:31:28] DEBUG ActiveRecord::Base : Query Trace:
      app/models/pipeline_run.rb:367:in `completed?'
      app/views/samples/pipeline_runs.html.erb:32:in `_app_views_samples_pipeline_runs_html_erb___95362624109686033_70140354077900'
      app/controllers/application_controller.rb:163:in `instrument_with_timer'
      app/middleware/resque_middleware.rb:13:in `call'
[2020-03-17T18:31:28] DEBUG ActiveRecord::Base :   PipelineRun Load (0.8ms)  SELECT `pipeline_runs`.* FROM `pipeline_runs` WHERE `pipeline_runs`.`sample_id` = 13444 ORDER BY `pipeline_runs`.`created_at` DESC
```
## After 

```
[2020-03-17T18:37:12] DEBUG ActiveRecord::Base :   PipelineRun Load (0.5ms)  SELECT  `pipeline_runs`.* FROM `pipeline_runs` WHERE `pipeline_runs`.`id` = 20160 LIMIT 1
[2020-03-17T18:37:13] INFO  Rails :   Checking pipeline run 20160 for sample 13442
[2020-03-17T18:37:13] DEBUG ActiveRecord::Base :   PipelineRunStage Load (0.7ms)  SELECT `pipeline_run_stages`.* FROM `pipeline_run_stages` WHERE `pipeline_run_stages`.`pipeline_run_id` = 20160 ORDER BY `pipeline_run_stages`.`step_number` ASC
[2020-03-17T18:37:13] DEBUG ActiveRecord::Base :   Sample Load (0.6ms)  SELECT  `samples`.* FROM `samples` WHERE `samples`.`id` = 13442 LIMIT 1
[2020-03-17T18:37:14] WARN  Rails : Cannot send metrics data. No Datadog API key set.
```

# Tests

re-start web server, see no error