### PR TITLE
[Hot fix] Fix manually removing taxon for old heatmap filtering

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -1089,7 +1089,10 @@ class SamplesHeatmapView extends React.Component {
           newestTaxonId={this.state.newestTaxonId}
           allTaxonIds={this.state.allTaxonIds}
           taxonIds={Array.from(
-            new Set(this.state.taxonIds, this.state.addedTaxonIds)
+            difference(
+              [...new Set(this.state.taxonIds, this.state.addedTaxonIds)],
+              [...this.removedTaxonIds]
+            )
           )}
           taxonCategories={this.state.selectedOptions.categories}
           taxonDetails={this.state.allTaxonDetails} // send allTaxonDetails in case of added taxa


### PR DESCRIPTION
# Description

A bug was identified where users with the server-side heatmap filtering were unable to remove taxa by clicking the X.

# Tests

* Verified that taxa could be removed with the X.
