### PR TITLE
IDSEQ-2364 - Async pipeline notification service

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1110,7 +1110,7 @@ class PipelineRun < ApplicationRecord
         check_and_log_long_run
       end
       self.job_status = "#{prs.step_number}.#{prs.name}-#{prs.job_status}"
-      self.job_status += "|#{STATUS_READY}" if report_ready?
+      self.job_status = "|#{STATUS_READY}" if report_ready?
     end
     save!
     enqueue_new_pipeline_run if automatic_restart
@@ -1154,9 +1154,9 @@ class PipelineRun < ApplicationRecord
   end
 
   def job_status_display
-    return "Pipeline Initializing" unless self.job_status
-    stage = self.job_status.to_s.split("-")[0].split(".")[1]
-    stage ? "Running #{stage}" : self.job_status
+    return "Pipeline Initializing" unless job_status
+    stage = job_status.to_s.split("-")[0].split(".")[1]
+    stage ? "Running #{stage}" : job_status
   end
 
   def run_time

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1090,7 +1090,7 @@ class PipelineRun < ApplicationRecord
         self.known_user_error, self.error_message = check_for_user_error(prs)
         automatic_restart = automatic_restart_allowed? unless known_user_error
         send_to_airbrake = !known_user_error
-        report_failed_pipeline_run_stage(prs, automatic_restart, known_user_error, send_to_airbrake)
+        report_failed_pipeline_run_stage(prs, known_user_error, send_to_airbrake, automatic_restart)
       elsif !prs.started?
         # Note: this is not ideally place to initialize an SFN pipeline but
         # in order to preserve most of the logic of the old pipeline we decided
@@ -1132,9 +1132,8 @@ class PipelineRun < ApplicationRecord
         self.job_status = STATUS_FAILED
         self.finalized = 1
         self.known_user_error, self.error_message = check_for_user_error(prs)
-        automatic_restart = false
         send_to_airbrake = !known_user_error
-        report_failed_pipeline_run_stage(prs, automatic_restart, known_user_error, send_to_airbrake)
+        report_failed_pipeline_run_stage(prs, known_user_error, send_to_airbrake)
       end
       self.job_status = format_job_status_text(prs.step_number, prs.name, prs.job_status || PipelineRunStage::STATUS_STARTED, report_ready?)
     end
@@ -1151,7 +1150,7 @@ class PipelineRun < ApplicationRecord
       "See: #{status_url}"
   end
 
-  private def report_failed_pipeline_run_stage(prs, automatic_restart, known_user_error, send_to_airbrake)
+  private def report_failed_pipeline_run_stage(prs, known_user_error, send_to_airbrake, automatic_restart = false)
     log_message = pipeline_run_stage_error_message(prs, automatic_restart, known_user_error)
     if send_to_airbrake
       LogUtil.log_err_and_airbrake(log_message)

--- a/app/services/update_pipeline_run_stage_service.rb
+++ b/app/services/update_pipeline_run_stage_service.rb
@@ -1,0 +1,26 @@
+class UpdatePipelineRunStageService
+  include Callable
+
+  attr_reader :pipeline_run_id, :stage_number, :job_status
+
+  def initialize(pipeline_run_id, stage_number, job_status)
+    @pipeline_run_id = pipeline_run_id
+    @stage_number = stage_number
+    @job_status = job_status
+  end
+
+  def call
+    pr = PipelineRun.find(@pipeline_run_id)
+    pr_stages = pr.pipeline_run_stages.sort_by(:step_number)
+    ActiveRecord::Base.transaction do
+      # set previous states to succeeded if message arrives out of order
+      pr_stages.where(step_number < stage_number) do |prs|
+        unless pr_stages.succeeded?
+          prs.update!(job_status: PipelineRunStage::STATUS_SUCCEEDED)
+        end
+      end
+      pr_stages.find_by(step_number: stage_number).update!(job_status: job_status)
+      pr.update_job_status
+    end
+  end
+end

--- a/app/services/update_pipeline_run_stage_service.rb
+++ b/app/services/update_pipeline_run_stage_service.rb
@@ -1,26 +1,29 @@
+# frozen_string_literal: true
+
 class UpdatePipelineRunStageService
   include Callable
+  include ActiveModel::Validations
 
   attr_reader :pipeline_run_id, :stage_number, :job_status
+
+  validates :pipeline_run_id, numericality: { only_integer: true }
+  validates :job_status, inclusion: { in: %w[SUCCEEDED FAILED] }
+  validates :stage_number, numericality: { only_integer: true }
 
   def initialize(pipeline_run_id, stage_number, job_status)
     @pipeline_run_id = pipeline_run_id
     @stage_number = stage_number
     @job_status = job_status
+    validate!
   end
 
   def call
-    pr = PipelineRun.find(@pipeline_run_id)
-    pr_stages = pr.pipeline_run_stages.sort_by(:step_number)
-    ActiveRecord::Base.transaction do
-      # set previous states to succeeded if message arrives out of order
-      pr_stages.where(step_number < stage_number) do |prs|
-        unless pr_stages.succeeded?
-          prs.update!(job_status: PipelineRunStage::STATUS_SUCCEEDED)
-        end
-      end
-      pr_stages.find_by(step_number: stage_number).update!(job_status: job_status)
-      pr.update_job_status
-    end
+    prs = pipeline_run.pipeline_run_stages.find_by(step_number: stage_number)
+    prs.update!(job_status: job_status)
+    pipeline_run.async_update_job_status
+  end
+
+  def pipeline_run
+    @pipeline_run ||= PipelineRun.find(pipeline_run_id)
   end
 end

--- a/spec/services/update_pipeline_run_stage_service_spec.rb
+++ b/spec/services/update_pipeline_run_stage_service_spec.rb
@@ -1,88 +1,44 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UpdatePipelineRunStageService do
   let(:pipeline_run_id) { 12_345 }
-  let(:stage_number) { 1 }
-  let(:status) { "STARTED" }
+  let(:stage_number) { 2 }
+  let(:job_status) { "SUCCEEDED" }
 
-  subject(:described_service_call) { described_class.call(pipeline_run_id, stage_number, status) }
+  let(:described_service_instance) { described_class.new(pipeline_run_id, stage_number, job_status) }
 
   context "when PipelineRun doesn't exist" do
     it "raises ActiveRecord::RecordNotFound error" do
-      expect { described_service_call }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_service_instance.call }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
   context "when PipelineRun exists" do
     let(:project) { create(:project) }
     let(:sample) { create(:sample, project_id: project.id) }
-    let(:pipeline_run) { @pipeline_run }
     let(:pipeline_execution_strategy) { 'step_function' }
 
     before do
-      @pipeline_run = create(:pipeline_run, id: pipeline_run_id, sample_id: sample.id, pipeline_execution_strategy: pipeline_execution_strategy)
+      create(:pipeline_run, id: pipeline_run_id, sample_id: sample.id, pipeline_execution_strategy: pipeline_execution_strategy)
     end
 
-    subject(:pipeline_run_stages_statuses) { @pipeline_run.pipeline_run_stages.order(:step_number).pluck(:job_status) }
-
-    shared_examples "check status changes" do |input_stage_number, expected_pipeline_run_stages_statuses, expected_pipeline_run_job_status|
-      let(:stage_number) { input_stage_number }
-      it "changes status for pipeline_run and pipeline_run_stages" do
-        described_service_call
-        expect(pipeline_run_stages_statuses).to eq(expected_pipeline_run_stages_statuses)
-        expect(pipeline_run).to have_attributes(job_status: expected_pipeline_run_job_status)
+    context "#pipeline_run" do
+      it "returns the pipeline_run" do
+        pipeline_run = described_service_instance.pipeline_run
+        expect(pipeline_run).to have_attributes(id: pipeline_run_id, sample_id: sample.id)
       end
     end
 
-    context "and has not started" do
-      context "and receives stage update in the correct order" do
-        include_examples("check status changes", 1, ["STARTED", nil, nil, nil], "1.Host Filtering-STARTED")
-      end
-      context "and receives stage update out of order" do
-        include_examples("check status changes", 3, ["COMPLETED", nil, nil, nil], "1.Host Filtering-STARTED")
-      end
-    end
-    context "and has alreay started" do
-      context "and receives pipeline_run_stage update in order" do
-      end
-      context "and receives an update out of order" do
+    context "#call" do
+      before { expect(described_service_instance.pipeline_run).to receive(:async_update_job_status) }
+
+      it "updates pipeline_run_stage" do
+        described_service_instance.call
+        prs = PipelineRun.find(pipeline_run_id).pipeline_run_stages.find_by(step_number: stage_number)
+        expect(prs).to have_attributes(job_status: job_status)
       end
     end
   end
-
-  # context "#initialize" do
-  #   let(:user) { build_stubbed(:user) }
-  #   let(:sample) { build_stubbed(:sample, user: user) }
-  #   let(:pipeline_execution_strategy) {}
-  #   let(:sfn_execution_arn) {}
-  #   let(:pipeline_run) { build_stubbed(:pipeline_run, sample: sample, pipeline_version: "3.7", pipeline_execution_strategy: pipeline_execution_strategy, sfn_execution_arn: sfn_execution_arn) }
-  #   let(:pipeline_run_stage) { build_stubbed(:pipeline_run_stage, pipeline_run: pipeline_run) }
-
-  #   subject! { pipeline_run_stage }
-
-  #   context "when pipeline_execution_strategy is step_function" do
-  #     let(:pipeline_execution_strategy) { 'step_function' }
-
-  #     context "and a precondition fails" do
-  #       let(:sfn_execution_arn) {}
-
-  #       it "notifies Airbrake with Invalid precondition" do
-  #         expect(LogUtil).to receive(:log_err_and_airbrake).with(match(/Invalid precondition/))
-  #         subject.update_job_status
-  #       end
-  #     end
-
-  #     context "and preconditions work" do
-  #       let(:sfn_execution_arn) { "arn:aws:states:us-west-2:123456789012:execution:idseq-dev-main:idseq-1234567890" }
-
-  #       before { is_expected.to receive(:sfn_info).with(sfn_execution_arn, subject.id, subject.step_number).and_return(["RUNNING", "FAKE_JOB_ID", "FAKE_JOB_DESCRIPTION"]) }
-  #       before { is_expected.to receive(:save) }
-
-  #       it "updates attributes from #sfn_info method" do
-  #         subject.update_job_status
-  #         is_expected.to have_attributes(job_status: "RUNNING", job_log_id: "FAKE_JOB_ID", job_description: "FAKE_JOB_DESCRIPTION")
-  #       end
-  #     end
-  #   end
-  # end
 end

--- a/spec/services/update_pipeline_run_stage_service_spec.rb
+++ b/spec/services/update_pipeline_run_stage_service_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe UpdatePipelineRunStageService do
+  let(:pipeline_run_id) { 12_345 }
+  let(:stage_number) { 1 }
+  let(:status) { "STARTED" }
+
+  subject(:described_service_call) { described_class.call(pipeline_run_id, stage_number, status) }
+
+  context "when PipelineRun doesn't exist" do
+    it "raises ActiveRecord::RecordNotFound error" do
+      expect { described_service_call }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context "when PipelineRun exists" do
+    let(:project) { create(:project) }
+    let(:sample) { create(:sample, project_id: project.id) }
+    let(:pipeline_run) { @pipeline_run }
+    let(:pipeline_execution_strategy) { 'step_function' }
+
+    before do
+      @pipeline_run = create(:pipeline_run, id: pipeline_run_id, sample_id: sample.id, pipeline_execution_strategy: pipeline_execution_strategy)
+    end
+
+    subject(:pipeline_run_stages_statuses) { @pipeline_run.pipeline_run_stages.order(:step_number).pluck(:job_status) }
+
+    shared_examples "check status changes" do |input_stage_number, expected_pipeline_run_stages_statuses, expected_pipeline_run_job_status|
+      let(:stage_number) { input_stage_number }
+      it "changes status for pipeline_run and pipeline_run_stages" do
+        described_service_call
+        expect(pipeline_run_stages_statuses).to eq(expected_pipeline_run_stages_statuses)
+        expect(pipeline_run).to have_attributes(job_status: expected_pipeline_run_job_status)
+      end
+    end
+
+    context "and has not started" do
+      context "and receives stage update in the correct order" do
+        include_examples("check status changes", 1, ["STARTED", nil, nil, nil], "1.Host Filtering-STARTED")
+      end
+      context "and receives stage update out of order" do
+        include_examples("check status changes", 3, ["COMPLETED", nil, nil, nil], "1.Host Filtering-STARTED")
+      end
+    end
+    context "and has alreay started" do
+      context "and receives pipeline_run_stage update in order" do
+      end
+      context "and receives an update out of order" do
+      end
+    end
+  end
+
+  # context "#initialize" do
+  #   let(:user) { build_stubbed(:user) }
+  #   let(:sample) { build_stubbed(:sample, user: user) }
+  #   let(:pipeline_execution_strategy) {}
+  #   let(:sfn_execution_arn) {}
+  #   let(:pipeline_run) { build_stubbed(:pipeline_run, sample: sample, pipeline_version: "3.7", pipeline_execution_strategy: pipeline_execution_strategy, sfn_execution_arn: sfn_execution_arn) }
+  #   let(:pipeline_run_stage) { build_stubbed(:pipeline_run_stage, pipeline_run: pipeline_run) }
+
+  #   subject! { pipeline_run_stage }
+
+  #   context "when pipeline_execution_strategy is step_function" do
+  #     let(:pipeline_execution_strategy) { 'step_function' }
+
+  #     context "and a precondition fails" do
+  #       let(:sfn_execution_arn) {}
+
+  #       it "notifies Airbrake with Invalid precondition" do
+  #         expect(LogUtil).to receive(:log_err_and_airbrake).with(match(/Invalid precondition/))
+  #         subject.update_job_status
+  #       end
+  #     end
+
+  #     context "and preconditions work" do
+  #       let(:sfn_execution_arn) { "arn:aws:states:us-west-2:123456789012:execution:idseq-dev-main:idseq-1234567890" }
+
+  #       before { is_expected.to receive(:sfn_info).with(sfn_execution_arn, subject.id, subject.step_number).and_return(["RUNNING", "FAKE_JOB_ID", "FAKE_JOB_DESCRIPTION"]) }
+  #       before { is_expected.to receive(:save) }
+
+  #       it "updates attributes from #sfn_info method" do
+  #         subject.update_job_status
+  #         is_expected.to have_attributes(job_status: "RUNNING", job_log_id: "FAKE_JOB_ID", job_description: "FAKE_JOB_DESCRIPTION")
+  #       end
+  #     end
+  #   end
+  # end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,7 +53,7 @@ RSpec.configure do |config|
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  # config.filter_run_when_matching :focus
+  config.filter_run_when_matching :focus
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend


### PR DESCRIPTION
# Description

IDSEQ-2364
This PR creates a service that will be invoked from pipeline step function via AWS -> Rails async interface (IDSEQ-2374/IDSEQ-2375/IDSEQ-2363) to notify successes or failures in pipeline stages.

This code is created in a way to support messages arriving out of order, and it will try to mimic the current {{PipelineRun#job_status}} behavior.

# Notes

We should consider refactoring and normalize `PipelineRun#job_status` field. It is a string field with an unclear domain, and there are multiple places in our source code using this field.
Examples:
https://github.com/chanzuckerberg/idseq-web/blob/b4bed182db116a77ad3a93898b18f983620fec54/app/models/pipeline_run.rb#L263-L274
We probably have more places using logic that parses this field content.
I created a new ticket for that task IDSEQ-2482.

# Tests

* Unit tested
