### PR TITLE
IDSEQ-2517: Fix contig count bug in CSV download of report

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -591,7 +591,7 @@ class SamplesController < ApplicationController
   def report_csv
     pipeline_run = select_pipeline_run(@sample, params[:pipeline_version])
     background_id = get_background_id(@sample, params[:background])
-    min_contig_reads = params[:min_contig_reads]
+    min_contig_reads = params[:min_contig_reads] || PipelineRun::MIN_CONTIG_READS
     @report_csv = PipelineReportService.call(pipeline_run, background_id, csv: true, min_contig_reads: min_contig_reads)
     send_data @report_csv, filename: @sample.name + '_report.csv'
   end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -431,12 +431,6 @@ class PipelineRun < ApplicationRecord
   end
 
   def align_viz_available?
-    if Rails.env == "test"
-      # Otherwise, tests will raise a WebMock::NetConnectNotAllowedError.
-      # TODO: (gdingle): see IDSEQ-2602
-      return true
-    end
-
     # TODO(tiago): we should not have to access aws. see IDSEQ-2602.
     align_summary_file = "#{alignment_viz_output_s3_path}.summary"
     return align_summary_file && get_s3_file(align_summary_file) ? true : false

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -431,7 +431,13 @@ class PipelineRun < ApplicationRecord
   end
 
   def align_viz_available?
-    # TODO(tiago): we should not have to access aws
+    if Rails.env == "test"
+      # Otherwise, tests will raise a WebMock::NetConnectNotAllowedError.
+      # TODO: (gdingle): see IDSEQ-2602
+      return true
+    end
+
+    # TODO(tiago): we should not have to access aws. see IDSEQ-2602.
     align_summary_file = "#{alignment_viz_output_s3_path}.summary"
     return align_summary_file && get_s3_file(align_summary_file) ? true : false
   end

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -47,8 +47,6 @@ class PipelineReportService
   Z_SCORE_WHEN_ABSENT_FROM_SAMPLE = -100
 
   DEFAULT_SORT_PARAM = :agg_score
-  # See also PipelineRun::MIN_CONTIG_READS
-  DEFAULT_MIN_CONTIG_READS = 0
 
   CATEGORIES = {
     2 => "bacteria",
@@ -91,11 +89,11 @@ class PipelineReportService
     "species_tax_ids",
   ].freeze
 
-  def initialize(pipeline_run, background_id, csv: false, min_contig_reads: DEFAULT_MIN_CONTIG_READS, parallel: true)
+  def initialize(pipeline_run, background_id, csv: false, min_contig_reads: PipelineRun::MIN_CONTIG_READS, parallel: true)
     @pipeline_run = pipeline_run
     @background_id = background_id
     @csv = csv
-    @min_contig_reads = min_contig_reads || DEFAULT_MIN_CONTIG_READS
+    @min_contig_reads = min_contig_reads || PipelineRun::MIN_CONTIG_READS
     @parallel = parallel
   end
 

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -95,8 +95,7 @@ class PipelineReportService
     @pipeline_run = pipeline_run
     @background_id = background_id
     @csv = csv
-    raise 'bad min_contig_reads' unless min_contig_reads
-    @min_contig_reads = min_contig_reads
+    @min_contig_reads = min_contig_reads || DEFAULT_MIN_CONTIG_READS
     @parallel = parallel
   end
 

--- a/app/services/pipeline_report_service.rb
+++ b/app/services/pipeline_report_service.rb
@@ -95,6 +95,7 @@ class PipelineReportService
     @pipeline_run = pipeline_run
     @background_id = background_id
     @csv = csv
+    raise 'bad min_contig_reads' unless min_contig_reads
     @min_contig_reads = min_contig_reads
     @parallel = parallel
   end

--- a/spec/factories/pipeline_runs.rb
+++ b/spec/factories/pipeline_runs.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
       # taxon_counts, amr_counts, output_states, pipeline_run_stage
       # The hash elements will be passed on to their respective factory as keyword arguments.
       taxon_counts_data { [] }
+      contigs_data { [] }
       amr_counts_data { [] }
       output_states_data { [] }
       pipeline_run_stages_data { nil }
@@ -20,6 +21,9 @@ FactoryBot.define do
     after :create do |pipeline_run, options|
       options.taxon_counts_data.each do |taxon_count_data|
         create(:taxon_count, pipeline_run: pipeline_run, **taxon_count_data)
+      end
+      options.contigs_data.each do |contig_data|
+        create(:contig, pipeline_run: pipeline_run, **contig_data)
       end
       options.amr_counts_data.each do |amr_count_data|
         create(:amr_count, pipeline_run: pipeline_run, **amr_count_data)

--- a/spec/services/pipeline_report_service_spec.rb
+++ b/spec/services/pipeline_report_service_spec.rb
@@ -3,6 +3,8 @@ require 'json'
 
 RSpec.describe PipelineReportService, type: :service do
   context "converted report test for species taxid 573" do
+    CSV_OUTPUT = "tax_id,tax_level,genus_tax_id,name,common_name,category,agg_score,max_z_score,nt_z_score,nt_rpm,nt_count,nt_contigs,nt_contig_r,nt_percent_identity,nt_alignment_length,nt_e_value,nt_bg_mean,nt_bg_stdev,nr_z_score,nr_rpm,nr_count,nr_contigs,nr_contig_r,nr_percent_identity,nr_alignment_length,nr_e_value,nr_bg_mean,nr_bg_stdev,species_tax_ids\n570,2,570,Klebsiella,,bacteria,2428411764.7058825,99,99,193404.63458110517,217,6,594,99.7014,149.424,89.5822,18.3311,64.2056,99,77540.10695187165,87,6,594,97.9598,46.4253,16.9874,35.0207,238.639,[573]\n573,1,570,Klebsiella pneumoniae,,bacteria,2428411764.7058825,99,99,186274.50980392157,209,2,198,99.6995,149.402,89.5641,9.35068,26.4471,99,61497.326203208555,69,2,198,97.8565,46.3623,16.9101,29.9171,236.332,\n".freeze
+
     before do
       ResqueSpec.reset!
 
@@ -162,9 +164,9 @@ RSpec.describe PipelineReportService, type: :service do
       expect(JSON.parse(@report)["counts"]["2"]["570"]).to include_json(genus_result)
     end
 
-    it "should show correct values in CSV" do
+    it "should show correct values in CSV in consistent order" do
       csv_report = PipelineReportService.call(@pipeline_run, @background.id, csv: true)
-      expect(csv_report).to eq("tax_id,tax_level,genus_tax_id,name,common_name,category,agg_score,max_z_score,nt_z_score,nt_rpm,nt_count,nt_contigs,nt_contig_r,nt_percent_identity,nt_alignment_length,nt_e_value,nt_bg_mean,nt_bg_stdev,nr_z_score,nr_rpm,nr_count,nr_contigs,nr_contig_r,nr_percent_identity,nr_alignment_length,nr_e_value,nr_bg_mean,nr_bg_stdev,species_tax_ids\n570,2,570,Klebsiella,,bacteria,2428411764.7058825,99,99,193404.63458110517,217,6,594,99.7014,149.424,89.5822,18.3311,64.2056,99,77540.10695187165,87,6,594,97.9598,46.4253,16.9874,35.0207,238.639,[573]\n573,1,570,Klebsiella pneumoniae,,bacteria,2428411764.7058825,99,99,186274.50980392157,209,2,198,99.6995,149.402,89.5641,9.35068,26.4471,99,61497.326203208555,69,2,198,97.8565,46.3623,16.9101,29.9171,236.332,\n")
+      expect(csv_report).to eq(CSV_OUTPUT)
     end
   end
 

--- a/spec/services/pipeline_report_service_spec.rb
+++ b/spec/services/pipeline_report_service_spec.rb
@@ -59,8 +59,32 @@ RSpec.describe PipelineReportService, type: :service do
                                e_value: -16.9874,
                                genus_taxid: 570,
                                superkingdom_taxid: 2,
+                             },],
+                             contigs_data: [{
+                               species_taxid_nt: 573,
+                               species_taxid_nr: 573,
+                               genus_taxid_nt: 570,
+                               genus_taxid_nr: 570,
+                               read_count: 99,
+                             }, {
+                               species_taxid_nt: 573,
+                               species_taxid_nr: 573,
+                               genus_taxid_nt: 570,
+                               genus_taxid_nr: 570,
+                               read_count: 99,
+                             }, {
+                               species_taxid_nt: 570,
+                               species_taxid_nr: 570,
+                               genus_taxid_nt: 570,
+                               genus_taxid_nr: 570,
+                               read_count: 99,
+                             }, {
+                               species_taxid_nt: 570,
+                               species_taxid_nr: 570,
+                               genus_taxid_nt: 570,
+                               genus_taxid_nr: 570,
+                               read_count: 99,
                              },])
-
       @background = create(:background,
                            pipeline_run_ids: [
                              create(:pipeline_run,
@@ -136,6 +160,11 @@ RSpec.describe PipelineReportService, type: :service do
       }
 
       expect(JSON.parse(@report)["counts"]["2"]["570"]).to include_json(genus_result)
+    end
+
+    it "should show correct values in CSV" do
+      csv_report = PipelineReportService.call(@pipeline_run, @background.id, csv: true)
+      expect(csv_report).to eq("tax_id,tax_level,genus_tax_id,name,common_name,category,agg_score,max_z_score,nt_z_score,nt_rpm,nt_count,nt_contigs,nt_contig_r,nt_percent_identity,nt_alignment_length,nt_e_value,nt_bg_mean,nt_bg_stdev,nr_z_score,nr_rpm,nr_count,nr_contigs,nr_contig_r,nr_percent_identity,nr_alignment_length,nr_e_value,nr_bg_mean,nr_bg_stdev,species_tax_ids\n570,2,570,Klebsiella,,bacteria,2428411764.7058825,99,99,193404.63458110517,217,6,594,99.7014,149.424,89.5822,18.3311,64.2056,99,77540.10695187165,87,6,594,97.9598,46.4253,16.9874,35.0207,238.639,[573]\n573,1,570,Klebsiella pneumoniae,,bacteria,2428411764.7058825,99,99,186274.50980392157,209,2,198,99.6995,149.402,89.5641,9.35068,26.4471,99,61497.326203208555,69,2,198,97.8565,46.3623,16.9101,29.9171,236.332,\n")
     end
   end
 


### PR DESCRIPTION
# Description

This fixes an issue that was revealed by #3169. If there is no `params[:min_contig_reads]`, the contigs counts would be stripped. 

# Notes

* This is where it would be great to have static typing or at least use asserts. `min_contig_reads` should never be `nil`. 

# Tests

* new unit test
* download csv locally and see new values in contig cols