### PR TITLE
[IDSEQ-1761] Description field is not saved when you collapse and re-open the side-bar.

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/DetailsTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/DetailsTab.jsx
@@ -55,7 +55,7 @@ export default class DetailsTab extends React.Component {
           )}
           <FieldList fields={fields} />
         </Accordion>
-        {bulkDownload.pipeline_runs && (
+        {bulkDownload.pipeline_runs.length > 0 && (
           <Accordion
             className={cs.accordion}
             header={<div className={cs.header}>Samples in this Download</div>}

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/DiscoverySidebar.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/DiscoverySidebar.jsx
@@ -105,7 +105,7 @@ export default class DiscoverySidebar extends React.Component {
       <div className={cs.histogramContainer}>
         <div className={cs.dateHistogram}>
           {dates.map(entry => {
-            const percent = Math.round(100 * entry.count / total, 0);
+            const percent = Math.round((100 * entry.count) / total, 0);
             const element = (
               <div
                 className={cs.bar}
@@ -207,7 +207,7 @@ export default class DiscoverySidebar extends React.Component {
     const { onFilterClick } = this.props;
     return rows.map((entry, i) => {
       const { count, text, value } = entry;
-      const percent = Math.round(100 * count / total, 0);
+      const percent = Math.round((100 * count) / total, 0);
       const onClick = () => onFilterClick && onFilterClick(field, value);
       return (
         <div className={cs.barChartRow} key={`${value}_row_${i}`}>
@@ -260,6 +260,7 @@ export default class DiscoverySidebar extends React.Component {
       loading,
       noDataAvailable,
       project,
+      onProjectDescriptionSave,
     } = this.props;
     if (!loading && !this.hasData()) {
       return (
@@ -280,7 +281,10 @@ export default class DiscoverySidebar extends React.Component {
       <div className={cx(className, cs.sidebar)}>
         {project && (
           <div className={cs.descriptionContainer}>
-            <ProjectDescription project={project} />
+            <ProjectDescription
+              project={project}
+              onProjectDescriptionSave={onProjectDescriptionSave}
+            />
           </div>
         )}
         <div className={cs.metadataContainer}>

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
@@ -53,6 +53,7 @@ class ProjectDescription extends React.Component {
         },
         () => {
           this._save(this.props.project.id, this.state.description);
+          this.props.onProjectDescriptionSave(this.state.description);
         }
       );
     }

--- a/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
+++ b/app/assets/src/components/views/discovery/DiscoverySidebar/ProjectDescription.jsx
@@ -46,14 +46,16 @@ class ProjectDescription extends React.Component {
   };
 
   handleDescriptionSave = async () => {
-    if (this.state.changed) {
+    const { changed } = this.state;
+    const { onProjectDescriptionSave } = this.props;
+    if (changed) {
       this.setState(
         {
           changed: false,
         },
         () => {
           this._save(this.props.project.id, this.state.description);
-          this.props.onProjectDescriptionSave(this.state.description);
+          onProjectDescriptionSave(this.state.description);
         }
       );
     }

--- a/app/assets/src/components/views/discovery/DiscoveryView.jsx
+++ b/app/assets/src/components/views/discovery/DiscoveryView.jsx
@@ -775,6 +775,12 @@ class DiscoveryView extends React.Component {
     }
   };
 
+  handleProjectDescriptionSave = value => {
+    this.setState({
+      project: { ...this.state.project, description: value },
+    });
+  };
+
   getServerSideSuggestions = async query => {
     const { domain } = this.props;
 
@@ -1338,6 +1344,7 @@ class DiscoveryView extends React.Component {
                 count: filteredSampleCount,
               }}
               project={project}
+              onProjectDescriptionSave={this.handleProjectDescriptionSave}
             />
           ))}
       </div>
@@ -1392,19 +1399,18 @@ class DiscoveryView extends React.Component {
         <Divider style="medium" />
         <div className={cs.mainContainer}>
           <div className={cs.leftPane}>
-            {showFilters &&
-              dimensions && (
-                <DiscoveryFilters
-                  {...mapValues(
-                    dim => dim.values,
-                    keyBy("dimension", dimensions)
-                  )}
-                  {...filters}
-                  domain={domain}
-                  onFilterChange={this.handleFilterChange}
-                  allowedFeatures={allowedFeatures}
-                />
-              )}
+            {showFilters && dimensions && (
+              <DiscoveryFilters
+                {...mapValues(
+                  dim => dim.values,
+                  keyBy("dimension", dimensions)
+                )}
+                {...filters}
+                domain={domain}
+                onFilterChange={this.handleFilterChange}
+                allowedFeatures={allowedFeatures}
+              />
+            )}
           </div>
           <div className={cs.centerPane}>
             {userDataCounts &&


### PR DESCRIPTION
# Description
Description field is not saved when you collapse and re-open the side-bar.

*The intended change, motivation and consequences.*
# Notes
The state in the parent component DiscoveryView was not getting the updated changes that was caused by saving the ProjectDescription component. ProjectDescription was only saving the changes to the server.

*Optional observations, comments or explanations.*
ProjectDescription component has a function called _handleDescriptionSave_ but may be misleading since it only saves the description to the server and the current component state... Since it does not update the state of _project_ in the DiscoveryView component, upon re-opening the side bar the description is not updated and thus shows the old description, not the updated one.


# Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*
* *See also [IDseq PR Guidelines](https://github.com/chanzuckerberg/idseq-web/blob/master/PR_GUIDELINES.md)*
