### PR TITLE
Async Elasticsearch

### DIFF
--- a/app/helpers/elasticsearch_callbacks_helper.rb
+++ b/app/helpers/elasticsearch_callbacks_helper.rb
@@ -1,9 +1,5 @@
-require 'elasticsearch/model'
-
 # Provides Async Callbacks for Elasticsearch Syncing
 module ElasticsearchCallbacksHelper
-  include Elasticsearch::Model
-
   def self.included(base)
     return unless base.ancestors.include?(::ActiveRecord::Base)
     base.class_eval do
@@ -17,8 +13,8 @@ module ElasticsearchCallbacksHelper
     Resque.enqueue(
       ElasticsearchIndex,
       :index,
-      index_name,
-      document_type,
+      __elasticsearch__.index_name,
+      __elasticsearch__.document_type,
       id,
       __elasticsearch__.as_indexed_json
     )
@@ -27,9 +23,9 @@ module ElasticsearchCallbacksHelper
   def async_elasticsearch_delete
     Resque.enqueue(
       ElasticsearchIndex,
-      :index,
-      index_name,
-      document_type,
+      :delete,
+      __elasticsearch__.index_name,
+      __elasticsearch__.document_type,
       id,
       __elasticsearch__.as_indexed_json
     )

--- a/app/helpers/elasticsearch_callbacks_helper.rb
+++ b/app/helpers/elasticsearch_callbacks_helper.rb
@@ -1,5 +1,10 @@
 # Provides Async Callbacks for Elasticsearch Syncing
 module ElasticsearchCallbacksHelper
+  # WARNING: using this with a model means you must ensure activerecord
+  #  callbacks are called on all updates. This module updates elasticsearch
+  #  using these callbacks. If you must circumvent them somehow (eg. using raw
+  #  SQL or bulk_import) you must explicitly update elasticsearch appropriately.
+
   def self.included(base)
     return unless base.ancestors.include?(::ActiveRecord::Base)
     base.class_eval do

--- a/app/helpers/elasticsearch_callbacks_helper.rb
+++ b/app/helpers/elasticsearch_callbacks_helper.rb
@@ -1,0 +1,37 @@
+require 'elasticsearch/model'
+
+# Provides Async Callbacks for Elasticsearch Syncing
+module ElasticsearchCallbacksHelper
+  include Elasticsearch::Model
+
+  def self.included(base)
+    return unless base.ancestors.include?(::ActiveRecord::Base)
+    base.class_eval do
+      after_commit -> { async_elasticsearch_index }, on: :create
+      after_commit -> { async_elasticsearch_index }, on: :update
+      after_commit -> { async_elasticsearch_delete }, on: :destroy
+    end
+  end
+
+  def async_elasticsearch_index
+    Resque.enqueue(
+      ElasticsearchIndex,
+      :index,
+      index_name,
+      document_type,
+      id,
+      __elasticsearch__.as_indexed_json
+    )
+  end
+
+  def async_elasticsearch_delete
+    Resque.enqueue(
+      ElasticsearchIndex,
+      :index,
+      index_name,
+      document_type,
+      id,
+      __elasticsearch__.as_indexed_json
+    )
+  end
+end

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -524,7 +524,7 @@ module SamplesHelper
     # With on_duplicate_key_update, activerecord-import will correctly update existing rows.
     # Rails model validations are also checked.
     update_keys = [:raw_value, :string_validated_value, :number_validated_value, :date_validated_value, :location_id]
-    results = Metadatum.bulk_import metadata_to_save, validate: true, on_duplicate_key_update: update_keys
+    results = Metadatum.bulk_import_safe metadata_to_save, validate: true, on_duplicate_key_update: update_keys
     results.failed_instances.each do |model|
       errors.push(MetadataUploadErrors.save_error(model.key, model.raw_value))
     end

--- a/app/helpers/samples_helper.rb
+++ b/app/helpers/samples_helper.rb
@@ -524,7 +524,7 @@ module SamplesHelper
     # With on_duplicate_key_update, activerecord-import will correctly update existing rows.
     # Rails model validations are also checked.
     update_keys = [:raw_value, :string_validated_value, :number_validated_value, :date_validated_value, :location_id]
-    results = Metadatum.bulk_import_safe metadata_to_save, validate: true, on_duplicate_key_update: update_keys
+    results = Metadatum.bulk_import metadata_to_save, validate: true, on_duplicate_key_update: update_keys
     results.failed_instances.each do |model|
       errors.push(MetadataUploadErrors.save_error(model.key, model.raw_value))
     end

--- a/app/jobs/elasticsearch_index.rb
+++ b/app/jobs/elasticsearch_index.rb
@@ -1,0 +1,41 @@
+require 'elasticsearch/model'
+
+# Indexes records for elasticsearch record
+class ElasticsearchIndex
+  @queue = :elasticsearch_index
+
+  def _index(index_name, index_type, record_id, indexed_json)
+    Elasticsearch::Model.client.index(
+      index: index_name,
+      type: index_type,
+      id: record_id,
+      body: indexed_json
+    )
+  end
+
+  def _delete(index_name, index_type, record_id)
+    Elasticsearch::Model.client.delete(
+      index: index_name,
+      type: index_type,
+      id: record_id
+    )
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    Rails.logger.debug("Elasticsearch: Attempted to delete document: \
+      #{record_id} from #{index_name} but it was not found")
+  end
+
+  def self.perform(operation, index_name, doc_type, record_id, indexed_json)
+    Rails.logger.debug("Elasticsearch: Attempting to #{operation} \
+      record: #{record_id} source table: #{index_name}")
+    case operation.to_s
+    when /index/
+      _index(index_name, doc_type, record_id, indexed_json)
+    when /delete/
+      _delete(index_name, doc_type, record_id)
+    else raise ArgumentError, "Unknown operation '#{operation}'"
+    end
+  rescue
+    LogUtil.log_err_and_airbrake("Elasticsearch: Failed to #{operation} record: \
+      #{record_id} source table: #{index_name}")
+  end
+end

--- a/app/jobs/elasticsearch_index.rb
+++ b/app/jobs/elasticsearch_index.rb
@@ -4,38 +4,22 @@ require 'elasticsearch/model'
 class ElasticsearchIndex
   @queue = :elasticsearch_index
 
-  def _index(index_name, index_type, record_id, indexed_json)
-    Elasticsearch::Model.client.index(
-      index: index_name,
-      type: index_type,
-      id: record_id,
-      body: indexed_json
-    )
-  end
-
-  def _delete(index_name, index_type, record_id)
-    Elasticsearch::Model.client.delete(
-      index: index_name,
-      type: index_type,
-      id: record_id
-    )
-  rescue Elasticsearch::Transport::Transport::Errors::NotFound
-    Rails.logger.debug("Elasticsearch: Attempted to delete document: \
-      #{record_id} from #{index_name} but it was not found")
-  end
-
   def self.perform(operation, index_name, doc_type, record_id, indexed_json)
-    Rails.logger.debug("Elasticsearch: Attempting to #{operation} \
-      record: #{record_id} source table: #{index_name}")
+    Rails.logger.debug("Elasticsearch: Attempting to #{operation} record: #{record_id} source table: #{index_name}")
     case operation.to_s
     when /index/
-      _index(index_name, doc_type, record_id, indexed_json)
+      Elasticsearch::Model.client.index(index: index_name, type: doc_type, id: record_id, body: indexed_json)
+      Rails.logger.debug("Elasticsearch: Successfully indexed record: #{record_id} source table: #{index_name}")
     when /delete/
-      _delete(index_name, doc_type, record_id)
+      Elasticsearch::Model.client.delete(index: index_name, type: index_type, id: record_id)
+      Rails.logger.debug("Elasticsearch: Successfully deleted record: #{record_id} source table: #{index_name}")
     else raise ArgumentError, "Unknown operation '#{operation}'"
     end
-  rescue
-    LogUtil.log_err_and_airbrake("Elasticsearch: Failed to #{operation} record: \
-      #{record_id} source table: #{index_name}")
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    Rails.logger.debug("Elasticsearch: Attempted to delete document: #{record_id} from #{index_name} but it was not found")
+  rescue => e
+    Rails.logger.error(e)
+    LogUtil.log_backtrace(e)
+    LogUtil.log_err_and_airbrake("Elasticsearch failed to #{operation} record: #{record_id} source table: #{index_name}, with error: #{e.message}")
   end
 end

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -258,6 +258,7 @@ class Metadatum < ApplicationRecord
     results.failed_instances.each do |model|
       missing_ids.add(model.id)
     end
+    return results unless ELASTICSEARCH_ON
     to_create.each do |metadatum|
       next if missing_ids.member?(metadatum.id)
       metadatum.async_elasticsearch_index

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -6,8 +6,10 @@ class Metadatum < ApplicationRecord
   include DateHelper
   include LocationHelper
 
-  include Elasticsearch::Model if ELASTICSEARCH_ON
-  include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
+  if ELASTICSEARCH_ON
+    include Elasticsearch::Model
+    include ElasticsearchCallbacksHelper
+  end
 
   Client = Aws::S3::Client.new
 

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -251,6 +251,7 @@ class Metadatum < ApplicationRecord
     errors
   end
 
+  # Bulk import safe to use with elasticsearch
   def self.bulk_import_safe(to_create, opts = {})
     missing_ids = Set.new
     results = Metadatum.bulk_import(to_create, opts)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,8 @@
 class Project < ApplicationRecord
-  include Elasticsearch::Model if ELASTICSEARCH_ON
-  include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
+  if ELASTICSEARCH_ON
+    include Elasticsearch::Model
+    include ElasticsearchCallbacksHelper
+  end
   include ReportHelper
 
   has_and_belongs_to_many :users

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,10 @@
 class Project < ApplicationRecord
   if ELASTICSEARCH_ON
     include Elasticsearch::Model
+    # WARNING: using this means you must ensure activerecord callbacks are
+    #  called on all updates. This module updates elasticsearch using these
+    #  callbacks. If you must circumvent them somehow (eg. using raw SQL or
+    #  bulk_import) you must explicitly update elasticsearch appropriately.
     include ElasticsearchCallbacksHelper
   end
   include ReportHelper

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,8 +1,5 @@
 class Project < ApplicationRecord
-  if ELASTICSEARCH_ON
-    include Elasticsearch::Model
-    include Elasticsearch::Model::Callbacks
-  end
+  include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
   include ReportHelper
 
   has_and_belongs_to_many :users

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,5 @@
 class Project < ApplicationRecord
+  include Elasticsearch::Model if ELASTICSEARCH_ON
   include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
   include ReportHelper
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -6,19 +6,7 @@ require 'elasticsearch/model'
 # TODO(mark): Move to an initializer. Make sure this works with Rails auto-reloading.
 
 class Sample < ApplicationRecord
-  if ELASTICSEARCH_ON
-    include Elasticsearch::Model
-    after_commit on: [:create, :update] do
-      __elasticsearch__.index_document
-    end
-    after_commit on: [:destroy] do
-      begin
-        __elasticsearch__.delete_document
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
-        Rails.logger.warn(e)
-      end
-    end
-  end
+  include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
   include TestHelper
   include MetadataHelper
   include PipelineRunsHelper

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -6,8 +6,10 @@ require 'elasticsearch/model'
 # TODO(mark): Move to an initializer. Make sure this works with Rails auto-reloading.
 
 class Sample < ApplicationRecord
-  include Elasticsearch::Model if ELASTICSEARCH_ON
-  include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
+  if ELASTICSEARCH_ON
+    include Elasticsearch::Model
+    include ElasticsearchCallbacksHelper
+  end
   include TestHelper
   include MetadataHelper
   include PipelineRunsHelper

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -8,6 +8,10 @@ require 'elasticsearch/model'
 class Sample < ApplicationRecord
   if ELASTICSEARCH_ON
     include Elasticsearch::Model
+    # WARNING: using this means you must ensure activerecord callbacks are
+    #  called on all updates. This module updates elasticsearch using these
+    #  callbacks. If you must circumvent them somehow (eg. using raw SQL or
+    #  bulk_import) you must explicitly update elasticsearch appropriately.
     include ElasticsearchCallbacksHelper
   end
   include TestHelper

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -6,6 +6,7 @@ require 'elasticsearch/model'
 # TODO(mark): Move to an initializer. Make sure this works with Rails auto-reloading.
 
 class Sample < ApplicationRecord
+  include Elasticsearch::Model if ELASTICSEARCH_ON
   include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
   include TestHelper
   include MetadataHelper

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -4,8 +4,10 @@
 require 'elasticsearch/model'
 
 class TaxonLineage < ApplicationRecord
-  include Elasticsearch::Model if ELASTICSEARCH_ON
-  include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
+  if ELASTICSEARCH_ON
+    include Elasticsearch::Model
+    include ElasticsearchCallbacksHelper
+  end
   include TaxonLineageHelper
 
   INVALID_CALL_BASE_ID = -100_000_000 # don't run into -2e9 limit (not common, mostly a concern for fp32 or int32)

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -6,6 +6,10 @@ require 'elasticsearch/model'
 class TaxonLineage < ApplicationRecord
   if ELASTICSEARCH_ON
     include Elasticsearch::Model
+    # WARNING: using this means you must ensure activerecord callbacks are
+    #  called on all updates. This module updates elasticsearch using these
+    #  callbacks. If you must circumvent them somehow (eg. using raw SQL or
+    #  bulk_import) you must explicitly update elasticsearch appropriately.
     include ElasticsearchCallbacksHelper
   end
   include TaxonLineageHelper

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -4,6 +4,7 @@
 require 'elasticsearch/model'
 
 class TaxonLineage < ApplicationRecord
+  include Elasticsearch::Model if ELASTICSEARCH_ON
   include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
   include TaxonLineageHelper
 

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -4,10 +4,7 @@
 require 'elasticsearch/model'
 
 class TaxonLineage < ApplicationRecord
-  unless Rails.env == "test"
-    include Elasticsearch::Model
-    include Elasticsearch::Model::Callbacks
-  end
+  include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
   include TaxonLineageHelper
 
   INVALID_CALL_BASE_ID = -100_000_000 # don't run into -2e9 limit (not common, mostly a concern for fp32 or int32)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,10 @@ require 'auth0'
 class User < ApplicationRecord
   if ELASTICSEARCH_ON
     include Elasticsearch::Model
+    # WARNING: using this means you must ensure activerecord callbacks are
+    #  called on all updates. This module updates elasticsearch using these
+    #  callbacks. If you must circumvent them somehow (eg. using raw SQL or
+    #  bulk_import) you must explicitly update elasticsearch appropriately.
     include ElasticsearchCallbacksHelper
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,10 @@ require 'elasticsearch/model'
 require 'auth0'
 
 class User < ApplicationRecord
-  include Elasticsearch::Model if ELASTICSEARCH_ON
-  include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
+  if ELASTICSEARCH_ON
+    include Elasticsearch::Model
+    include ElasticsearchCallbacksHelper
+  end
 
   # https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html#method-i-has_secure_token
   has_secure_token :authentication_token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,10 +2,7 @@ require 'elasticsearch/model'
 require 'auth0'
 
 class User < ApplicationRecord
-  if ELASTICSEARCH_ON
-    include Elasticsearch::Model
-    include Elasticsearch::Model::Callbacks
-  end
+  include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
 
   # https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html#method-i-has_secure_token
   has_secure_token :authentication_token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ require 'elasticsearch/model'
 require 'auth0'
 
 class User < ApplicationRecord
+  include Elasticsearch::Model if ELASTICSEARCH_ON
   include ElasticsearchCallbacksHelper if ELASTICSEARCH_ON
 
   # https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html#method-i-has_secure_token

--- a/lib/tasks/update_lineagedb.rake
+++ b/lib/tasks/update_lineagedb.rake
@@ -153,6 +153,18 @@ class LineageDatabaseImporter
     import_new_taxid_lineages!
     affected = build_new_taxon_lineages!
     upgrade_taxon_lineages!(affected, noverify)
+    # This is very slow, since this script is using raw SQL the
+    #  elasticsearch index will not be updated, since elasticsearch-model
+    #  relies on callbacks. The safest and easiest way to ensure the
+    #  index is in sync at the end is to refresh the whole thing.
+    #  Since this script is run rarely this shouldn't be a huge deal
+    #  but if it is slow you may want to look into only updating affected ids.
+    import_elasticsearch!
+  end
+
+  def import_elasticsearch!
+    puts "\nRefresh elasticsearch index..."
+    TaxonLineage.__elasticsearch__.import force: true
   end
 
   def upgrade_taxon_lineages!(new_count, noverify = false)

--- a/lib/tasks/update_lineagedb.rake
+++ b/lib/tasks/update_lineagedb.rake
@@ -164,6 +164,11 @@ class LineageDatabaseImporter
 
   def import_elasticsearch!
     puts "\nRefresh elasticsearch index..."
+    # There may be potential to optimize this based on the diff but:
+    # - Going through the ID and calling index would likely be slower
+    #   because import implements batching.
+    # - Using a query import based on updated timestamp misses
+    #   deletions.
     TaxonLineage.__elasticsearch__.import force: true
   end
 


### PR DESCRIPTION
# Description

This PR fixes issues that caused missing records in elasticsearch. It also makes our elasticsearch indexing asynchronous.

## Issues

These issues occurred because we add things to Elasticsearch with [elasticsearch-model[(https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-model), which relies on Active Record Callbacks. Any modifications that circumvent the Active Record Callback Flow result in missing data in Elasticsearch. 

### Taxon Lineages

These are only updated via the task `update_lineage_db`. About a year ago this task was modified to use raw SQL. We have been missing updates since then. To fix this I added a step to re-index after this job runs. It is a little slow but we can index the whole thing in <30 minutes and this task only runs once ever 28 days so I feel it isn't a huge deal.

### Metadata Bulk Import

To do bulk metadata importing we are using [https://github.com/zdennis/activerecord-import](https://github.com/zdennis/activerecord-import). This circumvents the Active Record Callback Flow. This is necessary to avoid blocking synchronous updates that would render the feature very slow. I created a version of this method that also indexes in Elasticsearch. However, this would still involve blocking synchronous updates without the async change I made.

## Async Elasticsearch

Currently we are blocking considering writes complete on updating the Elasticsearch Index. This slows down all of our database interactions with these tables. It also fails database operations when the re-index is not really required right away and could have been retried. In their docs elasticsearch-model [recommends async updates](https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-model/README.md#asynchronous-callbacks). These callbacks also have logging and alerting so we can debug potential missingness in Elasticsearch in the future, and we can know when to initiate a re-index.

# Tests

Tested all of the relevant models, bulk imports, as well as the rake task.