### PR TITLE
[IDSEQ-2509] Searching in DD, if the term is deleted there's no visual cue that it's still being applied

### DIFF
--- a/app/assets/src/components/ui/controls/LiveSearchBox.jsx
+++ b/app/assets/src/components/ui/controls/LiveSearchBox.jsx
@@ -13,6 +13,7 @@ class LiveSearchBox extends React.Component {
       results: [],
       value: this.props.initialValue,
       selectedResult: null,
+      lastSearchedTerm: null,
     };
 
     this.lastestTimerId = null;
@@ -28,11 +29,20 @@ class LiveSearchBox extends React.Component {
     return null;
   }
 
+  handleOnBlur = () => {
+    const { lastSearchedTerm } = this.state;
+    this.setState({ value: lastSearchedTerm });
+  };
+
   handleKeyDown = keyEvent => {
     const { onEnter, inputMode } = this.props;
-    const { value, selectedResult } = this.state;
+    const { value, selectedResult, lastSearchedTerm } = this.state;
 
     if (keyEvent.key === "Enter") {
+      if (lastSearchedTerm !== value) {
+        this.setState({ lastSearchedTerm: value });
+      }
+
       if (inputMode && !selectedResult) {
         // In input mode, if they didn't select anything, count it as submitting what they entered.
         this.handleResultSelect(keyEvent, { result: value });
@@ -108,6 +118,7 @@ class LiveSearchBox extends React.Component {
           className
         )}
         loading={isLoading}
+        onBlur={this.handleOnBlur}
         onKeyDown={this.handleKeyDown}
         onResultSelect={this.handleResultSelect}
         onSearchChange={this.handleSearchChange}


### PR DESCRIPTION
# Description
Searching in DD, if the term is deleted there's no visual cue that it's still being applied

*The intended change, motivation and consequences.*

Added to state* (not prop, sorry got it wrong in commit msg) lastSearchedTerm and onBlur method to fix bug.

# Notes 

*Optional observations, comments or explanations.*

# Tests

* *Server-side code should have automated tests*
* *Client-side code and scripts should have at least a manual test plan*
* *See also [IDseq PR Guidelines](https://github.com/chanzuckerberg/idseq-web/blob/master/PR_GUIDELINES.md)*
