### PR TITLE
[Release fix] Raw sql migration

### DIFF
--- a/db/migrate/20200414220332_rename_alignment.rb
+++ b/db/migrate/20200414220332_rename_alignment.rb
@@ -1,5 +1,10 @@
 class RenameAlignment < ActiveRecord::Migration[5.1]
-  def change
-    ActiveRecord::Base.connection.execute("UPDATE pipeline_run_stages SET name='GSNAPL/RAPSEARCH alignment' WHERE name='GSNAPL/RAPSEARCH alignment'")
+  # Using raw sql here because PipelineRunStage introduces dependencies on constants that may not be initialized
+  def up
+    ActiveRecord::Base.connection.execute("UPDATE pipeline_run_stages SET name='GSNAPL/RAPSEARCH alignment' WHERE name='GSNAPL/RAPSEARCH2 alignment'")
+  end
+
+  def down
+    ActiveRecord::Base.connection.execute("UPDATE pipeline_run_stages SET name='GSNAPL/RAPSEARCH2 alignment' WHERE name='GSNAPL/RAPSEARCH alignment'")
   end
 end

--- a/db/migrate/20200414220332_rename_alignment.rb
+++ b/db/migrate/20200414220332_rename_alignment.rb
@@ -1,8 +1,5 @@
-# This is needed to load the constants in PipelineRunStage
-require 'pipeline_run_stage'
-
 class RenameAlignment < ActiveRecord::Migration[5.1]
   def change
-    PipelineRunStage.where(name: "GSNAPL/RAPSEARCH alignment").find_each { |u| u.update(name: "GSNAPL/RAPSEARCH2 alignment") }
+    ActiveRecord::Base.connection.execute("UPDATE pipeline_run_stages SET name='GSNAPL/RAPSEARCH alignment' WHERE name='GSNAPL/RAPSEARCH alignment'")
   end
 end

--- a/db/migrate/20200414220332_rename_alignment.rb
+++ b/db/migrate/20200414220332_rename_alignment.rb
@@ -1,10 +1,10 @@
 class RenameAlignment < ActiveRecord::Migration[5.1]
   # Using raw sql here because PipelineRunStage introduces dependencies on constants that may not be initialized
   def up
-    ActiveRecord::Base.connection.execute("UPDATE pipeline_run_stages SET name='GSNAPL/RAPSEARCH alignment' WHERE name='GSNAPL/RAPSEARCH2 alignment'")
+    ActiveRecord::Base.connection.execute("UPDATE pipeline_run_stages SET name='GSNAPL/RAPSEARCH2 alignment' WHERE name='GSNAPL/RAPSEARCH alignment'")
   end
 
   def down
-    ActiveRecord::Base.connection.execute("UPDATE pipeline_run_stages SET name='GSNAPL/RAPSEARCH2 alignment' WHERE name='GSNAPL/RAPSEARCH alignment'")
+    ActiveRecord::Base.connection.execute("UPDATE pipeline_run_stages SET name='GSNAPL/RAPSEARCH alignment' WHERE name='GSNAPL/RAPSEARCH2 alignment'")
   end
 end


### PR DESCRIPTION
# Description

Due to lingering dependency issues with the migration I switched this to raw sql as per discussion with the team.

This issue started with the pipeline viz breaking https://jira.czi.team/browse/IDSEQ-2660. This breakage occurred because I refactored consistent usage of rapsearch2 vs rapsearch which changed the name of one of our stages. This worked for jobs going forward but historical jobs had the old value still which is used to construct the viz. I tried to migrate using the class but that caused issues because of some dependency issues with loading constants. To sidestep these issues I switched to raw sql.

# Tests

Though I have had difficulties with local testing in the past, I have more confidence this will work because it introduces no dependencies and it ran locally.
