### PR TITLE
Add log lines to silent rescue on result monitor.

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -989,8 +989,9 @@ class PipelineRun < ApplicationRecord
       compile_stats_file!
       load_stats_file
       load_chunk_stats
-    rescue
-      # TODO: Log this exception
+    rescue => e
+      LogUtil.log_err_and_airbrake("Failure compiling stats: #{e}")
+      LogUtil.log_backtrace(e)
       compiling_stats_failed = true
     end
 


### PR DESCRIPTION
# Description

* Adds log to a rescue catch

# Tests

* Run result monitor and see that nothing breaks.