### PR TITLE
[IDSEQ-2850] [Firefox] Scrolling creates large white gap in Heatmap between metadata and taxa rows

### DIFF
--- a/app/assets/src/components/visualizations/heatmap/Heatmap.js
+++ b/app/assets/src/components/visualizations/heatmap/Heatmap.js
@@ -478,8 +478,7 @@ export default class Heatmap {
     );
 
     // Set up space bar+click to pan behavior.
-    d3
-      .select("body")
+    d3.select("body")
       .on("keydown", () => {
         if (d3.event.code === "Space") {
           this.svg.style("cursor", "move");
@@ -522,7 +521,7 @@ export default class Heatmap {
   }
 
   scroll() {
-    this.pan(d3.event.wheelDeltaX, d3.event.wheelDeltaY);
+    this.pan(d3.event.deltaX, d3.event.deltaY);
     d3.event.stopPropagation();
   }
 
@@ -1484,14 +1483,12 @@ export default class Heatmap {
 
     columnMetadataLabel
       .select(".metadataSortIcon")
-      .attr(
-        "xlink:href",
-        d =>
-          d.value === this.columnMetadataSortField
-            ? `${this.options.iconPath}/sort_${
-                this.columnMetadataSortAsc ? "asc" : "desc"
-              }.svg`
-            : ""
+      .attr("xlink:href", d =>
+        d.value === this.columnMetadataSortField
+          ? `${this.options.iconPath}/sort_${
+              this.columnMetadataSortAsc ? "asc" : "desc"
+            }.svg`
+          : ""
       );
   }
 


### PR DESCRIPTION
Signed-off-by: ovalenzuela19 <ovalenzuela@chanzuckerberg.com>

# Description
When using the heatmap on Firefox, trying to scroll creates a large white gap between metadata row and taxa rows.

# Notes
Firefox does not support event.wheelDeltaX or event.wheelDeltaY
We can use event.deltaY instead, as all browsers support that.
https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaX

# Tests
Open Firefox
Create a heatmap with any number of samples
Scroll in any direction
