### PR TITLE
[Release fix] Use require to load PipelineRunStage constants

### DIFF
--- a/db/migrate/20200414220332_rename_alignment.rb
+++ b/db/migrate/20200414220332_rename_alignment.rb
@@ -1,3 +1,6 @@
+# This is needed to load the constants in PipelineRunStage
+require 'pipeline_run_stage'
+
 class RenameAlignment < ActiveRecord::Migration[5.1]
   def change
     PipelineRunStage.where(name: "GSNAPL/RAPSEARCH alignment").find_each { |u| u.update(name: "GSNAPL/RAPSEARCH2 alignment") }


### PR DESCRIPTION
# Description

This worked locally because the application was already running and the class was already loaded. It failed in staging. Here I add require to load class constants.

# Tests

Tested on a new migration locally, observed the constants loading.