### PR TITLE
Revert "Add cdhitdup files to PipelineStepGenerateAnnotatedFasta DAG …

### DIFF
--- a/app/lib/dags/non_host_alignment.json.jbuilder
+++ b/app/lib/dags/non_host_alignment.json.jbuilder
@@ -24,17 +24,8 @@ json.targets do
   json.taxon_count_out ["taxon_counts_with_dcr.json"]
   json.annotated_out ["annotated_merged.fa", "unidentified.fa"]
 
-  # NOTE: this should usually be last in input_files. See PipelineCountingStep
-  # in idseq-dag.
   json.cdhitdup_cluster_sizes [
     "cdhitdup_cluster_sizes.tsv",
-  ]
-
-  # These files are generated with the tsv above but are needed in
-  # fewer steps.
-  json.cdhitdup_out [
-    "dedup1.fa.clstr",
-    "dedup1.fa",
   ]
 end
 
@@ -103,7 +94,7 @@ json.steps do
   }
 
   steps << {
-    in: ["host_filter_out", "gsnap_out", "rapsearch2_out", "cdhitdup_out", "cdhitdup_cluster_sizes"],
+    in: ["host_filter_out", "gsnap_out", "rapsearch2_out", "cdhitdup_cluster_sizes"],
     out: "annotated_out",
     class: "PipelineStepGenerateAnnotatedFasta",
     module: "idseq_dag.steps.generate_annotated_fasta",
@@ -120,10 +111,6 @@ json.given_targets do
   end
 
   json.cdhitdup_cluster_sizes do
-    json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
-  end
-
-  json.cdhitdup_out do
     json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
   end
 end

--- a/app/lib/dags/postprocess.json.jbuilder
+++ b/app/lib/dags/postprocess.json.jbuilder
@@ -70,17 +70,8 @@ json.targets do
     "assembly/refined_taxid_locations_combined.json",
   ]
 
-  # NOTE: this should usually be last in input_files. See PipelineCountingStep
-  # in idseq-dag.
   json.cdhitdup_cluster_sizes [
     "cdhitdup_cluster_sizes.tsv",
-  ]
-
-  # These files are generated with the tsv above but are needed in
-  # fewer steps.
-  json.cdhitdup_out [
-    "dedup1.fa.clstr",
-    "dedup1.fa",
   ]
 end
 
@@ -195,7 +186,7 @@ json.steps do
   }
 
   steps << {
-    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out", "cdhitdup_out", "cdhitdup_cluster_sizes"],
+    in: ["host_filter_out", "refined_gsnap_out", "refined_rapsearch2_out", "cdhitdup_cluster_sizes"],
     out: "refined_annotated_out",
     class: "PipelineStepGenerateAnnotatedFasta",
     module: "idseq_dag.steps.generate_annotated_fasta",
@@ -240,10 +231,6 @@ json.given_targets do
   end
 
   json.cdhitdup_cluster_sizes do
-    json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
-  end
-
-  json.cdhitdup_out do
     json.s3_dir "s3://#{attr[:bucket]}/samples/#{attr[:project_id]}/#{attr[:sample_id]}/results/#{attr[:pipeline_version]}"
   end
 end


### PR DESCRIPTION
See #3335 

This reverts commit 56601e8f9cd44762596c4f1b173a60fe6401e831.

# Description

Pipeline runs in staging started to fail with the message 

```
missing required inputs for idseq_non_host_alignment: cdhitdup_out_dedup1_fa_clstr, cdhitdup_out_dedup1_fa
```

See for example https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logEventViewer:group=/aws/batch/job;stream=idseq-staging-main/default/1222229789924092bf68401743adf96e;start=2020-05-10T20:17:24Z . 

This reverts the change until we can debug further. 

Note: idseq-dag should be back compatible. 