### PR TITLE
Enable step function pipeline by default

### DIFF
--- a/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
+++ b/app/assets/src/components/views/SampleUploadFlow/ReviewStep.jsx
@@ -41,7 +41,7 @@ class ReviewStep extends React.Component {
     showLessDescription: true,
     showUploadModal: false,
     skipSampleProcessing: false,
-    useStepFunctionPipeline: false,
+    useStepFunctionPipeline: true,
     useTaxonWhitelist: false,
     adminOptions: {},
   };

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -744,7 +744,7 @@ class Sample < ApplicationRecord
     pr.subsample = subsample || PipelineRun::DEFAULT_SUBSAMPLING
     pr.max_input_fragments = max_input_fragments || PipelineRun::DEFAULT_MAX_INPUT_FRAGMENTS
     pr.pipeline_branch = pipeline_branch.blank? ? "master" : pipeline_branch
-    pr.pipeline_execution_strategy = pipeline_execution_strategy.blank? ? PipelineRun.directed_acyclic_graph : pipeline_execution_strategy
+    pr.pipeline_execution_strategy = pipeline_execution_strategy.blank? ? PipelineRun.step_function : pipeline_execution_strategy
     pr.dag_vars = dag_vars if dag_vars
     pr.use_taxon_whitelist = use_taxon_whitelist
     pr.pipeline_commit = Sample.pipeline_commit(pr.pipeline_branch)


### PR DESCRIPTION
# Description

Enable step function based pipeline processing by default

# Notes

I will be on call this week and will run a series of manual tests in staging, as well as a back-end-only test in production, before this goes out to production. (Back-end-only tests and all kinds of pipeline integration tests become radically easier to run with this change!)

# Tests

We ran a series of end-to-end pipeline tests last week, including a 1000-sample scale test with 5 different sample types, to test this change.