### PR TITLE
Add auto-populate metadata admin option.

### DIFF
--- a/app/assets/src/components/common/metadata_manual_input.scss
+++ b/app/assets/src/components/common/metadata_manual_input.scss
@@ -73,4 +73,11 @@ $metadata-input-extra-width: 225;
       cursor: pointer;
     }
   }
+
+  .autoPopulateButton {
+    @include font-label-s;
+    color: $primary-light;
+    cursor: pointer;
+    margin-top: $space-xxxs;
+  }
 }


### PR DESCRIPTION
# Description

Add admin-only auto-populate metadata option.

![Screen Shot 2020-04-20 at 4 56 29 PM](https://user-images.githubusercontent.com/837004/79810500-13a91500-8328-11ea-9b2d-97ed504212ea.png)

# Tests

* Verify that admin can successfully upload samples after pressing auto-populate button with no further modifications.
* Verify that non-admin cannot see auto-populate button and can still submit samples normally.
* Verify that when auto-populating, any populated fields are left alone.
* Verify that when editing metadata of existing samples, button does not display.

# Tests for QA
* Ensure that you cannot see the auto-populate metadata button.
