### PR TITLE
[Bug] [Heatmap] Fix heatmap disappearing while downloading

### DIFF
--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -932,13 +932,16 @@ export default class Heatmap {
     // This assumes that this.height contains the "normal" height of the heatmap.
     // We temporarily change the svg height to add the caption, and will revert it as
     // soon as the printing is done.
-    this.svg.attr("height", this.height + totalCaptionHeight);
+    this.svg.attr(
+      "height",
+      (this.height + totalCaptionHeight) * this.options.zoom
+    );
     this.renderCaption();
   };
 
   hidePrintCaption = () => {
     // Revert the svg to its previous height, without the caption.
-    this.svg.attr("height", this.height);
+    this.svg.attr("height", this.height * this.options.zoom);
 
     // Remove all captions.
     this.gCaption.selectAll(`.${cs.caption}`).remove();


### PR DESCRIPTION
# Description

When downloading heatmaps with approx. >= 55 samples as svg or png, the heatmap would disappear until interacted with (toggling the filters, zooming in or out).

This is because in resizing the height of the heatmap to allow for the caption (in the samples heatmap, this is used to provide information about applied threshold filters in the downloaded image), the height does not take the zoom factor into account, so the heatmap effectively disappears since it is not within the visible viewport.

# Tests

* Generated a heatmap with 55 samples or more and verified that the heatmap doesn't disappear when downloading as an svg or png. Also verified that the downloaded svg/png displays the caption as expected.
