### PR TITLE
Fix contig download button

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { compact, getOr, keys, map, orderBy } from "lodash/fp";
+import { compact, getOr, get, keys, map, orderBy } from "lodash/fp";
 import cx from "classnames";
 
 import { Table } from "~/components/visualizations/table";
@@ -474,8 +474,7 @@ class ReportTable extends React.Component {
     const validTaxId =
       rowData.taxId < INVALID_CALL_BASE_TAXID || rowData.taxId > 0;
     const contigVizEnabled =
-      !!keys(getOr({}, "nt.contigs", rowData)).length ||
-      !!keys(getOr({}, "nr.contigs", rowData)).length;
+      get("nt.contigs", rowData) || get("nr.contigs", rowData);
     const coverageVizEnabled =
       alignVizAvailable && validTaxId && getOr(0, "nt.count", rowData) > 0;
     const phyloTreeEnabled =

--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { compact, getOr, get, keys, map, orderBy } from "lodash/fp";
+import { compact, getOr, get, map, orderBy } from "lodash/fp";
 import cx from "classnames";
 
 import { Table } from "~/components/visualizations/table";

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -629,7 +629,7 @@ class PipelineReportService
   def self.report_info_cache_key(path, kvs)
     kvs = kvs.to_h.sort.to_h
     # Increment this if you ever change the response structure of report_info
-    kvs["_cache_key_version"] = 2
+    kvs["_cache_key_version"] = 3
     path + "?" + kvs.to_param
   end
 end


### PR DESCRIPTION
# Description

#3169 changed the structure of the contigs data in the report page. I missed two more changes needed:
1) check for presence of contigs to enable contig download button
2) invalidate cached data 

![image](https://user-images.githubusercontent.com/28797/77205602-718cd780-6ab2-11ea-8b79-e8bdd2815b6a.png)

# Notes

* Catching 1) would have been really hard because there was no error and the effect is subtle. I kept the convention of using the tolerant `getOr({}, "nr.contigs", rowData)`. I kept the tolerant `get` but I wonder if we would be better with some stricter types in our JS. 

# Tests

* try a report that has some contigs
* see button appear where contig > 0