### PR TITLE
[Release fix] remove sample accordion when necessary

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/DetailsTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/DetailsTab.jsx
@@ -55,7 +55,7 @@ export default class DetailsTab extends React.Component {
           )}
           <FieldList fields={fields} />
         </Accordion>
-        {bulkDownload.pipeline_runs && (
+        {bulkDownload.pipeline_runs.length > 0 && (
           <Accordion
             className={cs.accordion}
             header={<div className={cs.header}>Samples in this Download</div>}


### PR DESCRIPTION
# Description
The previous strategy for hiding "Samples in this Download" was not implemented properly so didn't have any effect. Now it is working properly.

# Tests
Downloads of type "Customer Support Request" don't have a "Samples in this Download" accordion in the Details Sidebar.