### PR TITLE
[IDSEQ-2456] CURL Download option overwrites files with same name

### DIFF
--- a/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/AdvancedDownloadTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/AdvancedDownloadTab.jsx
@@ -45,7 +45,7 @@ export default class AdvancedDownloadTab extends React.Component {
     }
 
     let currentTimestamp = moment().format("MM-D-YYYY hh-mm-ssa");
-    let bulkDownloadFileName = `${bulkDownload.download_name} - ${currentTimestamp}`;
+    let bulkDownloadFileName = `${bulkDownload.download_name}-${currentTimestamp}`;
 
     return `curl -L "${bulkDownload.presigned_output_url}" > "${bulkDownloadFileName}.tar.gz"\
         && mkdir -p "${bulkDownloadFileName}"\

--- a/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/AdvancedDownloadTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/AdvancedDownloadTab.jsx
@@ -43,13 +43,11 @@ export default class AdvancedDownloadTab extends React.Component {
       return "Failed to generate command. Please contact us for help.";
     }
 
-    return `curl -L "${bulkDownload.presigned_output_url}" > "${
-      bulkDownload.download_name
-    }.tar.gz"\
-        && mkdir -p "${bulkDownload.download_name}"\
-        && tar -zvxf "${bulkDownload.download_name}.tar.gz" -C "${
-      bulkDownload.download_name
-    }"\
+    let bulkDownloadFileName = `${bulkDownload.download_name} ID-${bulkDownload.id}`;
+
+    return `curl -L "${bulkDownload.presigned_output_url}" > "${bulkDownloadFileName}.tar.gz"\
+        && mkdir -p "${bulkDownloadFileName}"\
+        && tar -zvxf "${bulkDownloadFileName}.tar.gz" -C "${bulkDownloadFileName}"\
       `;
   };
 

--- a/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/AdvancedDownloadTab.jsx
+++ b/app/assets/src/components/common/DetailsSidebar/BulkDownloadDetailsMode/AdvancedDownloadTab.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import copy from "copy-to-clipboard";
 import cx from "classnames";
+import moment from "moment";
 
 import PropTypes from "~/components/utils/propTypes";
 import CopyIcon from "~ui/icons/CopyIcon";
@@ -43,7 +44,8 @@ export default class AdvancedDownloadTab extends React.Component {
       return "Failed to generate command. Please contact us for help.";
     }
 
-    let bulkDownloadFileName = `${bulkDownload.download_name} ID-${bulkDownload.id}`;
+    let currentTimestamp = moment().format("MM-D-YYYY hh-mm-ssa");
+    let bulkDownloadFileName = `${bulkDownload.download_name} - ${currentTimestamp}`;
 
     return `curl -L "${bulkDownload.presigned_output_url}" > "${bulkDownloadFileName}.tar.gz"\
         && mkdir -p "${bulkDownloadFileName}"\


### PR DESCRIPTION
# Description
Added the bulk_download ID to the tar.gz to prevent overwriting on conflicting files with same name – although overwriting of the same file with the same name + id will happen.

update: replaced the id with a timestamp

# Notes
I have searched through CURL's & tar's manuals and there's no functionality of incremental rename of files. One way to achieve the incremental rename of files would be to create a bash script (that each user would need to have).

# Tests

1. Go to downloads
2. Open details of file of these files
3. Select Advanced download and copy the URL
4. Open a terminal and paste the CURL pipeline
5. Perform steps 1-4 for a different download with the same file name that you just downloaded