### PR TITLE
[IDSEQ-2426] Trigger hover effect when taxon is added to heatmap

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -557,6 +557,7 @@ class SamplesHeatmapView extends React.Component {
       allData,
       addedTaxonIds,
       notifiedFilteredOutTaxonIds,
+      newestTaxonId,
     } = this.state;
     let taxonDetails = {};
     let taxonIds = new Set();
@@ -581,6 +582,7 @@ class SamplesHeatmapView extends React.Component {
           ) {
             this.showNotification(NOTIFICATION_TYPES.taxaFilteredOut, taxon);
             notifiedFilteredOutTaxonIds.add(taxon["id"]);
+            newestTaxonId = null;
           }
         }
       });
@@ -604,6 +606,7 @@ class SamplesHeatmapView extends React.Component {
       loading: false,
       data: filteredData,
       notifiedFilteredOutTaxonIds,
+      newestTaxonId,
     });
   }
 
@@ -790,6 +793,7 @@ class SamplesHeatmapView extends React.Component {
       ...selectedTaxonIds,
     ]);
     const currentAddedTaxa = new Set(newlyAddedTaxa, previouslyAddedTaxa);
+    const newestTaxonId = newlyAddedTaxa[newlyAddedTaxa.length - 1];
 
     // Update notifiedFilteredOutTaxonIds to remove taxa that were unselected.
     const currentFilteredOutTaxonIds = new Set(
@@ -808,6 +812,7 @@ class SamplesHeatmapView extends React.Component {
       {
         addedTaxonIds: currentAddedTaxa,
         notifiedFilteredOutTaxonIds: currentFilteredOutTaxonIds,
+        newestTaxonId: newestTaxonId,
       },
       this.updateFilters
     );
@@ -1081,6 +1086,7 @@ class SamplesHeatmapView extends React.Component {
           sampleDetails={this.state.sampleDetails}
           scale={SCALE_OPTIONS[scaleIndex][1]}
           selectedTaxa={this.state.addedTaxonIds}
+          newestTaxonId={this.state.newestTaxonId}
           allTaxonIds={this.state.allTaxonIds}
           taxonIds={Array.from(
             new Set(this.state.taxonIds, this.state.addedTaxonIds)

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -167,19 +167,17 @@ class SamplesHeatmapVis extends React.Component {
     return value > 0 && filtered ? originalColor : colorNoValue;
   };
 
-  extractTaxonLabels(focusNewTaxon = false) {
+  extractTaxonLabels() {
     return this.props.taxonIds.map(id => {
       const taxon = this.props.taxonDetails[id];
       const sortKey =
         taxon.parentId === -200 // MISSING_GENUS_ID
           ? Number.MAX_SAFE_INTEGER
           : taxon.parentId; // parentId is false when taxon level is genus
-      const newlyAdded = focusNewTaxon && id === this.props.newestTaxonId;
       return {
         label: taxon.name,
         sortKey: sortKey,
         genusName: taxon.genusName,
-        focus: newlyAdded,
       };
     });
   }
@@ -564,10 +562,9 @@ class SamplesHeatmapVis extends React.Component {
               this.setState({ addTaxonTrigger: null });
 
               if (this.props.newestTaxonId) {
-                this.heatmap.updateData({
-                  values: this.props.data[this.props.metric],
-                  rowLabels: this.extractTaxonLabels(true), // set focusNewTaxon to true
-                });
+                this.heatmap.scrollToRow(
+                  this.props.taxonDetails[this.props.newestTaxonId].name
+                );
               }
             }}
           />

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -124,13 +124,13 @@ class SamplesHeatmapVis extends React.Component {
     if (this.props.data !== prevProps.data) {
       this.heatmap.updateData({
         values: this.props.data[this.props.metric],
-        rowLabels: this.extractTaxonLabels(), // Also includes column metadata.
+        rowLabels: this.extractTaxonLabels(),
       });
     }
     if (this.props.taxonIds !== prevProps.taxonIds) {
       this.heatmap.updateData({
         values: this.props.data[this.props.metric],
-        rowLabels: this.extractTaxonLabels(), // Also includes column metadata.
+        rowLabels: this.extractTaxonLabels(),
       });
     }
     if (this.props.thresholdFilters !== prevProps.thresholdFilters) {
@@ -167,17 +167,19 @@ class SamplesHeatmapVis extends React.Component {
     return value > 0 && filtered ? originalColor : colorNoValue;
   };
 
-  extractTaxonLabels() {
+  extractTaxonLabels(focusNewTaxon = false) {
     return this.props.taxonIds.map(id => {
       const taxon = this.props.taxonDetails[id];
       const sortKey =
         taxon.parentId === -200 // MISSING_GENUS_ID
           ? Number.MAX_SAFE_INTEGER
           : taxon.parentId; // parentId is false when taxon level is genus
+      const newlyAdded = focusNewTaxon && id == this.props.newestTaxonId;
       return {
         label: taxon.name,
         sortKey: sortKey,
         genusName: taxon.genusName,
+        focus: newlyAdded,
       };
     });
   }
@@ -560,6 +562,13 @@ class SamplesHeatmapVis extends React.Component {
             onTaxonSelectionChange={this.props.onAddTaxon}
             onTaxonSelectionClose={() => {
               this.setState({ addTaxonTrigger: null });
+
+              if (this.props.newestTaxonId) {
+                this.heatmap.updateData({
+                  values: this.props.data[this.props.metric],
+                  rowLabels: this.extractTaxonLabels(true), // set focusNewTaxon to true
+                });
+              }
             }}
           />
         )}
@@ -608,6 +617,7 @@ SamplesHeatmapVis.propTypes = {
   allTaxonIds: PropTypes.array,
   taxonIds: PropTypes.array,
   selectedTaxa: PropTypes.object,
+  newestTaxonId: PropTypes.number,
   thresholdFilters: PropTypes.any,
   sampleSortType: PropTypes.string,
   fullScreen: PropTypes.bool,

--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -174,7 +174,7 @@ class SamplesHeatmapVis extends React.Component {
         taxon.parentId === -200 // MISSING_GENUS_ID
           ? Number.MAX_SAFE_INTEGER
           : taxon.parentId; // parentId is false when taxon level is genus
-      const newlyAdded = focusNewTaxon && id == this.props.newestTaxonId;
+      const newlyAdded = focusNewTaxon && id === this.props.newestTaxonId;
       return {
         label: taxon.name,
         sortKey: sortKey,

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -548,12 +548,26 @@ export default class Heatmap {
       containerHeight / 4 - (this.cellYPosition(this.focus) + metadataHeight);
     this.pan(0, focusOffset, true);
     // Briefly highlight the focused row.
+    const focusIndex = this.focus.rowIndex;
+    this.rowLabels[focusIndex].highlighted = true;
+    this.updateLabelHighlights(
+      this.gRowLabels.selectAll(`.${cs.rowLabel}`),
+      this.rowLabels
+    );
     this.updateCellHighlights();
+
     this.focus = null;
     for (let i = 0; i < this.rowLabels.length; i++) {
       this.rowLabels[i].shaded = false;
     }
-    setTimeout(this.updateCellHighlights.bind(this), 2750);
+    setTimeout(() => {
+      this.rowLabels[focusIndex].highlighted = false;
+      this.updateCellHighlights();
+      this.updateLabelHighlights(
+        this.gRowLabels.selectAll(`.${cs.rowLabel}`),
+        this.rowLabels
+      );
+    }, 2750);
   }
 
   pan(deltaX, deltaY, transition = false) {

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -586,7 +586,7 @@ export default class Heatmap {
     );
     this.g
       .transition()
-      .duration(transition ? 750 : 0)
+      .duration(transition ? this.options.transitionDuration : 0)
       .attr("transform", `translate(${[dx, dy]})`);
 
     // Translating the row labels in the opposite x direction of the svg.
@@ -638,32 +638,32 @@ export default class Heatmap {
   placeColumnLabelAndMetadataContainers(y, transition = false) {
     this.gColumnLabels
       .transition()
-      .duration(transition ? 750 : 0)
+      .duration(transition ? this.options.transitionDuration : 0)
       .attr("transform", `translate(${this.rowLabelsWidth},${y})`);
     this.gColumnMetadata
       .transition()
-      .duration(transition ? 750 : 0)
+      .duration(transition ? this.options.transitionDuration : 0)
       .attr("transform", `translate(0, ${y})`);
     // Placing the white background rectangle behind the column labels and metadata.
     this.columnLabelsBackground
       .transition()
-      .duration(transition ? 750 : 0)
+      .duration(transition ? this.options.transitionDuration : 0)
       .attr("y", y - this.columnLabelsHeight - this.options.marginTop);
     // Placing the white rectangle to hide column labels in the top left corner.
     this.metadataLabelsBackground
       .transition()
-      .duration(transition ? 750 : 0)
+      .duration(transition ? this.options.transitionDuration : 0)
       .attr("y", y - this.columnLabelsHeight - this.options.marginTop);
   }
 
   placeAddRowLinkContainer(y, transition = false) {
     this.gAddRow
       .transition()
-      .duration(transition ? 750 : 0)
+      .duration(transition ? this.options.transitionDuration : 0)
       .attr("transform", `translate(0, ${y})`);
     this.addRowBackground
       .transition()
-      .duration(transition ? 750 : 0)
+      .duration(transition ? this.options.transitionDuration : 0)
       .attr(
         "y",
         y + this.options.columnMetadata.length * this.options.minCellHeight

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -254,7 +254,7 @@ export default class Heatmap {
     for (let i = 0; i < this.rowLabels.length; i++) {
       this.rowLabels[i].rowIndex = i;
       if (this.focus) {
-        this.rowLabels[i].shaded = this.rowLabels[i] != this.focus;
+        this.rowLabels[i].shaded = this.rowLabels[i] !== this.focus;
       }
       for (let j = 0; j < this.columnLabels.length; j++) {
         this.columnLabels[j].columnIndex = j;

--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -584,14 +584,10 @@ export default class Heatmap {
       this.options.marginTop,
       Math.max(deltaY + gCurrentTranslate[1], yScrollMax)
     );
-    if (transition) {
-      this.g
-        .transition()
-        .duration(750)
-        .attr("transform", `translate(${[dx, dy]})`);
-    } else {
-      this.g.attr("transform", `translate(${[dx, dy]})`);
-    }
+    this.g
+      .transition()
+      .duration(transition ? 750 : 0)
+      .attr("transform", `translate(${[dx, dy]})`);
 
     // Translating the row labels in the opposite x direction of the svg.
     let rowLabelsCurrent = d3.transform(this.gRowLabels.attr("transform"))
@@ -640,64 +636,38 @@ export default class Heatmap {
   }
 
   placeColumnLabelAndMetadataContainers(y, transition = false) {
-    if (transition) {
-      this.gColumnLabels
-        .transition()
-        .duration(750)
-        .attr("transform", `translate(${this.rowLabelsWidth},${y})`);
-      this.gColumnMetadata
-        .transition()
-        .duration(750)
-        .attr("transform", `translate(0, ${y})`);
-      // Placing the white background rectangle behind the column labels and metadata.
-      this.columnLabelsBackground
-        .transition()
-        .duration(750)
-        .attr("y", y - this.columnLabelsHeight - this.options.marginTop);
-      // Placing the white rectangle to hide column labels in the top left corner.
-      this.metadataLabelsBackground
-        .transition()
-        .duration(750)
-        .attr("y", y - this.columnLabelsHeight - this.options.marginTop);
-    } else {
-      this.gColumnLabels.attr(
-        "transform",
-        `translate(${this.rowLabelsWidth},${y})`
-      );
-      this.gColumnMetadata.attr("transform", `translate(0, ${y})`);
-      // Placing the white background rectangle behind the column labels and metadata.
-      this.columnLabelsBackground.attr(
-        "y",
-        y - this.columnLabelsHeight - this.options.marginTop
-      );
-      // Placing the white rectangle to hide column labels in the top left corner.
-      this.metadataLabelsBackground.attr(
-        "y",
-        y - this.columnLabelsHeight - this.options.marginTop
-      );
-    }
+    this.gColumnLabels
+      .transition()
+      .duration(transition ? 750 : 0)
+      .attr("transform", `translate(${this.rowLabelsWidth},${y})`);
+    this.gColumnMetadata
+      .transition()
+      .duration(transition ? 750 : 0)
+      .attr("transform", `translate(0, ${y})`);
+    // Placing the white background rectangle behind the column labels and metadata.
+    this.columnLabelsBackground
+      .transition()
+      .duration(transition ? 750 : 0)
+      .attr("y", y - this.columnLabelsHeight - this.options.marginTop);
+    // Placing the white rectangle to hide column labels in the top left corner.
+    this.metadataLabelsBackground
+      .transition()
+      .duration(transition ? 750 : 0)
+      .attr("y", y - this.columnLabelsHeight - this.options.marginTop);
   }
 
   placeAddRowLinkContainer(y, transition = false) {
-    if (transition) {
-      this.gAddRow
-        .transition()
-        .duration(750)
-        .attr("transform", `translate(0, ${y})`);
-      this.addRowBackground
-        .transition()
-        .duration(750)
-        .attr(
-          "y",
-          y + this.options.columnMetadata.length * this.options.minCellHeight
-        );
-    } else {
-      this.gAddRow.attr("transform", `translate(0, ${y})`);
-      this.addRowBackground.attr(
+    this.gAddRow
+      .transition()
+      .duration(transition ? 750 : 0)
+      .attr("transform", `translate(0, ${y})`);
+    this.addRowBackground
+      .transition()
+      .duration(transition ? 750 : 0)
+      .attr(
         "y",
         y + this.options.columnMetadata.length * this.options.minCellHeight
       );
-    }
   }
 
   processMetadata() {


### PR DESCRIPTION
# Description

When a user adds a taxon to the heatmap, scroll to and temporarily highlight the newly added row.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/53838890/78185383-d1bf3a00-741f-11ea-8d38-0dcf64fe84f6.gif)

Since a user can potentially add multiple taxa, the effect is only triggered for the most recently added taxon when the user closes the `Add Taxon` dropdown menu.

# Tests

* Added taxa and verified that once the dropdown menu was closed, the heatmap would automatically scroll to and highlight the newest added taxon.
