### PR TITLE
[Release fix] Update asset manifest to include application.css

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+//= link application.css

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,5 +1,5 @@
 // This file needs to be in sync with webpack.config.prod.js. The first file
-// should contain should contain CSS from node_modules and the second file
+// should contain CSS from node_modules and the second file
 // idseq-written CSS. The order of requires is important!
 
 //= require vendors~main.bundle.min.css


### PR DESCRIPTION
# Description

The new version of the `sprockets` gem asks for an explicit declaration of `application.css` in `app/assets/config/manifest.js`. This PR does so.

# Notes

It's unclear if anything actually broke or what triggered the error, since the website continued to function fine.

# Tests

Since this is part of rendering actionview templates, testing endpoints that return html should test this. As noted above, currently rendering appears to continue to work.