### PR TITLE
Update icon playground with recent icons.

### DIFF
--- a/app/assets/src/components/ui/icons/index.js
+++ b/app/assets/src/components/ui/icons/index.js
@@ -1,6 +1,8 @@
 import AlertIcon from "./AlertIcon";
 import BacteriaIcon from "./BacteriaIcon";
+import BulletListIcon from "./BulletListIcon";
 import CheckmarkIcon from "./CheckmarkIcon";
+import CircleCheckmarkIcon from "./CircleCheckmarkIcon";
 import CompareIcon from "./CompareIcon";
 import CopyIcon from "./CopyIcon";
 import CoverageIcon from "./CoverageIcon";
@@ -10,21 +12,31 @@ import DiscoverIcon from "./DiscoverIcon";
 import DownloadIcon from "./DownloadIcon";
 import FiltersIcon from "./FiltersIcon";
 import GlobeIcon from "./GlobeIcon";
+import GlobeLinedIcon from "./GlobeLinedIcon";
 import HeatmapIcon from "./HeatmapIcon";
+import HeatmapPrivate from "./HeatmapPrivate";
+import HeatmapPublic from "./HeatmapPublic";
+import InfoCircleIcon from "./InfoCircleIcon";
+import InfoIcon from "./InfoIcon";
 import InfoPanelIcon from "./InfoPanelIcon";
 import InsightIcon from "./InsightIcon";
 import LargeDownloadIcon from "./LargeDownloadIcon";
 import LoadingIcon from "./LoadingIcon";
 import LockIcon from "./LockIcon";
 import LogoIcon from "./LogoIcon";
+import MinusControlIcon from "./MinusControlIcon";
 import NoResultsIcon from "./NoResultsIcon";
 import PhyloTreeIcon from "./PhyloTreeIcon";
+import PhyloTreePrivate from "./PhyloTreePrivate";
+import PhyloTreePublic from "./PhyloTreePublic";
+import PipelineStageArrowheadIcon from "./PipelineStageArrowheadIcon";
+import PlusControlIcon from "./PlusControlIcon";
 import PlusIcon from "./PlusIcon";
 import PublicProjectIcon from "./PublicProjectIcon";
 import PrivateProjectIcon from "./PrivateProjectIcon";
 import RemoveIcon from "./RemoveIcon";
-import SamplePublicIcon from "./SamplePublicIcon";
 import SamplePrivateIcon from "./SamplePrivateIcon";
+import SamplePublicIcon from "./SamplePublicIcon";
 import SaveIcon from "./SaveIcon";
 import SortIcon from "./SortIcon";
 import InfoIconSmall from "./InfoIconSmall";
@@ -35,6 +47,7 @@ export default {
   CUSTOM: {
     AlertIcon,
     BacteriaIcon,
+    CircleCheckmarkIcon,
     CompareIcon,
     CopyIcon,
     CoverageIcon,
@@ -45,24 +58,35 @@ export default {
     FiltersIcon,
     GlobeIcon,
     HeatmapIcon,
+    HeatmapPrivate,
+    HeatmapPublic,
+    InfoCircleIcon,
+    InfoIcon,
     InfoPanelIcon,
     LargeDownloadIcon,
     LockIcon,
+    MinusControlIcon,
     NoResultsIcon,
     PhyloTreeIcon,
+    PhyloTreePrivate,
+    PhyloTreePublic,
+    PipelineStageArrowheadIcon,
+    PlusControlIcon,
     PlusIcon,
-    RemoveIcon,
-    SamplePublicIcon,
-    SamplePrivateIcon,
-    UploadIcon,
-    UserIcon,
     PublicProjectIcon,
     PrivateProjectIcon,
+    RemoveIcon,
+    SamplePrivateIcon,
+    SamplePublicIcon,
     SaveIcon,
     InfoIconSmall,
+    UploadIcon,
+    UserIcon,
   },
   FONT_AWESOME: {
+    BulletListIcon,
     CheckmarkIcon,
+    GlobeLinedIcon,
     InsightIcon,
     LoadingIcon,
     SortIcon,

--- a/app/assets/src/components/views/playgrounds/playground_icons.scss
+++ b/app/assets/src/components/views/playgrounds/playground_icons.scss
@@ -18,8 +18,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  max-width: 120px;
-  max-height: 120px;
+  width: 200px;
+  height: 100px;
   padding: 10px;
 
   .icon {


### PR DESCRIPTION
# Description

Update icon playground with recent icons.
This admin-only page allows us to see all of our icons visually in one place.

<img width="1169" alt="Screen Shot 2020-04-17 at 2 20 43 PM" src="https://user-images.githubusercontent.com/837004/79615046-a93d6e00-80b6-11ea-91c0-ebac7cd2128f.png">