### PR TITLE
[Release Fix] Disable project creation trigger properly (IDSEQ-2454)

### DIFF
--- a/app/assets/src/components/common/ProjectCreationForm.jsx
+++ b/app/assets/src/components/common/ProjectCreationForm.jsx
@@ -30,7 +30,7 @@ class ProjectCreationForm extends React.Component {
     disableCreateButton: true,
   };
 
-  areCreationReqsUnmet(changed = {}) {
+  areCreationReqsMet(changed = {}) {
     const reqs = {
       name: this.state.name,
       accessLevel: this.state.accessLevel,
@@ -46,14 +46,14 @@ class ProjectCreationForm extends React.Component {
       reqs.accessLevel === ACCESS_LEVEL.noSelection ||
       reqs.description.length < 1
     ) {
-      return true;
+      return false;
     }
 
-    return false;
+    return true;
   }
 
   handleNameChange = name => {
-    const disableCreateButton = this.areCreationReqsUnmet({ name });
+    const disableCreateButton = !this.areCreationReqsMet({ name });
     this.setState({
       name,
       disableCreateButton,
@@ -61,7 +61,7 @@ class ProjectCreationForm extends React.Component {
   };
 
   handleAccessLevelChange = accessLevel => {
-    const disableCreateButton = this.areCreationReqsUnmet({ accessLevel });
+    const disableCreateButton = !this.areCreationReqsMet({ accessLevel });
     this.setState({
       accessLevel,
       disableCreateButton,
@@ -69,7 +69,7 @@ class ProjectCreationForm extends React.Component {
   };
 
   handleDescriptionChange = description => {
-    const disableCreateButton = this.areCreationReqsUnmet({ description });
+    const disableCreateButton = !this.areCreationReqsMet({ description });
     this.setState({
       description,
       disableCreateButton,

--- a/app/assets/src/components/common/ProjectCreationForm.jsx
+++ b/app/assets/src/components/common/ProjectCreationForm.jsx
@@ -30,8 +30,30 @@ class ProjectCreationForm extends React.Component {
     disableCreateButton: true,
   };
 
+  areCreationReqsUnmet(changed = {}) {
+    const reqs = {
+      name: this.state.name,
+      accessLevel: this.state.accessLevel,
+      description: this.state.description,
+    };
+
+    Object.keys(changed).forEach(requirement => {
+      reqs[requirement] = changed[requirement];
+    });
+
+    if (
+      reqs.name === "" ||
+      reqs.accessLevel === ACCESS_LEVEL.noSelection ||
+      reqs.description.length < 1
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   handleNameChange = name => {
-    const disableCreateButton = name === "";
+    const disableCreateButton = this.areCreationReqsUnmet({ name });
     this.setState({
       name,
       disableCreateButton,
@@ -39,7 +61,7 @@ class ProjectCreationForm extends React.Component {
   };
 
   handleAccessLevelChange = accessLevel => {
-    const disableCreateButton = accessLevel === -1;
+    const disableCreateButton = this.areCreationReqsUnmet({ accessLevel });
     this.setState({
       accessLevel,
       disableCreateButton,
@@ -47,7 +69,7 @@ class ProjectCreationForm extends React.Component {
   };
 
   handleDescriptionChange = description => {
-    const disableCreateButton = description.length < 1;
+    const disableCreateButton = this.areCreationReqsUnmet({ description });
     this.setState({
       description,
       disableCreateButton,
@@ -123,7 +145,7 @@ class ProjectCreationForm extends React.Component {
             }
           >
             <RadioButton
-              selected={accessLevel === 1}
+              selected={accessLevel === ACCESS_LEVEL.publicAccess}
               className={cs.radioButton}
             />
             <PublicProjectIcon className={cs.projectIcon} />
@@ -141,7 +163,7 @@ class ProjectCreationForm extends React.Component {
             }
           >
             <RadioButton
-              selected={accessLevel === 0}
+              selected={accessLevel === ACCESS_LEVEL.privateAccess}
               className={cs.radioButton}
             />
             <PrivateProjectIcon className={cs.projectIcon} />

--- a/app/assets/src/components/common/ProjectCreationForm.jsx
+++ b/app/assets/src/components/common/ProjectCreationForm.jsx
@@ -14,42 +14,61 @@ import { logAnalyticsEvent } from "~/api/analytics";
 
 import cs from "./project_creation_form.scss";
 
+const ACCESS_LEVEL = Object.freeze({
+  publicAccess: 1,
+  privateAccess: 0,
+  noSelection: -1,
+});
+
 class ProjectCreationForm extends React.Component {
   state = {
     name: "",
-    publicAccess: -1, // No selection by default
+    accessLevel: ACCESS_LEVEL.noSelection, // No selection by default
     error: "",
     description: "",
     showInfo: false,
+    disableCreateButton: true,
   };
 
   handleNameChange = name => {
+    const disableCreateButton = name === "";
     this.setState({
       name,
+      disableCreateButton,
+    });
+  };
+
+  handleAccessLevelChange = accessLevel => {
+    const disableCreateButton = accessLevel === -1;
+    this.setState({
+      accessLevel,
+      disableCreateButton,
     });
   };
 
   handleDescriptionChange = description => {
+    const disableCreateButton = description.length < 1;
     this.setState({
       description,
+      disableCreateButton,
     });
   };
 
   handleCreateProject = async () => {
-    if (this.state.name === "" || this.state.publicAccess === -1) {
-      return;
-    }
+    const { onCreate } = this.props;
+    const { name, accessLevel, description } = this.state;
+
     this.setState({
       error: "",
     });
     try {
       const newProject = await createProject({
-        name: this.state.name,
-        public_access: this.state.publicAccess,
-        description: this.state.description,
+        name: name,
+        public_access: accessLevel,
+        description: description,
       });
 
-      this.props.onCreate(newProject);
+      onCreate(newProject);
     } catch (e) {
       if (e[0] === "Name has already been taken") {
         this.setState({
@@ -80,12 +99,14 @@ class ProjectCreationForm extends React.Component {
 
   render() {
     const { onCancel } = this.props;
-    const { showInfo, name, publicAccess, description, error } = this.state;
-
-    let disableCreateButton = false;
-    if (name === "" || publicAccess === -1 || description.length < 1) {
-      disableCreateButton = true;
-    }
+    const {
+      showInfo,
+      name,
+      accessLevel,
+      description,
+      error,
+      disableCreateButton,
+    } = this.state;
 
     return (
       <div className={cs.projectCreationForm}>
@@ -97,10 +118,12 @@ class ProjectCreationForm extends React.Component {
           <div className={cs.label}>Project Sharing</div>
           <div
             className={cs.sharingOption}
-            onClick={() => this.setState({ publicAccess: 1 })}
+            onClick={() =>
+              this.handleAccessLevelChange(ACCESS_LEVEL.publicAccess)
+            }
           >
             <RadioButton
-              selected={publicAccess === 1}
+              selected={accessLevel === 1}
               className={cs.radioButton}
             />
             <PublicProjectIcon className={cs.projectIcon} />
@@ -113,10 +136,12 @@ class ProjectCreationForm extends React.Component {
           </div>
           <div
             className={cs.sharingOption}
-            onClick={() => this.setState({ publicAccess: 0 })}
+            onClick={() =>
+              this.handleAccessLevelChange(ACCESS_LEVEL.privateAccess)
+            }
           >
             <RadioButton
-              selected={publicAccess === 0}
+              selected={accessLevel === 0}
               className={cs.radioButton}
             />
             <PrivateProjectIcon className={cs.projectIcon} />
@@ -184,7 +209,9 @@ class ProjectCreationForm extends React.Component {
                   cs.createButton,
                   disableCreateButton && cs.disabled
                 )}
-                onClick={this.handleCreateProject}
+                onClick={
+                  disableCreateButton ? () => {} : this.handleCreateProject
+                }
               >
                 Create Project
               </div>


### PR DESCRIPTION
# Description

A logic error in React allowed a user to trigger the project creation function and make an api call to the backend even when the button was supposed to be disabled, although the backend properly rejected it. This fix prevents the project creation function from being triggered unless all the requirements are met: a name, description, and either public or private access.

# Notes

I also cleaned up some of the code to help prevent future programmers from making similar mistakes.

# Tests

Same as in #3161 
