### PR TITLE
[IDSEQ-2769] Table headers overlap when the right side panel is opened or window size changes.

### DIFF
--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -13,7 +13,6 @@
     flex: 1 0 auto;
     display: flex;
     flex-direction: column;
-    width: 100%;
     height: 100%;
   }
 

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -13,6 +13,8 @@
     flex: 1 0 auto;
     display: flex;
     flex-direction: column;
+    width: 100%;
+    height: 100%;
   }
 
   .map {

--- a/app/assets/src/components/views/samples/samples_view.scss
+++ b/app/assets/src/components/views/samples/samples_view.scss
@@ -13,7 +13,6 @@
     flex: 1 0 auto;
     display: flex;
     flex-direction: column;
-    height: 100%;
   }
 
   .map {

--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -222,7 +222,10 @@ class BaseTable extends React.Component {
     const { activeColumns, columns } = this.state;
     const columnOrder = activeColumns || map("dataKey", columns);
     return (
-      <div className={cs.tableContainer}>
+      <div
+        className={cs.tableContainer}
+        style={{ flexBasis: defaultHeaderHeight }}
+      >
         <AutoSizer>
           {({ width, height }) => (
             <VirtualizedTable


### PR DESCRIPTION
# Description
Table headers overlap when the right side panel is opened.

# Notes
Parent container contains the BaseTable with AutoSizer did not update width and height as expected. Setting the width & height of the parent container to 100% fixed the bug.

# Tests
Steps to Reproduce

1. Navigate to the All Data tab
2. Search for "aoeu"
3. Click the tab Samples** 
4. Shrink the window size by dragging the far right side of the browser OR expand the right side panel by clicking the blue info button. Also try expanding the window to full size and shrinking it.
