### PR TITLE
Update docker-compose to use ECR image rather than Dockerhub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,9 +86,9 @@ services:
       # See https://testdriven.io/blog/faster-ci-builds-with-docker-cache/
       # and https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache#leverage-build-cache
       cache_from:
-        - chanzuckerberg/idseq-web:latest
-        - chanzuckerberg/idseq-web:compose
-    image: chanzuckerberg/idseq-web:compose
+        - ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web:latest
+        - ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web:compose
+    image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web:compose
     volumes:
       - .:/app:ro
       - ./log:/app/log
@@ -111,7 +111,7 @@ services:
       <<: *env-variables
     command: bash -c "rm -f tmp/pids/server.pid && rails server -b 0.0.0.0 -p 3000"
   resque:
-    image: chanzuckerberg/idseq-web:compose
+    image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web:compose
     volumes:
       - .:/app:ro
       - ./log:/app/log
@@ -126,7 +126,7 @@ services:
       <<: *aws-variables
     command: bundle exec "COUNT=5 rake resque:workers"
   resque_result_monitor:
-    image: chanzuckerberg/idseq-web:compose
+    image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web:compose
     volumes:
       - .:/app:ro
       - ./log:/app/log
@@ -141,7 +141,7 @@ services:
       <<: *aws-variables
     command: bundle exec "rake result_monitor"
   resque_pipeline_monitor:
-    image: chanzuckerberg/idseq-web:compose
+    image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/idseq-web:compose
     volumes:
       - .:/app:ro
       - ./log:/app/log


### PR DESCRIPTION
# Description

Refactor docker-compose to use the ECR image. I parameterized the `AWS_ACCOUNT_ID` and `AWS_REGION` like in `build-docker`. This may cause an error for some people at first but the error is pretty easily understood in my opinion and it's cleaner than hard coding.

# Tests

Ran docker-compose up and it worked the same.
