### PR TITLE
Remove [Datadog] from logs

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1339,7 +1339,7 @@ class SamplesController < ApplicationController
     uploader = samples.first.user
     msg = "LargeBulkUploadEvent: #{samples.length} samples by #{uploader.role_name}." \
       " See: #{project.status_url}"
-    LogUtil.log_err_and_airbrake(msg)
+    Rails.logger.info(msg)
   rescue StandardError => e
     # catch all errors because we don't want to ever block uploads
     LogUtil.log_err_and_airbrake("warn_if_large_bulk_upload: #{e}")

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1337,7 +1337,7 @@ class SamplesController < ApplicationController
     # assume that all samples are in the same project and from the same user
     project = samples.first.project
     uploader = samples.first.user
-    msg = "[Datadog] LargeBulkUploadEvent: #{samples.length} samples by #{uploader.role_name}." \
+    msg = "LargeBulkUploadEvent: #{samples.length} samples by #{uploader.role_name}." \
       " See: #{project.status_url}"
     LogUtil.log_err_and_airbrake(msg)
   rescue StandardError => e

--- a/app/jobs/compute_background.rb
+++ b/app/jobs/compute_background.rb
@@ -3,6 +3,6 @@ class ComputeBackground
   def self.perform(background_id)
     Background.find(background_id).store_summary
   rescue
-    LogUtil.log_err_and_airbrake("[Datadog] Background computation failed for background_id #{background_id}")
+    LogUtil.log_err_and_airbrake("Background computation failed for background_id #{background_id}")
   end
 end

--- a/app/jobs/result_monitor_loader.rb
+++ b/app/jobs/result_monitor_loader.rb
@@ -15,7 +15,7 @@ class ResultMonitorLoader
       # TODO: revisit this
       sleep(Time.now.to_i % 30)
       output_state.update(state: PipelineRun::STATUS_LOADING_ERROR)
-      message = "[Datadog] SampleFailedEvent: Pipeline Run #{pr.id} for Sample #{pr.sample.id} by #{pr.sample.user.email} failed loading #{output} with #{pr.adjusted_remaining_reads || 0} reads remaining after #{pr.duration_hrs} hours. See: #{pr.status_url}"
+      message = "SampleFailedEvent: Pipeline Run #{pr.id} for Sample #{pr.sample.id} by #{pr.sample.user.email} failed loading #{output} with #{pr.adjusted_remaining_reads || 0} reads remaining after #{pr.duration_hrs} hours. See: #{pr.status_url}"
       LogUtil.log_err_and_airbrake(message)
       raise
     end

--- a/app/models/phylo_tree.rb
+++ b/app/models/phylo_tree.rb
@@ -149,7 +149,7 @@ class PhyloTree < ApplicationRecord
     if job_status == PipelineRunStage::STATUS_FAILED ||
        (job_status == "SUCCEEDED" && !required_outputs.all? { |ro| exists_in_s3?(s3_outputs[ro]["s3_path"]) })
       self.status = STATUS_FAILED
-      LogUtil.log_err_and_airbrake("[Datadog] Phylo tree creation failed for #{name} (#{id}). See #{log_url}.")
+      LogUtil.log_err_and_airbrake("Phylo tree creation failed for #{name} (#{id}). See #{log_url}.")
     end
     save
   end
@@ -163,7 +163,7 @@ class PhyloTree < ApplicationRecord
       self.status = STATUS_IN_PROGRESS
     else
       self.status = STATUS_FAILED
-      LogUtil.log_err_and_airbrake("[Datadog] Phylo tree failed to kick off for #{name} (#{id}).")
+      LogUtil.log_err_and_airbrake("Phylo tree failed to kick off for #{name} (#{id}).")
     end
     save
   end

--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -1100,7 +1100,7 @@ class PipelineRun < ApplicationRecord
     automatic_restart_text = automatic_restart ? "Automatic restart is being triggered. " : "** Manual action required **. "
     known_user_error = known_user_error ? "Known user error #{known_user_error}. " : ""
 
-    "[Datadog] SampleFailedEvent: Sample #{sample.id} by #{sample.user.role_name} failed #{prs.step_number}-#{prs.name} #{reads_remaining_text}" \
+    "SampleFailedEvent: Sample #{sample.id} by #{sample.user.role_name} failed #{prs.step_number}-#{prs.name} #{reads_remaining_text}" \
       "after #{duration_hrs} hours. #{automatic_restart_text}#{known_user_error}"\
       "See: #{status_url}"
   end
@@ -1156,7 +1156,7 @@ class PipelineRun < ApplicationRecord
       # NOTE (2019-08-02): Based on the last 3000 successful samples, only 0.17% took longer than 12 hours.
       threshold = 12.hours
       if run_time > threshold
-        msg = "[Datadog] LongRunningSampleEvent: Sample #{sample.id} by #{sample.user.role_name} has been running #{duration_hrs} hours. #{job_status_display} " \
+        msg = "LongRunningSampleEvent: Sample #{sample.id} by #{sample.user.role_name} has been running #{duration_hrs} hours. #{job_status_display} " \
           "See: #{status_url}"
         LogUtil.log_err_and_airbrake(msg)
         update(alert_sent: 1)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -410,7 +410,7 @@ class Sample < ApplicationRecord
     self.status = STATUS_UPLOADED
     save! # this triggers pipeline command
   rescue => e
-    LogUtil.log_err_and_airbrake("[Datadog] SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id}): #{e}")
+    LogUtil.log_err_and_airbrake("SampleUploadFailedEvent: Failed to upload S3 sample '#{name}' (#{id}): #{e}")
     self.status = STATUS_CHECKED
     self.upload_error = Sample::UPLOAD_ERROR_S3_UPLOAD_FAILED
     save!

--- a/lib/tasks/result_monitor.rake
+++ b/lib/tasks/result_monitor.rake
@@ -54,7 +54,7 @@ class MonitorPipelineResults
     samples = Sample.current_stalled_local_uploads(18.hours)
     unless samples.empty?
       LogUtil.log_err_and_airbrake(
-        "[Datadog] SampleFailedEvent: Failed to upload local samples after 18 hours #{samples.pluck(:id)}"
+        "SampleFailedEvent: Failed to upload local samples after 18 hours #{samples.pluck(:id)}"
       )
       samples.update_all( # rubocop:disable Rails/SkipsModelValidations
         status: Sample::STATUS_CHECKED,
@@ -79,7 +79,7 @@ class MonitorPipelineResults
     status_urls = samples.map(&:status_url)
     msg = %(LongRunningUploadsEvent: #{samples.length} samples were created more than #{duration_hrs} hours ago by #{role_names} in projects #{project_names}.
       #{client_updated_at ? "Last client ping was at #{client_updated_at}. " : ''} See: #{status_urls})
-    LogUtil.log_err_and_airbrake(msg)
+    Rails.logger.info(msg)
 
     samples.update_all(upload_error: Sample::UPLOAD_ERROR_LOCAL_UPLOAD_STALLED) # rubocop:disable Rails/SkipsModelValidations
   end


### PR DESCRIPTION
# Description

Remove the `[Datadog]` statement from our logs now that we are no longer forwarding them to Datadog for alerts. (Essentially reverting https://github.com/chanzuckerberg/idseq-web/pull/3104)

Also changes the logs for `LongRunningUploadsEvent` and `LargeBulkUploadEvent` to INFO rather than ERROR.
