### PR TITLE
IDSEQ-2635 IDSEQ-2641 Fix bugs with location metadata auto-adjusting.

### DIFF
--- a/app/assets/src/components/common/MetadataCSVLocationsMenu.jsx
+++ b/app/assets/src/components/common/MetadataCSVLocationsMenu.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { uniq, find, chunk, random } from "lodash/fp";
+import { uniq, find, chunk, random, get } from "lodash/fp";
 
 import { withAnalytics, logAnalyticsEvent } from "~/api/analytics";
 import { getGeoSearchSuggestions } from "~/api/locations";
@@ -139,7 +139,7 @@ class MetadataCSVLocationsMenu extends React.Component {
           metadata: newMetadata,
         });
         this.setState({ applyToAllSample: sampleName });
-        logAnalyticsEvent("MetadataManualInput_input_changed", {
+        logAnalyticsEvent("MetadataCSVLocationsMenu_input_changed", {
           key,
           value,
           sampleName,
@@ -156,7 +156,7 @@ class MetadataCSVLocationsMenu extends React.Component {
             metadataType={locationMetadataType}
             onChange={onChange}
             withinModal={true}
-            isHuman={isRowHuman(row)}
+            taxaCategory={get("taxa_category", this.getHostGenomeForRow(row))}
             warning={CSVLocationWarnings[sampleName]}
           />
           {applyToAllSample === sampleName &&
@@ -166,6 +166,12 @@ class MetadataCSVLocationsMenu extends React.Component {
       ];
     });
   };
+
+  getHostGenomeForRow = row =>
+    find(
+      ["name", row["Host Organism"] || row["Host Genome"]],
+      this.props.hostGenomes
+    );
 
   render() {
     const { metadata, locationMetadataType } = this.props;
@@ -202,6 +208,7 @@ MetadataCSVLocationsMenu.propTypes = {
   }),
   onCSVLocationWarningsChange: PropTypes.func.isRequired,
   onMetadataChange: PropTypes.func.isRequired,
+  hostGenomes: PropTypes.array,
 };
 
 export default MetadataCSVLocationsMenu;

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -15,11 +15,22 @@ export const LOCATION_UNRESOLVED_WARNING =
 // Process location selections and add warnings.
 export const processLocationSelection = (result, isHuman) => {
   let warning = "";
+  // For human samples, drop the city part of the name and show a warning.
+  // NOTE: The backend will redo the geosearch for confirmation and re-apply
+  // this restriction.
   if (isHuman && get("geo_level", result) === "city") {
     result = Object.assign({}, result); // make a copy to avoid side effects
-    // For human samples, drop the city part of the name and show a warning.
-    // NOTE: The backend will redo the geosearch for confirmation and re-apply
-    // this restriction.
+
+    // If the subdivision name is identical to the city name, remove the subdivision name as well to be safe.
+    if (result.subdivision_name === result.city_name) {
+      result.subdivision_name = "";
+    }
+    // Remove the city name.
+    result.city_name = "";
+
+    // Mark the result so that the back-end will know to refetch it.
+    result.refetch_adjusted_location = true;
+
     result.name = compact([
       result.subdivision_name,
       result.state_name,

--- a/app/helpers/error_helper.rb
+++ b/app/helpers/error_helper.rb
@@ -47,6 +47,7 @@ module ErrorHelper
     end
   end
 
+  LOCATION_INVALID_ERROR_HUMAN = "Please input a location at the county/district level of higher. (for human samples)".freeze
   LOCATION_INVALID_ERROR = "Please input a location.".freeze
   DATE_INVALID_ERROR_HUMAN = "Please input a date in the format YYYY-MM or MM/YYYY. (for human samples)".freeze
   DATE_INVALID_ERROR = "Please input a date in the format YYYY-MM-DD, YYYY-MM, MM/DD/YY, or MM/YYYY.".freeze
@@ -54,7 +55,11 @@ module ErrorHelper
 
   def get_field_error(field, is_human = false)
     if field.base_type == MetadataField::LOCATION_TYPE
-      return LOCATION_INVALID_ERROR
+      if is_human
+        return LOCATION_INVALID_ERROR_HUMAN
+      else
+        return LOCATION_INVALID_ERROR
+      end
     end
 
     if field.base_type == MetadataField::DATE_TYPE
@@ -187,10 +192,17 @@ module ErrorHelper
       unless @supported_errors[error_type]
         # Automatically determine the kind of error to display based on the field.
         if field.base_type == MetadataField::LOCATION_TYPE
-          @supported_errors[error_type] = {
-            headers: ["Row #", "Sample Name", "Invalid Value"],
-            title: ->(num_rows, _) { "#{num_rows} invalid values for \"#{field.display_name}\" (column #{col_index}). #{LOCATION_INVALID_ERROR}" },
-          }
+          @supported_errors[error_type] = if is_human
+                                            {
+                                              headers: ["Row #", "Sample Name", "Invalid Value"],
+                                              title: ->(num_rows, _) { "#{num_rows} invalid values for \"#{field.display_name}\" (column #{col_index}). #{LOCATION_INVALID_ERROR_HUMAN}" },
+                                            }
+                                          else
+                                            {
+                                              headers: ["Row #", "Sample Name", "Invalid Value"],
+                                              title: ->(num_rows, _) { "#{num_rows} invalid values for \"#{field.display_name}\" (column #{col_index}). #{LOCATION_INVALID_ERROR}" },
+                                            }
+                                          end
         end
 
         if field.base_type == MetadataField::DATE_TYPE

--- a/spec/factories/host_genomes.rb
+++ b/spec/factories/host_genomes.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
       options.metadata_fields.each do |metadata_field_name|
         metadata_field = MetadataField.find_by(name: metadata_field_name)
         unless metadata_field
-          create(:metadata_field, name: metadata_field_name)
+          metadata_field = create(:metadata_field, name: metadata_field_name)
         end
         host_genome.metadata_fields << metadata_field unless host_genome.metadata_fields.include?(metadata_field)
       end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :location do
+  end
+end

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -41,7 +41,11 @@ FactoryBot.define do
     after :create do |sample, options|
       if MetadataField.table_exists?
         # Make sure the sample's host_genome has the requested metadata fields
-        sample.host_genome.metadata_fields = MetadataField.where(name: options.metadata_fields.keys())
+        MetadataField.where(name: options.metadata_fields.keys()).each do |mf|
+          unless sample.host_genome.metadata_fields.include?(mf)
+            sample.host_genome.metadata_fields << mf
+          end
+        end
       end
 
       options.metadata_fields.each do |key, value|

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe Location, type: :model do
+  context "#find_or_new_by_fields" do
+    before do
+      user = create(:user)
+      @project = create(:project, users: [user])
+      @location_metadata_field = create(
+        :metadata_field, name: 'mock_collection_location', base_type: MetadataField::LOCATION_TYPE
+      )
+      host_genome = create(:host_genome, name: "mock_host_genome")
+      host_genome.metadata_fields << @location_metadata_field
+      @sample = create(:sample, project: @project, name: "Mock sample", host_genome: host_genome)
+    end
+
+    it "should return existing location if it exists" do
+      mock_location = create(:location, country_name: "USA")
+
+      loc_info = { country_name: "USA" }
+      location = Location.find_or_new_by_fields(loc_info)
+
+      expect(location.new_record?).to eq(false)
+      expect(location.id).to eq(mock_location.id)
+    end
+
+    it "should return newly created location if no osm_id or osm_type" do
+      loc_info = { country_name: "USA" }
+      location = Location.find_or_new_by_fields(loc_info)
+
+      expect(location.new_record?).to eq(true)
+      expect(location.country_name).to eq("USA")
+    end
+
+    it "should perform geosearch if osm_id or osm_type provided" do
+      loc_info = { country_name: "USA", osm_id: 123, osm_type: "Relation" }
+
+      expect(Location).to receive(:geosearch_by_osm_id).with(123, "Relation").exactly(1).times
+                                                       .and_return([true, "mock_response"])
+      expect(LocationHelper).to receive(:adapt_location_iq_response).with("mock_response").exactly(1).times
+                                                                    .and_return(country_name: "Mock Country", osm_id: 123, osm_type: "Relation")
+
+      location = Location.find_or_new_by_fields(loc_info)
+      expect(location.new_record?).to eq(true)
+      expect(location.country_name).to eq("Mock Country")
+    end
+
+    it "should return existing location if it matches geosearch response" do
+      # There is an existing location for USA, but not California.
+      mock_location = create(:location, country_name: "USA")
+      loc_info = { country_name: "USA", state_name: "California", osm_id: 123, osm_type: "Relation" }
+
+      expect(Location).to receive(:geosearch_by_osm_id).with(123, "Relation").exactly(1).times
+                                                       .and_return([true, "mock_response"])
+      expect(LocationHelper).to receive(:adapt_location_iq_response).with("mock_response").exactly(1).times
+                                                                    .and_return(country_name: "USA", osm_id: 123, osm_type: "Relation")
+
+      location = Location.find_or_new_by_fields(loc_info)
+      expect(location.new_record?).to eq(false)
+      expect(location.id).to eq(mock_location.id)
+    end
+  end
+
+  context "#specificity_valid?" do
+    it "should return true for non-human genomes non-specific locations" do
+      is_valid = Location.specificity_valid?({
+                                               geo_level: "country",
+                                               country_name: "USA",
+                                             }, "Mosquito")
+
+      expect(is_valid).to eq(true)
+    end
+
+    it "should return true for non-human genomes and city-level locations" do
+      is_valid = Location.specificity_valid?({
+                                               geo_level: "city",
+                                               country_name: "USA",
+                                               state_name: "California",
+                                               city_name: "San Francisco",
+                                             }, "Mosquito")
+
+      expect(is_valid).to eq(true)
+    end
+
+    it "should return false for human genomes and city-level locations" do
+      is_valid = Location.specificity_valid?({
+                                               geo_level: "city",
+                                               country_name: "USA",
+                                               state_name: "California",
+                                               city_name: "San Francisco",
+                                             }, "Human")
+
+      expect(is_valid).to eq(false)
+    end
+
+    it "should return true for human genomes and non-specific locations" do
+      is_valid = Location.specificity_valid?({
+                                               geo_level: "country",
+                                               country_name: "USA",
+                                             }, "Human")
+
+      expect(is_valid).to eq(true)
+    end
+  end
+end

--- a/spec/models/metadata_spec.rb
+++ b/spec/models/metadata_spec.rb
@@ -1,0 +1,145 @@
+require 'rails_helper'
+
+RSpec.describe Metadatum, type: :model do
+  context "#check_and_set_location_type" do
+    before do
+      user = create(:user)
+      @project = create(:project, users: [user])
+      @location_metadata_field = create(
+        :metadata_field, name: 'mock_collection_location', base_type: MetadataField::LOCATION_TYPE
+      )
+      host_genome = create(:host_genome, name: "mock_host_genome")
+      host_genome.metadata_fields << @location_metadata_field
+      @sample = create(:sample, project: @project, name: "Mock sample", host_genome: host_genome)
+    end
+
+    it "should pass in normal case" do
+      location = { name: "mock_location", locationiq_id: 100 }
+
+      # Test with location already created.
+      mock_location = create(:location, osm_id: 200, locationiq_id: 101)
+      # The following functions are expected to be called.
+      expect(Location).to receive(:find_or_new_by_fields).exactly(1).times
+                                                         .and_return(mock_location)
+
+      location_metadata = Metadatum.new(
+        raw_value: JSON.dump(location),
+        sample: @sample,
+        metadata_field: @location_metadata_field,
+        key: "mock_collection_location"
+      )
+
+      location_metadata.save!
+      expect(location_metadata.string_validated_value).to eq(nil)
+      expect(location_metadata.raw_value).to eq(nil)
+      expect(location_metadata.location_id).to eq(mock_location.id)
+    end
+
+    it "should save unwrapped strings without error" do
+      location_metadata = Metadatum.new(
+        raw_value: "mock_location",
+        sample: @sample,
+        metadata_field: @location_metadata_field,
+        key: "mock_collection_location"
+      )
+
+      location_metadata.save!
+      expect(location_metadata.string_validated_value).to eq("mock_location")
+      expect(location_metadata.location_id).to eq(nil)
+    end
+
+    it "should save plain text selection without error" do
+      location_metadata = Metadatum.new(
+        raw_value: JSON.dump(name: "mock_location"),
+        sample: @sample,
+        metadata_field: @location_metadata_field,
+        key: "mock_collection_location"
+      )
+
+      location_metadata.save!
+      expect(location_metadata.string_validated_value).to eq("mock_location")
+      expect(location_metadata.location_id).to eq(nil)
+    end
+
+    it "should succeed if location is already linked" do
+      location = create(:location, osm_id: 200, locationiq_id: 100)
+
+      location_metadata = Metadatum.new(
+        sample: @sample,
+        metadata_field: @location_metadata_field,
+        key: "mock_collection_location",
+        location: location
+      )
+
+      location_metadata.save!
+      expect(location_metadata.location_id).to eq(location.id)
+    end
+
+    it "should refetch adjusted location if refetch_adjusted_location is set" do
+      location = { name: "mock_location", locationiq_id: 100, refetch_adjusted_location: true }
+
+      # Test with location already created.
+      mock_location = create(:location, osm_id: 200, locationiq_id: 101)
+      # The following functions are expected to be called.
+      expect(Location).to receive(:refetch_adjusted_location).exactly(1).times
+                                                             .and_return(mock_location)
+
+      location_metadata = Metadatum.new(
+        raw_value: JSON.dump(location),
+        sample: @sample,
+        metadata_field: @location_metadata_field,
+        key: "mock_collection_location"
+      )
+
+      location_metadata.save!
+      expect(location_metadata.string_validated_value).to eq(nil)
+      expect(location_metadata.raw_value).to eq(nil)
+      expect(location_metadata.location_id).to eq(mock_location.id)
+    end
+
+    it "should run check_and_fetch_parents if location isn't already created" do
+      location = { name: "mock_location", locationiq_id: 100, refetch_adjusted_location: true }
+
+      # Test with location not yet created.
+      mock_location = Location.new(name: "mock_location_two", locationiq_id: 101, osm_id: 200)
+      # The following functions are expected to be called.
+      expect(Location).to receive(:refetch_adjusted_location).exactly(1).times
+                                                             .and_return(mock_location)
+      expect(Location).to receive(:check_and_fetch_parents).exactly(1).times
+                                                           .and_return(mock_location)
+
+      location_metadata = Metadatum.new(
+        raw_value: JSON.dump(location),
+        sample: @sample,
+        metadata_field: @location_metadata_field,
+        key: "mock_collection_location"
+      )
+
+      location_metadata.save!
+      expect(location_metadata.string_validated_value).to eq(nil)
+      expect(location_metadata.raw_value).to eq(nil)
+      created_location = Location.find(location_metadata.location_id)
+      expect(created_location.locationiq_id).to eq(101)
+      expect(created_location.osm_id).to eq(200)
+    end
+
+    it "should throw error if location for Human sample is too specific" do
+      host_genome_human = HostGenome.find_by(name: "Human")
+      host_genome_human.metadata_fields << @location_metadata_field
+      @human_sample = create(:sample, project: @project, name: "Mock sample human", host_genome: host_genome_human)
+
+      location = { name: "mock_location", locationiq_id: 100, city_name: "Mock City", geo_level: "city" }
+
+      location_metadata = Metadatum.new(
+        raw_value: JSON.dump(location),
+        sample: @human_sample,
+        metadata_field: @location_metadata_field,
+        key: "mock_collection_location"
+      )
+
+      expect do
+        location_metadata.save!
+      end.to raise_error
+    end
+  end
+end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -137,31 +137,6 @@ class LocationTest < ActiveSupport::TestCase
     assert mock.verify
   end
 
-  test "should restrict an overly specific sample location (human city to county/subdivision)" do
-    bad_location = locations(:ucsf)
-    api_response = [true, LocationTestHelper::API_GEOSEARCH_SF_COUNTY_RESPONSE]
-    mock = MiniTest::Mock.new
-    mock.expect(:call, api_response, [bad_location.country_name, bad_location.state_name, bad_location.subdivision_name])
-    Location.stub :find_by, nil do
-      Location.stub :geosearch_by_levels, mock do
-        Location.stub :new_from_params, locations(:sf_county) do
-          new_location = Location.check_and_restrict_specificity(bad_location, "Human")
-          assert_equal locations(:sf_county), new_location
-        end
-      end
-    end
-    assert mock.verify
-  end
-
-  test "should not restrict an appropriately specific sample location" do
-    original = locations(:ucsf)
-    mock = -> { raise "should not call geosearch" }
-    Location.stub :geosearch_by_levels, mock do
-      new_location = Location.check_and_restrict_specificity(original, "Mosquito")
-      assert_equal original, new_location
-    end
-  end
-
   test "should fetch a missing Country parent level for a location" do
     original = locations(:ucsf)
     api_response = [true, LocationTestHelper::API_GEOSEARCH_USA_RESPONSE]


### PR DESCRIPTION
# Description

This PR fixes the following bugs:
- MetadataCSVLocationMenu wasn't properly adjusting city-level locations for human samples. This was because the wrong prop was being passed (isHuman versus taxaCategory)
- Was allowing users to save city-level locations if the city_name wasn't present (but the geo_level was city). This does happen for some LocationIQ locations (possible data quality issue). This is addressed with the changes to `models/location.rb`.
- Was creating duplicate Location entries under specific conditions (due to LocationIQ passing back inconsistent results for the same osm_id). See changes in find_or_new_by_fields. See https://jira.czi.team/browse/IDSEQ-2641.

It makes the following changes:
- Now re-validates the locations after the user adjusts them in MetadataCSVLocationMenu. Shows any errors.
![Screen Shot 2020-04-10 at 10 13 15 AM](https://user-images.githubusercontent.com/837004/79013701-25b3d800-7b1e-11ea-97f3-0183199e9f01.png)
Note: there should never BE any errors, because we now properly auto-adjust the user's locations. The error message is confusing (it refers to a location in the original CSV) but it would be tricky to fix so deferring that for now since the error message should never actually show up.
- Displays a "Verifying collection locations..." loading message when we are running getCSVLocationMatches (a tiny UX improvement)
- Return a more specific error for invalid locations for human samples.
- Add the restriction that an "adjusted" location (which is shown in the UI as "Changed to county/district for privacy reasons") needs to have "refetchAdjustedLocation: true" set. Otherwise, we will assume that there was a bug and return an error. This will require a small change in idseq-cli. (See https://github.com/chanzuckerberg/idseq-cli/pull/67) 
- When auto-adjusting the location for privacy reasons, remove the city_name (no need to keep it around) and also remove the subdivision_name if it is the same as the city_name (as it creates confusion).

# Notes

https://jira.czi.team/browse/IDSEQ-2635 is partially fixed, in that if you try to perform the bug, the back-end will now catch it and throw a validation error. However, the front-end is also mis-behaving there (it should auto-adjust when Apply to All is clicked but it doesn't) This will be addressed in a subsequent PR.

Note that MetadataCSVLocationMenu also has an Apply to All button, and this one IS now working correctly.

Also, the existing CLI will not always work with these changes. We will need to submit https://github.com/chanzuckerberg/idseq-cli/pull/67.

# Tests

* Added rspec tests.
* Verified that location validation error is raised if you perform the steps in https://jira.czi.team/browse/IDSEQ-2635.
* Verified that sample upload succeeds with valid locations for both manual and CSV upload.
* Verified that duplicate locations are no longer being created in situations where they were being created before.
* Verified that MetadataCSVLocationMenu now correctly auto-adjusts the locations.
* Verifies that auto-adjusting logic behaves as expected.

# Tests for QA

* Verify that uploading a sample via the upload flow succeeds as before.
* Verify that for a human sample, there is no way to select a "city-specific" location (like "San Francisco"). The UI should always auto-correct.