### PR TITLE
Bump minimum idseq-cli version to 0.8.8

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -57,7 +57,7 @@ class SamplesController < ApplicationController
   PAGE_SIZE = 30
   MAX_PAGE_SIZE_V2 = 100
   MAX_BINS = 34
-  MIN_CLI_VERSION = '0.8.7'.freeze
+  MIN_CLI_VERSION = '0.8.8'.freeze
   CLI_DEPRECATION_MSG = "Outdated command line client. Please run `pip install --upgrade git+https://github.com/chanzuckerberg/idseq-cli.git` or with sudo + pip2/pip3 depending on your setup to update and try again.".freeze
 
   SAMPLE_DEFAULT_FIELDS = [

--- a/test/controllers/samples_bulk_upload_test.rb
+++ b/test/controllers/samples_bulk_upload_test.rb
@@ -13,6 +13,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     @host_genome_mosquito = host_genomes(:mosquito)
     @core_field = metadata_fields(:core_field)
     @user_nonadmin = users(:joe)
+    @client_version = "0.8.8"
   end
 
   test 'bulk upload basic remote' do
@@ -249,7 +250,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.8",
+      client: @client_version,
       metadata: {
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
@@ -293,7 +294,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.8",
+      client: @client_version,
       metadata: {
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
@@ -394,7 +395,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert !@metadata_validation_project.metadata_fields.include?(@core_field)
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.8",
+      client: @client_version,
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -445,7 +446,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert @host_genome_human.metadata_fields.pluck(:name).include?("Custom Field 2")
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.8",
+      client: @client_version,
       metadata: {
         "RR004_water_2_S23B" => {
           'sample_type' => 'blood',
@@ -498,7 +499,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert_equal 0, MetadataField.where(name: "Custom Field").length
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.8",
+      client: @client_version,
       metadata: {
         "Human Sample" => {
           'sample_type' => 'blood',
@@ -576,7 +577,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user_nonadmin
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.8",
+      client: @client_version,
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -620,7 +621,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user_nonadmin
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.8",
+      client: @client_version,
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -664,7 +665,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user_nonadmin
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.8",
+      client: @client_version,
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',

--- a/test/controllers/samples_bulk_upload_test.rb
+++ b/test/controllers/samples_bulk_upload_test.rb
@@ -249,7 +249,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.7",
+      client: "0.8.8",
       metadata: {
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
@@ -293,7 +293,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.7",
+      client: "0.8.8",
       metadata: {
         "RR004_water_2_S23A" => {
           'sex' => 'Female',
@@ -394,7 +394,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert !@metadata_validation_project.metadata_fields.include?(@core_field)
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.7",
+      client: "0.8.8",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -445,7 +445,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert @host_genome_human.metadata_fields.pluck(:name).include?("Custom Field 2")
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.7",
+      client: "0.8.8",
       metadata: {
         "RR004_water_2_S23B" => {
           'sample_type' => 'blood',
@@ -498,7 +498,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     assert_equal 0, MetadataField.where(name: "Custom Field").length
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.7",
+      client: "0.8.8",
       metadata: {
         "Human Sample" => {
           'sample_type' => 'blood',
@@ -576,7 +576,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user_nonadmin
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.7",
+      client: "0.8.8",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -620,7 +620,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user_nonadmin
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.7",
+      client: "0.8.8",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',
@@ -664,7 +664,7 @@ class SamplesBulkUploadTest < ActionDispatch::IntegrationTest
     sign_in @user_nonadmin
 
     post bulk_upload_with_metadata_samples_url, params: {
-      client: "0.8.7",
+      client: "0.8.8",
       metadata: {
         "RR004_water_2_S23A" => {
           'sample_type' => 'blood',


### PR DESCRIPTION
# Description

Bump CLI version so users will have access to the bug fix here: https://github.com/chanzuckerberg/idseq-cli/pull/69.
