### PR TITLE
[Bug] Prevent upload of metadata csv with missing column names

### DIFF
--- a/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapVis.jsx
@@ -480,9 +480,13 @@ class SamplesHeatmapVis extends React.Component {
   }
 
   getAvailableMetadataOptions() {
-    return this.props.metadataTypes.map(metadata => {
-      return { value: metadata.key, label: metadata.name };
-    });
+    return this.props.metadataTypes
+      .filter(metadata => {
+        return metadata.key && metadata.name;
+      })
+      .map(metadata => {
+        return { value: metadata.key, label: metadata.name };
+      });
   }
 
   handleZoom(increment) {

--- a/app/helpers/error_helper.rb
+++ b/app/helpers/error_helper.rb
@@ -1,5 +1,6 @@
 module ErrorHelper
   module MetadataValidationErrors
+    MISSING_COLUMN_HEADER = "Missing name for metadata field".freeze
     MISSING_SAMPLE_NAME_COLUMN = "\"Sample Name\" column is required.".freeze
     MISSING_HOST_GENOME_COLUMN = "\"Host Organism\" column is required.".freeze
     SAMPLE_NOT_FOUND = "Sample not found".freeze

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -235,10 +235,10 @@ module MetadataHelper
     warning_aggregator = ErrorAggregator.new
 
     # Require a header for every column.
-    # if (metadata["headers"].include? "")
-    #   errors.push(MetadataValidationErrors::MISSING_COLUMN_HEADER)
-    #   return { "errors" => errors, "warnings" => [] }
-    # end
+    if (metadata["headers"].include? "")
+      errors.push(MetadataValidationErrors::MISSING_COLUMN_HEADER)
+      return { "errors" => errors, "warnings" => [] }
+    end
 
     # Require sample_name or Sample Name column.
     if (metadata["headers"] & MetadataField::SAMPLE_NAME_SYNONYMS).blank?

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -234,6 +234,12 @@ module MetadataHelper
     error_aggregator.set_metadata("num_cols", metadata["headers"].length)
     warning_aggregator = ErrorAggregator.new
 
+    # Require a header for every column.
+    # if (metadata["headers"].include? "")
+    #   errors.push(MetadataValidationErrors::MISSING_COLUMN_HEADER)
+    #   return { "errors" => errors, "warnings" => [] }
+    # end
+
     # Require sample_name or Sample Name column.
     if (metadata["headers"] & MetadataField::SAMPLE_NAME_SYNONYMS).blank?
       errors.push(MetadataValidationErrors::MISSING_SAMPLE_NAME_COLUMN)

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -235,7 +235,7 @@ module MetadataHelper
     warning_aggregator = ErrorAggregator.new
 
     # Require a header for every column.
-    if (metadata["headers"].include? "")
+    if metadata["headers"].include? ""
       errors.push(MetadataValidationErrors::MISSING_COLUMN_HEADER)
       return { "errors" => errors, "warnings" => [] }
     end


### PR DESCRIPTION
# Description

See IDSEQ-2679.

Users can currently upload metadata csvs with blank column headers; if a user then selects this blank option in the metadata dropdown on the heatmap, the page will crash.

This change prevents the user from uploading a metadata csv with missing column headers and also has the heatmap ignore blank metadata options rather than displaying them in the dropdown.

# Tests

* Verified that an error is displayed if a metadata CSV is uploaded with a missing column name.
* Verified that a heatmap will not display blank metadata options in the dropdown.
