### PR TITLE
Add ability to configure subsample and max_input_fragment per project.

### DIFF
--- a/db/migrate/20200501044034_add_subsample_to_project.rb
+++ b/db/migrate/20200501044034_add_subsample_to_project.rb
@@ -1,0 +1,8 @@
+class AddSubsampleToProject < ActiveRecord::Migration[5.1]
+  def change
+    change_table :projects, bulk: true do |t|
+      t.integer :subsample_default, comment: "The default value of subsample for newly uploaded samples. Can be overridden by admin options."
+      t.integer :max_input_fragments_default, comment: "The default value of max_input_fragments for newly uploaded samples. Can be overridden by admin options."
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_423_161_207) do
+ActiveRecord::Schema.define(version: 20_200_501_044_034) do
   create_table "alignment_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "name"
     t.string "index_dir_suffix"
@@ -378,6 +378,8 @@ ActiveRecord::Schema.define(version: 20_200_423_161_207) do
     t.integer "days_to_keep_sample_private", default: 365, null: false
     t.integer "background_flag", limit: 1, default: 0
     t.text "description"
+    t.integer "subsample_default", comment: "The default value of subsample for newly uploaded samples. Can be overridden by admin options."
+    t.integer "max_input_fragments_default", comment: "The default value of max_input_fragments for newly uploaded samples. Can be overridden by admin options."
     t.index ["name"], name: "index_projects_on_name", unique: true
   end
 

--- a/spec/requests/sample_request_spec.rb
+++ b/spec/requests/sample_request_spec.rb
@@ -216,6 +216,124 @@ RSpec.describe "Sample request", type: :request do
           expect(test_sample.max_input_fragments).to eq(nil)
           expect(test_sample.subsample).to eq(nil)
         end
+
+        it "should set subsample or max_input_fragments if project default is set" do
+          @project.update(subsample_default: 101, max_input_fragments_default: 102)
+
+          post "/samples/bulk_upload_with_metadata", params: { samples: [@sample_params], metadata: @metadata_params, client: @client_params, format: :json }
+
+          expect(response.content_type).to eq("application/json")
+          expect(response).to have_http_status(:ok)
+          json_response = JSON.parse(response.body)
+          sample_id = json_response["sample_ids"][0]
+
+          test_sample = Sample.find(sample_id)
+          expect(test_sample.subsample).to eq(101)
+          expect(test_sample.max_input_fragments).to eq(102)
+        end
+
+        it "subsample or max_input_fragments in admin options should be ignored for normal users" do
+          sample_params = @sample_params.dup
+          # These admin options are only valid if the user is an admin.
+          sample_params[:subsample] = 103
+          sample_params[:max_input_fragments] = 104
+
+          post "/samples/bulk_upload_with_metadata", params: { samples: [sample_params], metadata: @metadata_params, client: @client_params, format: :json }
+
+          expect(response.content_type).to eq("application/json")
+          expect(response).to have_http_status(:ok)
+          json_response = JSON.parse(response.body)
+          sample_id = json_response["sample_ids"][0]
+
+          test_sample = Sample.find(sample_id)
+          expect(test_sample.subsample).to eq(nil)
+          expect(test_sample.max_input_fragments).to eq(nil)
+        end
+
+        it "whitelist defaults should take precedence over project defaults" do
+          AppConfigHelper.set_app_config(AppConfig::SUBSAMPLE_WHITELIST_DEFAULT_SUBSAMPLE, 100)
+          AppConfigHelper.set_app_config(AppConfig::SUBSAMPLE_WHITELIST_DEFAULT_MAX_INPUT_FRAGMENTS, 50)
+          AppConfigHelper.set_json_app_config(AppConfig::SUBSAMPLE_WHITELIST_PROJECT_IDS, [@project.id])
+
+          @project.update(subsample_default: 101, max_input_fragments_default: 102)
+
+          post "/samples/bulk_upload_with_metadata", params: { samples: [@sample_params], metadata: @metadata_params, client: @client_params, format: :json }
+
+          expect(response.content_type).to eq("application/json")
+          expect(response).to have_http_status(:ok)
+          json_response = JSON.parse(response.body)
+          sample_id = json_response["sample_ids"][0]
+
+          test_sample = Sample.find(sample_id)
+          expect(test_sample.subsample).to eq(100)
+          expect(test_sample.max_input_fragments).to eq(50)
+        end
+      end
+    end
+  end
+
+  context 'admin' do
+    before do
+      sign_in @admin
+    end
+
+    context "with a pre-existing project" do
+      before do
+        # Sample setup
+        @project = create(:public_project, users: [@admin])
+        create(:alignment_config, name: AlignmentConfig::DEFAULT_NAME)
+        hg = create(:host_genome)
+        @sample_params = {
+          client: "web",
+          host_genome_id: hg.id,
+          host_genome_name: hg.name,
+          input_files_attributes: [
+            { source_type: "local", source: "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R1.fastq.gz", parts: "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R1.fastq.gz" },
+            { source_type: "local", source: "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R2.fastq.gz", parts: "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__R2.fastq.gz" },
+          ],
+          length: 2,
+          name: "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__17",
+          project_id: @project.id,
+          do_not_process: false,
+        }
+
+        @metadata_params = {
+          "norg_6__nacc_27__uniform_weight_per_organism__hiseq_reads__v6__17" => {
+            "sex" => "Female",
+            "age" => 100,
+            "host_genome" => "Synthetic",
+            "water_control" => "No",
+            "sample_type" => "CSF",
+            "nucleotide_type" => "DNA",
+            "collection_date" => "2020-01",
+            "collection_location_v2" => { "title" => "Santa Barbara, CA", "name" => "Santa Barbara, CA" },
+          },
+        }
+
+        @client_params = "web"
+
+        # don't actually do any remote work
+        allow_any_instance_of(Sample).to receive(:set_presigned_url_for_local_upload).and_return(true)
+      end
+
+      it "subsample or max_input_fragments in the sample params should take precedence if project default is set" do
+        @project.update(subsample_default: 101, max_input_fragments_default: 102)
+
+        sample_params = @sample_params.dup
+        # These admin options are only valid if the user is an admin.
+        sample_params[:subsample] = 103
+        sample_params[:max_input_fragments] = 104
+
+        post "/samples/bulk_upload_with_metadata", params: { samples: [sample_params], metadata: @metadata_params, client: @client_params, format: :json }
+
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        sample_id = json_response["sample_ids"][0]
+
+        test_sample = Sample.find(sample_id)
+        expect(test_sample.subsample).to eq(103)
+        expect(test_sample.max_input_fragments).to eq(104)
       end
     end
   end


### PR DESCRIPTION
# Description
Previously, we were using AppConfig to control custom `subsample` and `max_input_fragments`.
The downside of this approach is that you only get a single custom value that applies to all projects in a "whitelist".

At the time, we thought that maybe only a single project would need this custom value temporarily. However, at this time there are now multiple projects in the "subsample whitelist".

This changes the approach to be more intuitive by adding a `subsample_default` and `max_input_fragment_default` field on the project, allowing each project to be configured independently.

# Notes
- Admin options, if they are present, will still take precedence over the project defaults.
- The rollout plan is to move the AppConfig values over to the defaults for individual projects once this PR lands in production and then immediately deprecate and remove the AppConfig mechanism. 
- Under this approach, the user would first create the project they intend to upload to. An admin would then need to go in and change the project defaults on their behalf. Any samples uploaded to this project would then get the project defaults.

# Tests

* Wrote unit tests for the various scenarios.
* Also verified manually that samples get the expected defaults in various situations.
