### PR TITLE
[IDSEQ-2724] Bad count badge locations in heatmap

### DIFF
--- a/app/assets/src/components/ui/controls/dropdowns/common/DropdownTrigger.jsx
+++ b/app/assets/src/components/ui/controls/dropdowns/common/DropdownTrigger.jsx
@@ -17,6 +17,8 @@ class DropdownTrigger extends React.Component {
       placeholder,
     } = this.props;
 
+    const hasBadgeCount =
+      label === "Threshold Filters:" || label === "Categories:";
     return (
       <div
         className={cx(
@@ -29,7 +31,7 @@ class DropdownTrigger extends React.Component {
         )}
         onClick={onClick}
       >
-        <div className={cs.labelContainer}>
+        <div className={cx(cs.labelContainer, hasBadgeCount && cs.badgeCount)}>
           {label && <span className={cs.label}>{label}</span>}
           <span className={cx(value === null && cs.placeholder)}>
             {value || placeholder}

--- a/app/assets/src/components/ui/controls/dropdowns/common/dropdown_trigger.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/common/dropdown_trigger.scss
@@ -32,6 +32,11 @@
     white-space: nowrap;
   }
 
+  .badgeCount {
+    display: flex;
+    justify-content: space-between;
+  }
+
   .label {
     font-weight: 600;
     margin-right: 5px;

--- a/app/assets/src/components/ui/controls/dropdowns/threshold_filter_dropdown.scss
+++ b/app/assets/src/components/ui/controls/dropdowns/threshold_filter_dropdown.scss
@@ -2,10 +2,6 @@
 @import "~styles/typography";
 
 :global(.ui):global(.dropdown).thresholdFilterDropdown {
-  .dropdownLabel {
-    margin-left: 6px;
-  }
-
   &:global(.active) {
     .dropdownTrigger {
       border: 1px solid $primary-light;

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/SamplesHeatmapControls.jsx
@@ -84,7 +84,7 @@ export default class SamplesHeatmapControls extends React.Component {
         onChange={this.onCategoryChange}
         selectedOptions={this.props.selectedOptions.categories}
         selectedSuboptions={this.props.selectedOptions.subcategories}
-        label="Taxon Categories"
+        label="Categories"
         disabled={this.props.loading || !this.props.data}
       />
     );
@@ -160,12 +160,12 @@ export default class SamplesHeatmapControls extends React.Component {
   };
 
   renderThresholdFilterSelect() {
+    const { options, selectedOptions } = this.props;
     return (
       <ThresholdFilterDropdown
-        options={this.props.options.thresholdFilters}
-        thresholds={this.props.selectedOptions.thresholdFilters}
+        options={options.thresholdFilters}
+        thresholds={selectedOptions.thresholdFilters}
         onApply={this.onThresholdFilterApply}
-        disabled={this.props.loading || !this.props.data}
       />
     );
   }
@@ -477,14 +477,13 @@ export default class SamplesHeatmapControls extends React.Component {
             <div className="col">{this.renderFilterTags()}</div>
           </div>
         )}
-        {!loading &&
-          displayFilterStats && (
-            <div className={cx(cs.filterRow, "row")}>
-              <div className={cx(cs.statsRow, "col")}>
-                {this.renderFilterStatsInfo()}
-              </div>
+        {!loading && displayFilterStats && (
+          <div className={cx(cs.filterRow, "row")}>
+            <div className={cx(cs.statsRow, "col")}>
+              {this.renderFilterStatsInfo()}
             </div>
-          )}
+          </div>
+        )}
         <Divider />
       </div>
     );

--- a/app/assets/src/components/views/compare/SamplesHeatmapView/samples_heatmap_view.scss
+++ b/app/assets/src/components/views/compare/SamplesHeatmapView/samples_heatmap_view.scss
@@ -22,13 +22,13 @@
 
     .filterRow {
       margin-top: $space-l;
-      margin-bottom: $space-s;
+      margin-bottom: $space-l;
     }
 
     .filterTagsList {
       margin-bottom: $space-l;
       .filterTag {
-        margin-right: 6px;
+        margin-right: $space-xs;
 
         &:last-child {
           margin-right: 0;


### PR DESCRIPTION
# Description
The count badges for taxon categories and threshold filters were below where they should be.
To view the discussion thread, check out the JIRA ticket [here](https://jira.czi.team/browse/IDSEQ-2724)

# Notes
Decreased the space between filter dropdowns to the same as the report page
Changed "taxon categories" to "categories" as it is on the report page to match and to give it more space. (as a result of discussion thread)

# Tests
Create a heatmap with any # samples and add threshold filters and/or category filters 
