### PR TITLE
Persist SFN results path to the database

### DIFF
--- a/app/models/pipeline_run.rb
+++ b/app/models/pipeline_run.rb
@@ -801,8 +801,8 @@ class PipelineRun < ApplicationRecord
 
   def update_results_path_from_sfn
     Rails.logger.info("[SFN] [PR=#{id}] Get path from SFN execution (arn=#{sfn_execution_arn})")
+    # TODO: move to initializer
     sfn_client = Aws::States::Client.new
-
     execution_resp = sfn_client.describe_execution(execution_arn: sfn_execution_arn)
 
     sfn_resp = sfn_client.list_tags_for_resource(resource_arn: execution_resp.state_machine_arn)
@@ -821,7 +821,8 @@ class PipelineRun < ApplicationRecord
     )
     Rails.logger.info("[SFN] [PR=#{id}] Output path: #{path}")
 
-    self.sfn_results_path = path
+    update(sfn_results_path: path)
+    path
   end
 
   def sfn_results_path


### PR DESCRIPTION
# Description

* A SFN execution can be deleted from AWS, thus we need to preserve the path to the results in the database.
* This PR saves the results path to the database on the first access to the variable.

# Notes

* Will need to run a script to load this field for all existing SFN pipeline runs.

# Tests

* Tested from the console. Loading a pipeline run with null results path and running `pr.sfn_results_path`.
