### PR TITLE
Remove validation of missing col reads_before

### DIFF
--- a/app/models/job_stat.rb
+++ b/app/models/job_stat.rb
@@ -2,6 +2,5 @@ class JobStat < ApplicationRecord
   belongs_to :pipeline_run
   validates :pipeline_run, presence: true, if: :mass_validation_enabled?
   validates :task, presence: true, inclusion: { in: PipelineRunsHelper::ALL_STEP_NAMES }, if: :mass_validation_enabled?
-  validates :reads_before, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
   validates :reads_after, numericality: { greater_than_or_equal_to: 0 }, if: :mass_validation_enabled?
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -194,7 +194,6 @@ ActiveRecord::Schema.define(version: 20_200_311_225_541) do
 
   create_table "job_stats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "task"
-    t.integer "reads_before"
     t.integer "reads_after"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# Description

This caused a pipeline monitor error when `mass_validation_enabled` was turned on. 

# Notes

* It is not clear yet why would reads_before still be in schema.rb after being dropped in a migration in august 2019.

# Tests

* will test in staging