### PR TITLE
[IDSEQ-2465] Fix bug that prevent making projects public

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -586,7 +586,7 @@ class ProjectsController < ApplicationController
   def project_params
     result = params.require(:project).permit(:name, :public_access, :description, user_ids: [])
     result[:name] = sanitize_project_name(result[:name]) if result[:name]
-    result[:description] = sanitize_project_description(result[:description])
+    result[:description] = sanitize_project_description(result[:description]) if result[:description]
     result
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -19,7 +19,7 @@ class Project < ApplicationRecord
   # NOTE: all values of background_flag in prod db are currently zero.
   validates :background_flag, inclusion: { in: [0, 1] }, allow_nil: true, if: :mass_validation_enabled?
   # Description requirement added 2020-03-11
-  validates :description, presence: true
+  validates :description, presence: true, if: :description_changed?
 
   before_create :add_default_metadata_fields
 


### PR DESCRIPTION
# Description

* Fix bug where project update to public would fail due to validation issues.
* The fix allows making legacy projects public even if they do not have a description (the action would fail silently in that case). It only enable validation if the description field is being changed.
* Jira: https://jira.czi.team/browse/IDSEQ-2465

# Tests

Confirm that you can make a project public in settings when:
* Updating a project with description set
* Updating an old project no description.
