### PR TITLE
Update to Python 3 and Ruby 2.5 Buster image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
         - redis
       before_install:
         # Install python and dependencies
-        - source ~/virtualenv/python2.7/bin/activate
+        - source ~/virtualenv/python3.7/bin/activate
         - pip install -r requirements.txt
         # Upgrade bundler to v2 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
         - gem install bundler
@@ -59,7 +59,7 @@ jobs:
         - redis
       before_install:
         # Install python and dependencies
-        - source ~/virtualenv/python2.7/bin/activate
+        - source ~/virtualenv/python3.7/bin/activate
         - pip install -r requirements.txt
         # Upgrade bundler to v2 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
         - gem install bundler
@@ -102,11 +102,11 @@ jobs:
     #   seem to start later. This job is the fastest by far so keep it last.
     - name: "Python Test"
       language: python
-      python: 2.7
-      cache: pip
+      python: 3.7
+      cache: pip3
       script:
-        - pip install mock
-        - python -m unittest discover -v -s test/ -p 'test_*.py'
+        - pip3 install mock
+        - python3 -m unittest discover -v -s test/ -p 'test_*.py'
 env:
   global:
   - secure: l6JImOInd+PoLwf9hbAl6QmjXE4mShlG7SEkasSKk6XzT4npNTUqqYVVpNewr1f58U97SdHShv6WgxKIiUpX+adIBp9b59CsI7SCKxt1aSp9egyZE6F1ZIoqjmfH6o9U4dUkE32TJdG4Tn/QMd0fj3nCqathFIWFhato6ovqXmJpklJHH9BGbK330bEYG1LoUU3u/hIhBc8bAuNIO15eih1vMltYiSw5ScQxBMjcCskAjEeb8EA7i82pEpyD9iBWcIomw5Mrro0IInjJbudIQ5RukNZtI3zZXiSbR8m8VWzK8A8ixihHKRbBoLXn3X719s13FIJKL2Pn1utxMx4zrLLUx4iMafey2e8iG9C3JYyHu6UoR/E5hcSCdhHDmwiCiIQF8cHt2sZNVE33rEGdEkhsPgwlH16O6kBJmVOqaaihPN/yjzIyjxDoyknPfswpkiRiuqaa9XDXh5dgU0xHDfKic6ioAJvRMn0Ngbo7Ogi90rTaxksFFo7UAL9mChQaB+qtJk+tU0I7PFTR52ie62KcIAfqU3PFOo1jchmw7uEu/k8yNpZM4gar2gnl8gqe5dIVqkTDfNWBTlYX17dTqeHB7ZqCRKZzYcEZK8SVmw9fs/JTouwQK2nXgwEnp7dJdofvZgXhLZ4/ZhNniLn0ObDQauzYKPKgk819CtIb968=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,30 @@
-FROM ruby:2.5-stretch
+FROM ruby:2.5-buster
 
 # Install apt based dependencies required to run Rails as
 # well as RubyGems. As the Ruby image itself is based on a
 # Debian image, we use apt-get to install those.
-RUN apt-get update && apt-get install -y build-essential nodejs mysql-client python-dev python-pip apt-transport-https
+RUN apt-get update && \
+    apt-get install -y \
+      build-essential \
+      nodejs \
+      default-mysql-client \
+      python3-dev \
+      python3-pip \
+      apt-transport-https
 
 # Install node + npm
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 # Install pip
-RUN pip install --upgrade pip
+RUN pip3 install --upgrade pip
 
 # Install chamber, for pulling secrets into the container.
 RUN curl -L https://github.com/segmentio/chamber/releases/download/v2.2.0/chamber-v2.2.0-linux-amd64 -o /bin/chamber
 RUN chmod +x /bin/chamber
 
 COPY requirements.txt ./
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Configure the main working directory. This is the base
 # directory used in any further RUN, COPY, and ENTRYPOINT


### PR DESCRIPTION
# Description

Installs Python 3 on the Docker image for web. The base image is changed to `2.5-buster` to make Python 3.7 available.

Python 2 is long out of date and now officially unsupported. However the immediate motivation for this change is for the pipeline visualization work. With the pipeline's workflow described in WDL, parsing the workflow via miniwdl requires Python 3.6+, which `2.5-stretch` does not support.

# Notes

Part of pipeline visualization work for step function compatibility.

# Tests

* Server side tests pass, Travis YML updated
* No client side code changed