### PR TITLE
Add group_concat_max_len to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1
       - MYSQL_DATABASE=idseq_development
-    command: ['--character-set-server=utf8', '--collation-server=utf8_unicode_ci']
+    command: ['--character-set-server=utf8', '--collation-server=utf8_unicode_ci', '--group_concat_max_len=1073741824']
   redis:
     image: redis:5.0.3
     container_name: redis


### PR DESCRIPTION
# Description

This parameter was applied to the prod/staging databases to fix https://jira.czi.team/browse/IDSEQ-2500. Adding this parameter to the local db as well, for consistency.

# Tests
Verified in SQL shell that the parameter is set correctly.
