### PR TITLE
Fix analytics call for bulk download notification.

### DIFF
--- a/app/assets/src/components/views/bulk_download/BulkDownloadNotification.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadNotification.jsx
@@ -18,9 +18,11 @@ export default class BulkDownloadNotification extends React.Component {
           To check the status of your download, visit the{" "}
           <a
             href="bulk_downloads"
-            onClick={logAnalyticsEvent(
-              "BulkDownloadNotification_downloads-page-link-clicked"
-            )}
+            onClick={() =>
+              logAnalyticsEvent(
+                "BulkDownloadNotification_downloads-page-link-clicked"
+              )
+            }
           >
             Downloads page
           </a>.


### PR DESCRIPTION
# Notes

The logging call was previously getting called whenever the notification re-rendered, even if the user didn't click on the link.

# Tests

* Verified that logging call now behaves as expected. (by adding a console.log statement to test)
