### PR TITLE
Restyle coverage viz bottom sidebar error message for consistency.

### DIFF
--- a/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/CoverageVizBottomSidebar.jsx
@@ -427,7 +427,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
         <div className={cs.headerControls}>
           <div className={cs.vizLinkContainer}>
             <a
-              className={cs.vizLink}
+              className={cs.linkWithArrow}
               href={params.alignmentVizUrl}
               target="_blank"
               rel="noopener noreferrer"
@@ -467,13 +467,32 @@ export default class CoverageVizBottomSidebar extends React.Component {
 
     if (!this.isAccessionDataValid(currentAccessionData)) {
       return (
-        <div className={cs.unknownErrorContainer}>
-          <div className={cs.unknownErrorMessage}>
-            Failed to load data due to an unknown error. Please{" "}
-            <a className={cs.helpLink} href="mailto:help@idseq.net">
-              contact us
-            </a>{" "}
-            for help.
+        <div className={cs.noDataBody}>
+          <div className={cs.noDataContainer}>
+            <div className={cs.text}>
+              <div className={cs.message}>
+                Sorry, we failed to load the coverage data due to an unexpected
+                error.
+              </div>
+              <a
+                className={cs.linkWithArrow}
+                href="mailto:help@idseq.net"
+                onClick={() =>
+                  logAnalyticsEvent(
+                    "CoverageVizBottomSidebar_accession-data-invalid-contact-us_clicked",
+                    {
+                      accessionId: currentAccessionSummary.id,
+                      taxonId: params.taxonId,
+                      sampleId,
+                    }
+                  )
+                }
+              >
+                Contact us for help
+                <i className={cx("fa fa-chevron-right", cs.rightArrow)} />
+              </a>
+            </div>
+            <BacteriaIcon className={cs.icon} />
           </div>
         </div>
       );
@@ -617,7 +636,7 @@ export default class CoverageVizBottomSidebar extends React.Component {
                 with at least one assembled contig in NT.
               </div>
               <a
-                className={cs.vizLink}
+                className={cs.linkWithArrow}
                 href={params.alignmentVizUrl}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
+++ b/app/assets/src/components/common/CoverageVizBottomSidebar/coverage_viz_bottom_sidebar.scss
@@ -83,7 +83,8 @@ $genome-viz-spacing: $space-xxs;
   }
 }
 
-.vizLink {
+// Used to style multiple links in different locations in coverage viz sidebar.
+.linkWithArrow {
   @include font-header-xxs;
   // Override color: inherit in _header.scss.
   color: $primary-light !important;


### PR DESCRIPTION
# Description

This is a follow-up to https://github.com/chanzuckerberg/idseq-web/pull/3315.
Jenn made a comment on the design of the error message. Since the issue was blocking the deploy, I moved the re-styling to this follow-up PR.

Before:
![Screen Shot 2020-05-01 at 2 25 55 PM](https://user-images.githubusercontent.com/837004/80845013-e0367800-8bbc-11ea-9b05-1a416a70120d.png)

After:
![Screen Shot 2020-05-01 at 3 03 28 PM](https://user-images.githubusercontent.com/837004/80845034-f3494800-8bbc-11ea-912b-31531db9c3a2.png)

# Notes

* There are enough differences between the other "no data message" and this one that I decided to just duplicate the html markup. The styling is shared between the two instances.

# Tests
* Verified that the message looks as expected and the styling of other links is unaffected.
