### PR TITLE
IDSEQ-2600: Add bulk download type for betacoronavirus

### DIFF
--- a/app/assets/src/components/views/bulk_download/BulkDownloadModalOptions.jsx
+++ b/app/assets/src/components/views/bulk_download/BulkDownloadModalOptions.jsx
@@ -246,6 +246,9 @@ class BulkDownloadModalOptions extends React.Component {
             {downloadType.admin_only && (
               <StatusLabel inline status="Admin Only" />
             )}
+            {downloadType.required_allowed_feature && (
+              <StatusLabel inline status="Beta" />
+            )}
           </div>
           <div className={cs.description}>{downloadType.description}</div>
           {downloadType.fields &&

--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -18,7 +18,7 @@ class BulkDownloadsController < ApplicationController
     unless current_user.admin?
       download_types = download_types.reject do |type|
         type[:admin_only] ||
-          (type[:required_allowed_feature] && !current_user.allowed_feature?(type.type))
+          (type[:required_allowed_feature] && !current_user.allowed_feature?(type[:type]))
       end
     end
 

--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -14,10 +14,11 @@ class BulkDownloadsController < ApplicationController
   def types
     download_types = BulkDownloadTypesHelper.bulk_download_types
 
-    # Filter out all types that are admin-only.
+    # Filter out all types that are admin-only or require feature flags.
     unless current_user.admin?
       download_types = download_types.reject do |type|
-        type[:admin_only]
+        type[:admin_only] ||
+          (type[:required_allowed_feature] && !current_user.allowed_feature?(type.type))
       end
     end
 

--- a/app/controllers/bulk_downloads_controller.rb
+++ b/app/controllers/bulk_downloads_controller.rb
@@ -18,7 +18,7 @@ class BulkDownloadsController < ApplicationController
     unless current_user.admin?
       download_types = download_types.reject do |type|
         type[:admin_only] ||
-          (type[:required_allowed_feature] && !current_user.allowed_feature?(type[:type]))
+          (type[:required_allowed_feature] && !current_user.allowed_feature?(type[:required_allowed_feature]))
       end
     end
 

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -9,6 +9,7 @@ module BulkDownloadTypesHelper
   CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE = "contigs_non_host".freeze
   UNMAPPED_READS_BULK_DOWNLOAD_TYPE = "unmapped_reads".freeze
   ORIGINAL_INPUT_FILE_BULK_DOWNLOAD_TYPE = "original_input_file".freeze
+  BETACORONOVIRUS_BULK_DOWNLOAD_TYPE = "betacoronavirus".freeze
 
   RESQUE_EXECUTION_TYPE = "resque".freeze
   VARIABLE_EXECUTION_TYPE = "variable".freeze
@@ -17,6 +18,7 @@ module BulkDownloadTypesHelper
   # The "type" value of the bulk download fields is really the field key.
   # There isn't currently anything that specifies what data type the field is.
   # The front-end is hard-coded to display a select dropdown or a checkbox depending on the field type.
+  # For more documentation, see https://czi.quip.com/TJEaAeFaAewG/Making-a-Bulk-Download-Things-to-Know
   BULK_DOWNLOAD_TYPES = [
     {
       type: SAMPLE_OVERVIEW_BULK_DOWNLOAD_TYPE,
@@ -111,6 +113,14 @@ module BulkDownloadTypesHelper
         },
       ],
       execution_type: VARIABLE_EXECUTION_TYPE,
+    },
+    {
+      type: BETACORONOVIRUS_BULK_DOWNLOAD_TYPE,
+      display_name: "Betacoronavirus Reads (Paired, Non-Deduplicated)",
+      description: "Paired, non-deduplicated, FASTQs of betacoronavirus reads",
+      category: "raw",
+      execution_type: ECS_EXECUTION_TYPE,
+      file_type_display: ".fastq",
     },
     {
       type: CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE,

--- a/app/helpers/bulk_download_types_helper.rb
+++ b/app/helpers/bulk_download_types_helper.rb
@@ -116,6 +116,7 @@ module BulkDownloadTypesHelper
     },
     {
       type: BETACORONOVIRUS_BULK_DOWNLOAD_TYPE,
+      required_allowed_feature: "betacoronavirus_fastqs", # see allowed_features
       display_name: "Betacoronavirus Reads (Paired, Non-Deduplicated)",
       description: "Paired, non-deduplicated, FASTQs of betacoronavirus reads",
       category: "raw",

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -358,6 +358,22 @@ class BulkDownload < ApplicationRecord
       end.flatten
     end
 
+    # This is very similar to READS_NON_HOST_BULK_DOWNLOAD_TYPE by design.
+    if download_type == BETACORONOVIRUS_BULK_DOWNLOAD_TYPE
+      pipeline_runs_ordered = pipeline_runs_ordered.includes(sample: [:input_files])
+
+      download_src_urls = pipeline_runs_ordered.map(&:betacoronavirus_fastq_s3_paths).flatten
+      download_tar_names = pipeline_runs_ordered.map do |pipeline_run|
+        sample = pipeline_run.sample
+        # Inputs for this type we expect to always be fastq but logically both could work
+        file_ext = sample.fasta_input? ? 'fasta' : 'fastq'
+        sample.input_files.map.with_index do |_input_file, input_file_index|
+          "#{get_output_file_prefix(sample, cleaned_project_names)}" \
+            "betacoronavirus_reads_R#{input_file_index + 1}.#{file_ext}"
+        end
+      end.flatten
+    end
+
     if download_type == CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE
       download_src_urls = pipeline_runs_ordered.map(&:contigs_fasta_s3_path)
 

--- a/app/models/bulk_download.rb
+++ b/app/models/bulk_download.rb
@@ -362,7 +362,7 @@ class BulkDownload < ApplicationRecord
     if download_type == BETACORONOVIRUS_BULK_DOWNLOAD_TYPE
       pipeline_runs_ordered = pipeline_runs_ordered.includes(sample: [:input_files])
 
-      download_src_urls = pipeline_runs_ordered.map(&:betacoronavirus_fastq_s3_paths).flatten
+      download_src_urls = pipeline_runs_ordered.map { |pr| pr.nonhost_fastq_s3_paths('betacoronavirus__') }.flatten
       download_tar_names = pipeline_runs_ordered.map do |pipeline_run|
         sample = pipeline_run.sample
         # Inputs for this type we expect to always be fastq but logically both could work

--- a/app/models/input_file.rb
+++ b/app/models/input_file.rb
@@ -43,4 +43,8 @@ class InputFile < ApplicationRecord
   def file_type
     FILE_REGEX.match(name)[1] if FILE_REGEX.match(name)
   end
+
+  def without_gz
+    name.gsub(/.gz$/, '')
+  end
 end

--- a/app/models/input_file.rb
+++ b/app/models/input_file.rb
@@ -43,8 +43,4 @@ class InputFile < ApplicationRecord
   def file_type
     FILE_REGEX.match(name)[1] if FILE_REGEX.match(name)
   end
-
-  def without_gz
-    name.gsub(/.gz$/, '')
-  end
 end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -570,6 +570,23 @@ class PipelineRun < ApplicationRecord
     files
   end
 
+  def betacoronavirus_fastq_s3_paths
+    # must be in sync with naming in idseq_dag/steps/nonhost_fastq.py
+    s3_path = lambda do |name|
+      "#{postprocess_output_s3_path}/betacoronavirus__#{name.gsub(/.gz$/, '')}"
+    end
+
+    s3_paths = [
+      s3_path.call(sample.input_files[0].name),
+    ]
+
+    if sample.input_files.length == 2
+      s3_paths << s3_path.call(sample.input_files[1].name)
+    end
+
+    s3_paths
+  end
+
   # Unidentified is also referred to as "unmapped"
   def unidentified_fasta_s3_path
     return "#{assembly_s3_path}/#{ASSEMBLY_PREFIX}#{DAG_UNIDENTIFIED_FASTA_BASENAME}" if supports_assembly?

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -573,15 +573,15 @@ class PipelineRun < ApplicationRecord
   def betacoronavirus_fastq_s3_paths
     # must be in sync with naming in idseq_dag/steps/nonhost_fastq.py
     s3_path = lambda do |name|
-      "#{postprocess_output_s3_path}/betacoronavirus__#{name.gsub(/.gz$/, '')}"
+      "#{postprocess_output_s3_path}/betacoronavirus__#{name}"
     end
 
     s3_paths = [
-      s3_path.call(sample.input_files[0].name),
+      s3_path.call(sample.input_files[0].without_gz),
     ]
 
     if sample.input_files.length == 2
-      s3_paths << s3_path.call(sample.input_files[1].name)
+      s3_paths << s3_path.call(sample.input_files[1].without_gz)
     end
 
     s3_paths

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -556,35 +556,18 @@ class PipelineRun < ApplicationRecord
     return "#{host_filter_output_s3_path}/#{READS_PER_GENE_STAR_TAB_NAME}"
   end
 
-  def nonhost_fastq_s3_paths
+  def nonhost_fastq_s3_paths(prefix = '')
     input_file_ext = sample.fasta_input? ? 'fasta' : 'fastq'
 
     files = [
-      "#{postprocess_output_s3_path}/nonhost_R1.#{input_file_ext}",
+      "#{postprocess_output_s3_path}/#{prefix}nonhost_R1.#{input_file_ext}",
     ]
 
     if sample.input_files.length == 2
-      files << "#{postprocess_output_s3_path}/nonhost_R2.#{input_file_ext}"
+      files << "#{postprocess_output_s3_path}/#{prefix}nonhost_R2.#{input_file_ext}"
     end
 
     files
-  end
-
-  def betacoronavirus_fastq_s3_paths
-    # must be in sync with naming in idseq_dag/steps/nonhost_fastq.py
-    s3_path = lambda do |name|
-      "#{postprocess_output_s3_path}/betacoronavirus__#{name}"
-    end
-
-    s3_paths = [
-      s3_path.call(sample.input_files[0].without_gz),
-    ]
-
-    if sample.input_files.length == 2
-      s3_paths << s3_path.call(sample.input_files[1].without_gz)
-    end
-
-    s3_paths
   end
 
   # Unidentified is also referred to as "unmapped"

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -75,7 +75,6 @@ describe BulkDownload, type: :model do
   context "#bulk_download_ecs_task_command" do
     before do
       @joe = create(:joe)
-      @joe.add_allowed_feature("betacoronavirus_fastqs")
       @project = create(:project, users: [@joe], name: "Test Project")
       @sample_one = create(:sample, project: @project, name: "Test Sample One",
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])
@@ -246,17 +245,15 @@ describe BulkDownload, type: :model do
                                 },
                               })
 
+      expect(@sample_one.input_files[0].without_gz.ends_with?('.gz')).to be false
       task_command = [
         "python",
         "s3_tar_writer.py",
         "--src-urls",
-        # NOTE: BETACORONOVIRUS_BULK_DOWNLOAD_TYPE uses the original file name,
-        # which in rspec is determined by input_files factory, so it is missing
-        # the R1 and R2 suffix which it normally would have.
-        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__file.17.fastq",
-        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__file.18.fastq",
-        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__file.19.fastq",
-        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__file.20.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__#{@sample_one.input_files[0].without_gz}",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__#{@sample_one.input_files[1].without_gz}",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__#{@sample_two.input_files[0].without_gz}",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__#{@sample_two.input_files[1].without_gz}",
         "--tar-names",
         get_expected_tar_name(@project, @sample_one, "betacoronavirus_reads_R1.fastq"),
         get_expected_tar_name(@project, @sample_one, "betacoronavirus_reads_R2.fastq"),

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -245,15 +245,14 @@ describe BulkDownload, type: :model do
                                 },
                               })
 
-      expect(@sample_one.input_files[0].without_gz.ends_with?('.gz')).to be false
       task_command = [
         "python",
         "s3_tar_writer.py",
         "--src-urls",
-        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__#{@sample_one.input_files[0].without_gz}",
-        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__#{@sample_one.input_files[1].without_gz}",
-        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__#{@sample_two.input_files[0].without_gz}",
-        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__#{@sample_two.input_files[1].without_gz}",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__nonhost_R1.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__nonhost_R2.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__nonhost_R1.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__nonhost_R2.fastq",
         "--tar-names",
         get_expected_tar_name(@project, @sample_one, "betacoronavirus_reads_R1.fastq"),
         get_expected_tar_name(@project, @sample_one, "betacoronavirus_reads_R2.fastq"),

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -230,6 +230,51 @@ describe BulkDownload, type: :model do
       expect(@bulk_download.bulk_download_ecs_task_command).to eq(task_command)
     end
 
+    it "returns the correct task command for betacoronavirus download type with fastq file format" do
+      @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::BETACORONOVIRUS_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
+                                @sample_one.first_pipeline_run.id,
+                                @sample_two.first_pipeline_run.id,
+                              ], params: {
+                                "file_format": {
+                                  "value": ".fastq",
+                                  "displayName": ".fastq",
+                                },
+                                "taxa_with_reads": {
+                                  "value": "all",
+                                  "displayName": "All Taxa",
+                                },
+                              })
+
+      task_command = [
+        "python",
+        "s3_tar_writer.py",
+        "--src-urls",
+        # NOTE: BETACORONOVIRUS_BULK_DOWNLOAD_TYPE uses the original file name,
+        # which in rspec is determined by input_files factory, so it is missing
+        # the R1 and R2 suffix which it normally would have.
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__file.17.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_one.id}/postprocess/3.12/betacoronavirus__file.18.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__file.19.fastq",
+        "s3://idseq-samples-prod/samples/#{@project.id}/#{@sample_two.id}/postprocess/3.12/betacoronavirus__file.20.fastq",
+        "--tar-names",
+        get_expected_tar_name(@project, @sample_one, "betacoronavirus_reads_R1.fastq"),
+        get_expected_tar_name(@project, @sample_one, "betacoronavirus_reads_R2.fastq"),
+        get_expected_tar_name(@project, @sample_two, "betacoronavirus_reads_R1.fastq"),
+        get_expected_tar_name(@project, @sample_two, "betacoronavirus_reads_R2.fastq"),
+        "--dest-url",
+        "s3://idseq-samples-prod/downloads/#{@bulk_download.id}/Betacoronavirus Reads (Paired, Non-Deduplicated).tar.gz",
+        "--progress-delay",
+        15,
+        "--success-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/success/#{@bulk_download.access_token}",
+        "--error-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/error/#{@bulk_download.access_token}",
+        "--progress-url",
+        "https://idseq.net/bulk_downloads/#{@bulk_download.id}/progress/#{@bulk_download.access_token}",
+      ]
+      expect(@bulk_download.bulk_download_ecs_task_command).to eq(task_command)
+    end
+
     it "returns the correct task command for contigs_non_host download type" do
       @bulk_download = create(:bulk_download, user: @joe, download_type: BulkDownloadTypesHelper::CONTIGS_NON_HOST_BULK_DOWNLOAD_TYPE, pipeline_run_ids: [
                                 @sample_one.first_pipeline_run.id,

--- a/spec/models/bulk_download_spec.rb
+++ b/spec/models/bulk_download_spec.rb
@@ -75,6 +75,7 @@ describe BulkDownload, type: :model do
   context "#bulk_download_ecs_task_command" do
     before do
       @joe = create(:joe)
+      @joe.add_allowed_feature("betacoronavirus_fastqs")
       @project = create(:project, users: [@joe], name: "Test Project")
       @sample_one = create(:sample, project: @project, name: "Test Sample One",
                                     pipeline_runs_data: [{ finalized: 1, job_status: PipelineRun::STATUS_CHECKED, pipeline_version: "3.12" }])


### PR DESCRIPTION
# Description

This adds a new type for biohub COMET group. Goes with pipeline PRs https://github.com/chanzuckerberg/idseq-dag/pull/282 and https://github.com/chanzuckerberg/idseq-dag/pull/283.

![image](https://user-images.githubusercontent.com/28797/78852297-cd22f480-79d0-11ea-96a0-cc59e42d1d59.png)

# Notes

* Still waiting on https://github.com/chanzuckerberg/idseq-dag/pull/282 and https://github.com/chanzuckerberg/idseq-dag/pull/283 for real files to download
* Not sure whether it is better to allow all admins access or only those with the `allowed_feature`
* It seems a little dangerous to have s3 names that contain spaces like `test_project_79/Test Sample One_131_betacoronavirus_reads_R1.fastq`

# Tests

* unit test
* open bulk download dialog, see new choice
* tested with allowed features