### PR TITLE
[IDSEQ-2516] Fix report cache key

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -745,13 +745,8 @@ class SamplesController < ApplicationController
       cache_key = PipelineReportService.report_info_cache_key(
         request.path,
         report_info_params
-          .merge(
-            params
-              .reject { |_, v| v.blank? }
-              .permit(report_info_params.keys)
-          ).merge(
-            background_id: background_id
-          ).symbolize_keys
+          .merge(background_id: background_id)
+          .symbolize_keys
       )
       httpdate = Time.at(report_info_params[:report_ts]).utc.httpdate
 


### PR DESCRIPTION
# Description

* Fix report cache key by eliminating merging of params. In this particular case, null or undefined where interpreted as strings and they all need to go through a validation step.

# Tests

* Request: `/samples/13457/report_v2.json?background=undefined&pipeline_version=null`
	* Cache key before: <pre>samples/13457/report_v2.json?_cache_key_version=3&background_id=93&format=json&pipeline_run_id=20174&<b>pipeline_version=null</b>&report_ts=1585612800</pre>
	* Cache key after: <pre>/samples/13457/report_v2.json?_cache_key_version=3&background_id=93&format=json&pipeline_run_id=20174&<b>pipeline_version=4.1</b>&report_ts=1585612800</pre>
