### PR TITLE
IDSEQ-2635 Fix apply-all city-level metadata bug.

### DIFF
--- a/app/assets/src/components/common/MetadataInput.jsx
+++ b/app/assets/src/components/common/MetadataInput.jsx
@@ -31,27 +31,17 @@ class MetadataInput extends React.Component {
     this.state = {
       // Small warning below the input. Only used for Locations currently.
       warning: props.warning,
-      // This stores the value that the current warning is associated with.
-      warnedValue: props.value,
     };
   }
 
   static getDerivedStateFromProps(props, state) {
     const newState = {};
 
-    if (props.warning !== state.prevPropsWarning) {
+    // warnings passed in as props take precedence.
+    if (props.warning) {
       newState.warning = props.warning;
-      newState.prevPropsWarning = props.warning;
-      newState.warnedValue = props.value;
-    } else if (props.value !== state.warnedValue) {
-      // If the currently passed value is not equal to the value we have a warning about,
-      // calculate the warning for this value.
-      newState.warnedValue = props.value;
-
-      // warnings passed in as props take precedence.
-      if (!props.warning) {
-        newState.warning = getLocationWarning(props.value);
-      }
+    } else if (props.metadataType.dataType === "location") {
+      newState.warning = getLocationWarning(props.value);
     }
 
     return newState;
@@ -137,15 +127,10 @@ class MetadataInput extends React.Component {
             inputClassName={cx(warning && value && "warning")}
             // Calls save on selection
             onResultSelect={({ result: selection }) => {
-              const { result, warning } = processLocationSelection(
+              const result = processLocationSelection(
                 selection,
                 taxaCategory === "human"
               );
-              // Set warnedValue, so that a LOCATION_PRIVACY_WARNING warning isn't overwritten when the result propagates back down
-              // as this.props.value.
-              // When the result comes back down, we won't be able to detect whether LOCATION_PRIVACY_WARNING applies,
-              // since we've modified the location object here in processLocationSelection.
-              this.setState({ warning, warnedValue: result });
               onChange(metadataType.key, result, true);
             }}
             value={value}

--- a/app/assets/src/components/common/MetadataUpload.jsx
+++ b/app/assets/src/components/common/MetadataUpload.jsx
@@ -34,7 +34,6 @@ class MetadataUpload extends React.Component {
     validatingCSV: false,
     fetchingCSVLocationMatches: false,
     showMetadataCSVLocationsMenu: false,
-    CSVLocationWarnings: {},
   };
 
   // Define the order in which metadata fields should be render in the upload
@@ -158,7 +157,7 @@ class MetadataUpload extends React.Component {
       this.setState({
         fetchingCSVLocationMatches: true,
       });
-      const { newMetadata, warnings } = await geosearchCSVLocations(
+      const newMetadata = await geosearchCSVLocations(
         metadata,
         this.getRequiredLocationMetadataType()
       );
@@ -171,7 +170,6 @@ class MetadataUpload extends React.Component {
         issues: null,
       });
       this.setState({
-        CSVLocationWarnings: warnings,
         showMetadataCSVLocationsMenu: true,
         fetchingCSVLocationMatches: false,
       });
@@ -225,9 +223,6 @@ class MetadataUpload extends React.Component {
       Object.values(projectMetadataFields)
     );
   };
-
-  handleCSVLocationWarningsChange = CSVLocationWarnings =>
-    this.setState({ CSVLocationWarnings });
 
   renderTab = () => {
     if (this.state.currentTab === "Manual Input") {
@@ -375,7 +370,6 @@ class MetadataUpload extends React.Component {
   renderCSVLocationsMenu = () => {
     const { metadata } = this.props;
     const {
-      CSVLocationWarnings,
       currentTab,
       showMetadataCSVLocationsMenu,
       hostGenomes,
@@ -383,10 +377,8 @@ class MetadataUpload extends React.Component {
 
     return currentTab === "CSV Upload" && showMetadataCSVLocationsMenu ? (
       <MetadataCSVLocationsMenu
-        CSVLocationWarnings={CSVLocationWarnings}
         locationMetadataType={this.getRequiredLocationMetadataType()}
         metadata={metadata}
-        onCSVLocationWarningsChange={this.handleCSVLocationWarningsChange}
         onMetadataChange={this.onMetadataChangeCSVLocationsMenu}
         hostGenomes={hostGenomes}
       />

--- a/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
+++ b/app/assets/src/components/ui/controls/GeoSearchInputBox.jsx
@@ -12,9 +12,8 @@ export const LOCATION_UNRESOLVED_WARNING =
   // this is the max length to appear on one line
   "No match. Sample will not appear on maps.";
 
-// Process location selections and add warnings.
+// Process location selections.
 export const processLocationSelection = (result, isHuman) => {
-  let warning = "";
   // For human samples, drop the city part of the name and show a warning.
   // NOTE: The backend will redo the geosearch for confirmation and re-apply
   // this restriction.
@@ -44,17 +43,18 @@ export const processLocationSelection = (result, isHuman) => {
     } else if (result.country_name) {
       result.geo_level = "country";
     }
-
-    warning = LOCATION_PRIVACY_WARNING;
-  } else {
-    warning = getLocationWarning(result);
   }
-  return { result, warning };
+
+  return result;
 };
 
 export const getLocationWarning = result => {
   if (!result || !result.geo_level) {
     return LOCATION_UNRESOLVED_WARNING;
+  }
+  // If the result was processed due to privacy reasons, show a warning.
+  if (result.refetch_adjusted_location) {
+    return LOCATION_PRIVACY_WARNING;
   }
   return "";
 };


### PR DESCRIPTION
# Description

Fix bug where you can set a human sample location to city-level via Apply All.

Also simplify confusing "warning" logic. Instead of generating the warning with the location and passing it into MetadataInput, we determine the correct warning to display in MetadataInput based on the location.

# Tests

* Verify that the bug is fixed, following steps from https://jira.czi.team/browse/IDSEQ-2635.
* Verify that in all four cases where processLocationSelection is called, the behavior is as expected when trying to select a city-level location for a human sample.
* The four cases are: select a location using the location dropdown, clicking Apply to All after picking a location, uploading a CSV with locations, clicking Apply to all in the "Confirm your collection locations" menu after CSV upload.

# Tests for QA

* Verify that bug is fixed following reproduction steps from https://jira.czi.team/browse/IDSEQ-2635