### PR TITLE
Release fix/dropbox 3

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+//= link application.css

--- a/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/DetailsTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/DetailsTab.jsx
@@ -55,7 +55,7 @@ export default class DetailsTab extends React.Component {
           )}
           <FieldList fields={fields} />
         </Accordion>
-        {bulkDownload.pipeline_runs && (
+        {bulkDownload.pipeline_runs.length > 0 && (
           <Accordion
             className={cs.accordion}
             header={<div className={cs.header}>Samples in this Download</div>}

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapView.jsx
@@ -785,9 +785,9 @@ class SamplesHeatmapView extends React.Component {
                 allData[metric.value][taxon["index"]]
               );
             });
-            count++;
           }
         }
+        count++;
       }
     });
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,5 +1,5 @@
 // This file needs to be in sync with webpack.config.prod.js. The first file
-// should contain should contain CSS from node_modules and the second file
+// should contain CSS from node_modules and the second file
 // idseq-written CSS. The order of requires is important!
 
 //= require vendors~main.bundle.min.css

--- a/lib/tasks/create_customer_support_download.rake
+++ b/lib/tasks/create_customer_support_download.rake
@@ -31,7 +31,7 @@ task create_customer_support_download: :environment do
   end
 
   begin
-    bulk_download.mark_success
+    bulk_download.verify_and_mark_success
     puts "Success! You can now notify the user that the file is available on their Downloads page."
   rescue
     bulk_download.destroy


### PR DESCRIPTION
# Description
The previous strategy for hiding "Samples in this Download" was not implemented properly so didn't have any effect. Now it is working properly.


# Tests
Downloads of type "Customer Support Request" don't have a "Samples in this Download" accordion in the Details Sidebar.