### PR TITLE
change total_runtime display to overall wait

### DIFF
--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -289,12 +289,12 @@ module SamplesHelper
     samples.where(id: matching_sample_ids)
   end
 
-  def get_total_runtime(pipeline_run, run_stages)
+  def get_total_runtime(pipeline_run, _run_stages)
     if pipeline_run.finalized?
-      # total processing time (without time spent waiting), for performance evaluation
-      (run_stages || []).map { |rs| rs.updated_at - rs.created_at }.sum
+      # total processing time
+      (pipeline_run.updated_at - pipeline_run.created_at)
     else
-      # time since pipeline kickoff (including time spent waiting), for run diagnostics
+      # time since pipeline kickoff
       (Time.current - pipeline_run.created_at)
     end
   end


### PR DESCRIPTION
# Description
This is a proposal. I'm curious to hear people's thoughts. 
Previously the runtime displayed for each sample only included time spent running Batch jobs and not the time spend waiting for workers. It would be more accurate to display the overall time from the pipeline creation until pipeline completion.

If people think this is a good change, I can invest the time to clean up the now unnecessary argument to the function.

# Tests
Numbers in the "Total Runtime" column on the project page may increase to account for wait time in addition to compute time.
