### PR TITLE
SFN dispatch: Fix deuterostome parameter boolean logic

### DIFF
--- a/app/services/sfn_pipeline_dispatch_service.rb
+++ b/app/services/sfn_pipeline_dispatch_service.rb
@@ -152,7 +152,7 @@ class SfnPipelineDispatchService
           accession2taxid_db: @pipeline_run.alignment_config.s3_accession2taxid_path,
           taxon_blacklist: @pipeline_run.alignment_config.s3_taxon_blacklist_path,
           index_dir_suffix: @pipeline_run.alignment_config.index_dir_suffix,
-          deuterostome_db: @sample.skip_deutero_filter_flag ? nil : @pipeline_run.alignment_config.s3_deuterostome_db_path,
+          deuterostome_db: @sample.skip_deutero_filter_flag == 1 ? @pipeline_run.alignment_config.s3_deuterostome_db_path : nil,
           use_taxon_whitelist: @pipeline_run.use_taxon_whitelist,
         }, Postprocess: {
           nt_db: @pipeline_run.alignment_config.s3_nt_db_path,
@@ -161,7 +161,7 @@ class SfnPipelineDispatchService
           nr_loc_db: @pipeline_run.alignment_config.s3_nr_loc_db_path,
           lineage_db: @pipeline_run.alignment_config.s3_lineage_path,
           taxon_blacklist: @pipeline_run.alignment_config.s3_taxon_blacklist_path,
-          deuterostome_db: @sample.skip_deutero_filter_flag ? nil : @pipeline_run.alignment_config.s3_deuterostome_db_path,
+          deuterostome_db: @sample.skip_deutero_filter_flag == 1 ? @pipeline_run.alignment_config.s3_deuterostome_db_path : nil,
           use_taxon_whitelist: @pipeline_run.use_taxon_whitelist,
         }, Experimental: {
           nt_db: @pipeline_run.alignment_config.s3_nt_db_path,


### PR DESCRIPTION
# Description

Ruby evaluates 0 to true in boolean conditionals. The code in #3347 falsely assumed otherwise, and therefore contained a bug where the deuterostome db URL was not passed to the pipeline.

# Tests

* Tested by re-running a pipeline sample with the deuterostome db parameter set to its expected value and confirming the change caused the pipeline to produce the expected result.