### PR TITLE
Add cdhitdup files to PipelineStepGenerateAnnotatedFasta DAG

### DIFF
--- a/app/lib/dags/non_host_alignment.json.jbuilder
+++ b/app/lib/dags/non_host_alignment.json.jbuilder
@@ -24,8 +24,17 @@ json.targets do
   json.taxon_count_out ["taxon_counts_with_dcr.json"]
   json.annotated_out ["annotated_merged.fa", "unidentified.fa"]
 
+  # NOTE: this should usually be last in input_files. See PipelineCountingStep
+  # in idseq-dag.
   json.cdhitdup_cluster_sizes [
     "cdhitdup_cluster_sizes.tsv",
+  ]
+
+  # These files are generated with the tsv above but are needed in
+  # fewer steps.
+  json.cdhitdup_out [
+    "dedup1.fa.clstr",
+    "dedup1.fa",
   ]
 end
 
@@ -94,7 +103,7 @@ json.steps do
   }
 
   steps << {
-    in: ["host_filter_out", "gsnap_out", "rapsearch2_out", "cdhitdup_cluster_sizes"],
+    in: ["host_filter_out", "gsnap_out", "rapsearch2_out", "cdhitdup_out", "cdhitdup_cluster_sizes"],
     out: "annotated_out",
     class: "PipelineStepGenerateAnnotatedFasta",
     module: "idseq_dag.steps.generate_annotated_fasta",
@@ -111,6 +120,10 @@ json.given_targets do
   end
 
   json.cdhitdup_cluster_sizes do
+    json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
+  end
+
+  json.cdhitdup_out do
     json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
   end
 end

--- a/app/lib/dags/postprocess.json.jbuilder
+++ b/app/lib/dags/postprocess.json.jbuilder
@@ -195,7 +195,7 @@ json.steps do
   }
 
   steps << {
-    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out", "cdhitdup_out", "cdhitdup_out", "cdhitdup_cluster_sizes"],
+    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out", "cdhitdup_out", "cdhitdup_cluster_sizes"],
     out: "refined_annotated_out",
     class: "PipelineStepGenerateAnnotatedFasta",
     module: "idseq_dag.steps.generate_annotated_fasta",

--- a/app/lib/dags/postprocess.json.jbuilder
+++ b/app/lib/dags/postprocess.json.jbuilder
@@ -70,8 +70,17 @@ json.targets do
     "assembly/refined_taxid_locations_combined.json",
   ]
 
+  # NOTE: this should usually be last in input_files. See PipelineCountingStep
+  # in idseq-dag.
   json.cdhitdup_cluster_sizes [
     "cdhitdup_cluster_sizes.tsv",
+  ]
+
+  # These files are generated with the tsv above but are needed in
+  # fewer steps.
+  json.cdhitdup_out [
+    "dedup1.fa.clstr",
+    "dedup1.fa",
   ]
 end
 
@@ -186,7 +195,7 @@ json.steps do
   }
 
   steps << {
-    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out", "cdhitdup_cluster_sizes"],
+    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out", "cdhitdup_out", "cdhitdup_out", "cdhitdup_cluster_sizes"],
     out: "refined_annotated_out",
     class: "PipelineStepGenerateAnnotatedFasta",
     module: "idseq_dag.steps.generate_annotated_fasta",
@@ -231,6 +240,10 @@ json.given_targets do
   end
 
   json.cdhitdup_cluster_sizes do
+    json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
+  end
+
+  json.cdhitdup_out do
     json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
   end
 end


### PR DESCRIPTION
# Description

This goes with https://github.com/chanzuckerberg/idseq-dag/pull/300 .

# Tests

`bin/rails export_dags[15153,1]`

See `cdhitdup_out` files in DAG json

Run pipeline run locally 