### PR TITLE
IDSEQ-2569 Cache location validation keyed on raw_value.

### DIFF
--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -181,11 +181,11 @@ class Metadatum < ApplicationRecord
     # Use a cache for this function so that, if the exact same raw location value is passed for multiple samples
     # in one request, we only validate it once, which saves time.
     # Use the raw value as the cache key.
-    # Use a very short cache expiration time because our current performance requirements only require this cache
+    # Use a short cache expiration time because our current performance requirements only require this cache
     # to persist for the duration of one request.
     # A short cache expiration time mitigates the risk in case someone forgets to
     # increment the cache_version_key above when making a change.
-    location_params = Rails.cache.fetch(cache_key, expires_in: 1.minute) do
+    location_params = Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
       _determine_location_params(raw_value)
     end
 

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -17,11 +17,6 @@ class MetadatumTest < ActiveSupport::TestCase
     mock_create.verify
   end
 
-  test "should delete cleared out Location values" do
-    loc = Metadatum.new(raw_value: "{}")
-    assert_nil loc.check_and_set_location_type
-  end
-
   test "should raise Location validation/setting errors" do
     loc = metadata(:sample_collection_location_v2)
     loc.raw_value = "{\"locationiq_id\":\"123\"}"


### PR DESCRIPTION
# Description

I ended up caching not the location API calls, but the validation of location metadata.
This is because validation of location metadata also includes additional calls to Location table for each metadata value, and this is also a contributing factor to the slowness of validation.

Benchmarks for validation of 24 samples:
With text string locations (no location validation at all) - 300ms
With location objects prior to PR - 5000ms
With caching of just location API calls - 3000ms
With caching of location metadata validation (this PR's approach) - 500ms

We make a couple of assumptions in order to cache the validation. The most important is if the raw location value (e.g. the JSON) that is being passed in is exactly the same (including the locationiq_id, the osm_id, etc.), then the location validation will always produce the same result, and return the same Location object in our database. This allows us to use the raw_value as the key for the cache. It is quite common that the raw_value is exactly the same across all location objects in a batch of sample uploads (when the user clicks Apply All), so this strict strategy for caching gets a lot of hits.

Also some benchmarks for the actual uploading of 24 samples:
With text string locations (no location validation at all) - 4.3s
With location objects prior to PR - 9.1s
With caching of location metadata validation (this PR's approach) - 4.3s

We may want to investigate other causes for the slowness of uploads, though that is outside the scope of this PR.

# Notes

See various comments in the code. 
Things to note: choice of very short cache expiration time.

# Tests

* Verified for both CSV and manual metadata upload that upload still works.
* Verified for when Redis cache is enabled locally (by adding tmp/caching-dev.txt)
* Verified for both raw text, the same location value for all samples, and differing location values for samples in one upload.
* Updated rspec tests and added a test for the cache.

# Tests for QA
* Upload a batch of multiple samples with the same Collection Location metadata value and another with different Collection Location metadata values, and ensure that the Collection Locations are what you expect after the upload is complete.