### PR TITLE
[IDSEQ-1913][QA] Remove sortable style from columns that do not sort data

### DIFF
--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -31,6 +31,7 @@ class ProjectsView extends React.Component {
         dataKey: "project",
         flexGrow: 1,
         width: 350,
+        disableSort: true,
         cellRenderer: ({ cellData }) =>
           TableRenderers.renderItemDetails(
             merge(

--- a/app/assets/src/components/views/projects/ProjectsView.jsx
+++ b/app/assets/src/components/views/projects/ProjectsView.jsx
@@ -50,6 +50,7 @@ class ProjectsView extends React.Component {
         dataKey: "created_at",
         label: "Created On",
         width: 120,
+        disableSort: true,
         cellRenderer: TableRenderers.renderDateWithElapsed,
       },
       {
@@ -68,8 +69,9 @@ class ProjectsView extends React.Component {
       },
       {
         dataKey: "number_of_samples",
-        width: 140,
         label: "No. of Samples",
+        width: 140,
+        disableSort: true,
       },
     ];
 

--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -113,10 +113,13 @@ class BaseTable extends React.Component {
             content={label}
           />
         )}
-        <SortIcon
-          sortDirection={sortDirection === "ASC" ? "ascending" : "descending"}
-          className={cx(cs.sortIcon, sortBy === dataKey && cs.active)}
-        />
+        {/* Commenting out because we don't have any sorting functionality right now.
+          TODO(omar): Uncomment when sorting functionality becomes live.
+          <SortIcon
+            sortDirection={sortDirection === "ASC" ? "ascending" : "descending"}
+            className={cx(cs.sortIcon, sortBy === dataKey && cs.active)}
+          />S
+        */}
       </div>
     );
   };

--- a/app/assets/src/components/visualizations/table/BaseTable.jsx
+++ b/app/assets/src/components/visualizations/table/BaseTable.jsx
@@ -65,9 +65,10 @@ class BaseTable extends React.Component {
     });
   }
 
-  basicHeaderRenderer({ columnData, label }) {
+  basicHeaderRenderer({ dataKey, columnData, label }) {
+    const isProjectHeader = dataKey === "project";
     return (
-      <div>
+      <div className={isProjectHeader && cs.projectHeader}>
         {columnData ? (
           <ColumnHeaderTooltip
             trigger={<span className={cs.label}>{label}</span>}
@@ -113,13 +114,10 @@ class BaseTable extends React.Component {
             content={label}
           />
         )}
-        {/* Commenting out because we don't have any sorting functionality right now.
-          TODO(omar): Uncomment when sorting functionality becomes live.
-          <SortIcon
-            sortDirection={sortDirection === "ASC" ? "ascending" : "descending"}
-            className={cx(cs.sortIcon, sortBy === dataKey && cs.active)}
-          />S
-        */}
+        <SortIcon
+          sortDirection={sortDirection === "ASC" ? "ascending" : "descending"}
+          className={cx(cs.sortIcon, sortBy === dataKey && cs.active)}
+        />
       </div>
     );
   };

--- a/app/assets/src/components/visualizations/table/base_table.scss
+++ b/app/assets/src/components/visualizations/table/base_table.scss
@@ -40,6 +40,14 @@
   justify-content: center;
   text-align: center;
 
+  .projectHeader {
+    max-width: 100%;
+    display: flex;
+    flex: 1 0 auto;
+    align-items: inherit;
+    justify-content: inherit;
+  }
+
   .sortableHeader {
     max-width: 100%;
     display: flex;


### PR DESCRIPTION
Signed-off-by: ovalenzuela19 <ovalenzuela@chanzuckerberg.com>

# Description
List headers showed inconsistent behavior (some with chevrons, text effects, or lack of both)

# Notes
Table headers "Project", "Created On", and "No. of Samples" appear as if they're clickable and did not have disableSort set to true. 
"Project" is a special case and required some added styling that .sortableHeader offers because it needs to be aligned left and not center.

# Tests
Steps to reproduce:

1. Go to projects
2. At Projects list (you are on the Projects tab, viewing a list of all Projects), mouseover column headers
3. Observe column header behavior
