### PR TITLE
[Release fix] IDSEQ-2718 Fix crash and add error message if coverage viz data not found.

### DIFF
--- a/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
@@ -113,7 +113,11 @@ export default class CoverageVizBottomSidebar extends React.Component {
       );
     }
 
-    if (!prevState.currentAccessionData && currentAccessionData) {
+    if (
+      !prevState.currentAccessionData &&
+      currentAccessionData &&
+      this.isAccessionDataValid(currentAccessionData)
+    ) {
       this.renderHistogram(currentAccessionData);
       this.renderRefAccessionViz(currentAccessionData);
     }
@@ -151,6 +155,11 @@ export default class CoverageVizBottomSidebar extends React.Component {
       },
     });
   };
+
+  // It's possible that the accessionData failed to load.
+  // For example, the coverage viz s3 files couldn't be found.
+  // In this case, the accessionData is not valid, and we will display an error message.
+  isAccessionDataValid = accessionData => !!accessionData.coverage;
 
   setCurrentAccession = accessionId => {
     const { params } = this.props;
@@ -451,6 +460,20 @@ export default class CoverageVizBottomSidebar extends React.Component {
         <div className={cs.loadingContainer}>
           <div className={cs.loadingMessage}>
             <LoadingIcon className={cs.loadingIcon} />Loading Visualization...
+          </div>
+        </div>
+      );
+    }
+
+    if (!this.isAccessionDataValid(currentAccessionData)) {
+      return (
+        <div className={cs.unknownErrorContainer}>
+          <div className={cs.unknownErrorMessage}>
+            Failed to load data due to an unknown error. Please{" "}
+            <a className={cs.helpLink} href="mailto:help@idseq.net">
+              contact us
+            </a>{" "}
+            for help.
           </div>
         </div>
       );

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
@@ -223,15 +223,21 @@ $genome-viz-spacing: $space-xxs;
   }
 }
 
-.loadingContainer {
+.loadingContainer,
+.unknownErrorContainer {
   display: flex;
   align-items: center;
   justify-content: center;
   height: $body-height;
   color: $medium-grey;
 
-  .loadingMessage {
+  .loadingMessage,
+  .unknownErrorMessage {
     margin-bottom: 20px;
+  }
+
+  .helpLink {
+    color: $primary-light !important;
   }
 
   .loadingIcon {


### PR DESCRIPTION
# Description

See IDSEQ-2718 for bug description.

Now show an error message if we detect that the per-accession coverage viz data couldn't be fetched:
![Screen Shot 2020-04-29 at 6 20 17 PM](https://user-images.githubusercontent.com/837004/80662587-7d22d500-8a46-11ea-87ec-90f33c3e0d5f.png)

# Note
This doesn't fix the underlying bug, which has to do with SFN-WDL not handling certain generated files correctly. But it makes the front-end more robust to lack of data.

# Tests

* Verified that page no longer crashes in error case and was crashing before the fix.