### PR TITLE
Fix combined samples taxons download edge case.

### DIFF
--- a/app/helpers/heatmap_helper.rb
+++ b/app/helpers/heatmap_helper.rb
@@ -226,8 +226,9 @@ module HeatmapHelper
 
     # fraction_subsampled was introduced 2018-03-30. For prior runs, we assume
     # fraction_subsampled = 1.0.
+    # The total_ercc_reads can be nil, which we interpret as 0.
     rpm_sql = "count / (
-          (total_reads - total_ercc_reads) *
+          (total_reads - COALESCE(total_ercc_reads, 0)) *
           COALESCE(fraction_subsampled, 1.0)
         ) * 1000 * 1000"
 


### PR DESCRIPTION
# Description

This fixes a bug where if the total_ercc_reads of a pipeline run is nil, that sample will fail to process in the combined samples taxons download (because all of its rpm values are reported as 0).

The root cause is a heatmap query. If total_ercc_reads is nil, rpm will be calculated as 0 (whereas rpm would be non-zero if total_ercc_reads was 0).

The heatmap does NOT suffer from this bug because the same query is made again in `fetch_samples_taxons_counts` and rpm is re-calculated correctly using the PipelineRun.rpm function (which uses 0 if total_ercc_reads is nil).

# Tests

* Verify that bulk downloads works properly and reports correct values with the change (the bug is fixed).
* Verify that report table and heatmap still display correct values with the change.

# Tests for QA

* Verify that Combined Samples Taxons Report bulk download with NT.rpm selected still generates file without error.
* Verify that a Taxon Heatmap of the same samples still displays the correct NT.rpm values.
* Verify that the values of NT.rpm match on the report page, the combined samples taxons report bulk download output, and the taxon heatmap.
* No need to test whether the bug was fixed as it is rare (and will be tested on prod). The above tests verify that there is no regression.
