### PR TITLE
[Release fix] Update minimum CLI version to 0.8.7. (#3273)

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -56,7 +56,7 @@ class SamplesController < ApplicationController
   PAGE_SIZE = 30
   MAX_PAGE_SIZE_V2 = 100
   MAX_BINS = 34
-  MIN_CLI_VERSION = '0.7.3'.freeze
+  MIN_CLI_VERSION = '0.8.7'.freeze
   CLI_DEPRECATION_MSG = "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git` or with sudo + pip2/pip3 depending on your setup to update and try again.".freeze
 
   SAMPLE_DEFAULT_FIELDS = [

--- a/test/controllers/samples_bulk_upload_test.rb
+++ b/test/controllers/samples_bulk_upload_test.rb
@@ -249,7 +249,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.0",
+      client: "0.8.7",
       metadata: {
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
@@ -293,7 +293,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.0",
+      client: "0.8.7",
       metadata: {
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
@@ -394,7 +394,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert !@metadata_validation_project.metadata_fields.include?(@core_field)
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.0",
+      client: "0.8.7",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -445,7 +445,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert @host_genome_human.metadata_fields.pluck(:name).include?("Custom Field 2")
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.0",
+      client: "0.8.7",
       metadata: {
         "RR004_water_2_S23B" => {
           'sample_type' => 'blood',
@@ -498,7 +498,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert_equal 0, MetadataField.where(name: "Custom Field").length
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.0",
+      client: "0.8.7",
       metadata: {
         "Human Sample" => {
           'sample_type' => 'blood',
@@ -576,7 +576,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user_nonadmin
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.0",
+      client: "0.8.7",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -620,7 +620,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user_nonadmin
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.0",
+      client: "0.8.7",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -664,7 +664,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user_nonadmin
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.0",
+      client: "0.8.7",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',


### PR DESCRIPTION
Release fix for https://github.com/chanzuckerberg/idseq-web/pull/3273

This fixes a bug on staging where if a users have an old CLI version, they may trigger a bug with city-level location metadata for human samples. By updating the CLI version, the user will get a message telling them to update their CLI.