### PR TITLE
[IDSEQ-2843] Fix fetch of pipeline outputs from s3

### DIFF
--- a/spec/services/retrieve_pipeline_viz_graph_data_service_spec.rb
+++ b/spec/services/retrieve_pipeline_viz_graph_data_service_spec.rb
@@ -93,7 +93,7 @@ shared_examples "pipeline viz" do
 
     Aws.config[:s3] = {
       stub_responses: {
-        list_objects: {
+        list_objects_v2: {
           contents: %w[
             unmapped1.fq
             trimmomatic1.fq
@@ -122,7 +122,6 @@ shared_examples "pipeline viz" do
 
     it "should be structured correctly" do
       results = RetrievePipelineVizGraphDataService.call(pr.id, true, false)
-      puts results
       expect(results).to include_json(expected_stage_results)
       expect(results.keys).to contain_exactly(*expected_stage_results.keys)
     end
@@ -132,7 +131,6 @@ shared_examples "pipeline viz" do
       s3.stub_responses(:get_object, body: step_status_data.to_json)
 
       stub_const("PipelineOutputsHelper::Client", s3)
-      # allow(PipelineOutputsHelper).to receive(:get_s3_file).and_return(step_status_data.to_json)
       results = RetrievePipelineVizGraphDataService.call(pr.id, true, false)
 
       results[:stages][0][:steps].each do |step|


### PR DESCRIPTION
# Description
[Jira IDSEQ-2842](https://jira.czi.team/browse/IDSEQ-2843)

This bug was caused by a combinations of:
1. flattening of results in s3 
1. by the number of align and coverage viz file and
1. lack of pagination

This PR:
* Add pagination to output fetching
* Remove redundant s3 fetches since all files are in the same folder now. 

# Tests

* Tested locally and confirmed that reads table loads and all outputs are listed in results folder.
