### PR TITLE
Handle error in kickoff_pipeline

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1444,5 +1444,6 @@ class SamplesController < ApplicationController
   rescue StandardError => e
     # catch all errors because we don't want to ever block uploads
     LogUtil.log_err_and_airbrake("warn_if_large_bulk_upload: #{e}")
+    LogUtil.log_backtrace(e)
   end
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -61,7 +61,10 @@ class Sample < ApplicationRecord
   before_save :check_host_genome, :concatenate_input_parts, :check_status
   after_save :set_presigned_url_for_local_upload
 
-  # Constants for upload errors.
+  # Constants for upload_error field. NOTE: the name of this field is
+  # inaccurate. The intention of the field is to carry a message (a constant
+  # that refers to a message) to be shown to the user for exceptional
+  # conditions. See app/assets/src/components/utils/sample.js
   UPLOAD_ERROR_BASESPACE_UPLOAD_FAILED = "BASESPACE_UPLOAD_FAILED".freeze
   UPLOAD_ERROR_S3_UPLOAD_FAILED = "S3_UPLOAD_FAILED".freeze
   UPLOAD_ERROR_LOCAL_UPLOAD_STALLED = "LOCAL_UPLOAD_STALLED".freeze
@@ -753,8 +756,8 @@ class Sample < ApplicationRecord
     LogUtil.log_err_and_airbrake("Error saving pipeline run: #{err.inspect}")
     # This may cause a message to be shown to the user on the sample page.
     # See app/assets/src/components/utils/sample.js
-    # Use low-level update_columns to avoid callbacks, because kickoff_pipeline
-    # may be running in a callback already.
+    # HACK ALERT! Use low-level update_columns to avoid callbacks, because
+    # kickoff_pipeline may be running in a callback already.
     update_columns(upload_error: Sample::UPLOAD_ERROR_PIPELINE_KICKOFF) # rubocop:disable SkipsModelValidations
   end
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -751,10 +751,10 @@ class Sample < ApplicationRecord
     pr.save!
   rescue StandardError => err
     LogUtil.log_err_and_airbrake("Error saving pipeline run: #{err.inspect}")
-    # This will cause a message to be shown to the user on the sample page.
+    # This may cause a message to be shown to the user on the sample page.
     # See app/assets/src/components/utils/sample.js
     self.upload_error = Sample::UPLOAD_ERROR_PIPELINE_KICKOFF
-    save!
+    # kickoff_pipeline is assumed to be called in before_save callback
   end
 
   def get_existing_metadatum(key)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -754,6 +754,8 @@ class Sample < ApplicationRecord
     pr.save!
   rescue StandardError => err
     LogUtil.log_err_and_airbrake("Error saving pipeline run: #{err.inspect}")
+    LogUtil.log_backtrace(err)
+    # This may cause a message to be shown to the user on the sample page.
     # This may cause a message to be shown to the user on the sample page.
     # See app/assets/src/components/utils/sample.js
     # HACK ALERT! Use low-level update_columns to avoid callbacks, because

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -751,7 +751,7 @@ class Sample < ApplicationRecord
     pr.save!
   rescue StandardError => err
     LogUtil.log_err_and_airbrake("Error saving pipeline run: #{err.inspect}")
-    # This will cause a message a to be shown to the user on the sample page.
+    # This will cause a message to be shown to the user on the sample page.
     # See app/assets/src/components/utils/sample.js
     self.upload_error = Sample::UPLOAD_ERROR_PIPELINE_KICKOFF
     save!

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -753,8 +753,9 @@ class Sample < ApplicationRecord
     LogUtil.log_err_and_airbrake("Error saving pipeline run: #{err.inspect}")
     # This may cause a message to be shown to the user on the sample page.
     # See app/assets/src/components/utils/sample.js
-    self.upload_error = Sample::UPLOAD_ERROR_PIPELINE_KICKOFF
-    # kickoff_pipeline is assumed to be called in before_save callback
+    # Use low-level update_columns to avoid callbacks, because kickoff_pipeline
+    # may be running in a callback already.
+    update_columns(upload_error: Sample::UPLOAD_ERROR_PIPELINE_KICKOFF) # rubocop:disable SkipsModelValidations
   end
 
   def get_existing_metadatum(key)


### PR DESCRIPTION
# Description

In trying to run samples locally, I found a silent error when I didn't have the correct alignment config. This handles any error in `kickoff_pipeline` and makes it a upload error so a "sample failed" message is shown instead of "waiting". 

![image](https://user-images.githubusercontent.com/28797/76900888-6db14900-6857-11ea-8923-8ffb850b16c8.png)

# Notes

* In general we should favor `save!` over `save`. 

# Tests

* force an error, see message on sample page
* save no error, see pipeline run kickoff