### PR TITLE
Fix typo in align_viz output json file glob

### DIFF
--- a/app/jobs/idd2wdl.py
+++ b/app/jobs/idd2wdl.py
@@ -111,7 +111,7 @@ for step in dag["steps"]:
         wdl_step_output += '\n    Array[File] coverage_viz = glob("coverage_viz/*_coverage_viz.json")'
         unaccounted_workflow_outputs.append("    Array[File] coverage_viz = GenerateCoverageViz.coverage_viz")
     elif task_name(step) == "GenerateAlignmentViz":
-        wdl_step_output += '\n    Array[File] align_viz = glob("align_viz/*_align_viz.json")'
+        wdl_step_output += '\n    Array[File] align_viz = glob("align_viz/*.align_viz.json")'
         unaccounted_workflow_outputs.append("    Array[File] align_viz = GenerateAlignmentViz.align_viz")
 
     print("""


### PR DESCRIPTION
# Description
Fix typo that prevented outputting alignment viz JSON files.

# Notes

*Optional observations, comments or explanations.*

# Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*
* *See also [IDseq PR Guidelines](https://github.com/chanzuckerberg/idseq-web/blob/master/PR_GUIDELINES.md)*
