### PR TITLE
Fix line number in awk validation error message

### DIFF
--- a/scripts/fastq-fasta-line-validation.awk
+++ b/scripts/fastq-fasta-line-validation.awk
@@ -5,7 +5,7 @@
 #    cat somefile.fastq | awk -f "../scripts/fastq-fasta-line-validation.awk" -v max_line_length=10000
 {
   if ($0 ~ /[^\x20-\x7F\x01\x09]/) {
-    printf "PARSE ERROR: not an ascii file. Line %d contains non-ascii characters.\n", FILENAME, NR > "/dev/stderr";
+    printf "PARSE ERROR: not an ascii file. Line %d contains non-ascii characters.\n", NR > "/dev/stderr";
     exit 1;
   }
   if (length > max_line_length) {


### PR DESCRIPTION
# Description

AWK validation was working properly, but line number wasn't properly displayed when non-ascii characters were found

# Tests

* Manual
