### PR TITLE
More debug info in update_lineage_db

### DIFF
--- a/lib/tasks/update_lineagedb.rake
+++ b/lib/tasks/update_lineagedb.rake
@@ -175,7 +175,7 @@ class LineageDatabaseImporter
     upgrade_ids = (insert_ids + update_ids + unchanged_ids)
     upgrade_count = upgrade_ids.count
 
-    if new_count != upgrade_count and !noverify
+    if new_count != upgrade_count && !noverify
       # Should be investigated if counts are mismatched before ignoring. You can spot check taxids
       # on NCBI. Ex: Some taxids may have no Rank, so they won't be used in IDseq.
       new_ids = TaxonLineage.connection.select_all("SELECT taxid FROM #{@taxid_table}").pluck("taxid")


### PR DESCRIPTION
# Description

This will allow running to completion without patching the script in normal use. 

```
Keep active records...
2051603 records
Only in new_ids: 
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=3312
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=10658
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=300169
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=338099
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=1891684
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=2169718
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=2175606
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=2202641
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=2607588

Only in upgrade_ids: 
rails aborted!
Mismatched upgrade counts: 2241821 and 2241812. Try running update_lineage_db[noverify].
```

# Tests

run local update_lineage_db, see error output

run local update_lineage_db[noverify], see no output, script completes