### PR TITLE
Log and notify if more than 100 samples uploaded at once

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1434,8 +1434,10 @@ class SamplesController < ApplicationController
     if samples.length < 100
       return
     end
-    msg = "[Datadog] LargeBulkUploadEvent: #{samples.length} samples by #{samples.first.user.role_name} in project #{samples.first.project.name}." \
-      "See: #{project_url(samples.first.project)}"
+    project = samples.first.project
+    uploader = samples.first.user
+    msg = "[Datadog] LargeBulkUploadEvent: #{samples.length} samples by #{uploader.role_name} in project #{project.name}." \
+      " See: #{project.status_url}"
     LogUtil.log_err_and_airbrake(msg)
   end
 end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1431,9 +1431,11 @@ class SamplesController < ApplicationController
 
   def warn_if_large_bulk_upload(samples)
     # 100 is the limit that was chosen during covid19 surge for biohub projects.
+    # At the time, we had successfully handled up to ~1000 uploads per day.
     if samples.length < 100
       return
     end
+    # assume that all samples are in the same project and from the same user
     project = samples.first.project
     uploader = samples.first.user
     msg = "[Datadog] LargeBulkUploadEvent: #{samples.length} samples by #{uploader.role_name} in project #{project.name}." \

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1438,7 +1438,7 @@ class SamplesController < ApplicationController
     # assume that all samples are in the same project and from the same user
     project = samples.first.project
     uploader = samples.first.user
-    msg = "[Datadog] LargeBulkUploadEvent: #{samples.length} samples by #{uploader.role_name} in project #{project.name}." \
+    msg = "[Datadog] LargeBulkUploadEvent: #{samples.length} samples by #{uploader.role_name}." \
       " See: #{project.status_url}"
     LogUtil.log_err_and_airbrake(msg)
   rescue StandardError => e

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1439,5 +1439,8 @@ class SamplesController < ApplicationController
     msg = "[Datadog] LargeBulkUploadEvent: #{samples.length} samples by #{uploader.role_name} in project #{project.name}." \
       " See: #{project.status_url}"
     LogUtil.log_err_and_airbrake(msg)
+  rescue StandardError => e
+    # catch all errors because we don't want to ever block uploads
+    LogUtil.log_err_and_airbrake("warn_if_large_bulk_upload: #{e}")
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -162,4 +162,8 @@ class Project < ApplicationRecord
   def add_default_metadata_fields
     metadata_fields.push(MetadataField.where(is_default: 1) - metadata_fields)
   end
+
+  def status_url
+    UrlUtil.absolute_base_url + "/projects/#{id}"
+  end
 end


### PR DESCRIPTION
# Description

After reading the announcement in biohub slack, I had the thought that it would be easy to add an airbrake alert when >100 samples are uploaded, as a second layer of warning.

```
"[Datadog] LargeBulkUploadEvent: 1 samples by non-admin user. See: http://localhost:3000/projects/855"
```

After merging this, I intend to setup a datadog alert similar to the LongRunningSample alert to raise the warning in our slack. 

# Notes

* The code assumes that all samples are in the same project and from the same user. Not sure how safe an assumption this is. @MarkAZhang ?
* Not sure whether `project_url` or DD project page is better to  link to

# Tests

`bundle exec rspec spec/requests/sample_request_spec.rb`

use byebug to inspect error message