### PR TITLE
[Heatmap] Fix top taxa implementation

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -785,9 +785,9 @@ class SamplesHeatmapView extends React.Component {
                 allData[metric.value][taxon["index"]]
               );
             });
-            count++;
           }
         }
+        count++;
       }
     });
 


### PR DESCRIPTION
# Description

The top N taxa per sample included in the heatmap should be independent of other samples (even if the taxon is already included in a different sample, it should still count towards the sample's top N count).

For example, if a heatmap includes 5 samples which all have the same top 10 taxa, then the heatmap (with taxa per sample set to 10) should only display 10 taxa rather than 50 taxa.

# Tests

* Loaded a heatmap with client-side filtering and verified that the appropriate number of taxa was displayed.
