### PR TITLE
Fix bug with admin-only metadata auto-populate.

### DIFF
--- a/app/assets/src/components/common/MetadataManualInput.jsx
+++ b/app/assets/src/components/common/MetadataManualInput.jsx
@@ -160,13 +160,21 @@ class MetadataManualInput extends React.Component {
   };
 
   autoPopulateMetadata = () => {
+    const { samples } = this.props;
     const { metadataFieldsToEdit, headersToEdit } = this.state;
 
+    let newMetadataFieldsToEdit = {};
+
+    // For each sample, merge auto-populate fields into existing fields (which may be empty).
+    // Existing fields take precedence.
+    samples.forEach(sample => {
+      newMetadataFieldsToEdit[sample.name] = merge(
+        AUTO_POPULATE_FIELDS,
+        metadataFieldsToEdit[sample.name] || {}
+      );
+    });
+
     const newHeadersToEdit = union(headersToEdit, keys(AUTO_POPULATE_FIELDS));
-    const newMetadataFieldsToEdit = mapValues(
-      metadataFields => merge(AUTO_POPULATE_FIELDS, metadataFields),
-      metadataFieldsToEdit
-    );
 
     this.setState({
       metadataFieldsToEdit: newMetadataFieldsToEdit,


### PR DESCRIPTION
# Description

The feature previously relied on a metadata object already existing
for each sample, which only occurred if the water control field was
present in the project and was getting set to a default value.
This fix removes that unintended constraint.

# Tests

* Verified that feature still works as intended (samples can still be submitted successfully) and the bug is fixed.
