### PR TITLE
[Release Fix CP] Fix link styling and name collision (#3304)

### DIFF
--- a/app/assets/src/components/views/landing.scss
+++ b/app/assets/src/components/views/landing.scss
@@ -36,6 +36,8 @@
     .link {
       margin-left: 3px;
       text-decoration: underline;
+      // override styling in the Link component
+      color: white !important;
     }
   }
 


### PR DESCRIPTION
# Description

Fixes the styling for the public site banner on the landing page, so that the text doesn't disappear in the background.

# Notes

Cherry-picked from a release fix in staging

# Tests

Check the landing page for proper styling.