### PR TITLE
Add admin upload options.

### DIFF
--- a/app/assets/src/api/upload.js
+++ b/app/assets/src/api/upload.js
@@ -45,6 +45,12 @@ export const bulkUploadLocalWithMetadata = async ({
       "do_not_process",
       "pipeline_execution_strategy",
       "use_taxon_whitelist",
+      "max_input_fragments",
+      "subsample",
+      "pipeline_branch",
+      "dag_vars",
+      "alignment_config_name",
+      "s3_preload_result_path",
     ]),
     samples
   );

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
@@ -351,12 +351,8 @@ export default class CoverageVizBottomSidebar extends React.Component {
       `;
       return (
         <div className={cs.taxonLabel}>
-          {taxonName} Coverage
-          <span>
-            {" "}
-            - {speciesTaxonName}
-            <HelpIcon text={helpText} className={cs.helpIcon} />
-          </span>
+          {taxonName} Coverage - {speciesTaxonName}
+          <HelpIcon text={helpText} className={cs.helpIcon} />
         </div>
       );
     } else {

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
@@ -29,6 +29,8 @@ $genome-viz-spacing: $space-xxs;
     .taxonLabel {
       @include font-header-xs;
       color: $medium-grey;
+      display: flex;
+      align-items: center;
     }
 
     .accessionSelectMenu {
@@ -51,6 +53,8 @@ $genome-viz-spacing: $space-xxs;
       @include font-body-xs;
       color: $light-grey;
       height: $accession-count-label-height;
+      display: flex;
+      align-items: center;
     }
 
     .notShownMsg {
@@ -59,6 +63,7 @@ $genome-viz-spacing: $space-xxs;
 
     .helpIcon {
       margin-left: 5px;
+      height: 14px;
     }
   }
 

--- a/app/assets/src/components/ui/containers/HelpIcon.jsx
+++ b/app/assets/src/components/ui/containers/HelpIcon.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import BasicPopup from "~/components/BasicPopup";
+import SmallInfoIcon from "~ui/icons/SmallInfoIcon";
 import cs from "./help_icon.scss";
 
 class HelpIcon extends React.Component {
@@ -9,13 +10,9 @@ class HelpIcon extends React.Component {
     return (
       <BasicPopup
         trigger={
-          <i
-            className={cx(
-              "fa fa-question-circle",
-              cs.helpIcon,
-              this.props.className
-            )}
-          />
+          <div className={this.props.className}>
+            <SmallInfoIcon className={cx(cs.helpIcon)} />
+          </div>
         }
         hoverable
         inverted={false}

--- a/app/assets/src/components/ui/containers/HelpIcon.jsx
+++ b/app/assets/src/components/ui/containers/HelpIcon.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import { Popup } from "semantic-ui-react";
+import BasicPopup from "~/components/BasicPopup";
 import cs from "./help_icon.scss";
 
 class HelpIcon extends React.Component {
   render() {
     return (
-      <Popup
+      <BasicPopup
         trigger={
           <i
             className={cx(
@@ -17,9 +17,12 @@ class HelpIcon extends React.Component {
             )}
           />
         }
-        inverted
-        content={this.props.text}
-        horizontalOffset={13}
+        hoverable
+        inverted={false}
+        basic={false}
+        size="small"
+        position="top center"
+        content={<div className={cs.tooltip}>{this.props.text}</div>}
       />
     );
   }

--- a/app/assets/src/components/ui/containers/help_icon.scss
+++ b/app/assets/src/components/ui/containers/help_icon.scss
@@ -1,5 +1,11 @@
 @import "~styles/themes/colors";
+@import "~styles/themes/typography";
 
 .helpIcon {
   color: $light-grey;
+}
+
+.tooltip {
+  text-align: left;
+  @include font-body-xs;
 }

--- a/app/assets/src/components/ui/containers/help_icon.scss
+++ b/app/assets/src/components/ui/containers/help_icon.scss
@@ -2,7 +2,7 @@
 @import "~styles/themes/typography";
 
 .helpIcon {
-  color: $light-grey;
+  fill: $light-grey;
 }
 
 .tooltip {

--- a/app/assets/src/components/views/SampleUploadFlow/AdminUploadOptions.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/AdminUploadOptions.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { set } from "lodash/fp";
+
+import Input from "~ui/controls/Input";
+import HelpIcon from "~ui/containers/HelpIcon";
+
+import cs from "./admin_upload_options.scss";
+
+const ADMIN_OPTIONS = {
+  max_input_fragments: {
+    helpText:
+      "The maximum number of fragments permitted in an input file from S3. Additional fragments will be truncated.",
+    placeholder: 75000000,
+  },
+  subsample: {
+    helpText:
+      "The number of fragments to randomly subsample to after host filtering.",
+    placeholder: 1000000,
+  },
+  pipeline_branch: {
+    helpText: "The idseq-dag branch to run the samples on.",
+    placeholder: "master",
+  },
+  dag_vars: {
+    helpText: "Variables to pass to the dag template.",
+    placeholder: "{}",
+  },
+  alignment_config_name: {
+    helpText: "The name of the alignment config to use for these samples.",
+    placeholder: "2019-01-01",
+  },
+  s3_preload_result_path: {
+    helpText:
+      "The contents of this s3 folder will be copied to the sample result folder prior to pipeline start.",
+    placeholder: "s3://yunfang-workdir/id-rr004/RR004_water_2_S23/",
+  },
+};
+
+export default class AdminUploadOptions extends React.Component {
+  state = {
+    showOptions: false,
+  };
+
+  handleChange = (key, newValue) => {
+    const { adminOptions, onAdminOptionsChanged } = this.props;
+    onAdminOptionsChanged(set(key, newValue, adminOptions));
+  };
+
+  toggleShow = () => {
+    this.setState({
+      showOptions: !this.state.showOptions,
+    });
+  };
+
+  renderAdminOption = key => {
+    const optionMetadata = ADMIN_OPTIONS[key];
+
+    const { adminOptions } = this.props;
+    return (
+      <div className={cs.field} key={key}>
+        <div className={cs.label}>
+          {key}
+          <HelpIcon text={optionMetadata.helpText} className={cs.helpIcon} />
+        </div>
+        <Input
+          className={cs.input}
+          onChange={val => this.handleChange(key, val)}
+          value={adminOptions[key] || ""}
+          placeholder={optionMetadata.placeholder}
+        />
+      </div>
+    );
+  };
+
+  render() {
+    const { showOptions } = this.state;
+
+    return (
+      <div>
+        <div className={cs.subheader}>
+          Admin options
+          <span className={cs.toggleLink} onClick={this.toggleShow}>
+            {showOptions ? "Hide" : "Show"} options
+          </span>
+        </div>
+        {showOptions && (
+          <div className={cs.adminUploadOptions}>
+            {Object.keys(ADMIN_OPTIONS).map(option =>
+              this.renderAdminOption(option)
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+AdminUploadOptions.propTypes = {
+  adminOptions: PropTypes.objectOf(PropTypes.string).isRequired,
+  onAdminOptionsChanged: PropTypes.func.isRequired,
+};

--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -26,6 +26,7 @@ import PrivateProjectIcon from "~ui/icons/PrivateProjectIcon";
 import cs from "./sample_upload_flow.scss";
 import UploadProgressModal from "./UploadProgressModal";
 import HostOrganismMessage from "./HostOrganismMessage";
+import AdminUploadOptions from "./AdminUploadOptions";
 
 const processMetadataRows = metadataRows =>
   flow(
@@ -42,6 +43,7 @@ class ReviewStep extends React.Component {
     skipSampleProcessing: false,
     useStepFunctionPipeline: false,
     useTaxonWhitelist: false,
+    adminOptions: {},
   };
 
   componentDidMount() {
@@ -183,6 +185,10 @@ class ReviewStep extends React.Component {
     return 0;
   };
 
+  handleAdminOptionsChanged = adminOptions => {
+    this.setState({ adminOptions });
+  };
+
   toggleSkipSampleProcessing = () => {
     const { skipSampleProcessing } = this.state;
     this.setState({
@@ -272,6 +278,7 @@ class ReviewStep extends React.Component {
       consentChecked,
       useStepFunctionPipeline,
       useTaxonWhitelist,
+      adminOptions,
     } = this.state;
 
     const {
@@ -287,7 +294,7 @@ class ReviewStep extends React.Component {
     const shouldTruncateDescription =
       project.description && this.countNewLines(project.description) > 5;
 
-    const { userSettings, allowedFeatures } = this.context || {};
+    const { userSettings, allowedFeatures, admin } = this.context || {};
 
     return (
       <div
@@ -394,6 +401,12 @@ class ReviewStep extends React.Component {
             <div className={cs.tableScrollWrapper}>
               {this.renderReviewTable()}
             </div>
+            {admin && (
+              <AdminUploadOptions
+                adminOptions={adminOptions}
+                onAdminOptionsChanged={this.handleAdminOptionsChanged}
+              />
+            )}
           </div>
         </div>
         <div className={cs.controls}>
@@ -448,6 +461,7 @@ class ReviewStep extends React.Component {
               skipSampleProcessing={skipSampleProcessing}
               useStepFunctionPipeline={useStepFunctionPipeline}
               useTaxonWhitelist={useTaxonWhitelist}
+              adminOptions={adminOptions}
             />
           )}
         </div>

--- a/app/assets/src/components/views/SampleUploadFlow/UploadProgressModal.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/UploadProgressModal.jsx
@@ -125,6 +125,7 @@ export default class UploadProgressModal extends React.Component {
       skipSampleProcessing,
       useStepFunctionPipeline,
       useTaxonWhitelist,
+      adminOptions,
     } = this.props;
 
     const pipeline_execution_strategy = useStepFunctionPipeline
@@ -136,6 +137,7 @@ export default class UploadProgressModal extends React.Component {
       do_not_process: skipSampleProcessing,
       pipeline_execution_strategy,
       use_taxon_whitelist: useTaxonWhitelist,
+      ...adminOptions,
     }));
   };
 
@@ -530,4 +532,5 @@ UploadProgressModal.propTypes = {
   skipSampleProcessing: PropTypes.bool,
   useStepFunctionPipeline: PropTypes.bool,
   useTaxonWhitelist: PropTypes.bool,
+  adminOptions: PropTypes.objectOf(PropTypes.string).isRequired,
 };

--- a/app/assets/src/components/views/SampleUploadFlow/admin_upload_options.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/admin_upload_options.scss
@@ -1,0 +1,47 @@
+@import "~styles/themes/elements";
+@import "~styles/themes/typography";
+@import "~styles/themes/colors";
+
+.subheader {
+  @include font-header-s;
+  margin-top: $space-xxs;
+
+  .toggleLink {
+    @include font-label-s;
+    color: $primary-light;
+    cursor: pointer;
+    margin-left: $space-xxs;
+  }
+}
+
+.adminUploadOptions {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: $space-xxs;
+  padding: $space-m;
+  padding-bottom: 0;
+  background-color: $off-white;
+}
+
+.field {
+  width: calc(33.3% - #{$space-l * 2 / 3});
+  margin-right: $space-l;
+  margin-bottom: $space-m;
+
+  &:nth-child(3n) {
+    margin-right: 0;
+  }
+
+  .label {
+    @include font-body-xs;
+    margin-bottom: 2px;
+  }
+
+  .input {
+    display: flex;
+  }
+
+  .helpIcon {
+    margin-left: $space-xxxs;
+  }
+}

--- a/app/assets/src/components/views/SampleUploadFlow/admin_upload_options.scss
+++ b/app/assets/src/components/views/SampleUploadFlow/admin_upload_options.scss
@@ -4,7 +4,7 @@
 
 .subheader {
   @include font-header-s;
-  margin-top: $space-xxs;
+  margin-top: $space-m;
 
   .toggleLink {
     @include font-label-s;
@@ -35,6 +35,8 @@
   .label {
     @include font-body-xs;
     margin-bottom: 2px;
+    display: flex;
+    align-items: center;
   }
 
   .input {
@@ -43,5 +45,6 @@
 
   .helpIcon {
     margin-left: $space-xxxs;
+    height: 14px;
   }
 }

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1392,8 +1392,12 @@ class SamplesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def samples_params
-    new_params = params.permit(samples: [:name, :project_id, :status, :host_genome_id, :host_genome_name, :basespace_dataset_id, :basespace_access_token, :skip_cache, :do_not_process, :pipeline_execution_strategy, :use_taxon_whitelist,
-                                         input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts],])
+    permitted_sample_params = [:name, :project_id, :status, :host_genome_id, :host_genome_name, :basespace_dataset_id, :basespace_access_token, :skip_cache, :do_not_process, :pipeline_execution_strategy, :use_taxon_whitelist,
+                               input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts],]
+
+    permitted_sample_params.concat([:pipeline_branch, :dag_vars, :s3_preload_result_path, :alignment_config_name, :subsample, :max_input_fragments]) if current_user.admin?
+
+    new_params = params.permit(samples: permitted_sample_params)
     new_params[:samples] if new_params
   end
 
@@ -1401,10 +1405,10 @@ class SamplesController < ApplicationController
     permitted_params = [:name, :project_name, :project_id, :status,
                         :s3_star_index_path, :s3_bowtie2_index_path,
                         :host_genome_id, :host_genome_name,
-                        :sample_notes, :search, :subsample, :max_input_fragments,
+                        :sample_notes, :search,
                         :basespace_dataset_id, :basespace_access_token, :client, :do_not_process, :pipeline_execution_strategy, :use_taxon_whitelist,
                         input_files_attributes: [:name, :presigned_url, :source_type, :source, :parts],]
-    permitted_params.concat([:pipeline_branch, :dag_vars, :s3_preload_result_path, :alignment_config_name, :subsample]) if current_user.admin?
+    permitted_params.concat([:pipeline_branch, :dag_vars, :s3_preload_result_path, :alignment_config_name, :subsample, :max_input_fragments]) if current_user.admin?
     params.require(:sample).permit(*permitted_params)
   end
 


### PR DESCRIPTION
# Description

Migrate admin options from legacy sample flow to new one.

These admin options are the last feature that needed to be ported over. Notably, in the legacy flow, you can only allow these admin options in the SINGLE sample upload flow, whereas in this updated flow, you can apply the options to multiple samples if needed.

This unblocks deleting the legacy sample flow as everything is ported over.

![Screen Shot 2020-03-19 at 1 55 42 PM](https://user-images.githubusercontent.com/837004/77114211-5f933200-69e9-11ea-9441-4f583dbefd90.png)

![Screen Shot 2020-03-19 at 1 55 46 PM](https://user-images.githubusercontent.com/837004/77114216-61f58c00-69e9-11ea-879b-5b92e1e0a928.png)

![Screen Shot 2020-03-19 at 1 55 48 PM](https://user-images.githubusercontent.com/837004/77114224-6457e600-69e9-11ea-9440-096f0bbd1a95.png)

Also changed the help icon to the SmallInfoIcon (Jenn's request). Verified that icon in coverage viz is still behaving correctly.

# Tests

* Verify that when the options are filled out, the corresponding fields on the sample are set correctly on all uploaded samples.
* Verify that when options are not filled out, the fields are set to nil.
* Verify that non-admin users don't see the options, and the fields are set to nil for their samples.

# QA Impact
* Normal users should not see admin options.