### PR TITLE
[IDSEQ-2656] The filter for e-value says ">=" but right now it is only ">"

### DIFF
--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -334,7 +334,7 @@ class ReportTable extends React.Component {
   renderNtNrDecimalValues = ({ cellData, decimalPlaces }) => {
     return this.renderNtNrStack({
       cellData: cellData.map(val => {
-        let needsTruncation = val % 1 != 0; // Checks if a number has a decimal place/is a whole number
+        let needsTruncation = val % 1 !== 0; // Checks if a number has a decimal place/is a whole number
         let processedValue = needsTruncation
           ? Number(val).toFixed(2)
           : Number(val);

--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -333,11 +333,13 @@ class ReportTable extends React.Component {
 
   renderNtNrDecimalValues = ({ cellData, decimalPlaces }) => {
     return this.renderNtNrStack({
-      cellData: cellData.map(val =>
-        TableRenderers.formatNumberWithCommas(
-          Number(val).toFixed(decimalPlaces || 0)
-        )
-      ),
+      cellData: cellData.map(val => {
+        let needsTruncation = val % 1 != 0; // Checks if a number has a decimal place/is a whole number
+        let processedValue = needsTruncation
+          ? Number(val).toFixed(2)
+          : Number(val);
+        return TableRenderers.formatNumberWithCommas(processedValue);
+      }),
     });
   };
 
@@ -586,8 +588,8 @@ class ReportTable extends React.Component {
           rowData.genus
             ? getOr(nullValue, path, rowData)
             : sortDirection === "asc"
-              ? limits[0]
-              : limits[1],
+            ? limits[0]
+            : limits[1],
       ],
       [sortDirection, sortDirection, sortDirection],
       data


### PR DESCRIPTION
# Description
The threshold filter says "greater than or equal to" but things that are "equal" are being filtered out in the sample's report.
For more information, visit [IDSEQ-2656](https://jira.czi.team/browse/IDSEQ-2656) 

# Notes
The bug is caused by the function 
renderNtNrDecimalValues(val, decimalPlaces) in app/assets/src/components/views/SampleViewV2/ReportTable.jsx
 
The line Number(val).toFixed(decimalPlaces || 0)
has an unintended rounding effect that rounds up when given a float greater than 2 decimal places but specify to round to one decimal place. 

For example:
Mastadenovirus has an e-value of 88.27 – but since the value passes through renderNtNrDecimalValues(88.27, 1)
it gets rounded up to 88.3 and is displayed like that – even though the data is stored as 88.27.
 
This is why the threshold filter appears like it doesn't work properly. The same issue applies to every other column and filter so I am sure there are other bugs caused by this same issue. I believe what we are looking for is truncation and not rounding.

# Tests
Create a new threshold filter with any value and apply it.
The bug fix worked if the taxon still appears in the report after the threshold filter was applied. 

