### PR TITLE
[RELEASE_CHECKLIST] - v0.59

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
         - redis
       before_install:
         # Install python and dependencies
-        - source ~/virtualenv/python2.7/bin/activate
+        - source ~/virtualenv/python3.7/bin/activate
         - pip install -r requirements.txt
         # Upgrade bundler to v2 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
         - gem install bundler
@@ -59,7 +59,7 @@ jobs:
         - redis
       before_install:
         # Install python and dependencies
-        - source ~/virtualenv/python2.7/bin/activate
+        - source ~/virtualenv/python3.7/bin/activate
         - pip install -r requirements.txt
         # Upgrade bundler to v2 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
         - gem install bundler
@@ -102,11 +102,11 @@ jobs:
     #   seem to start later. This job is the fastest by far so keep it last.
     - name: "Python Test"
       language: python
-      python: 2.7
-      cache: pip
+      python: 3.7
+      cache: pip3
       script:
-        - pip install mock
-        - python -m unittest discover -v -s test/ -p 'test_*.py'
+        - pip3 install mock
+        - python3 -m unittest discover -v -s test/ -p 'test_*.py'
 env:
   global:
   - secure: l6JImOInd+PoLwf9hbAl6QmjXE4mShlG7SEkasSKk6XzT4npNTUqqYVVpNewr1f58U97SdHShv6WgxKIiUpX+adIBp9b59CsI7SCKxt1aSp9egyZE6F1ZIoqjmfH6o9U4dUkE32TJdG4Tn/QMd0fj3nCqathFIWFhato6ovqXmJpklJHH9BGbK330bEYG1LoUU3u/hIhBc8bAuNIO15eih1vMltYiSw5ScQxBMjcCskAjEeb8EA7i82pEpyD9iBWcIomw5Mrro0IInjJbudIQ5RukNZtI3zZXiSbR8m8VWzK8A8ixihHKRbBoLXn3X719s13FIJKL2Pn1utxMx4zrLLUx4iMafey2e8iG9C3JYyHu6UoR/E5hcSCdhHDmwiCiIQF8cHt2sZNVE33rEGdEkhsPgwlH16O6kBJmVOqaaihPN/yjzIyjxDoyknPfswpkiRiuqaa9XDXh5dgU0xHDfKic6ioAJvRMn0Ngbo7Ogi90rTaxksFFo7UAL9mChQaB+qtJk+tU0I7PFTR52ie62KcIAfqU3PFOo1jchmw7uEu/k8yNpZM4gar2gnl8gqe5dIVqkTDfNWBTlYX17dTqeHB7ZqCRKZzYcEZK8SVmw9fs/JTouwQK2nXgwEnp7dJdofvZgXhLZ4/ZhNniLn0ObDQauzYKPKgk819CtIb968=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,30 @@
-FROM ruby:2.5-stretch
+FROM ruby:2.5-buster
 
 # Install apt based dependencies required to run Rails as
 # well as RubyGems. As the Ruby image itself is based on a
 # Debian image, we use apt-get to install those.
-RUN apt-get update && apt-get install -y build-essential nodejs mysql-client python-dev python-pip apt-transport-https
+RUN apt-get update && \
+    apt-get install -y \
+      build-essential \
+      nodejs \
+      default-mysql-client \
+      python3-dev \
+      python3-pip \
+      apt-transport-https
 
 # Install node + npm
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 # Install pip
-RUN pip install --upgrade pip
+RUN pip3 install --upgrade pip
 
 # Install chamber, for pulling secrets into the container.
 RUN curl -L https://github.com/segmentio/chamber/releases/download/v2.2.0/chamber-v2.2.0-linux-amd64 -o /bin/chamber
 RUN chmod +x /bin/chamber
 
 COPY requirements.txt ./
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Configure the main working directory. This is the base
 # directory used in any further RUN, COPY, and ENTRYPOINT

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -963,7 +963,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
-    puma (3.12.4)
+    puma (3.12.6)
     quantile (0.2.1)
     raabro (1.1.6)
     rack (2.2.2)

--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -333,13 +333,11 @@ class ReportTable extends React.Component {
 
   renderNtNrDecimalValues = ({ cellData, decimalPlaces }) => {
     return this.renderNtNrStack({
-      cellData: cellData.map(val => {
-        let needsTruncation = val % 1 !== 0; // Checks if a number has a decimal place/is a whole number
-        let processedValue = needsTruncation
-          ? Number(val).toFixed(2)
-          : Number(val);
-        return TableRenderers.formatNumberWithCommas(processedValue);
-      }),
+      cellData: cellData.map(val =>
+        TableRenderers.formatNumberWithCommas(
+          Number(val).toFixed(decimalPlaces || 0)
+        )
+      ),
     });
   };
 
@@ -588,8 +586,8 @@ class ReportTable extends React.Component {
           rowData.genus
             ? getOr(nullValue, path, rowData)
             : sortDirection === "asc"
-            ? limits[0]
-            : limits[1],
+              ? limits[0]
+              : limits[1],
       ],
       [sortDirection, sortDirection, sortDirection],
       data

--- a/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
+++ b/app/assets/src/components/views/SampleViewV2/ReportTable.jsx
@@ -333,11 +333,13 @@ class ReportTable extends React.Component {
 
   renderNtNrDecimalValues = ({ cellData, decimalPlaces }) => {
     return this.renderNtNrStack({
-      cellData: cellData.map(val =>
-        TableRenderers.formatNumberWithCommas(
-          Number(val).toFixed(decimalPlaces || 0)
-        )
-      ),
+      cellData: cellData.map(val => {
+        let needsTruncation = val % 1 !== 0; // Checks if a number has a decimal place/is a whole number
+        let processedValue = needsTruncation
+          ? Number(val).toFixed(2)
+          : Number(val);
+        return TableRenderers.formatNumberWithCommas(processedValue);
+      }),
     });
   };
 
@@ -586,8 +588,8 @@ class ReportTable extends React.Component {
           rowData.genus
             ? getOr(nullValue, path, rowData)
             : sortDirection === "asc"
-              ? limits[0]
-              : limits[1],
+            ? limits[0]
+            : limits[1],
       ],
       [sortDirection, sortDirection, sortDirection],
       data

--- a/app/helpers/elasticsearch_callbacks_helper.rb
+++ b/app/helpers/elasticsearch_callbacks_helper.rb
@@ -1,0 +1,38 @@
+# Provides Async Callbacks for Elasticsearch Syncing
+module ElasticsearchCallbacksHelper
+  # WARNING: using this with a model means you must ensure activerecord
+  #  callbacks are called on all updates. This module updates elasticsearch
+  #  using these callbacks. If you must circumvent them somehow (eg. using raw
+  #  SQL or bulk_import) you must explicitly update elasticsearch appropriately.
+
+  def self.included(base)
+    return unless base.ancestors.include?(::ActiveRecord::Base)
+    base.class_eval do
+      after_commit -> { async_elasticsearch_index }, on: :create
+      after_commit -> { async_elasticsearch_index }, on: :update
+      after_commit -> { async_elasticsearch_delete }, on: :destroy
+    end
+  end
+
+  def async_elasticsearch_index
+    Resque.enqueue(
+      ElasticsearchIndex,
+      :index,
+      __elasticsearch__.index_name,
+      __elasticsearch__.document_type,
+      id,
+      __elasticsearch__.as_indexed_json
+    )
+  end
+
+  def async_elasticsearch_delete
+    Resque.enqueue(
+      ElasticsearchIndex,
+      :delete,
+      __elasticsearch__.index_name,
+      __elasticsearch__.document_type,
+      id,
+      __elasticsearch__.as_indexed_json
+    )
+  end
+end

--- a/app/jobs/elasticsearch_index.rb
+++ b/app/jobs/elasticsearch_index.rb
@@ -1,0 +1,25 @@
+require 'elasticsearch/model'
+
+# Indexes records for elasticsearch record
+class ElasticsearchIndex
+  @queue = :elasticsearch_index
+
+  def self.perform(operation, index_name, doc_type, record_id, indexed_json)
+    Rails.logger.debug("Elasticsearch: Attempting to #{operation} record: #{record_id} source table: #{index_name}")
+    case operation.to_s
+    when /index/
+      Elasticsearch::Model.client.index(index: index_name, type: doc_type, id: record_id, body: indexed_json)
+      Rails.logger.debug("Elasticsearch: Successfully indexed record: #{record_id} source table: #{index_name}")
+    when /delete/
+      Elasticsearch::Model.client.delete(index: index_name, type: index_type, id: record_id)
+      Rails.logger.debug("Elasticsearch: Successfully deleted record: #{record_id} source table: #{index_name}")
+    else raise ArgumentError, "Unknown operation '#{operation}'"
+    end
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    Rails.logger.debug("Elasticsearch: Attempted to delete document: #{record_id} from #{index_name} but it was not found")
+  rescue => e
+    Rails.logger.error(e)
+    LogUtil.log_backtrace(e)
+    LogUtil.log_err_and_airbrake("Elasticsearch failed to #{operation} record: #{record_id} source table: #{index_name}, with error: #{e.message}")
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,7 +1,11 @@
 class Project < ApplicationRecord
   if ELASTICSEARCH_ON
     include Elasticsearch::Model
-    include Elasticsearch::Model::Callbacks
+    # WARNING: using this means you must ensure activerecord callbacks are
+    #  called on all updates. This module updates elasticsearch using these
+    #  callbacks. If you must circumvent them somehow (eg. using raw SQL or
+    #  bulk_import) you must explicitly update elasticsearch appropriately.
+    include ElasticsearchCallbacksHelper
   end
   include ReportHelper
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -8,16 +8,11 @@ require 'elasticsearch/model'
 class Sample < ApplicationRecord
   if ELASTICSEARCH_ON
     include Elasticsearch::Model
-    after_commit on: [:create, :update] do
-      __elasticsearch__.index_document
-    end
-    after_commit on: [:destroy] do
-      begin
-        __elasticsearch__.delete_document
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
-        Rails.logger.warn(e)
-      end
-    end
+    # WARNING: using this means you must ensure activerecord callbacks are
+    #  called on all updates. This module updates elasticsearch using these
+    #  callbacks. If you must circumvent them somehow (eg. using raw SQL or
+    #  bulk_import) you must explicitly update elasticsearch appropriately.
+    include ElasticsearchCallbacksHelper
   end
   include TestHelper
   include MetadataHelper

--- a/app/models/taxon_lineage.rb
+++ b/app/models/taxon_lineage.rb
@@ -4,9 +4,13 @@
 require 'elasticsearch/model'
 
 class TaxonLineage < ApplicationRecord
-  unless Rails.env == "test"
+  if ELASTICSEARCH_ON
     include Elasticsearch::Model
-    include Elasticsearch::Model::Callbacks
+    # WARNING: using this means you must ensure activerecord callbacks are
+    #  called on all updates. This module updates elasticsearch using these
+    #  callbacks. If you must circumvent them somehow (eg. using raw SQL or
+    #  bulk_import) you must explicitly update elasticsearch appropriately.
+    include ElasticsearchCallbacksHelper
   end
   include TaxonLineageHelper
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,11 @@ require 'auth0'
 class User < ApplicationRecord
   if ELASTICSEARCH_ON
     include Elasticsearch::Model
-    include Elasticsearch::Model::Callbacks
+    # WARNING: using this means you must ensure activerecord callbacks are
+    #  called on all updates. This module updates elasticsearch using these
+    #  callbacks. If you must circumvent them somehow (eg. using raw SQL or
+    #  bulk_import) you must explicitly update elasticsearch appropriately.
+    include ElasticsearchCallbacksHelper
   end
 
   # https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html#method-i-has_secure_token

--- a/lib/tasks/update_lineagedb.rake
+++ b/lib/tasks/update_lineagedb.rake
@@ -153,6 +153,23 @@ class LineageDatabaseImporter
     import_new_taxid_lineages!
     affected = build_new_taxon_lineages!
     upgrade_taxon_lineages!(affected, noverify)
+    # This is very slow, since this script is using raw SQL the
+    #  elasticsearch index will not be updated, since elasticsearch-model
+    #  relies on callbacks. The safest and easiest way to ensure the
+    #  index is in sync at the end is to refresh the whole thing.
+    #  Since this script is run rarely this shouldn't be a huge deal
+    #  but if it is slow you may want to look into only updating affected ids.
+    import_elasticsearch!
+  end
+
+  def import_elasticsearch!
+    puts "\nRefresh elasticsearch index..."
+    # There may be potential to optimize this based on the diff but:
+    # - Going through the ID and calling index would likely be slower
+    #   because import implements batching.
+    # - Using a query import based on updated timestamp misses
+    #   deletions.
+    TaxonLineage.__elasticsearch__.import force: true
   end
 
   def upgrade_taxon_lineages!(new_count, noverify = false)


### PR DESCRIPTION
# Release checklist
_Please check your commits after testing:_
### dependabot[bot]
* [x] ae0026d1 - Bump puma from 3.12.4 to 3.12.6 (#3359)  (master) (Tue, 26 May 2020 11:02:55 -0700)
### Omar Valenzuela
* [x] d71f059b - Revert "[IDSEQ-2656] The filter for e-value says ">=" but right now it is only ">" (#3353)" (#3354)  (Wed, 20 May 2020 16:14:08 -0700)
* [x] 6104760c - [IDSEQ-2656] The filter for e-value says ">=" but right now it is only ">" (#3353)  (Tue, 19 May 2020 17:24:47 -0700)
### Lucia Reynoso
* [x] 12175d72 - Update to Python 3 and Ruby 2.5 Buster image (#3357)  (Tue, 26 May 2020 10:48:38 -0700)
### Todd Morse
* [x] 92ebc8b9 - Async Elasticsearch (#3355)  (tag: v0.59.0_staging_2020-05-26, origin/staging, origin/master, origin/HEAD, staging) (Tue, 26 May 2020 14:38:06 -0400)

_(included commits: (92ebc8b9)..(e821e6a9), created on 2020-05-26 16:35:59)_

# Release/Hot fixes
_Make sure all your release/hot fixes are listed here. Check your commits after testing and cherry-picking to staging/master accordingly:_