### PR TITLE
Remove alignment chunk columns

### DIFF
--- a/db/migrate/20200422181622_remove_chunk_counts_from_pipeline_runs.rb
+++ b/db/migrate/20200422181622_remove_chunk_counts_from_pipeline_runs.rb
@@ -1,0 +1,5 @@
+class RemoveChunkCountsFromPipelineRuns < ActiveRecord::Migration[5.1]
+  def change
+    remove_columns :pipeline_runs, :completed_rapsearch2_chunks, :completed_gsnap_chunks
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_403_194_501) do
+ActiveRecord::Schema.define(version: 20_200_422_181_622) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -359,8 +359,6 @@ ActiveRecord::Schema.define(version: 20_200_403_194_501) do
     t.integer "alert_sent", default: 0
     t.text "dag_vars"
     t.integer "assembled", limit: 2
-    t.integer "completed_gsnap_chunks"
-    t.integer "completed_rapsearch2_chunks"
     t.integer "max_input_fragments"
     t.text "error_message"
     t.string "known_user_error"


### PR DESCRIPTION
# Description

These columns currently have no usages. I kept them in to ease the transition to the new alignment implementation but now that that is running stably we can drop these columns.

I know the last time I migrated it didn't go well so here are some reasons why I feel this will go better:
- The timeout happened as a result of renaming while this is dropping, which is a faster operation
- I did a global search for usages of the column names (I did that last time but just including for thoroughness)
- The string mismatch issue that happened last time was a result of changing values within a column not the column name itself. It would be much more unlikely that we have a dependency on the column name that doesn't show up anywhere in the code.
- The uninitialized constants issue only happens when you use class methods but this migration does not.
- The issue of the pipeline monitor and results monitor spitting out errors won't happen this time because the pipeline monitor no longer uses these values at all.

# Tests

Ran the migration locally and tested a sample.
